### PR TITLE
RELATED: SD-2350 - Modify the SDK to support to get workspace hierarchy

### DIFF
--- a/libs/sdk-backend-bear/src/backend/workspaces/index.ts
+++ b/libs/sdk-backend-bear/src/backend/workspaces/index.ts
@@ -1,6 +1,11 @@
-// (C) 2019-2021 GoodData Corporation
+// (C) 2019-2022 GoodData Corporation
 import { ServerPaging } from "@gooddata/sdk-backend-base";
-import { IWorkspacesQueryFactory, IWorkspacesQuery, IWorkspacesQueryResult } from "@gooddata/sdk-backend-spi";
+import {
+    IWorkspacesQueryFactory,
+    IWorkspacesQuery,
+    IWorkspacesQueryResult,
+    NotSupported,
+} from "@gooddata/sdk-backend-spi";
 import { convertUserProject } from "../../convertors/toBackend/WorkspaceConverter";
 import { BearAuthenticatedCallGuard } from "../../types/auth";
 import { userLoginMd5FromAuthenticatedPrincipal } from "../../utils/api";
@@ -33,6 +38,10 @@ class BearWorkspaceQuery implements IWorkspacesQuery {
     public withOffset(offset: number): IWorkspacesQuery {
         this.offset = offset;
         return this;
+    }
+
+    public withParent(): IWorkspacesQuery {
+        throw new NotSupported("not supported");
     }
 
     public withSearch(search: string): IWorkspacesQuery {

--- a/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
+++ b/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
@@ -1748,6 +1748,7 @@ export interface IWorkspacesQuery {
     query(): Promise<IWorkspacesQueryResult>;
     withLimit(limit: number): IWorkspacesQuery;
     withOffset(offset: number): IWorkspacesQuery;
+    withParent(workspaceId: string | undefined): IWorkspacesQuery;
     withSearch(search: string): IWorkspacesQuery;
 }
 

--- a/libs/sdk-backend-spi/src/workspace/index.ts
+++ b/libs/sdk-backend-spi/src/workspace/index.ts
@@ -177,6 +177,12 @@ export interface IWorkspacesQuery {
     withOffset(offset: number): IWorkspacesQuery;
 
     /**
+     * Sets a identifier of the parent workspace to get its children, otherwise the root workspace.
+     * @param workspaceId - identifier of the parent workspace
+     */
+    withParent(workspaceId: string | undefined): IWorkspacesQuery;
+
+    /**
      * Sets a text to search.
      * @param search - text to search
      */

--- a/libs/sdk-backend-tiger/src/backend/workspaces/index.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspaces/index.ts
@@ -32,6 +32,7 @@ class TigerWorkspaceQuery implements IWorkspacesQuery {
     private limit: number = 100;
     private offset: number = 0;
     private search: string | undefined = undefined;
+    private parentWorkspaceId: string | undefined = undefined;
 
     constructor(
         private readonly authCall: TigerAuthenticatedCallGuard,
@@ -47,6 +48,11 @@ class TigerWorkspaceQuery implements IWorkspacesQuery {
 
     public withOffset(offset: number): IWorkspacesQuery {
         this.offset = offset;
+        return this;
+    }
+
+    public withParent(workspaceId: string): IWorkspacesQuery {
+        this.parentWorkspaceId = workspaceId;
         return this;
     }
 
@@ -91,9 +97,11 @@ class TigerWorkspaceQuery implements IWorkspacesQuery {
         search?: string,
     ): Promise<IWorkspacesQueryResult> {
         const allWorkspaces = await this.authCall((client) => {
+            const filterParam = this.parentWorkspaceId ? `parent.id==${this.parentWorkspaceId}` : undefined;
             return OrganizationUtilities.getAllPagesOf(client, client.entities.getAllEntitiesWorkspaces, {
                 sort: ["name"],
                 include: ["workspaces"],
+                filter: filterParam,
             })
                 .then(OrganizationUtilities.mergeEntitiesResults)
                 .then(this.resultToWorkspaceDescriptors)


### PR DESCRIPTION
Improving the workspaces on TIGER:
_ Can set the parent workspace id
_ With the parent workspace can get its child workspaces
JIRA: SD-2350

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
