### PR TITLE
RAIL-4393 - Prepare plugins API for filters customizations

### DIFF
--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -5167,9 +5167,6 @@ export const selectExecutionResultByRef: (ref: ObjRef) => OutputSelector<Dashboa
 // @alpha (undocumented)
 export const selectFilterBarExpanded: OutputSelector<DashboardState, boolean, (res: UiState) => boolean>;
 
-// @internal (undocumented)
-export const selectFilterBarHeight: OutputSelector<DashboardState, number, (res: UiState) => number>;
-
 // @public
 export const selectFilterContextAttributeFilterByDisplayForm: (displayForm: ObjRef) => OutputSelector<DashboardState, IDashboardAttributeFilter | undefined, (res1: ObjRefMap<IAttributeDisplayFormMetadataObject>, res2: IDashboardAttributeFilter[]) => IDashboardAttributeFilter | undefined>;
 
@@ -5510,10 +5507,6 @@ openScheduleEmailManagementDialog: CaseReducer<UiState, AnyAction>;
 closeScheduleEmailManagementDialog: CaseReducer<UiState, AnyAction>;
 openSaveAsDialog: CaseReducer<UiState, AnyAction>;
 closeSaveAsDialog: CaseReducer<UiState, AnyAction>;
-setFilterBarHeight: CaseReducer<UiState, {
-payload: number;
-type: string;
-}>;
 setFilterBarExpanded: CaseReducer<UiState, {
 payload: boolean;
 type: string;
@@ -5568,7 +5561,6 @@ export interface UiState {
     };
     // (undocumented)
     filterBar: {
-        height: number;
         expanded: boolean;
     };
     // (undocumented)

--- a/libs/sdk-ui-dashboard/src/assets/filter-bar-background.svg
+++ b/libs/sdk-ui-dashboard/src/assets/filter-bar-background.svg
@@ -1,5 +1,0 @@
-<svg xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 4 56" height="56" width="4">
-    <g>
-        <rect y="55" x="0" height="1" width="1" fill="#ccc" />
-    </g>
-</svg>

--- a/libs/sdk-ui-dashboard/src/model/store/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/index.ts
@@ -197,7 +197,6 @@ export {
     selectIsSaveAsDialogOpen,
     selectIsShareDialogOpen,
     selectFilterBarExpanded,
-    selectFilterBarHeight,
     selectIsKpiAlertOpenedByWidgetRef,
     selectIsKpiAlertHighlightedByWidgetRef,
     selectMenuButtonItemsVisibility,

--- a/libs/sdk-ui-dashboard/src/model/store/ui/uiReducers.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/ui/uiReducers.ts
@@ -54,10 +54,6 @@ const closeDeleteDialog: UiReducer = (state) => {
     state.deleteDialog.open = false;
 };
 
-const setFilterBarHeight: UiReducer<PayloadAction<number>> = (state, action) => {
-    state.filterBar.height = action.payload;
-};
-
 const setFilterBarExpanded: UiReducer<PayloadAction<boolean>> = (state, action) => {
     state.filterBar.expanded = action.payload;
 };
@@ -118,7 +114,6 @@ export const uiReducers = {
     closeScheduleEmailManagementDialog,
     openSaveAsDialog,
     closeSaveAsDialog,
-    setFilterBarHeight,
     setFilterBarExpanded,
     closeKpiAlertDialog,
     openKpiAlertDialog,

--- a/libs/sdk-ui-dashboard/src/model/store/ui/uiSelectors.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/ui/uiSelectors.ts
@@ -51,11 +51,6 @@ export const selectIsShareDialogOpen = createSelector(selectSelf, (state) => sta
 export const selectIsDeleteDialogOpen = createSelector(selectSelf, (state) => state.deleteDialog.open);
 
 /**
- * @internal
- */
-export const selectFilterBarHeight = createSelector(selectSelf, (state) => state.filterBar.height);
-
-/**
  * @alpha
  */
 export const selectFilterBarExpanded = createSelector(selectSelf, (state) => state.filterBar.expanded);

--- a/libs/sdk-ui-dashboard/src/model/store/ui/uiState.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/ui/uiState.ts
@@ -24,7 +24,6 @@ export interface UiState {
         open: boolean;
     };
     filterBar: {
-        height: number;
         expanded: boolean;
     };
     kpiAlerts: {
@@ -58,7 +57,6 @@ export const uiInitialState: UiState = {
         open: false,
     },
     filterBar: {
-        height: 0,
         expanded: false,
     },
     kpiAlerts: {

--- a/libs/sdk-ui-dashboard/src/presentation/constants/filterBar.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/constants/filterBar.ts
@@ -1,2 +1,0 @@
-// (C) 2021 GoodData Corporation
-export const DEFAULT_FILTER_BAR_HEIGHT = 58;

--- a/libs/sdk-ui-dashboard/src/presentation/constants/index.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/constants/index.ts
@@ -2,5 +2,4 @@
 
 export * from "./zIndex";
 export * from "./layout";
-export * from "./filterBar";
 export * from "./dashboard";

--- a/libs/sdk-ui-dashboard/src/presentation/dashboard/components/DashboardMainContent.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/dashboard/components/DashboardMainContent.tsx
@@ -1,33 +1,15 @@
 // (C) 2022 GoodData Corporation
-import React, { useMemo } from "react";
-import {
-    useDashboardSelector,
-    selectFilterBarExpanded,
-    selectFilterBarHeight,
-    useDispatchDashboardCommand,
-    changeFilterContextSelection,
-} from "../../../model";
-import { DEFAULT_FILTER_BAR_HEIGHT } from "../../constants";
+import React from "react";
+import { useDispatchDashboardCommand, changeFilterContextSelection } from "../../../model";
 import { DashboardLayout } from "../../layout";
 import { IDashboardProps } from "../types";
 import { DateFilterConfigWarnings } from "./DateFilterConfigWarnings";
 
 export const DashboardMainContent: React.FC<IDashboardProps> = () => {
-    const isFilterBarExpanded = useDashboardSelector(selectFilterBarExpanded);
-    const filterBarHeight = useDashboardSelector(selectFilterBarHeight);
-
     const onFiltersChange = useDispatchDashboardCommand(changeFilterContextSelection);
 
-    const dashSectionStyles = useMemo(
-        () => ({
-            marginTop: isFilterBarExpanded ? filterBarHeight - DEFAULT_FILTER_BAR_HEIGHT + "px" : undefined,
-            transition: "margin-top 0.2s",
-        }),
-        [isFilterBarExpanded, filterBarHeight],
-    );
-
     return (
-        <div className="gd-flex-item-stretch dash-section dash-section-kpis" style={dashSectionStyles}>
+        <div className="gd-flex-item-stretch dash-section dash-section-kpis">
             <div className="gd-flex-container root-flex-maincontent">
                 <DateFilterConfigWarnings />
                 <DashboardLayout onFiltersChange={onFiltersChange} />

--- a/libs/sdk-ui-dashboard/src/presentation/filterBar/filterBar/hooks/useFilterBarState.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/filterBar/filterBar/hooks/useFilterBarState.ts
@@ -1,0 +1,57 @@
+// (C) 2021-2022 GoodData Corporation
+
+import { useState, useEffect } from "react";
+import { CalculatedRows, CalculatedRowsDefault } from "./useRowsCalculator";
+import {
+    useDashboardDispatch,
+    useDashboardSelector,
+    selectFilterBarExpanded,
+    uiActions,
+} from "../../../../model";
+
+//NOTE: This 1px is size of border bottom on filter bar
+const BorderWidth = 1;
+//NOTE: This must be same value as $transition-length
+const TransitionLength = 200;
+
+export function useFilterBarState() {
+    const [calculatedRows, setCalculatedRows] = useState<CalculatedRows>(CalculatedRowsDefault);
+    const { expandedHeight, collapsedHeight, rows } = calculatedRows;
+
+    const dispatch = useDashboardDispatch();
+    const isFilterBarExpanded = useDashboardSelector(selectFilterBarExpanded);
+
+    const scrollable = useScrollable(isFilterBarExpanded);
+
+    const setFilterBarExpanded = (isExpanded: boolean) =>
+        dispatch(uiActions.setFilterBarExpanded(isExpanded));
+
+    return {
+        rows,
+        scrollable,
+        height: isFilterBarExpanded ? expandedHeight + BorderWidth : collapsedHeight,
+        isFilterBarExpanded,
+        setCalculatedRows,
+        setFilterBarExpanded,
+    };
+}
+
+function useScrollable(expanded: boolean) {
+    const [scrollable, setScrollable] = useState(false);
+
+    useEffect(() => {
+        let timer: number | null = null;
+        if (expanded) {
+            timer = window.setTimeout(() => setScrollable(true), TransitionLength);
+        } else {
+            setScrollable(false);
+        }
+        return () => {
+            if (timer !== null) {
+                window.clearTimeout(timer);
+            }
+        };
+    }, [expanded]);
+
+    return scrollable;
+}

--- a/libs/sdk-ui-dashboard/src/presentation/filterBar/filterBar/hooks/useRowsCalculator.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/filterBar/filterBar/hooks/useRowsCalculator.ts
@@ -1,0 +1,58 @@
+// (C) 2021-2022 GoodData Corporation
+import { useCallback, MutableRefObject } from "react";
+import { ContentRect } from "react-measure";
+
+export type CalculatedRows = {
+    expandedHeight: number;
+    collapsedHeight: number;
+    rows: number[];
+};
+
+export const CalculatedRowsDefault = { expandedHeight: 0, collapsedHeight: 0, rows: [] };
+
+export function useRowsCalculator(
+    element: MutableRefObject<Element | null>,
+): (dimensions: ContentRect) => CalculatedRows {
+    return useCallback(
+        (dimensions) => {
+            const current = element.current;
+            //no data yet
+            if (!current || !dimensions.bounds) {
+                return CalculatedRowsDefault;
+            }
+
+            const { height } = dimensions.bounds;
+            const determinedRows = determineRows(current);
+            const rows = createRows(determinedRows);
+
+            return { expandedHeight: height, collapsedHeight: rows[0], rows };
+        },
+        [element],
+    );
+}
+
+function determineRows(element: Element) {
+    const children = Array.prototype.slice.call(element.childNodes);
+    let last = Number.MIN_SAFE_INTEGER;
+
+    return children.reduce(
+        (rows, item) => {
+            const lastRow = rows[rows.length - 1];
+            if (item.offsetLeft <= last) {
+                rows.push([item]);
+            } else {
+                lastRow.push(item);
+            }
+            last = item.offsetLeft;
+            return rows;
+        },
+        [[]] as HTMLElement[][],
+    );
+}
+
+function createRows(determinedRows: HTMLElement[][]) {
+    return determinedRows.map((row) => {
+        const itemsHeight = row.map((item) => item.offsetHeight ?? 0);
+        return Math.max(...itemsHeight);
+    });
+}

--- a/libs/sdk-ui-dashboard/styles/scss/_variables.scss
+++ b/libs/sdk-ui-dashboard/styles/scss/_variables.scss
@@ -21,6 +21,8 @@ $gd-color-negative-dimmed: mix($gd-color-negative, $default-gd-color-text-light,
 $grey-background: #eceff3;
 $darker-grey-background: var(--gd-palette-complementary-7, #b4c0cf);
 
+$scrollbar-width: 15px;
+
 $item-border: 2px;
 $item-min-height: 178px;
 $item-inner-padding: 8px;
@@ -41,6 +43,7 @@ $button-grey-background: var(--gd-palette-complementary-2, #ebeff4);
 $gd-dashboards-content-backgroundColor: var(--gd-dashboards-content-backgroundColor, $gd-color-white);
 
 $filter-bar-height: 55px;
+$filter-bar-drop-zone-height: 30px;
 
 $gd-dashboards-filterBar-backgroundColor: var(--gd-dashboards-filterBar-backgroundColor, $gd-color-white);
 
@@ -83,7 +86,7 @@ $gd-configuration-bubble-height: 450px;
 $gd-configuration-bubble-width: 251px;
 $gd-configuration-bubble-borders-width: 2px;
 $gd-configuration-bubble-margin: 15px;
-$gd-configuration-right-scrollbar-spacer: 15px;
+$gd-configuration-right-scrollbar-spacer: $scrollbar-width;
 $gd-configuration-panel-inner-width: $gd-configuration-bubble-width - $gd-configuration-bubble-borders-width -
     (2 * $gd-configuration-bubble-margin) - $gd-configuration-right-scrollbar-spacer;
 

--- a/libs/sdk-ui-dashboard/styles/scss/dashboard.scss
+++ b/libs/sdk-ui-dashboard/styles/scss/dashboard.scss
@@ -498,7 +498,9 @@
 
     @media #{$xsmall-only}, #{$small-only} {
         margin: 0;
-        padding: 5px;
+        padding-left: 5px;
+        padding-right: 5px;
+        padding-bottom: 5px;
     }
 }
 

--- a/libs/sdk-ui-dashboard/styles/scss/filterBar.scss
+++ b/libs/sdk-ui-dashboard/styles/scss/filterBar.scss
@@ -7,14 +7,14 @@ $attribute-filter-drag-handle-left: 10px;
     position: relative;
 
     .show-all {
+        display: none;
+    }
+    .show-all:last-child {
         position: absolute;
         bottom: -25px;
         left: 50%;
+        display: block;
         transform: translateX(-50%);
-
-        @media #{$xsmall-only}, #{$small-only} {
-            display: none;
-        }
     }
 }
 
@@ -65,29 +65,56 @@ $attribute-filter-drag-handle-left: 10px;
 }
 
 .dash-filters-visible {
+    position: relative;
     overflow-y: hidden;
     padding: 0 15px;
     border-bottom: $nav-border;
     border-bottom-color: var(--gd-dashboards-filterBar-borderColor, $gd-border-color);
     background-color: $gd-dashboards-filterBar-backgroundColor;
     transition: height $transition-length;
+    max-height: 50vh;
+
+    &.scrollable {
+        overflow-y: auto;
+    }
+
+    .dash-filters-rows {
+        position: absolute;
+        top: 0;
+        right: 15px;
+        left: 15px;
+        display: flex;
+        flex-direction: column;
+        pointer-events: none;
+
+        .dash-filters-row {
+            width: 100%;
+            background-image: linear-gradient(
+                to right,
+                var(--gd-dashboards-filterBar-borderColor, $gd-border-color) 15%,
+                rgba(255, 255, 255, 0) 0%
+            );
+            background-position: bottom;
+            background-size: 4px 1px;
+            background-repeat: repeat-x;
+        }
+        .dash-filters-row:last-child {
+            background: none;
+        }
+    }
 }
 
 .dash-filters-all {
+    position: relative;
     display: flex;
-    align-items: center;
+    align-items: stretch;
     flex-wrap: wrap;
-    width: 100%;
+    width: calc(100% - $scrollbar-width);
     min-height: $filter-bar-height;
-    background-image: url("~@gooddata/sdk-ui-dashboard/esm/assets/filter-bar-background.svg");
-    background-repeat: repeat;
+    margin-right: $scrollbar-width;
 
     .dash-filters-attribute {
         position: relative;
-    }
-
-    @media #{$xsmall-only}, #{$small-only} {
-        flex-wrap: nowrap;
     }
 }
 
@@ -162,14 +189,14 @@ $attribute-filter-drag-handle-left: 10px;
 
 .attr-filter-dropzone-box-outer {
     display: flex;
-    align-items: center;
-    height: $filter-bar-height;
+    align-items: stretch;
 }
 
 .attr-filter-dropzone-box {
     display: flex;
     min-width: 160px;
-    height: 30px;
+    height: calc(100% - ($filter-bar-height - $filter-bar-drop-zone-height));
+    margin: calc(($filter-bar-height - $filter-bar-drop-zone-height) / 2) 0;
     padding: 3px;
     border: 2px dashed var(--gd-palette-complementary-3, transparentize($default-gd-color-disabled, 0.55));
     color: $gd-color-state-blank;
@@ -190,7 +217,7 @@ $attribute-filter-drag-handle-left: 10px;
         text-transform: uppercase;
         border-radius: 3px;
         justify-content: center;
-        align-items: flex-start;
+        align-items: center;
 
         .attribute-filter-icon {
             margin: 0 4px;


### PR DESCRIPTION
Rework filter bar to be able to work with different heights of filters used in filter bar.

 - Remove bar height in state and all things around (selectors, reducers, state record)
 - Remove adding top margin on if filter bar is expanded, its cause space after filter bar and content
 - Move state of filter bar into separate hook
   => Add class scrollable after opening animation is done
 - Row calculator hook that is able to determine rows in flex box and height of each row

JIRA: RAIL-4393

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
