### PR TITLE
Unify dialog types to accept also color palette

### DIFF
--- a/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
+++ b/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
@@ -951,7 +951,7 @@ export type InsightDrillDefinition = m.InsightDrillDefinition;
 export type InsightOrdering = "id" | "title" | "updated";
 
 // @public (undocumented)
-export type InsightReferenceTypes = Exclude<ObjectType, "insight" | "tag">;
+export type InsightReferenceTypes = Exclude<ObjectType, "insight" | "tag" | "colorPalette">;
 
 // @public
 export interface IObjectExpressionToken {
@@ -1916,7 +1916,7 @@ export type SupportedDashboardReferenceTypes = "insight" | "dashboardPlugin";
 export type SupportedInsightReferenceTypes = Exclude<InsightReferenceTypes, "displayForm" | "variable">;
 
 // @alpha
-export type SupportedWidgetReferenceTypes = Exclude<ObjectType, "fact" | "attribute" | "displayForm" | "dataSet" | "tag" | "insight" | "variable">;
+export type SupportedWidgetReferenceTypes = Exclude<ObjectType, "fact" | "attribute" | "displayForm" | "dataSet" | "tag" | "insight" | "variable" | "colorPalette">;
 
 // @beta @deprecated
 export type ThemeColor = m.ThemeColor;

--- a/libs/sdk-backend-spi/src/workspace/dashboards/index.ts
+++ b/libs/sdk-backend-spi/src/workspace/dashboards/index.ts
@@ -50,7 +50,7 @@ export interface IDashboardWithReferences {
  */
 export type SupportedWidgetReferenceTypes = Exclude<
     ObjectType,
-    "fact" | "attribute" | "displayForm" | "dataSet" | "tag" | "insight" | "variable"
+    "fact" | "attribute" | "displayForm" | "dataSet" | "tag" | "insight" | "variable" | "colorPalette"
 >;
 
 //

--- a/libs/sdk-backend-spi/src/workspace/insights/index.ts
+++ b/libs/sdk-backend-spi/src/workspace/insights/index.ts
@@ -120,7 +120,7 @@ export interface IWorkspaceInsightsService {
 /**
  * @public
  */
-export type InsightReferenceTypes = Exclude<ObjectType, "insight" | "tag">;
+export type InsightReferenceTypes = Exclude<ObjectType, "insight" | "tag" | "colorPalette">;
 
 /**
  * List of currently supported types of references that can be retrieved using the {@link IWorkspaceInsightsService.getInsightReferencedObjects} function.

--- a/libs/sdk-ui-kit/api/sdk-ui-kit.api.md
+++ b/libs/sdk-ui-kit/api/sdk-ui-kit.api.md
@@ -16,6 +16,8 @@ import { IAccessControlAware } from '@gooddata/sdk-model';
 import { IAccessGrantee } from '@gooddata/sdk-model';
 import { IAnalyticalBackend } from '@gooddata/sdk-backend-spi';
 import { IAuditableUsers } from '@gooddata/sdk-model';
+import { IColorPalette } from '@gooddata/sdk-model';
+import { IColorPaletteDefinition } from '@gooddata/sdk-model';
 import { IMeasureSortTarget } from '@gooddata/sdk-model';
 import { IntlShape } from 'react-intl';
 import { ISeparators } from '@gooddata/sdk-ui';
@@ -325,6 +327,9 @@ export const DEFAULT_ITEM_HEIGHT = 28;
 export const DEFAULT_MOBILE_ITEM_HEIGHT = 40;
 
 // @internal
+export const defaultColorPaletteMetadataObject: IColorPaletteDefinition;
+
+// @internal
 export const defaultThemeMetadataObject: IThemeDefinition;
 
 // @internal (undocumented)
@@ -545,7 +550,10 @@ export function generateHeaderStaticHelpMenuItems(documentationUrl?: string, com
 export function generateSupportUrl(projectId?: string, sessionId?: string, userEmail?: string, url?: string): string;
 
 // @internal
-export const getColorsPreviewFromTheme: (themeDef: IThemeDefinition) => string[];
+export const getColorsPreviewFromColorPalette: (colorPalette: IColorPalette) => string[];
+
+// @internal
+export const getColorsPreviewFromTheme: (theme: ITheme) => string[];
 
 // @internal
 export function getDateTimeConfig(date: string, options?: IDateTimeConfigOptions): IInsightListItemDateConfig;
@@ -3151,15 +3159,15 @@ export interface IStylingEditorDialogFooterProps extends IDialogBaseProps {
 }
 
 // @internal (undocumented)
-export interface IStylingEditorDialogProps extends IStylingEditorDialogFooterProps {
+export interface IStylingEditorDialogProps<T> extends IStylingEditorDialogFooterProps {
     // (undocumented)
-    examples?: StylingPickerItem[];
+    examples?: IStylingPickerItem<T>[];
     // (undocumented)
-    exampleToColorPreview?: (example: StylingPickerItem) => string[];
+    exampleToColorPreview?: (example: T) => string[];
     // (undocumented)
     locale?: string;
     // (undocumented)
-    stylingContent?: StylingPickerItem;
+    stylingItem?: IStylingPickerItem<T>;
     // (undocumented)
     title: string;
     // (undocumented)
@@ -3177,13 +3185,23 @@ export interface IStylingExampleProps {
 }
 
 // @internal (undocumented)
-export interface IStylingPickerProps {
+export interface IStylingPickerItem<T extends StylingPickerItemContent> {
+    // (undocumented)
+    content: T;
+    // (undocumented)
+    name?: string;
+    // (undocumented)
+    ref?: ObjRef;
+}
+
+// @internal (undocumented)
+export interface IStylingPickerProps<T> {
     // (undocumented)
     className?: string;
     // (undocumented)
-    customItems: StylingPickerItem[];
+    customItems: IStylingPickerItem<T>[];
     // (undocumented)
-    defaultItem: StylingPickerItem;
+    defaultItem: IStylingPickerItem<T>;
     // (undocumented)
     emptyMessage: () => JSX.Element;
     // (undocumented)
@@ -3195,13 +3213,15 @@ export interface IStylingPickerProps {
     // (undocumented)
     isLoading?: boolean;
     // (undocumented)
+    itemToColorPreview: (itemContent: T) => string[];
+    // (undocumented)
     locale?: string;
     // (undocumented)
     onApply?: (ref: ObjRef) => void;
     // (undocumented)
     onItemDelete?: (ref: ObjRef) => void;
     // (undocumented)
-    onItemEdit?: (modifiedItem: StylingPickerItem) => void;
+    onItemEdit?: (modifiedItem: IStylingPickerItem<T>) => void;
     // (undocumented)
     onListActionClick?: () => void;
     // (undocumented)
@@ -3713,7 +3733,7 @@ export class Spinner extends PureComponent<ISpinnerProps> {
 export type SpinnerSize = "large" | "small";
 
 // @internal (undocumented)
-export const StylingEditorDialog: (props: IStylingEditorDialogProps) => JSX.Element;
+export const StylingEditorDialog: <T extends StylingPickerItemContent>(props: IStylingEditorDialogProps<T>) => JSX.Element;
 
 // @internal (undocumented)
 export const StylingEditorDialogFooter: (props: IStylingEditorDialogFooterProps) => JSX.Element;
@@ -3722,13 +3742,10 @@ export const StylingEditorDialogFooter: (props: IStylingEditorDialogFooterProps)
 export const StylingExample: (props: IStylingExampleProps) => JSX.Element;
 
 // @internal (undocumented)
-export class StylingPicker extends React_2.PureComponent<IStylingPickerProps> {
-    // (undocumented)
-    render(): JSX.Element;
-}
+export const StylingPicker: <T extends StylingPickerItemContent>(props: IStylingPickerProps<T>) => JSX.Element;
 
 // @internal (undocumented)
-export type StylingPickerItem = IThemeDefinition;
+export type StylingPickerItemContent = ITheme | IColorPalette;
 
 // @internal (undocumented)
 export const SubMenu: React_2.FC<ISubMenuProps>;

--- a/libs/sdk-ui-kit/src/Dialog/StylingEditorDialog/index.ts
+++ b/libs/sdk-ui-kit/src/Dialog/StylingEditorDialog/index.ts
@@ -4,4 +4,4 @@ export { ColorPreview, IColorPreviewProps } from "./ColorPreview";
 export { StylingExample, IStylingExampleProps } from "./StylingExample";
 export { BubbleHeaderSeparator, IBubbleHeaderSeparatorProps } from "./BubbleHeaderSeparator";
 export { StylingEditorDialogFooter, IStylingEditorDialogFooterProps } from "./StylingEditorDialogFooter";
-export { StylingPickerItem } from "./StylingEditorDialog";
+export { IStylingPickerItem, StylingPickerItemContent } from "./StylingEditorDialog";

--- a/libs/sdk-ui-kit/src/Dialog/tests/StylingEditorDialog.test.tsx
+++ b/libs/sdk-ui-kit/src/Dialog/tests/StylingEditorDialog.test.tsx
@@ -1,27 +1,32 @@
 // (C) 2022 GoodData Corporation
+import { ITheme } from "@gooddata/sdk-model";
 
 import { mount } from "enzyme";
 import React from "react";
-import { IStylingEditorDialogProps, StylingEditorDialog, StylingExample } from "../StylingEditorDialog";
-import { IThemeMetadataObject } from "@gooddata/sdk-model";
+import {
+    IStylingEditorDialogProps,
+    StylingEditorDialog,
+    StylingExample,
+    IStylingPickerItem,
+} from "../StylingEditorDialog";
 
 describe("Styling editor dialog", () => {
-    const theme = (color: string): IThemeMetadataObject => {
+    const theme = (color: string): IStylingPickerItem<ITheme> => {
         return {
-            title: `Theme ${color}`,
-            theme: {
+            name: `Theme ${color}`,
+            content: {
                 palette: {
                     primary: {
                         base: color,
                     },
                 },
             },
-        } as IThemeMetadataObject;
+        };
     };
 
-    const referenceTheme = (color: string) => JSON.stringify(theme(color).theme, null, 4);
+    const referenceTheme = (color: string) => JSON.stringify(theme(color).content, null, 4);
 
-    const getWrapper = (customProps: Partial<IStylingEditorDialogProps> = {}) => {
+    const getWrapper = (customProps: Partial<IStylingEditorDialogProps<ITheme>> = {}) => {
         const defaultProps = {
             title: "Dialog title",
             link: {
@@ -29,7 +34,7 @@ describe("Styling editor dialog", () => {
                 url: "#",
             },
             tooltip: "Tooltip to describe examples usage.",
-            stylingContent: theme("red"),
+            stylingItem: theme("red"),
             examples: [theme("green"), theme("blue")],
             exampleToColorPreview: () => ["#313441", "#FFFFFF", "#14B2E2", "#464E56", "#94A1AD", "#E2E7EC"],
         };
@@ -72,8 +77,8 @@ describe("Styling editor dialog", () => {
         expect(wrapper.find(".s-gd-styling-editor-dialog-content-examples")).not.toExist();
     });
 
-    it("should render empty fields if stylingContent not provided", () => {
-        const wrapper = getWrapper({ stylingContent: undefined });
+    it("should render empty fields if stylingItem not provided", () => {
+        const wrapper = getWrapper({ stylingItem: undefined });
         expect(wrapper.find(".s-input-field").hostNodes()).toHaveValue("");
         expect(wrapper.find(".s-textarea-field").hostNodes()).toHaveValue("");
     });

--- a/libs/sdk-ui-kit/src/StylingPicker/StylingPicker.tsx
+++ b/libs/sdk-ui-kit/src/StylingPicker/StylingPicker.tsx
@@ -4,7 +4,7 @@ import React, { useCallback, useEffect, useMemo, useState } from "react";
 import cx from "classnames";
 import { areObjRefsEqual, ObjRef } from "@gooddata/sdk-model";
 import { IntlWrapper } from "@gooddata/sdk-ui";
-import { ContentDivider, StylingPickerItem } from "../Dialog";
+import { ContentDivider, IStylingPickerItem, StylingPickerItemContent } from "../Dialog";
 import { useMediaQuery } from "../responsive";
 import { StylingPickerHeader } from "./StylingPickerHeader";
 import { StylingPickerFooter } from "./StylingPickerFooter";
@@ -13,10 +13,11 @@ import { StylingPickerBody } from "./StylingPickerBody";
 /**
  * @internal
  */
-export interface IStylingPickerProps {
+export interface IStylingPickerProps<T> {
     title: string;
-    defaultItem: StylingPickerItem;
-    customItems: StylingPickerItem[];
+    defaultItem: IStylingPickerItem<T>;
+    customItems: IStylingPickerItem<T>[];
+    itemToColorPreview: (itemContent: T) => string[];
     emptyMessage: () => JSX.Element;
     selectedItemRef?: ObjRef;
     isLoading?: boolean;
@@ -27,16 +28,19 @@ export interface IStylingPickerProps {
     className?: string;
     onApply?: (ref: ObjRef) => void;
     onListActionClick?: () => void;
-    onItemEdit?: (modifiedItem: StylingPickerItem) => void;
+    onItemEdit?: (modifiedItem: IStylingPickerItem<T>) => void;
     onItemDelete?: (ref: ObjRef) => void;
     locale?: string;
 }
 
-const StylingPickerCore: React.FC<IStylingPickerProps> = (props) => {
+const StylingPickerCore = <T extends StylingPickerItemContent>(
+    props: IStylingPickerProps<T>,
+): JSX.Element => {
     const {
         title,
         defaultItem,
         customItems,
+        itemToColorPreview,
         emptyMessage,
         selectedItemRef,
         isLoading,
@@ -84,6 +88,7 @@ const StylingPickerCore: React.FC<IStylingPickerProps> = (props) => {
                 isMobile={isMobileDevice}
                 defaultItem={defaultItem}
                 customItems={customItems}
+                itemToColorPreview={itemToColorPreview}
                 emptyMessage={emptyMessage}
                 isLoading={isLoading}
                 onListActionClick={onListActionClick}
@@ -111,12 +116,12 @@ const StylingPickerCore: React.FC<IStylingPickerProps> = (props) => {
 /**
  * @internal
  */
-export class StylingPicker extends React.PureComponent<IStylingPickerProps> {
-    public render() {
-        return (
-            <IntlWrapper locale={this.props.locale}>
-                <StylingPickerCore {...this.props} />
-            </IntlWrapper>
-        );
-    }
-}
+export const StylingPicker = <T extends StylingPickerItemContent>(
+    props: IStylingPickerProps<T>,
+): JSX.Element => {
+    return (
+        <IntlWrapper locale={props.locale}>
+            <StylingPickerCore {...props} />
+        </IntlWrapper>
+    );
+};

--- a/libs/sdk-ui-kit/src/StylingPicker/StylingPickerBody.tsx
+++ b/libs/sdk-ui-kit/src/StylingPicker/StylingPickerBody.tsx
@@ -3,29 +3,31 @@
 import React from "react";
 import { useIntl } from "react-intl";
 import { ObjRef } from "@gooddata/sdk-model";
-import { DialogListHeader, StylingPickerItem } from "../Dialog";
+import { DialogListHeader, IStylingPickerItem, StylingPickerItemContent } from "../Dialog";
 import { DialogListLoading } from "../Dialog/DialogList/DialogListLoading";
 import { StylingPickerList } from "./StylingPickerList";
 import { StylingPickerListItem } from "./StylingPickerListItem";
 
-interface IStylingPickerBodyProps {
+interface IStylingPickerBodyProps<T> {
     isMobile: boolean;
-    defaultItem: StylingPickerItem;
-    customItems: StylingPickerItem[];
+    defaultItem: IStylingPickerItem<T>;
+    customItems: IStylingPickerItem<T>[];
+    itemToColorPreview: (itemContent: T) => string[];
     emptyMessage: () => JSX.Element;
     isLoading?: boolean;
     onListActionClick?: () => void;
     initiallySelectedItemRef: ObjRef;
     selectedItemRef: ObjRef;
     onItemClick: (ref: ObjRef) => void;
-    onItemEdit?: (item: StylingPickerItem) => void;
+    onItemEdit?: (item: IStylingPickerItem<T>) => void;
     onItemDelete?: (ref: ObjRef) => void;
 }
 
-export const StylingPickerBody: React.FC<IStylingPickerBodyProps> = ({
+export const StylingPickerBody = <T extends StylingPickerItemContent>({
     isMobile,
     defaultItem,
     customItems,
+    itemToColorPreview,
     emptyMessage,
     isLoading,
     onListActionClick,
@@ -34,7 +36,7 @@ export const StylingPickerBody: React.FC<IStylingPickerBodyProps> = ({
     onItemClick,
     onItemEdit,
     onItemDelete,
-}) => {
+}: IStylingPickerBodyProps<T>) => {
     const intl = useIntl();
 
     return (
@@ -47,6 +49,7 @@ export const StylingPickerBody: React.FC<IStylingPickerBodyProps> = ({
                         <DialogListHeader title={intl.formatMessage({ id: "stylingPicker.title.basic" })} />
                         <StylingPickerListItem
                             item={defaultItem}
+                            itemToColorPreview={itemToColorPreview}
                             isSelected={!selectedItemRef}
                             onClick={() => onItemClick(null)}
                         />
@@ -64,6 +67,7 @@ export const StylingPickerBody: React.FC<IStylingPickerBodyProps> = ({
                         />
                         <StylingPickerList
                             items={customItems}
+                            itemToColorPreview={itemToColorPreview}
                             emptyMessageElement={emptyMessage()}
                             onItemClick={onItemClick}
                             onItemEdit={isMobile ? undefined : onItemEdit}

--- a/libs/sdk-ui-kit/src/StylingPicker/StylingPickerHeader.tsx
+++ b/libs/sdk-ui-kit/src/StylingPicker/StylingPickerHeader.tsx
@@ -5,7 +5,19 @@ import { Bubble, BubbleHoverTrigger } from "../Bubble";
 import { Typography } from "../Typography";
 import { IAlignPoint } from "../typings/positioning";
 
-const TOOLTIP_ALIGN_POINTS: IAlignPoint[] = [{ align: "bl tl", offset: { x: 10, y: 4 } }];
+const TOOLTIP_ALIGN_POINTS: IAlignPoint[] = [{ align: "tr tl" }];
+
+// offset arrow to solve an issue with a tooltip being hidden when cursor goes to the right part of the icon
+const BUBBLE_ARROW_LARGE_OFFSET = 20;
+const BUBBLE_ARROW_SMALL_OFFSET = 13;
+
+export const BUBBLE_ARROW_OFFSETS = {
+    "tr tl": [BUBBLE_ARROW_LARGE_OFFSET, 0],
+    "cr bl": [BUBBLE_ARROW_LARGE_OFFSET, BUBBLE_ARROW_SMALL_OFFSET],
+    "cr tl": [BUBBLE_ARROW_LARGE_OFFSET, -BUBBLE_ARROW_SMALL_OFFSET],
+    "cl cr": [-BUBBLE_ARROW_SMALL_OFFSET, 0],
+    "bc tc": [0, BUBBLE_ARROW_LARGE_OFFSET],
+};
 
 interface IStylingPickerHeaderProps {
     title: string;
@@ -15,19 +27,23 @@ interface IStylingPickerHeaderProps {
 export const StylingPickerHeader: React.FC<IStylingPickerHeaderProps> = ({ title, titleTooltip }) => {
     return (
         <div className="gd-styling-picker-header s-styling-picker-header">
-            <BubbleHoverTrigger showDelay={0} hideDelay={0}>
-                <div className="gd-styling-picker-header-content">
-                    <Typography tagName="h3">{title}</Typography>
+            <div className="gd-styling-picker-header-content">
+                <Typography tagName="h3">{title}</Typography>
+                <BubbleHoverTrigger showDelay={0} hideDelay={0}>
                     {titleTooltip && (
                         <span className="gd-icon-circle-question gd-styling-picker-header-icon" />
                     )}
-                </div>
-                {titleTooltip && (
-                    <Bubble className="bubble-primary" alignPoints={TOOLTIP_ALIGN_POINTS}>
-                        {titleTooltip}
-                    </Bubble>
-                )}
-            </BubbleHoverTrigger>
+                    {titleTooltip && (
+                        <Bubble
+                            className="bubble-primary"
+                            alignPoints={TOOLTIP_ALIGN_POINTS}
+                            arrowOffsets={BUBBLE_ARROW_OFFSETS}
+                        >
+                            {titleTooltip}
+                        </Bubble>
+                    )}
+                </BubbleHoverTrigger>
+            </div>
         </div>
     );
 };

--- a/libs/sdk-ui-kit/src/StylingPicker/StylingPickerList.tsx
+++ b/libs/sdk-ui-kit/src/StylingPicker/StylingPickerList.tsx
@@ -2,29 +2,31 @@
 
 import React from "react";
 import { StylingPickerListItem } from "./StylingPickerListItem";
-import { areObjRefsEqual, ObjRef } from "@gooddata/sdk-model";
+import { areObjRefsEqual, ObjRef, objRefToString } from "@gooddata/sdk-model";
 import { DialogListEmpty } from "../Dialog/DialogList/DialogListEmpty";
-import { StylingPickerItem } from "../Dialog";
+import { IStylingPickerItem, StylingPickerItemContent } from "../Dialog";
 
-interface IStylingPickerListProps {
-    items: StylingPickerItem[];
+interface IStylingPickerListProps<T> {
+    items: IStylingPickerItem<T>[];
+    itemToColorPreview: (itemContent: T) => string[];
     emptyMessageElement: JSX.Element;
     onItemClick: (ref: ObjRef) => void;
     initiallySelectedItemRef?: ObjRef;
     selectedItemRef?: ObjRef;
-    onItemEdit?: (item: StylingPickerItem) => void;
+    onItemEdit?: (item: IStylingPickerItem<T>) => void;
     onItemDelete?: (ref: ObjRef) => void;
 }
 
-export const StylingPickerList: React.FC<IStylingPickerListProps> = ({
+export const StylingPickerList = <T extends StylingPickerItemContent>({
     items,
+    itemToColorPreview,
     emptyMessageElement,
     onItemClick,
     onItemEdit,
     onItemDelete,
     initiallySelectedItemRef,
     selectedItemRef,
-}) => {
+}: IStylingPickerListProps<T>): JSX.Element => {
     if (items.length === 0) {
         return <DialogListEmpty message={emptyMessageElement} className="gd-styling-picker-list-empty" />;
     }
@@ -32,9 +34,10 @@ export const StylingPickerList: React.FC<IStylingPickerListProps> = ({
     return (
         <div className="gd-styling-picker-list s-styling-picker-list">
             {items.map((item) => (
-                <StylingPickerListItem
-                    key={item.id}
+                <StylingPickerListItem<T>
+                    key={objRefToString(item.ref)}
                     item={item}
+                    itemToColorPreview={itemToColorPreview}
                     isSelected={areObjRefsEqual(item.ref, selectedItemRef)}
                     isDeletable={!areObjRefsEqual(item.ref, initiallySelectedItemRef)}
                     onClick={onItemClick}

--- a/libs/sdk-ui-kit/src/StylingPicker/StylingPickerListItem.tsx
+++ b/libs/sdk-ui-kit/src/StylingPicker/StylingPickerListItem.tsx
@@ -6,19 +6,19 @@ import cx from "classnames";
 import { ObjRef } from "@gooddata/sdk-model";
 import { stringUtils } from "@gooddata/util";
 import { ShortenedText } from "../ShortenedText";
-import { getColorsPreviewFromTheme } from "./utils";
-import { ColorPreview, StylingPickerItem } from "../Dialog";
+import { ColorPreview, IStylingPickerItem, StylingPickerItemContent } from "../Dialog";
 import { IOnOpenedChangeParams, Menu } from "../Menu";
 import { Item, ItemsWrapper, Separator } from "../List";
 import { Button } from "../Button";
 import { Bubble, BubbleHoverTrigger } from "../Bubble";
 
-interface IStylingPickerListItemProps {
-    item: StylingPickerItem;
+interface IStylingPickerListItemProps<T> {
+    item: IStylingPickerItem<T>;
+    itemToColorPreview: (itemContent: T) => string[];
     isSelected: boolean;
     isDeletable?: boolean;
     onClick: (ref: ObjRef) => void;
-    onEdit?: (item: StylingPickerItem) => void;
+    onEdit?: (item: IStylingPickerItem<T>) => void;
     onDelete?: (ref: ObjRef) => void;
 }
 
@@ -27,18 +27,19 @@ const TEXT_TOOLTIP_ALIGN_POINTS = [
     { align: "bc tc", offset: { x: 0, y: 0 } },
 ];
 
-export const StylingPickerListItem: React.FC<IStylingPickerListItemProps> = ({
+export const StylingPickerListItem = <T extends StylingPickerItemContent>({
     item,
+    itemToColorPreview,
     isSelected,
     isDeletable,
     onClick,
     onEdit,
     onDelete,
-}) => {
+}: IStylingPickerListItemProps<T>): JSX.Element => {
     const intl = useIntl();
 
-    const { title, ref } = item;
-    const colorsPreview = getColorsPreviewFromTheme(item);
+    const { name, ref, content } = item;
+    const colorsPreview = itemToColorPreview(content);
 
     const [opened, setOpened] = useState(false);
 
@@ -52,7 +53,7 @@ export const StylingPickerListItem: React.FC<IStylingPickerListItemProps> = ({
             className={cx(
                 "gd-styling-picker-list-item",
                 "s-styling-picker-list-item",
-                `s-styling-picker-list-item-${stringUtils.simplifyText(title)}`,
+                `s-styling-picker-list-item-${stringUtils.simplifyText(name)}`,
                 {
                     "is-selected": isSelected,
                 },
@@ -69,7 +70,7 @@ export const StylingPickerListItem: React.FC<IStylingPickerListItemProps> = ({
                         className="gd-styling-picker-list-item-text-shortened"
                         tooltipAlignPoints={TEXT_TOOLTIP_ALIGN_POINTS}
                     >
-                        {title}
+                        {name}
                     </ShortenedText>
                 </span>
             </label>

--- a/libs/sdk-ui-kit/src/StylingPicker/index.ts
+++ b/libs/sdk-ui-kit/src/StylingPicker/index.ts
@@ -1,4 +1,9 @@
 // (C) 2022 GoodData Corporation
 
 export { StylingPicker, IStylingPickerProps } from "./StylingPicker";
-export { defaultThemeMetadataObject, getColorsPreviewFromTheme } from "./utils";
+export {
+    defaultThemeMetadataObject,
+    defaultColorPaletteMetadataObject,
+    getColorsPreviewFromTheme,
+    getColorsPreviewFromColorPalette,
+} from "./utils";

--- a/libs/sdk-ui-kit/src/StylingPicker/tests/StylingPicker.test.tsx
+++ b/libs/sdk-ui-kit/src/StylingPicker/tests/StylingPicker.test.tsx
@@ -4,15 +4,17 @@ import React from "react";
 import { mount } from "enzyme";
 import { IntlWrapper } from "@gooddata/sdk-ui";
 import { IStylingPickerProps, StylingPicker } from "../StylingPicker";
-import { defaultThemeMock, customThemesMock } from "./mocks";
+import { defaultItemMock, customItemsMock } from "./mocks";
 import * as useMediaQuery from "../../responsive/useMediaQuery";
+import { ITheme } from "@gooddata/sdk-model";
 
 describe("StylingPicker", () => {
-    const renderComponent = (props: Partial<IStylingPickerProps>) => {
+    const renderComponent = (props: Partial<IStylingPickerProps<ITheme>>) => {
         const defaultProps = {
             title: "Styling picker",
-            defaultItem: defaultThemeMock,
-            customItems: customThemesMock,
+            defaultItem: defaultItemMock,
+            customItems: customItemsMock,
+            itemToColorPreview: (): string[] => [],
             emptyMessage: () => <span className="s-empty-message-test" />,
         };
 
@@ -62,7 +64,7 @@ describe("StylingPicker", () => {
     });
 
     it("should select provided selected item", () => {
-        const selectedItemRef = customThemesMock[0].ref;
+        const selectedItemRef = customItemsMock[0].ref;
         const component = renderComponent({ selectedItemRef });
 
         expect(component.find(".s-styling-picker-list-item-first_theme input").prop("checked")).toBe(true);
@@ -75,14 +77,14 @@ describe("StylingPicker", () => {
     });
 
     it("should render footer buttons when selected item is different from basic item", () => {
-        const selectedItemRef = customThemesMock[0].ref;
+        const selectedItemRef = customItemsMock[0].ref;
         const component = renderComponent({ selectedItemRef });
 
         expect(component.find(".s-styling-picker-footer-buttons")).toExist();
     });
 
     it("should disable footer buttons when currently selected item is the same as provided selected item", () => {
-        const selectedItemRef = customThemesMock[0].ref;
+        const selectedItemRef = customItemsMock[0].ref;
         const component = renderComponent({ selectedItemRef });
 
         expect(component.find(".s-cancel").hasClass("disabled")).toBe(true);
@@ -90,7 +92,7 @@ describe("StylingPicker", () => {
     });
 
     it("should enable footer buttons after click on item that is not the same as provided selected item", () => {
-        const selectedItemRef = customThemesMock[0].ref;
+        const selectedItemRef = customItemsMock[0].ref;
         const component = renderComponent({ selectedItemRef });
 
         expect(component.find(".s-cancel").hasClass("disabled")).toBe(true);
@@ -103,7 +105,7 @@ describe("StylingPicker", () => {
     });
 
     it("should reset list selection to provided selected item when cancel button is clicked", () => {
-        const selectedItemRef = customThemesMock[0].ref;
+        const selectedItemRef = customItemsMock[0].ref;
         const component = renderComponent({ selectedItemRef });
 
         expect(component.find(".s-styling-picker-list-item-first_theme input").prop("checked")).toBe(true);
@@ -168,7 +170,7 @@ describe("StylingPicker", () => {
         component.find(".s-styling-picker-list-item-first_theme input").simulate("click");
         component.find(".s-apply").simulate("click");
 
-        expect(onApply).toHaveBeenCalledWith(customThemesMock[0].ref);
+        expect(onApply).toHaveBeenCalledWith(customItemsMock[0].ref);
     });
 
     it("should not render list action link on mobile device", () => {

--- a/libs/sdk-ui-kit/src/StylingPicker/tests/mocks.ts
+++ b/libs/sdk-ui-kit/src/StylingPicker/tests/mocks.ts
@@ -1,18 +1,12 @@
 // (C) 2022 GoodData Corporation
 
-import { idRef, IThemeMetadataObject } from "@gooddata/sdk-model";
+import { idRef, ITheme } from "@gooddata/sdk-model";
+import { IStylingPickerItem } from "../../Dialog/StylingEditorDialog";
 
-export const defaultThemeMock: IThemeMetadataObject = {
-    id: "default-theme",
+export const defaultItemMock: IStylingPickerItem<ITheme> = {
     ref: idRef("default-theme"),
-    uri: "",
-    type: "theme",
-    description: "",
-    production: false,
-    deprecated: false,
-    unlisted: false,
-    title: "Default theme",
-    theme: {
+    name: "Default theme",
+    content: {
         palette: {
             primary: {
                 base: "#14b2e2",
@@ -28,18 +22,11 @@ export const defaultThemeMock: IThemeMetadataObject = {
     },
 };
 
-export const customThemesMock: IThemeMetadataObject[] = [
+export const customItemsMock: IStylingPickerItem<ITheme>[] = [
     {
-        id: "theme1",
         ref: idRef("theme1"),
-        uri: "",
-        type: "theme",
-        description: "",
-        production: false,
-        deprecated: false,
-        unlisted: false,
-        title: "First theme",
-        theme: {
+        name: "First theme",
+        content: {
             palette: {
                 complementary: {
                     c0: "#292727",
@@ -57,16 +44,9 @@ export const customThemesMock: IThemeMetadataObject[] = [
         },
     },
     {
-        id: "theme2",
         ref: idRef("theme2"),
-        uri: "",
-        type: "theme",
-        description: "",
-        production: false,
-        deprecated: false,
-        unlisted: false,
-        title: "Second theme",
-        theme: {
+        name: "Second theme",
+        content: {
             palette: {
                 complementary: {
                     c0: "#122330",
@@ -85,127 +65,115 @@ export const customThemesMock: IThemeMetadataObject[] = [
     },
 ];
 
-export const fullyDefinedThemeMock: IThemeMetadataObject = {
-    id: "full-theme",
-    ref: idRef("full-theme"),
-    uri: "",
-    type: "theme",
-    description: "",
-    production: false,
-    deprecated: false,
-    unlisted: false,
-    title: "Full theme",
-    theme: {
-        analyticalDesigner: {
+export const fullyDefinedThemeMock: ITheme = {
+    analyticalDesigner: {
+        title: {
+            color: "#000",
+        },
+    },
+    button: {
+        borderRadius: "15",
+        dropShadow: true,
+        textCapitalization: true,
+    },
+    dashboards: {
+        content: {
+            backgroundColor: "#dfdfdf",
+            kpiWidget: {
+                backgroundColor: "#1b4096",
+                borderColor: "#000",
+                borderRadius: "4",
+                borderWidth: "1",
+                dropShadow: false,
+                kpi: {
+                    primaryMeasureColor: "#fff",
+                    secondaryInfoColor: "#eba12a",
+                },
+                title: {
+                    color: "#fff",
+                    textAlign: "left",
+                },
+            },
+            widget: {
+                borderColor: "#1b4096",
+                borderRadius: "50",
+                borderWidth: "1",
+                dropShadow: false,
+                title: {
+                    color: "#101010",
+                    textAlign: "center",
+                },
+            },
+        },
+        filterBar: {
+            backgroundColor: "#f0f0f0",
+            filterButton: {
+                backgroundColor: "#dfdfdf",
+            },
+        },
+        navigation: {
+            backgroundColor: "#f0f0f0",
+            borderColor: "#1b4096",
+            item: {
+                color: "#101010",
+                hoverColor: "#000",
+                selectedBackgroundColor: "#1b4096",
+                selectedColor: "#fff",
+            },
             title: {
                 color: "#000",
             },
         },
-        button: {
-            borderRadius: "15",
-            dropShadow: true,
-            textCapitalization: true,
-        },
-        dashboards: {
-            content: {
-                backgroundColor: "#dfdfdf",
-                kpiWidget: {
-                    backgroundColor: "#1b4096",
-                    borderColor: "#000",
-                    borderRadius: "4",
-                    borderWidth: "1",
-                    dropShadow: false,
-                    kpi: {
-                        primaryMeasureColor: "#fff",
-                        secondaryInfoColor: "#eba12a",
-                    },
-                    title: {
-                        color: "#fff",
-                        textAlign: "left",
-                    },
-                },
-                widget: {
-                    borderColor: "#1b4096",
-                    borderRadius: "50",
-                    borderWidth: "1",
-                    dropShadow: false,
-                    title: {
-                        color: "#101010",
-                        textAlign: "center",
-                    },
-                },
-            },
-            filterBar: {
-                backgroundColor: "#f0f0f0",
-                filterButton: {
-                    backgroundColor: "#dfdfdf",
-                },
-            },
-            navigation: {
-                backgroundColor: "#f0f0f0",
-                borderColor: "#1b4096",
-                item: {
-                    color: "#101010",
-                    hoverColor: "#000",
-                    selectedBackgroundColor: "#1b4096",
-                    selectedColor: "#fff",
-                },
-                title: {
-                    color: "#000",
-                },
-            },
-            section: {
-                description: {
-                    color: "#101010",
-                },
-                title: {
-                    color: "#000000",
-                    lineColor: "#dde4eb",
-                },
+        section: {
+            description: {
+                color: "#101010",
             },
             title: {
-                color: "#ff0000",
+                color: "#000000",
+                lineColor: "#dde4eb",
             },
         },
-        modal: {
-            borderColor: "#14b2e2",
-            borderRadius: "50px",
-            borderWidth: "15",
-            dropShadow: false,
-            outsideBackgroundColor: "#ffffbf",
-            title: {
-                color: "#1b4096",
-                lineColor: "#000",
-            },
+        title: {
+            color: "#ff0000",
         },
-        palette: {
-            error: {
-                base: "#ff2e5f",
-            },
-            info: {
-                base: "#00f",
-                contrast: "rgba(255,0,0,0.5)",
-                dark: "rgb(0,0,125)",
-                light: "rgb(100,100,255)",
-            },
-            primary: {
-                base: "#eba12a",
-            },
-            success: {
-                base: "#13ed4d",
-            },
-            warning: {
-                base: "#ddff19",
-            },
+    },
+    modal: {
+        borderColor: "#14b2e2",
+        borderRadius: "50px",
+        borderWidth: "15",
+        dropShadow: false,
+        outsideBackgroundColor: "#ffffbf",
+        title: {
+            color: "#1b4096",
+            lineColor: "#000",
         },
-        tooltip: {
-            backgroundColor: "#101010",
-            color: "#fff",
+    },
+    palette: {
+        error: {
+            base: "#ff2e5f",
         },
-        typography: {
-            font: "local('Trebuchet MS')",
-            fontBold:
-                "url(https://cdn.jsdelivr.net/npm/roboto-font@0.1.0/fonts/Roboto/roboto-bold-webfont.ttf)",
+        info: {
+            base: "#00f",
+            contrast: "rgba(255,0,0,0.5)",
+            dark: "rgb(0,0,125)",
+            light: "rgb(100,100,255)",
         },
+        primary: {
+            base: "#eba12a",
+        },
+        success: {
+            base: "#13ed4d",
+        },
+        warning: {
+            base: "#ddff19",
+        },
+    },
+    tooltip: {
+        backgroundColor: "#101010",
+        color: "#fff",
+    },
+    typography: {
+        font: "local('Trebuchet MS')",
+        fontBold: "url(https://cdn.jsdelivr.net/npm/roboto-font@0.1.0/fonts/Roboto/roboto-bold-webfont.ttf)",
     },
 };

--- a/libs/sdk-ui-kit/src/StylingPicker/tests/utils.test.ts
+++ b/libs/sdk-ui-kit/src/StylingPicker/tests/utils.test.ts
@@ -1,29 +1,18 @@
 // (C) 2022 GoodData Corporation
 
-import { idRef } from "@gooddata/sdk-model";
+import { ITheme } from "@gooddata/sdk-model";
 import { getColorsPreviewFromTheme } from "../utils";
-import { customThemesMock, fullyDefinedThemeMock } from "./mocks";
+import { customItemsMock, fullyDefinedThemeMock } from "./mocks";
 
 describe("getColorsPreviewFromTheme", () => {
     it("should return default array of colors when theme is empty", () => {
-        const result = getColorsPreviewFromTheme({
-            id: "",
-            ref: idRef("default-them"),
-            uri: "",
-            type: "theme",
-            description: "",
-            production: false,
-            deprecated: false,
-            unlisted: false,
-            title: "",
-            theme: {},
-        });
+        const result = getColorsPreviewFromTheme({});
 
         expect(result).toMatchSnapshot();
     });
 
     it("should return correct array of colors when only complementary colors are set in theme", () => {
-        const result = getColorsPreviewFromTheme(customThemesMock[0]);
+        const result = getColorsPreviewFromTheme(customItemsMock[0].content as ITheme);
 
         expect(result).toMatchSnapshot();
     });

--- a/libs/sdk-ui-kit/src/StylingPicker/utils.ts
+++ b/libs/sdk-ui-kit/src/StylingPicker/utils.ts
@@ -1,6 +1,14 @@
 // (C) 2022 GoodData Corporation
 
-import { idRef, IThemeDefinition } from "@gooddata/sdk-model";
+import {
+    idRef,
+    IThemeDefinition,
+    IColorPaletteDefinition,
+    colorPaletteToColors,
+    ITheme,
+    IColorPalette,
+} from "@gooddata/sdk-model";
+import { DefaultColorPalette } from "@gooddata/sdk-ui";
 
 /**
  * Dummy theme metadata object which represents the default colors of GD.
@@ -44,8 +52,7 @@ export const defaultThemeMetadataObject: IThemeDefinition = {
  *
  * @internal
  */
-export const getColorsPreviewFromTheme = (themeDef: IThemeDefinition): string[] => {
-    const { theme } = themeDef;
+export const getColorsPreviewFromTheme = (theme: ITheme): string[] => {
     const { theme: defaultTheme } = defaultThemeMetadataObject;
 
     const color1 =
@@ -68,4 +75,36 @@ export const getColorsPreviewFromTheme = (themeDef: IThemeDefinition): string[] 
     const color6 = theme.palette?.complementary?.c7 || defaultTheme.palette.complementary.c7;
 
     return [color1, color2, color3, color4, color5, color6];
+};
+
+/**
+ * Dummy theme metadata object which represents the default colors of GD.
+ *
+ * This object is used as default when rendering theme as a sequence of colored elements in styling
+ * picker. It's properties are also used as defaults when some custom theme is missing a crucial
+ * property for the same rendering purposes.
+ *
+ * @internal
+ */
+export const defaultColorPaletteMetadataObject: IColorPaletteDefinition = {
+    id: "default-color-palette",
+    ref: idRef("default-color-palette"),
+    uri: "",
+    type: "colorPalette",
+    description: "",
+    production: false,
+    deprecated: false,
+    unlisted: false,
+    title: "Indigo",
+    colorPalette: DefaultColorPalette,
+};
+
+/**
+ * This function transforms a color palette into an array of max ten colors which is used
+ * to render the color palette in styling picker.
+ *
+ * @internal
+ */
+export const getColorsPreviewFromColorPalette = (colorPalette: IColorPalette): string[] => {
+    return colorPaletteToColors(colorPalette).slice(0, 10);
 };

--- a/libs/sdk-ui-tests/stories/visual-regression/kit/Dialog/Dialog.tsx
+++ b/libs/sdk-ui-tests/stories/visual-regression/kit/Dialog/Dialog.tsx
@@ -14,7 +14,6 @@ import { wrapWithTheme } from "../../themeWrapper";
 
 import "@gooddata/sdk-ui-kit/styles/css/main.css";
 import "./styles.scss";
-import { IThemeMetadataObject } from "@gooddata/sdk-model";
 
 class DialogExamples extends PureComponent {
     state = {
@@ -202,21 +201,19 @@ class DialogExamples extends PureComponent {
                 }}
                 locale="en-US"
                 tooltip="Tooltip to describe examples usage."
-                stylingContent={
-                    {
-                        title: "Red theme",
-                        theme: theme("red"),
-                    } as IThemeMetadataObject
-                }
+                stylingItem={{
+                    name: "Red theme",
+                    content: theme("red"),
+                }}
                 examples={[
                     {
-                        title: "Green theme",
-                        theme: theme("green"),
-                    } as IThemeMetadataObject,
+                        name: "Green theme",
+                        content: theme("green"),
+                    },
                     {
-                        title: "Blue theme",
-                        theme: theme("blue"),
-                    } as IThemeMetadataObject,
+                        name: "Blue theme",
+                        content: theme("blue"),
+                    },
                 ]}
                 exampleToColorPreview={() => [
                     "#313441",

--- a/libs/sdk-ui-tests/stories/visual-regression/kit/StylingPicker/StylingPicker.tsx
+++ b/libs/sdk-ui-tests/stories/visual-regression/kit/StylingPicker/StylingPicker.tsx
@@ -1,8 +1,13 @@
 // (C) 2022 GoodData Corporation
 
 import React from "react";
-import { idRef } from "@gooddata/sdk-model";
-import { defaultThemeMetadataObject, StylingPicker } from "@gooddata/sdk-ui-kit";
+import { idRef, ITheme } from "@gooddata/sdk-model";
+import {
+    defaultThemeMetadataObject,
+    getColorsPreviewFromTheme,
+    IStylingPickerItem,
+    StylingPicker,
+} from "@gooddata/sdk-ui-kit";
 import { InternalIntlWrapper } from "@gooddata/sdk-ui-ext/dist/internal/utils/internalIntlProvider";
 import { action } from "@storybook/addon-actions";
 import { storiesOf } from "../../../_infra/storyRepository";
@@ -20,6 +25,11 @@ const emptyMessage = () => (
 const footerHelpLink = "https://gooddata.com";
 const footerHelpTitle = "How to create a custom theme?";
 const footerMessage = "To create theme please use your computer.";
+const defaultItem: IStylingPickerItem<ITheme> = {
+    ref: defaultThemeMetadataObject.ref,
+    content: defaultThemeMetadataObject.theme,
+    name: defaultThemeMetadataObject.title,
+};
 
 const StylingPickerTest: React.FC = () => {
     return (
@@ -33,8 +43,9 @@ const StylingPickerTest: React.FC = () => {
                         footerHelpTitle={footerHelpTitle}
                         footerMobileMessage={footerMessage}
                         emptyMessage={emptyMessage}
-                        defaultItem={defaultThemeMetadataObject}
+                        defaultItem={defaultItem}
                         customItems={customThemeItems}
+                        itemToColorPreview={getColorsPreviewFromTheme}
                         selectedItemRef={idRef("theme2")}
                         onApply={action("onApply")}
                         onListActionClick={action("onListActionClick")}
@@ -49,8 +60,9 @@ const StylingPickerTest: React.FC = () => {
                         footerHelpTitle={footerHelpTitle}
                         footerMobileMessage={footerMessage}
                         emptyMessage={emptyMessage}
-                        defaultItem={defaultThemeMetadataObject}
+                        defaultItem={defaultItem}
                         customItems={customThemeItems.slice(0, 2)}
+                        itemToColorPreview={getColorsPreviewFromTheme}
                         onApply={action("onApply")}
                         onListActionClick={action("onListActionClick")}
                         onItemEdit={action("onItemEdit")}
@@ -63,8 +75,9 @@ const StylingPickerTest: React.FC = () => {
                         titleTooltip="Theme customize the look of Dashboards and Analytical Designer. Default theme is inherited by all workspaces within the organization. You can select non default theme for individual workspaces through API."
                         footerMobileMessage={footerMessage}
                         emptyMessage={emptyMessage}
-                        defaultItem={defaultThemeMetadataObject}
+                        defaultItem={defaultItem}
                         customItems={[]}
+                        itemToColorPreview={getColorsPreviewFromTheme}
                         onApply={action("onApply")}
                         onListActionClick={action("onListActionClick")}
                     />

--- a/libs/sdk-ui-tests/stories/visual-regression/kit/StylingPicker/itemsMock.ts
+++ b/libs/sdk-ui-tests/stories/visual-regression/kit/StylingPicker/itemsMock.ts
@@ -1,19 +1,13 @@
 // (C) 2022 GoodData Corporation
 
-import { idRef, IThemeMetadataObject } from "@gooddata/sdk-model";
+import { idRef, ITheme } from "@gooddata/sdk-model";
+import { IStylingPickerItem } from "@gooddata/sdk-ui-kit";
 
-export const customThemeItems: IThemeMetadataObject[] = [
+export const customThemeItems: IStylingPickerItem<ITheme>[] = [
     {
-        id: "theme1",
         ref: idRef("theme1"),
-        uri: "",
-        type: "theme",
-        description: "",
-        production: false,
-        deprecated: false,
-        unlisted: false,
-        title: "My first theme",
-        theme: {
+        name: "My first theme",
+        content: {
             palette: {
                 complementary: {
                     c0: "#292727",
@@ -31,16 +25,9 @@ export const customThemeItems: IThemeMetadataObject[] = [
         },
     },
     {
-        id: "theme2",
         ref: idRef("theme2"),
-        uri: "",
-        type: "theme",
-        description: "",
-        production: false,
-        deprecated: false,
-        unlisted: false,
-        title: "My second theme with a longer name than usual so that we can see the shortened text in action",
-        theme: {
+        name: "My second theme with a longer name than usual so that we can see the shortened text in action",
+        content: {
             palette: {
                 complementary: {
                     c0: "#122330",
@@ -58,16 +45,9 @@ export const customThemeItems: IThemeMetadataObject[] = [
         },
     },
     {
-        id: "theme3",
         ref: idRef("theme3"),
-        uri: "",
-        type: "theme",
-        description: "",
-        production: false,
-        deprecated: false,
-        unlisted: false,
-        title: "My third theme",
-        theme: {
+        name: "My third theme",
+        content: {
             palette: {
                 complementary: {
                     c0: "#FFFFFF",
@@ -85,16 +65,9 @@ export const customThemeItems: IThemeMetadataObject[] = [
         },
     },
     {
-        id: "theme4",
         ref: idRef("theme4"),
-        uri: "",
-        type: "theme",
-        description: "",
-        production: false,
-        deprecated: false,
-        unlisted: false,
-        title: "My fourth theme",
-        theme: {
+        name: "My fourth theme",
+        content: {
             palette: {
                 complementary: {
                     c0: "#FFFFFF",


### PR DESCRIPTION
JIRA: TNT-932 TNT-933
Styling dialogs now accept also color palette

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
