### PR TITLE
RELATED: RAIL-4170 add adding insight into existing sections

### DIFF
--- a/libs/sdk-ui-dashboard/.dependency-cruiser.js
+++ b/libs/sdk-ui-dashboard/.dependency-cruiser.js
@@ -73,6 +73,7 @@ options = {
             "src/presentation/componentDefinition",
             "src/presentation/filterBar",
             "src/presentation/filterBar/types.ts",
+            "src/presentation/widget/types.ts",
         ]),
         depCruiser.moduleWithDependencies("drill", "src/presentation/drill", [
             "src/_staging/*",
@@ -155,6 +156,7 @@ options = {
             "src/presentation/constants",
             "src/presentation/componentDefinition",
             "src/presentation/dashboardContexts",
+            "src/presentation/dragAndDrop",
             "src/presentation/drill",
             "src/presentation/drill/types.ts",
             "src/presentation/localization",

--- a/libs/sdk-ui-dashboard/.dependency-cruiser.js
+++ b/libs/sdk-ui-dashboard/.dependency-cruiser.js
@@ -74,6 +74,7 @@ options = {
             "src/presentation/filterBar",
             "src/presentation/filterBar/types.ts",
             "src/presentation/widget/types.ts",
+            "src/widgets/placeholders/types.ts",
         ]),
         depCruiser.moduleWithDependencies("drill", "src/presentation/drill", [
             "src/_staging/*",
@@ -103,6 +104,7 @@ options = {
             "src/presentation/widget",
             "src/presentation/componentDefinition",
             "src/model/store/([^/]+)/.+Selectors.ts",
+            "src/widgets/placeholders/types.ts",
             "src/types.ts",
         ]),
         depCruiser.moduleWithDependencies("logUserInteraction", "src/logUserInteraction", ["src/model"]),
@@ -121,6 +123,7 @@ options = {
             "src/model/layout",
             "src/model/react",
             "src/model/store/([^/]+)/.+Selectors.ts",
+            "src/widgets/placeholders/types.ts",
             "src/types.ts",
         ]),
         depCruiser.moduleWithDependencies("scheduledEmail", "src/presentation/scheduledEmail", [
@@ -161,6 +164,7 @@ options = {
             "src/presentation/drill/types.ts",
             "src/presentation/localization",
             "src/presentation/presentationComponents",
+            "src/widgets/placeholders/types.ts",
             "src/types.ts",
         ]),
     ],

--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -1971,6 +1971,7 @@ export interface DashboardState {
     meta: DashboardMetaState;
     // (undocumented)
     permissions: PermissionsState;
+    placeholders: PlaceholdersState;
     // @internal
     _queryCache: {
         [queryName: string]: any;
@@ -3996,6 +3997,19 @@ export interface IUseInsightWidgetDataView {
 }
 
 // @alpha (undocumented)
+export interface IWidgetPlaceholderSpec {
+    // (undocumented)
+    itemIndex: number;
+    // (undocumented)
+    sectionIndex: number;
+    // (undocumented)
+    size: {
+        width: number;
+        height: number;
+    };
+}
+
+// @alpha (undocumented)
 export interface IXlsxExportConfig {
     // (undocumented)
     format: "xlsx";
@@ -4298,6 +4312,21 @@ export type OptionalWidgetComponentProvider = OptionalProvider<WidgetComponentPr
 export interface PermissionsState {
     // (undocumented)
     permissions?: IWorkspacePermissions;
+}
+
+// @internal
+export const placeholdersActions: CaseReducerActions<    {
+setWidgetPlaceholder: CaseReducer<PlaceholdersState, {
+payload: IWidgetPlaceholderSpec;
+type: string;
+}>;
+clearWidgetPlaceholder: CaseReducer<PlaceholdersState, AnyAction>;
+}>;
+
+// @alpha (undocumented)
+export interface PlaceholdersState {
+    // (undocumented)
+    widgetPlaceholder: IWidgetPlaceholderSpec | undefined;
 }
 
 // @internal
@@ -5302,6 +5331,9 @@ itemIndex: number;
 
 // @alpha
 export const selectWidgetDrills: (ref: ObjRef | undefined) => OutputSelector<DashboardState, IDrillToLegacyDashboard[] | InsightDrillDefinition[], (res: IKpiWidget | IInsightWidget | undefined) => IDrillToLegacyDashboard[] | InsightDrillDefinition[]>;
+
+// @alpha (undocumented)
+export const selectWidgetPlaceholder: OutputSelector<DashboardState, IWidgetPlaceholderSpec | undefined, (res: PlaceholdersState) => IWidgetPlaceholderSpec | undefined>;
 
 // @internal
 export const selectWidgets: OutputSelector<DashboardState, ExtendedDashboardWidget[], (res: IDashboardLayout<ExtendedDashboardWidget>) => ExtendedDashboardWidget[]>;

--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -4036,6 +4036,12 @@ export type KpiComponentProvider = (kpi: IKpi, widget: IKpiWidget) => CustomDash
 export interface KpiPlaceholderWidget extends ICustomWidget {
     // (undocumented)
     readonly customType: "kpiPlaceholder";
+    // (undocumented)
+    readonly isLastInSection: boolean;
+    // (undocumented)
+    readonly itemIndex: number;
+    // (undocumented)
+    readonly sectionIndex: number;
 }
 
 // @alpha (undocumented)

--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -3534,9 +3534,15 @@ export type InsightMenuComponentProvider = (insight: IInsight, widget: IInsightW
 export type InsightMenuItemsProvider = (insight: IInsight, widget: IInsightWidget, defaultItems: IInsightMenuItem[], closeMenu: () => void, renderMode: RenderMode) => IInsightMenuItem[];
 
 // @alpha (undocumented)
-export interface InsightPlaceholderWidget extends ICustomWidgetBase {
+export interface InsightPlaceholderWidget extends ICustomWidget {
     // (undocumented)
     readonly customType: "insightPlaceholder";
+    // (undocumented)
+    readonly isLastInSection: boolean;
+    // (undocumented)
+    readonly itemIndex: number;
+    // (undocumented)
+    readonly sectionIndex: number;
 }
 
 // @alpha
@@ -4027,7 +4033,7 @@ export type KpiAlertDialogOpenedPayload = UserInteractionPayloadWithDataBase<"kp
 export type KpiComponentProvider = (kpi: IKpi, widget: IKpiWidget) => CustomDashboardKpiComponent;
 
 // @alpha (undocumented)
-export interface KpiPlaceholderWidget extends ICustomWidgetBase {
+export interface KpiPlaceholderWidget extends ICustomWidget {
     // (undocumented)
     readonly customType: "kpiPlaceholder";
 }
@@ -5244,6 +5250,9 @@ export const selectIsScheduleEmailManagementDialogOpen: OutputSelector<Dashboard
 
 // @alpha (undocumented)
 export const selectIsShareDialogOpen: OutputSelector<DashboardState, boolean, (res: UiState) => boolean>;
+
+// @alpha (undocumented)
+export const selectIsWidgetPlaceholderShown: OutputSelector<DashboardState, boolean, (res: IWidgetPlaceholderSpec | undefined) => boolean>;
 
 // @alpha
 export const selectLayout: OutputSelector<DashboardState, IDashboardLayout<ExtendedDashboardWidget>, (res: LayoutState) => IDashboardLayout<ExtendedDashboardWidget>>;

--- a/libs/sdk-ui-dashboard/src/model/layout/sizing.ts
+++ b/libs/sdk-ui-dashboard/src/model/layout/sizing.ts
@@ -5,6 +5,7 @@ import {
     IInsight,
     IInsightDefinition,
     IKpi,
+    isDashboardWidget,
     ISettings,
     isInsight,
     isKpi,
@@ -114,23 +115,27 @@ export function getDashboardLayoutWidgetMaxGridHeight(
 }
 
 export function getMinHeight(widgets: IWidget[], insightMap: ObjRefMap<IInsight>): number {
-    const mins: number[] = widgets.map((widget) =>
-        getDashboardLayoutWidgetMinGridHeight(
-            { enableKDWidgetCustomHeight: true },
-            widgetType(widget),
-            isKpiWidget(widget) ? widget.kpi : insightMap.get(widget.insight),
-        ),
-    );
+    const mins: number[] = widgets
+        .filter(isDashboardWidget)
+        .map((widget) =>
+            getDashboardLayoutWidgetMinGridHeight(
+                { enableKDWidgetCustomHeight: true },
+                widgetType(widget),
+                isKpiWidget(widget) ? widget.kpi : insightMap.get(widget.insight),
+            ),
+        );
     return Math.max(...mins);
 }
 
 export function getMaxHeight(widgets: IWidget[], insightMap: ObjRefMap<IInsight>): number {
-    const maxs: number[] = widgets.map((widget) =>
-        getDashboardLayoutWidgetMaxGridHeight(
-            { enableKDWidgetCustomHeight: true },
-            widgetType(widget),
-            isKpiWidget(widget) ? widget.kpi : insightMap.get(widget.insight),
-        ),
-    );
+    const maxs: number[] = widgets
+        .filter(isDashboardWidget)
+        .map((widget) =>
+            getDashboardLayoutWidgetMaxGridHeight(
+                { enableKDWidgetCustomHeight: true },
+                widgetType(widget),
+                isKpiWidget(widget) ? widget.kpi : insightMap.get(widget.insight),
+            ),
+        );
     return Math.min(...maxs);
 }

--- a/libs/sdk-ui-dashboard/src/model/store/dashboardStore.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/dashboardStore.ts
@@ -39,6 +39,7 @@ import { uiSliceReducer } from "./ui";
 import { getDashboardContext } from "./_infra/contexts";
 import { RenderMode } from "../../types";
 import { legacyDashboardsSliceReducer } from "./legacyDashboards";
+import { placeholdersSliceReducer } from "./placeholders";
 
 const nonSerializableEventsAndCommands: (DashboardEventType | DashboardCommandType | string)[] = [
     "GDC.DASH/EVT.COMMAND.STARTED",
@@ -278,7 +279,7 @@ export function createDashboardStore(config: DashboardStoreConfig): ReduxedDashb
         },
     });
 
-    const rootReducer = combineReducers({
+    const rootReducer = combineReducers<DashboardState>({
         loading: loadingSliceReducer,
         saving: savingSliceReducer,
         backendCapabilities: backendCapabilitiesSliceReducer,
@@ -299,6 +300,7 @@ export function createDashboardStore(config: DashboardStoreConfig): ReduxedDashb
         legacyDashboards: legacyDashboardsSliceReducer,
         executionResults: executionResultsSliceReducer,
         ui: uiSliceReducer,
+        placeholders: placeholdersSliceReducer,
         _queryCache: queryProcessing.queryCacheReducer,
     });
 

--- a/libs/sdk-ui-dashboard/src/model/store/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/index.ts
@@ -210,6 +210,9 @@ export {
 } from "./ui/uiSelectors";
 export { uiActions } from "./ui";
 export { LegacyDashboardsState } from "./legacyDashboards/legacyDashboardsState";
+export { PlaceholdersState, IWidgetPlaceholderSpec } from "./placeholders/placeholdersState";
+export { selectWidgetPlaceholder } from "./placeholders/placeholdersSelectors";
+export { placeholdersActions } from "./placeholders";
 
 export { queryAndWaitFor } from "./_infra/queryAndWaitFor";
 export { dispatchAndWaitFor } from "./_infra/dispatchAndWaitFor";

--- a/libs/sdk-ui-dashboard/src/model/store/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/index.ts
@@ -211,7 +211,10 @@ export {
 export { uiActions } from "./ui";
 export { LegacyDashboardsState } from "./legacyDashboards/legacyDashboardsState";
 export { PlaceholdersState, IWidgetPlaceholderSpec } from "./placeholders/placeholdersState";
-export { selectWidgetPlaceholder } from "./placeholders/placeholdersSelectors";
+export {
+    selectWidgetPlaceholder,
+    selectIsWidgetPlaceholderShown,
+} from "./placeholders/placeholdersSelectors";
 export { placeholdersActions } from "./placeholders";
 
 export { queryAndWaitFor } from "./_infra/queryAndWaitFor";

--- a/libs/sdk-ui-dashboard/src/model/store/placeholders/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/placeholders/index.ts
@@ -1,0 +1,19 @@
+// (C) 2021-2022 GoodData Corporation
+import { createSlice } from "@reduxjs/toolkit";
+import { placeholdersInitialState } from "./placeholdersState";
+import { placeholdersReducers } from "./placeholdersReducers";
+
+const placeholdersSlice = createSlice({
+    name: "placeholdersSlice",
+    initialState: placeholdersInitialState,
+    reducers: placeholdersReducers,
+});
+
+export const placeholdersSliceReducer = placeholdersSlice.reducer;
+
+/**
+ * Actions to control placeholders state of the dashboard.
+ *
+ * @internal
+ */
+export const placeholdersActions = placeholdersSlice.actions;

--- a/libs/sdk-ui-dashboard/src/model/store/placeholders/placeholdersReducers.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/placeholders/placeholdersReducers.ts
@@ -1,0 +1,18 @@
+// (C) 2021-2022 GoodData Corporation
+import { Action, AnyAction, CaseReducer, PayloadAction } from "@reduxjs/toolkit";
+import { IWidgetPlaceholderSpec, PlaceholdersState } from "./placeholdersState";
+
+type PlaceholdersReducer<A extends Action = AnyAction> = CaseReducer<PlaceholdersState, A>;
+
+const setWidgetPlaceholder: PlaceholdersReducer<PayloadAction<IWidgetPlaceholderSpec>> = (state, action) => {
+    state.widgetPlaceholder = action.payload;
+};
+
+const clearWidgetPlaceholder: PlaceholdersReducer = (state) => {
+    state.widgetPlaceholder = undefined;
+};
+
+export const placeholdersReducers = {
+    setWidgetPlaceholder,
+    clearWidgetPlaceholder,
+};

--- a/libs/sdk-ui-dashboard/src/model/store/placeholders/placeholdersSelectors.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/placeholders/placeholdersSelectors.ts
@@ -12,3 +12,11 @@ const selectSelf = createSelector(
  * @alpha
  */
 export const selectWidgetPlaceholder = createSelector(selectSelf, (state) => state.widgetPlaceholder);
+
+/**
+ * @alpha
+ */
+export const selectIsWidgetPlaceholderShown = createSelector(
+    selectWidgetPlaceholder,
+    (placeholder) => !!placeholder,
+);

--- a/libs/sdk-ui-dashboard/src/model/store/placeholders/placeholdersSelectors.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/placeholders/placeholdersSelectors.ts
@@ -1,0 +1,14 @@
+// (C) 2021-2022 GoodData Corporation
+import { createSelector } from "@reduxjs/toolkit";
+
+import { DashboardState } from "../types";
+
+const selectSelf = createSelector(
+    (state: DashboardState) => state,
+    (state) => state.placeholders,
+);
+
+/**
+ * @alpha
+ */
+export const selectWidgetPlaceholder = createSelector(selectSelf, (state) => state.widgetPlaceholder);

--- a/libs/sdk-ui-dashboard/src/model/store/placeholders/placeholdersState.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/placeholders/placeholdersState.ts
@@ -1,0 +1,24 @@
+// (C) 2021-2022 GoodData Corporation
+
+/**
+ * @alpha
+ */
+export interface IWidgetPlaceholderSpec {
+    sectionIndex: number;
+    itemIndex: number;
+    size: {
+        width: number;
+        height: number;
+    };
+}
+
+/**
+ * @alpha
+ */
+export interface PlaceholdersState {
+    widgetPlaceholder: IWidgetPlaceholderSpec | undefined;
+}
+
+export const placeholdersInitialState: PlaceholdersState = {
+    widgetPlaceholder: undefined,
+};

--- a/libs/sdk-ui-dashboard/src/model/store/types.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/types.ts
@@ -17,6 +17,7 @@ import { IDrillTargets } from "./drillTargets/drillTargetsTypes";
 import { IExecutionResultEnvelope } from "./executionResults/types";
 import { UiState } from "./ui/uiState";
 import { LegacyDashboardsState } from "./legacyDashboards/legacyDashboardsState";
+import { PlaceholdersState } from "./placeholders/placeholdersState";
 
 /*
  * This explicit typing is unfortunate but cannot find better way. Normally the typings get inferred from store,
@@ -61,6 +62,11 @@ export interface DashboardState {
      * Ui state controllable from the outside.
      */
     ui: UiState;
+
+    /**
+     * State of temporary placeholders.
+     */
+    placeholders: PlaceholdersState;
 
     /**
      * Part of state where execution results of the individual widgets are stored.

--- a/libs/sdk-ui-dashboard/src/model/tests/fixtures/Layout.fixtures.ts
+++ b/libs/sdk-ui-dashboard/src/model/tests/fixtures/Layout.fixtures.ts
@@ -13,17 +13,19 @@ import {
     IDashboardLayoutItem,
 } from "@gooddata/sdk-model";
 import { PivotTableWithRowAndColumnAttributes } from "./Insights.fixtures";
-import { InsightPlaceholderWidget, KpiPlaceholderWidget } from "../../../widgets/placeholders/types";
+import {
+    InsightPlaceholderWidget,
+    KpiPlaceholderWidget,
+    newInsightPlaceholderWidget,
+    newKpiPlaceholderWidget,
+} from "../../../widgets/placeholders/types";
 
 export const TestSectionHeader: IDashboardLayoutSectionHeader = {
     title: "Test Section",
     description: "Section added for test purposes",
 };
 
-const TestKpiPlaceholderWidget: KpiPlaceholderWidget = {
-    type: "customWidget",
-    customType: "kpiPlaceholder",
-};
+const TestKpiPlaceholderWidget = newKpiPlaceholderWidget(0, 0, false);
 export const TestKpiPlaceholderItem: IDashboardLayoutItem<KpiPlaceholderWidget> = {
     type: "IDashboardLayoutItem",
     widget: TestKpiPlaceholderWidget,
@@ -34,10 +36,7 @@ export const TestKpiPlaceholderItem: IDashboardLayoutItem<KpiPlaceholderWidget> 
     },
 };
 
-const TestInsightPlaceholderWidget: InsightPlaceholderWidget = {
-    type: "customWidget",
-    customType: "insightPlaceholder",
-};
+const TestInsightPlaceholderWidget = newInsightPlaceholderWidget(0, 0, false);
 export const TestInsightPlaceholderItem: IDashboardLayoutItem<InsightPlaceholderWidget> = {
     type: "IDashboardLayoutItem",
     widget: TestInsightPlaceholderWidget,

--- a/libs/sdk-ui-dashboard/src/model/utils/arrayOps.ts
+++ b/libs/sdk-ui-dashboard/src/model/utils/arrayOps.ts
@@ -1,4 +1,4 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 import { RelativeIndex } from "../types/layoutTypes";
 import { Draft } from "@reduxjs/toolkit";
 import { invariant } from "ts-invariant";
@@ -48,7 +48,8 @@ export function resolveRelativeIndex<T>(arr: T[], index: RelativeIndex): number 
  * where the new item _will be_ placed.
  */
 export function resolveIndexOfNewItem<T>(arr: T[], index: RelativeIndex): number {
-    invariant(index === 0 || (index < arr.length && index >= -1));
+    // using <= here so that we can add to the last place not only by using -1 by also by using (lastIndex+1)
+    invariant(index === 0 || (index <= arr.length && index >= -1));
 
     return index < 0 ? arr.length : index;
 }

--- a/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/DraggableInsightListItem.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/DraggableInsightListItem.tsx
@@ -2,7 +2,12 @@
 import React from "react";
 import { useDashboardDrag } from "../useDashboardDrag";
 import classNames from "classnames";
-import { useDashboardSelector, selectIsInEditMode } from "../../../model";
+import {
+    useDashboardSelector,
+    selectIsInEditMode,
+    useDashboardDispatch,
+    placeholdersActions,
+} from "../../../model";
 import {
     CustomDashboardInsightListItemComponent,
     CustomDashboardInsightListItemComponentProps,
@@ -20,15 +25,25 @@ export function DraggableInsightListItem({
     listItemComponentProps,
     insight,
 }: DraggableInsightProps) {
+    const dispatch = useDashboardDispatch();
     const isInEditMode = useDashboardSelector(selectIsInEditMode);
-    const [{ isDragging }, dragRef] = useDashboardDrag({
-        dragItem: {
-            type: "insightListItem",
-            insight,
+
+    const [{ isDragging }, dragRef] = useDashboardDrag(
+        {
+            dragItem: {
+                type: "insightListItem",
+                insight,
+            },
+            canDrag: isInEditMode,
+            hideDefaultPreview: false,
+            dragEnd: (_, monitor) => {
+                if (!monitor.didDrop()) {
+                    dispatch(placeholdersActions.clearWidgetPlaceholder());
+                }
+            },
         },
-        canDrag: isInEditMode,
-        hideDefaultPreview: false,
-    });
+        [isInEditMode, insight],
+    );
 
     return (
         <div className={classNames({ "is-dragging": isDragging })} ref={dragRef}>

--- a/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/Hotspot.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/Hotspot.tsx
@@ -2,7 +2,17 @@
 import React from "react";
 import cx from "classnames";
 import { getDropZoneDebugStyle } from "../debug";
-import { addSectionItem, selectSettings, useDashboardDispatch, useDashboardSelector } from "../../../model";
+import {
+    addSectionItem,
+    selectSettings,
+    useDashboardDispatch,
+    useDashboardSelector,
+    placeholdersActions,
+    selectWidgetPlaceholder,
+    IWidgetPlaceholderSpec,
+    dispatchAndWaitFor,
+} from "../../../model";
+import stringify from "json-stable-stringify";
 import { useDashboardDrop } from "../useDashboardDrop";
 import { getInsightSizeInfo } from "@gooddata/sdk-ui-ext";
 import { insightRef, insightTitle } from "@gooddata/sdk-model";
@@ -19,41 +29,57 @@ export const Hotspot: React.FC<IHotspotProps> = (props) => {
 
     const dispatch = useDashboardDispatch();
     const settings = useDashboardSelector(selectSettings);
+    const widgetPlaceholder = useDashboardSelector(selectWidgetPlaceholder);
+
+    // for "next" we need to add the item after the current index, for "prev" on the current one
+    const targetItemIndex = dropZoneType === "next" ? itemIndex + 1 : itemIndex;
 
     const [{ canDrop, isOver }, dropRef] = useDashboardDrop(
         "insightListItem",
         {
             drop: ({ insight }) => {
                 const sizeInfo = getInsightSizeInfo(insight, settings);
-                dispatch(
-                    addSectionItem(
-                        sectionIndex,
-                        // for "next" we need to add the item after the current index, for "prev" on the current one
-                        dropZoneType === "next" ? itemIndex + 1 : itemIndex,
-                        {
-                            type: "IDashboardLayoutItem",
-                            widget: {
-                                type: "insight",
-                                insight: insightRef(insight),
-                                ignoreDashboardFilters: [],
-                                drills: [],
-                                title: insightTitle(insight),
-                                description: "",
-                                configuration: { hideTitle: false },
-                                properties: {},
-                            },
-                            size: {
-                                xl: {
-                                    gridHeight: sizeInfo.height.default,
-                                    gridWidth: sizeInfo.width.default!,
-                                },
+                dispatchAndWaitFor(
+                    dispatch,
+                    addSectionItem(sectionIndex, targetItemIndex, {
+                        type: "IDashboardLayoutItem",
+                        widget: {
+                            type: "insight",
+                            insight: insightRef(insight),
+                            ignoreDashboardFilters: [],
+                            drills: [],
+                            title: insightTitle(insight),
+                            description: "",
+                            configuration: { hideTitle: false },
+                            properties: {},
+                        },
+                        size: {
+                            xl: {
+                                gridHeight: sizeInfo.height.default,
+                                gridWidth: sizeInfo.width.default!,
                             },
                         },
-                    ),
-                );
+                    }),
+                ).then(() => {
+                    dispatch(placeholdersActions.clearWidgetPlaceholder());
+                });
+            },
+            hover: ({ insight }) => {
+                const sizeInfo = getInsightSizeInfo(insight, settings);
+                const placeholderSpec: IWidgetPlaceholderSpec = {
+                    itemIndex: targetItemIndex,
+                    sectionIndex,
+                    size: {
+                        height: sizeInfo.height.default!,
+                        width: sizeInfo.width.default!,
+                    },
+                };
+                if (stringify(placeholderSpec) !== stringify(widgetPlaceholder)) {
+                    dispatch(placeholdersActions.setWidgetPlaceholder(placeholderSpec));
+                }
             },
         },
-        [dispatch],
+        [dispatch, widgetPlaceholder, settings, targetItemIndex, sectionIndex],
     );
 
     const debugStyle = getDropZoneDebugStyle({ isOver });

--- a/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/SectionHotspot.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/SectionHotspot.tsx
@@ -3,7 +3,14 @@ import React from "react";
 import cx from "classnames";
 
 import { getDropZoneDebugStyle } from "../debug";
-import { addLayoutSection, selectSettings, useDashboardDispatch, useDashboardSelector } from "../../../model";
+import {
+    addLayoutSection,
+    placeholdersActions,
+    selectIsWidgetPlaceholderShown,
+    selectSettings,
+    useDashboardDispatch,
+    useDashboardSelector,
+} from "../../../model";
 import { useDashboardDrop } from "../useDashboardDrop";
 import { SectionDropZoneBox } from "./SectionDropZoneBox";
 import { DashboardLayoutSectionBorderLine } from "./DashboardLayoutSectionBorder";
@@ -22,6 +29,8 @@ export const SectionHotspot: React.FC<ISectionHotspotProps> = (props) => {
 
     const dispatch = useDashboardDispatch();
     const settings = useDashboardSelector(selectSettings);
+    const isWidgetPlaceholderShown = useDashboardSelector(selectIsWidgetPlaceholderShown);
+
     const [{ canDrop, isOver }, dropRef] = useDashboardDrop(
         "insightListItem",
         {
@@ -51,8 +60,13 @@ export const SectionHotspot: React.FC<ISectionHotspotProps> = (props) => {
                     ]),
                 );
             },
+            hover: () => {
+                if (isWidgetPlaceholderShown) {
+                    dispatch(placeholdersActions.clearWidgetPlaceholder());
+                }
+            },
         },
-        [dispatch],
+        [dispatch, isWidgetPlaceholderShown, settings],
     );
 
     if (!canDrop) {

--- a/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/WidgetDropZone.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/WidgetDropZone.tsx
@@ -1,0 +1,68 @@
+// (C) 2022 GoodData Corporation
+import React from "react";
+import { insightRef, insightTitle } from "@gooddata/sdk-model";
+import { getInsightSizeInfo } from "@gooddata/sdk-ui-ext";
+import invariant from "ts-invariant";
+
+import { CustomDashboardWidgetComponent } from "../../widget/types";
+import {
+    addSectionItem,
+    dispatchAndWaitFor,
+    placeholdersActions,
+    selectSettings,
+    useDashboardDispatch,
+    useDashboardSelector,
+} from "../../../model";
+import { useDashboardDrop } from "../useDashboardDrop";
+import { WidgetDropZoneBox } from "./WidgetDropZoneBox";
+import { isInsightPlaceholderWidget } from "../../../widgets/placeholders/types";
+
+export const WidgetDropZone: CustomDashboardWidgetComponent = (props) => {
+    const { widget } = props;
+    invariant(isInsightPlaceholderWidget(widget));
+
+    const { sectionIndex, itemIndex, isLastInSection } = widget;
+
+    const dispatch = useDashboardDispatch();
+    const settings = useDashboardSelector(selectSettings);
+
+    const [, dropRef] = useDashboardDrop(
+        "insightListItem",
+        {
+            drop: ({ insight }) => {
+                const sizeInfo = getInsightSizeInfo(insight, settings);
+                dispatchAndWaitFor(
+                    dispatch,
+                    addSectionItem(sectionIndex, itemIndex, {
+                        type: "IDashboardLayoutItem",
+                        widget: {
+                            type: "insight",
+                            insight: insightRef(insight),
+                            ignoreDashboardFilters: [],
+                            drills: [],
+                            title: insightTitle(insight),
+                            description: "",
+                            configuration: { hideTitle: false },
+                            properties: {},
+                        },
+                        size: {
+                            xl: {
+                                gridHeight: sizeInfo.height.default,
+                                gridWidth: sizeInfo.width.default!,
+                            },
+                        },
+                    }),
+                ).then(() => {
+                    dispatch(placeholdersActions.clearWidgetPlaceholder());
+                });
+            },
+        },
+        [dispatch, settings, sectionIndex, itemIndex],
+    );
+
+    return (
+        <div className="widget-dropzone" ref={dropRef}>
+            <WidgetDropZoneBox isLast={isLastInSection} />
+        </div>
+    );
+};

--- a/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/WidgetDropZoneBox.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/WidgetDropZoneBox.tsx
@@ -1,0 +1,38 @@
+// (C) 2022 GoodData Corporation
+import React from "react";
+import cx from "classnames";
+import { FormattedMessage } from "react-intl";
+import { Typography } from "@gooddata/sdk-ui-kit";
+
+interface IWidgetDropZoneBoxProps {
+    isLast: boolean;
+}
+
+export const WidgetDropZoneBox: React.FC<IWidgetDropZoneBoxProps> = (props) => {
+    const { isLast } = props;
+    return (
+        <div
+            className={cx("drag-info-placeholder", "widget-dropzone-box", "s-last-drop-position", "type-kpi")}
+        >
+            <div className={cx("drag-info-placeholder-inner", "can-drop", "is-over")}>
+                <div className="drag-info-placeholder-drop-target">
+                    <div className="drop-target-inner">
+                        <Typography tagName="p" className="drop-target-message kpi-drop-target">
+                            {isLast ? (
+                                <FormattedMessage
+                                    id="dropzone.widget.last.in.row.desc"
+                                    values={{ b: (chunks: string) => <b>{chunks}</b> }}
+                                />
+                            ) : (
+                                <FormattedMessage
+                                    id="dropzone.widget.desc"
+                                    values={{ b: (chunks: string) => <b>{chunks}</b> }}
+                                />
+                            )}
+                        </Typography>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+};

--- a/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/index.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/index.ts
@@ -2,3 +2,4 @@
 export * from "./DraggableInsightListItem";
 export * from "./SectionHotspot";
 export * from "./Hotspot";
+export * from "./WidgetDropZone";

--- a/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/useDashboardDrop.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/useDashboardDrop.ts
@@ -5,7 +5,7 @@ import { DraggableItemType, DraggableItemTypeMapping } from "./types";
 
 type DashboardDropTargetHookSpec<DragObject, CollectedProps> = Pick<
     DropTargetHookSpec<DragObject, void, CollectedProps>,
-    "canDrop" | "drop"
+    "canDrop" | "drop" | "hover"
 >;
 
 const basicDropCollect = (monitor: DropTargetMonitor) => ({
@@ -29,6 +29,7 @@ export function useDashboardDrop<
             drop: specArg.drop,
             canDrop: specArg.canDrop,
             collect: basicDropCollect,
+            hover: specArg.hover,
         },
         deps,
     );

--- a/libs/sdk-ui-dashboard/src/presentation/layout/DashboardLayoutWidget.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/layout/DashboardLayoutWidget.tsx
@@ -29,6 +29,7 @@ import { ObjRefMap } from "../../_staging/metadata/objRefMap";
 import { useDashboardComponentsContext } from "../dashboardContexts";
 import { Hotspot, ResizeOverlay, useResizeStatus } from "../dragAndDrop";
 import { getDashboardLayoutWidgetDefaultHeight } from "../../model/layout";
+import { isInsightPlaceholderWidget } from "../../widgets/placeholders/types";
 
 function calculateWidgetMinHeight(
     widget: ExtendedDashboardWidget,
@@ -128,8 +129,20 @@ export const DashboardLayoutWidget: IDashboardLayoutWidgetRenderer<
                 isUnderWidthMinLimit={false}
                 reachedHeightLimit={heightLimitReached}
             />
-            <Hotspot dropZoneType="prev" itemIndex={item.index()} sectionIndex={item.section().index()} />
-            <Hotspot dropZoneType="next" itemIndex={item.index()} sectionIndex={item.section().index()} />
+            {!isInsightPlaceholderWidget(widget) && (
+                <>
+                    <Hotspot
+                        dropZoneType="prev"
+                        itemIndex={item.index()}
+                        sectionIndex={item.section().index()}
+                    />
+                    <Hotspot
+                        dropZoneType="next"
+                        itemIndex={item.index()}
+                        sectionIndex={item.section().index()}
+                    />
+                </>
+            )}
         </DefaultWidgetRenderer>
     );
 };

--- a/libs/sdk-ui-dashboard/src/presentation/layout/DashboardLayoutWidget.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/layout/DashboardLayoutWidget.tsx
@@ -63,14 +63,29 @@ function calculateWidgetMinHeight(
 /**
  * Tests in KD require widget index for css selectors.
  * Widget index equals to the widget order in the layout.
+ * Also placeholders are ignored for this.
  */
 function getWidgetIndex(item: IDashboardLayoutItemFacade<ExtendedDashboardWidget>): number {
     const sectionIndex = item.section().index();
+    const isIgnoredForIndexes = (widget: ExtendedDashboardWidget | undefined) => {
+        return !widget || isInsightPlaceholderWidget(widget);
+    };
+
     let itemsInSectionsBefore = 0;
     for (let i = 0; i < sectionIndex; i += 1) {
-        itemsInSectionsBefore += item.section().layout().section(i)?.items().count() ?? 0;
+        itemsInSectionsBefore +=
+            item
+                .section()
+                .layout()
+                .section(i)
+                ?.items()
+                .filter((i) => !isIgnoredForIndexes(i.widget())).length ?? 0;
     }
-    return itemsInSectionsBefore + item.index();
+    const ignoredWidgetsBeforeItemCount = item
+        .section()
+        .items()
+        .filter((i) => i.index() < item.index() && isIgnoredForIndexes(i.widget())).length;
+    return itemsInSectionsBefore + item.index() - ignoredWidgetsBeforeItemCount;
 }
 
 /**

--- a/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayoutRenderer/DashboardLayoutEditSectionHeaderRenderer.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayoutRenderer/DashboardLayoutEditSectionHeaderRenderer.tsx
@@ -13,24 +13,24 @@ export function DashboardLayoutEditSectionHeaderRenderer(
     const { section, screen } = props;
     const sectionHeader = section.header();
 
-    return sectionHeader ? (
+    return (
         <DashboardLayoutItemRenderer
             DefaultItemRenderer={DashboardLayoutItemRenderer}
             item={emptyItemFacadeWithFullSize}
             screen={screen}
         >
             <DashboardLayoutSectionHeader
-                title={sectionHeader.title}
-                description={sectionHeader.description}
+                title={sectionHeader?.title}
+                description={sectionHeader?.description}
                 renderBeforeHeader={<SectionHotspot index={section.index()} targetPosition="above" />}
                 renderHeader={
                     <SectionHeaderEditable
-                        title={sectionHeader.title || ""}
-                        description={sectionHeader.description || ""}
+                        title={sectionHeader?.title || ""}
+                        description={sectionHeader?.description || ""}
                         index={section.index()}
                     />
                 }
             />
         </DashboardLayoutItemRenderer>
-    ) : null;
+    );
 }

--- a/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayoutRenderer/DashboardLayoutSection.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayoutRenderer/DashboardLayoutSection.tsx
@@ -48,8 +48,10 @@ export function DashboardLayoutSection<TWidget>(props: IDashboardLayoutSectionPr
     const renderProps = { section, screen, renderMode };
 
     const items = flatMap(section.items().asGridRows(screen), (itemsInRow) => {
+        const rowKey = itemsInRow.map((item) => itemKeyGetter({ item, screen })).join(";");
         return (
             <DashboardLayoutGridRow
+                key={rowKey}
                 screen={screen}
                 section={section}
                 items={itemsInRow}

--- a/libs/sdk-ui-dashboard/src/presentation/localization/bundles/en-US.json
+++ b/libs/sdk-ui-dashboard/src/presentation/localization/bundles/en-US.json
@@ -1505,5 +1505,15 @@
         "value": "Drop to create a{nbsp}<b>new section</b>",
         "comment": "Used as placeholder when user drags some widget and tries to drop it on dashboard. Dropping the widget over such placeholder creates new section of a dashboard. Do not translate HTML markup enclosed in <>. Translate words 'new section'.",
         "limit": 0
+    },
+    "dropzone.widget.desc": {
+        "value": "Drop <b>here</b>",
+        "comment": "Do not translate HTML markup enclosed in <>. Translate word 'here'.",
+        "limit": 0
+    },
+    "dropzone.widget.last.in.row.desc": {
+        "value": "Drop to the <b>existing section</b>",
+        "comment": "Used as placeholder when user drags some widget and tries to drop it on dashboard. Dropping the widget over such placeholder will cause adding the widget to an existing section of a dashboard. Do not translate HTML markup enclosed in <>. Translate words 'existing section'.",
+        "limit": 0
     }
 }

--- a/libs/sdk-ui-dashboard/src/presentation/widget/widget/DashboardWidget.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/widget/DashboardWidget.tsx
@@ -4,7 +4,9 @@ import { useDashboardComponentsContext } from "../../dashboardContexts";
 import { extendedWidgetDebugStr } from "../../../model";
 import { DefaultDashboardWidget } from "./DefaultDashboardWidget";
 import { isDashboardWidget } from "@gooddata/sdk-model";
-import { IDashboardWidgetProps } from "./types";
+import { CustomDashboardWidgetComponent, IDashboardWidgetProps } from "./types";
+import { WidgetDropZone } from "../../dragAndDrop";
+import { isInsightPlaceholderWidget } from "../../../widgets/placeholders/types";
 
 const BadWidgetType: React.FC = () => {
     return <div>Missing renderer</div>;
@@ -24,7 +26,7 @@ export const DashboardWidget = (props: IDashboardWidgetProps): JSX.Element => {
         // @ts-expect-error Don't expose index prop on public interface (we need it only for css class for KD tests)
         index,
     } = props;
-    const WidgetComponent = useMemo((): React.ComponentType<IDashboardWidgetProps> => {
+    const WidgetComponent = useMemo((): CustomDashboardWidgetComponent => {
         // TODO: we need to get rid of this; the widget being optional at this point is the problem; the parent
         //  components (or possibly the model) should deal with layout items that have no valid widgets associated
         //  and thus short-circuit.
@@ -36,8 +38,13 @@ export const DashboardWidget = (props: IDashboardWidgetProps): JSX.Element => {
 
         const Component = WidgetComponentProvider(widget);
 
-        if (Component) {
+        // the default WidgetComponentProvider always returns something, DefaultDashboardWidget by default
+        if (Component && Component !== DefaultDashboardWidget) {
             return Component;
+        }
+
+        if (isInsightPlaceholderWidget(widget)) {
+            return WidgetDropZone;
         }
 
         if (isDashboardWidget(widget)) {

--- a/libs/sdk-ui-dashboard/src/widgets/placeholders/types.ts
+++ b/libs/sdk-ui-dashboard/src/widgets/placeholders/types.ts
@@ -1,11 +1,11 @@
 // (C) 2021-2022 GoodData Corporation
 import isEmpty from "lodash/isEmpty";
-import { ICustomWidgetBase } from "../../model";
+import { ICustomWidget, newCustomWidget } from "../../model";
 
 /**
  * @alpha
  */
-export interface KpiPlaceholderWidget extends ICustomWidgetBase {
+export interface KpiPlaceholderWidget extends ICustomWidget {
     readonly customType: "kpiPlaceholder";
 }
 
@@ -22,8 +22,11 @@ export function isKpiPlaceholderWidget(obj: unknown): obj is KpiPlaceholderWidge
 /**
  * @alpha
  */
-export interface InsightPlaceholderWidget extends ICustomWidgetBase {
+export interface InsightPlaceholderWidget extends ICustomWidget {
     readonly customType: "insightPlaceholder";
+    readonly sectionIndex: number;
+    readonly itemIndex: number;
+    readonly isLastInSection: boolean;
 }
 
 /**
@@ -34,4 +37,19 @@ export interface InsightPlaceholderWidget extends ICustomWidgetBase {
  */
 export function isInsightPlaceholderWidget(obj: unknown): obj is InsightPlaceholderWidget {
     return !isEmpty(obj) && (obj as InsightPlaceholderWidget).customType === "insightPlaceholder";
+}
+
+/**
+ * @alpha
+ */
+export function newInsightPlaceholderWidget(
+    sectionIndex: number,
+    itemIndex: number,
+    isLastInSection: boolean,
+): InsightPlaceholderWidget {
+    return newCustomWidget("__insightPlaceholder__", "insightPlaceholder", {
+        sectionIndex,
+        itemIndex,
+        isLastInSection,
+    }) as InsightPlaceholderWidget;
 }

--- a/libs/sdk-ui-dashboard/src/widgets/placeholders/types.ts
+++ b/libs/sdk-ui-dashboard/src/widgets/placeholders/types.ts
@@ -7,6 +7,9 @@ import { ICustomWidget, newCustomWidget } from "../../model";
  */
 export interface KpiPlaceholderWidget extends ICustomWidget {
     readonly customType: "kpiPlaceholder";
+    readonly sectionIndex: number;
+    readonly itemIndex: number;
+    readonly isLastInSection: boolean;
 }
 
 /**
@@ -17,6 +20,21 @@ export interface KpiPlaceholderWidget extends ICustomWidget {
  */
 export function isKpiPlaceholderWidget(obj: unknown): obj is KpiPlaceholderWidget {
     return !isEmpty(obj) && (obj as KpiPlaceholderWidget).customType === "kpiPlaceholder";
+}
+
+/**
+ * @alpha
+ */
+export function newKpiPlaceholderWidget(
+    sectionIndex: number,
+    itemIndex: number,
+    isLastInSection: boolean,
+): KpiPlaceholderWidget {
+    return newCustomWidget("__kpiPlaceholder__", "kpiPlaceholder", {
+        sectionIndex,
+        itemIndex,
+        isLastInSection,
+    }) as KpiPlaceholderWidget;
 }
 
 /**


### PR DESCRIPTION
This adds support for adding insights to the existing sections including the placeholders (the last missing variant).
Also prevents a React key warning and makes rootReducer type-safe.

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
