### PR TITLE
RELATED: RAIL-4342 Expose selectors for SDK edit mode

### DIFF
--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -4976,6 +4976,9 @@ export const selectAllInsightWidgets: OutputSelector<DashboardState, IInsightWid
 // @alpha
 export const selectAllKpiWidgets: OutputSelector<DashboardState, IKpiWidget[], (res: ExtendedDashboardWidget[]) => IKpiWidget[]>;
 
+// @internal
+export const selectAllowUnfinishedFeatures: OutputSelector<DashboardState, boolean, (res: ResolvedDashboardConfig) => boolean>;
+
 // @alpha
 export const selectAnalyticalWidgetByRef: (ref: ObjRef | undefined) => OutputSelector<DashboardState, IKpiWidget | IInsightWidget | undefined, (res: ObjRefMap<ExtendedDashboardWidget>) => IKpiWidget | IInsightWidget | undefined>;
 

--- a/libs/sdk-ui-dashboard/src/model/store/config/configSelectors.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/config/configSelectors.ts
@@ -359,3 +359,13 @@ export const selectShouldHidePixelPerfectExperience = createSelector(selectConfi
 export const selectDisableKpiDashboardHeadlineUnderline = createSelector(selectConfig, (state) => {
     return !!(state.settings?.disableKpiDashboardHeadlineUnderline ?? false);
 });
+
+/**
+ * Returns whether unfinished features are allowed.
+ *
+ * @internal
+ */
+export const selectAllowUnfinishedFeatures = createSelector(
+    selectConfig,
+    (state) => state.allowUnfinishedFeatures || false,
+);

--- a/libs/sdk-ui-dashboard/src/model/store/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/index.ts
@@ -50,8 +50,9 @@ export {
     selectDisableKpiDashboardHeadlineUnderline,
     selectIsWhiteLabeled,
     selectEnableAnalyticalDashboardPermissions,
-    selectDashboardEditModeDevRollout,
     selectIsSaveAsNewButtonHidden,
+    selectAllowUnfinishedFeatures,
+    selectDashboardEditModeDevRollout,
 } from "./config/configSelectors";
 export { PermissionsState } from "./permissions/permissionsState";
 export {


### PR DESCRIPTION
JIRA: RAIL-4342

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
