### PR TITLE
RELATED: RAIL-4170 Fix handling of insight placeholder drop

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/useInsightPlaceholderDropHandler.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/useInsightPlaceholderDropHandler.ts
@@ -1,13 +1,16 @@
 // (C) 2022 GoodData Corporation
 import { useCallback } from "react";
 import { idRef } from "@gooddata/sdk-model";
+import invariant from "ts-invariant";
 
 import {
     useDashboardDispatch,
     uiActions,
     useDashboardSelector,
     selectSettings,
-    addSectionItem,
+    selectWidgetPlaceholder,
+    replaceSectionItem,
+    useDashboardCommandProcessing,
 } from "../../../model";
 import { INSIGHT_PLACEHOLDER_WIDGET_ID, newInsightPlaceholderWidget } from "../../../widgets";
 import { getInsightPlaceholderSizeInfo } from "../../../_staging/layout/sizing";
@@ -15,25 +18,33 @@ import { getInsightPlaceholderSizeInfo } from "../../../_staging/layout/sizing";
 export function useInsightPlaceholderDropHandler() {
     const dispatch = useDashboardDispatch();
     const settings = useDashboardSelector(selectSettings);
+    const widgetPlaceholder = useDashboardSelector(selectWidgetPlaceholder);
+
+    const { run: replaceInsightOntoPlaceholder } = useDashboardCommandProcessing({
+        commandCreator: replaceSectionItem,
+        errorEvent: "GDC.DASH/EVT.COMMAND.FAILED",
+        successEvent: "GDC.DASH/EVT.FLUID_LAYOUT.ITEM_REPLACED",
+        onSuccess: () => {
+            dispatch(uiActions.selectWidget(idRef(INSIGHT_PLACEHOLDER_WIDGET_ID)));
+            dispatch(uiActions.setConfigurationPanelOpened(true));
+        },
+    });
 
     return useCallback(
         (sectionIndex: number, itemIndex: number, isLastInSection: boolean) => {
             const sizeInfo = getInsightPlaceholderSizeInfo(settings);
-            dispatch(uiActions.selectWidget(idRef(INSIGHT_PLACEHOLDER_WIDGET_ID)));
-            dispatch(uiActions.setConfigurationPanelOpened(true));
-            dispatch(
-                addSectionItem(sectionIndex, sectionIndex, {
-                    type: "IDashboardLayoutItem",
-                    size: {
-                        xl: {
-                            gridHeight: sizeInfo.height.default!,
-                            gridWidth: sizeInfo.width.default!,
-                        },
+            invariant(widgetPlaceholder, "cannot drop onto placeholder, there is none");
+            replaceInsightOntoPlaceholder(widgetPlaceholder.sectionIndex, widgetPlaceholder.itemIndex, {
+                type: "IDashboardLayoutItem",
+                size: {
+                    xl: {
+                        gridHeight: sizeInfo.height.default!,
+                        gridWidth: sizeInfo.width.default!,
                     },
-                    widget: newInsightPlaceholderWidget(sectionIndex, itemIndex, isLastInSection),
-                }),
-            );
+                },
+                widget: newInsightPlaceholderWidget(sectionIndex, itemIndex, isLastInSection),
+            });
         },
-        [dispatch, settings],
+        [replaceInsightOntoPlaceholder, settings, widgetPlaceholder],
     );
 }


### PR DESCRIPTION
Make the logic very similar to how KPI placeholders are handled.
This ensures any widget placeholders are properly replaced.

JIRA: RAIL-4170

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
