### PR TITLE
RELATED: RAIL-4170 preselect default date dataset for newly added widgets

### DIFF
--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -5495,6 +5495,9 @@ export const selectIsShareDialogOpen: OutputSelector<DashboardState, boolean, (r
 export const selectIsWhiteLabeled: OutputSelector<DashboardState, boolean, (res: ResolvedDashboardConfig) => boolean>;
 
 // @internal (undocumented)
+export const selectIsWidgetLoadingAdditionalDataByWidgetRef: (ref: ObjRef) => OutputSelector<DashboardState, boolean, (res: ObjRef[]) => boolean>;
+
+// @internal (undocumented)
 export const selectKpiDateDatasetAutoOpen: OutputSelector<DashboardState, boolean, (res: UiState) => boolean>;
 
 // @internal (undocumented)
@@ -5781,6 +5784,14 @@ payload: boolean;
 type: string;
 }>;
 requestInsightListUpdate: CaseReducer<UiState, AnyAction>;
+setWidgetLoadingAdditionalDataStarted: CaseReducer<UiState, {
+payload: ObjRef;
+type: string;
+}>;
+setWidgetLoadingAdditionalDataStopped: CaseReducer<UiState, {
+payload: ObjRef;
+type: string;
+}>;
 }>;
 
 // @alpha (undocumented)
@@ -5831,6 +5842,8 @@ export interface UiState {
     shareDialog: {
         open: boolean;
     };
+    // (undocumented)
+    widgetsLoadingAdditionalData: ObjRef[];
 }
 
 // @alpha

--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -2491,10 +2491,10 @@ export const EditableTitle: CustomTitleComponent;
 export const EditButton: (props: IEditButtonProps) => JSX.Element;
 
 // @alpha
-export function enableInsightWidgetDateFilter(ref: ObjRef, dateDataset: ObjRef, correlationId?: string): ChangeInsightWidgetFilterSettings;
+export function enableInsightWidgetDateFilter(ref: ObjRef, dateDataset: ObjRef | "default", correlationId?: string): ChangeInsightWidgetFilterSettings;
 
 // @alpha
-export function enableKpiWidgetDateFilter(ref: ObjRef, dateDataset: ObjRef, correlationId?: string): ChangeKpiWidgetFilterSettings;
+export function enableKpiWidgetDateFilter(ref: ObjRef, dateDataset: ObjRef | "default", correlationId?: string): ChangeKpiWidgetFilterSettings;
 
 // @alpha (undocumented)
 export interface ExportDashboardToPdf extends IDashboardCommand {
@@ -2584,7 +2584,7 @@ export interface FilterOpDisableDateFilter extends FilterOp {
 
 // @alpha
 export interface FilterOpEnableDateFilter extends FilterOp {
-    dateDataset: ObjRef;
+    dateDataset: ObjRef | "default";
     // (undocumented)
     type: "enableDateFilter";
 }

--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -2631,9 +2631,7 @@ export type FiltersInfo = {
 export type FluidLayoutCustomizationFn = (layout: IDashboardLayout<ExtendedDashboardWidget>, customizer: IFluidLayoutCustomizer) => void;
 
 // @internal (undocumented)
-export function getDefaultInsightEditMenuItems(intl: IntlShape, config: {
-    widget: IInsightWidget;
-}): IInsightMenuItem[];
+export function getDefaultInsightEditMenuItems(intl: IntlShape): IInsightMenuItem[];
 
 // @internal (undocumented)
 export function getDefaultInsightMenuItems(intl: IntlShape, config: {
@@ -3452,7 +3450,9 @@ export interface IInsightMenuSubmenu {
     // (undocumented)
     itemName: string;
     // (undocumented)
-    renderSubmenu: () => JSX.Element;
+    SubmenuComponent: ComponentType<{
+        widget: IInsightWidget;
+    }>;
     tooltip?: string;
     // (undocumented)
     type: "submenu";

--- a/libs/sdk-ui-dashboard/src/model/commands/insight.ts
+++ b/libs/sdk-ui-dashboard/src/model/commands/insight.ts
@@ -128,7 +128,7 @@ export function replaceInsightWidgetFilterSettings(
  * be enabled and the provided date data set will be used for date-filtering widget's insight.
  *
  * @param ref - reference of the insight widget to modify
- * @param dateDataset - date data set to use for filtering the insight
+ * @param dateDataset - date data set to use for filtering the insight, if "default" is provided, the default date dataset will be resolved and used
  * @param correlationId - specify correlation id to use for this command. this will be included in all
  *  events that will be emitted during the command processing
  *
@@ -136,7 +136,7 @@ export function replaceInsightWidgetFilterSettings(
  */
 export function enableInsightWidgetDateFilter(
     ref: ObjRef,
-    dateDataset: ObjRef,
+    dateDataset: ObjRef | "default",
     correlationId?: string,
 ): ChangeInsightWidgetFilterSettings {
     return {

--- a/libs/sdk-ui-dashboard/src/model/commands/kpi.ts
+++ b/libs/sdk-ui-dashboard/src/model/commands/kpi.ts
@@ -188,7 +188,7 @@ export function replaceKpiWidgetFilterSettings(
  * be enabled and the provided date data set will be used for date-filtering widget's KPI.
  *
  * @param ref - reference of the KPI widget to modify
- * @param dateDataset - date data set to use for filtering the KPI
+ * @param dateDataset - date data set to use for filtering the insight, if "default" is provided, the default date dataset will be resolved and used
  * @param correlationId - specify correlation id to use for this command. this will be included in all
  *  events that will be emitted during the command processing
  *
@@ -196,7 +196,7 @@ export function replaceKpiWidgetFilterSettings(
  */
 export function enableKpiWidgetDateFilter(
     ref: ObjRef,
-    dateDataset: ObjRef,
+    dateDataset: ObjRef | "default",
     correlationId?: string,
 ): ChangeKpiWidgetFilterSettings {
     return {

--- a/libs/sdk-ui-dashboard/src/model/store/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/index.ts
@@ -226,6 +226,7 @@ export {
     selectIsKpiDeleteDialogOpen,
     selectKpiDeleteDialogWidgetCoordinates,
     selectInsightListLastUpdateRequested,
+    selectIsWidgetLoadingAdditionalDataByWidgetRef,
 } from "./ui/uiSelectors";
 export { uiActions } from "./ui";
 export { RenderModeState } from "./renderMode/renderModeState";

--- a/libs/sdk-ui-dashboard/src/model/store/ui/uiReducers.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/ui/uiReducers.ts
@@ -1,6 +1,6 @@
 // (C) 2021-2022 GoodData Corporation
 import { Action, AnyAction, CaseReducer, PayloadAction } from "@reduxjs/toolkit";
-import { ObjRef } from "@gooddata/sdk-model";
+import { areObjRefsEqual, ObjRef } from "@gooddata/sdk-model";
 import { UiState } from "./uiState";
 import { ILayoutCoordinates, IMenuButtonItemsVisibility } from "../../../types";
 
@@ -105,6 +105,16 @@ const requestInsightListUpdate: UiReducer = (state) => {
     state.insightListLastUpdateRequested = +new Date();
 };
 
+const setWidgetLoadingAdditionalDataStarted: UiReducer<PayloadAction<ObjRef>> = (state, action) => {
+    state.widgetsLoadingAdditionalData.push(action.payload);
+};
+
+const setWidgetLoadingAdditionalDataStopped: UiReducer<PayloadAction<ObjRef>> = (state, action) => {
+    state.widgetsLoadingAdditionalData = state.widgetsLoadingAdditionalData.filter(
+        (item) => !areObjRefsEqual(item, action.payload),
+    );
+};
+
 export const uiReducers = {
     openScheduleEmailDialog,
     closeScheduleEmailDialog,
@@ -130,4 +140,6 @@ export const uiReducers = {
     setConfigurationPanelOpened,
     setKpiDateDatasetAutoOpen,
     requestInsightListUpdate,
+    setWidgetLoadingAdditionalDataStarted,
+    setWidgetLoadingAdditionalDataStopped,
 };

--- a/libs/sdk-ui-dashboard/src/model/store/ui/uiSelectors.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/ui/uiSelectors.ts
@@ -1,7 +1,7 @@
 // (C) 2021-2022 GoodData Corporation
 
 import { createSelector } from "@reduxjs/toolkit";
-import { ObjRef } from "@gooddata/sdk-model";
+import { areObjRefsEqual, ObjRef } from "@gooddata/sdk-model";
 import { selectWidgetsMap } from "../layout/layoutSelectors";
 import { DashboardState } from "../types";
 import { createMemoizedSelector } from "../_infra/selectors";
@@ -170,4 +170,18 @@ export const selectKpiDateDatasetAutoOpen = createSelector(
 export const selectInsightListLastUpdateRequested = createSelector(
     selectSelf,
     (state) => state.insightListLastUpdateRequested,
+);
+
+const selectWidgetsLoadingAdditionalData = createSelector(
+    selectSelf,
+    (state) => state.widgetsLoadingAdditionalData,
+);
+
+/**
+ * @internal
+ */
+export const selectIsWidgetLoadingAdditionalDataByWidgetRef = createMemoizedSelector((ref: ObjRef) =>
+    createSelector(selectWidgetsLoadingAdditionalData, (widgetsLoading) => {
+        return widgetsLoading.some((loadingRef) => areObjRefsEqual(loadingRef, ref));
+    }),
 );

--- a/libs/sdk-ui-dashboard/src/model/store/ui/uiState.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/ui/uiState.ts
@@ -43,6 +43,7 @@ export interface UiState {
     configurationPanelOpened: boolean;
     kpiDateDatasetAutoOpen: boolean;
     insightListLastUpdateRequested: number;
+    widgetsLoadingAdditionalData: ObjRef[];
 }
 
 export const uiInitialState: UiState = {
@@ -79,4 +80,5 @@ export const uiInitialState: UiState = {
     configurationPanelOpened: true,
     kpiDateDatasetAutoOpen: false,
     insightListLastUpdateRequested: 0,
+    widgetsLoadingAdditionalData: [],
 };

--- a/libs/sdk-ui-dashboard/src/model/types/widgetTypes.ts
+++ b/libs/sdk-ui-dashboard/src/model/types/widgetTypes.ts
@@ -51,8 +51,9 @@ export interface FilterOpEnableDateFilter extends FilterOp {
 
     /**
      * Ref of date data set to use in date filters applied on the content of the widget.
+     * If passed "default", the default date dataset will be resolved and used.
      */
-    dateDataset: ObjRef;
+    dateDataset: ObjRef | "default";
 }
 
 /**

--- a/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/SectionHotspot.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/SectionHotspot.tsx
@@ -68,10 +68,12 @@ export const SectionHotspot: React.FC<ISectionHotspotProps> = (props) => {
         commandCreator: addLayoutSection,
         errorEvent: "GDC.DASH/EVT.COMMAND.FAILED",
         successEvent: "GDC.DASH/EVT.FLUID_LAYOUT.SECTION_ADDED",
-        onSuccess: () => {
+        onSuccess: (event) => {
+            const ref = event.payload.section.items[0].widget!.ref;
             dispatch(uiActions.selectWidget(idRef(KPI_PLACEHOLDER_WIDGET_ID)));
             dispatch(uiActions.setConfigurationPanelOpened(true));
             dispatch(uiActions.setKpiDateDatasetAutoOpen(true));
+            dispatch(uiActions.setWidgetLoadingAdditionalDataStarted(ref));
         },
     });
 

--- a/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/SectionHotspot.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/SectionHotspot.tsx
@@ -4,7 +4,10 @@ import cx from "classnames";
 import { getDropZoneDebugStyle } from "../debug";
 import {
     addLayoutSection,
+    ChangeInsightWidgetFilterSettings,
+    DashboardCommandFailed,
     eagerRemoveSectionItem,
+    enableInsightWidgetDateFilter,
     selectSettings,
     selectWidgetPlaceholder,
     uiActions,
@@ -43,6 +46,18 @@ export const SectionHotspot: React.FC<ISectionHotspotProps> = (props) => {
     const settings = useDashboardSelector(selectSettings);
     const widgetPlaceholder = useDashboardSelector(selectWidgetPlaceholder);
 
+    const { run: preselectDateDataset } = useDashboardCommandProcessing({
+        commandCreator: enableInsightWidgetDateFilter,
+        errorEvent: "GDC.DASH/EVT.COMMAND.FAILED",
+        successEvent: "GDC.DASH/EVT.INSIGHT_WIDGET.FILTER_SETTINGS_CHANGED",
+        onSuccess: (event) => {
+            dispatch(uiActions.setWidgetLoadingAdditionalDataStopped(event.payload.ref));
+        },
+        onError: (event: DashboardCommandFailed<ChangeInsightWidgetFilterSettings>) => {
+            dispatch(uiActions.setWidgetLoadingAdditionalDataStopped(event.payload.command.payload.ref));
+        },
+    });
+
     const { run: addNewSectionWithInsight } = useDashboardCommandProcessing({
         commandCreator: addLayoutSection,
         errorEvent: "GDC.DASH/EVT.COMMAND.FAILED",
@@ -51,6 +66,8 @@ export const SectionHotspot: React.FC<ISectionHotspotProps> = (props) => {
             const ref = event.payload.section.items[0].widget!.ref;
             dispatch(uiActions.selectWidget(ref));
             dispatch(uiActions.setConfigurationPanelOpened(true));
+            dispatch(uiActions.setWidgetLoadingAdditionalDataStarted(ref));
+            preselectDateDataset(ref, "default");
         },
     });
 

--- a/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/useInsightListItemDropHandler.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/useInsightListItemDropHandler.ts
@@ -11,6 +11,9 @@ import {
     uiActions,
     selectWidgetPlaceholder,
     replaceSectionItem,
+    enableInsightWidgetDateFilter,
+    DashboardCommandFailed,
+    ChangeInsightWidgetFilterSettings,
 } from "../../../model";
 import { getSizeInfo } from "../../../_staging/layout/sizing";
 
@@ -18,6 +21,18 @@ export function useInsightListItemDropHandler() {
     const dispatch = useDashboardDispatch();
     const settings = useDashboardSelector(selectSettings);
     const widgetPlaceholder = useDashboardSelector(selectWidgetPlaceholder);
+
+    const { run: preselectDateDataset } = useDashboardCommandProcessing({
+        commandCreator: enableInsightWidgetDateFilter,
+        errorEvent: "GDC.DASH/EVT.COMMAND.FAILED",
+        successEvent: "GDC.DASH/EVT.INSIGHT_WIDGET.FILTER_SETTINGS_CHANGED",
+        onSuccess: (event) => {
+            dispatch(uiActions.setWidgetLoadingAdditionalDataStopped(event.payload.ref));
+        },
+        onError: (event: DashboardCommandFailed<ChangeInsightWidgetFilterSettings>) => {
+            dispatch(uiActions.setWidgetLoadingAdditionalDataStopped(event.payload.command.payload.ref));
+        },
+    });
 
     const { run: replaceInsightOntoPlaceholder } = useDashboardCommandProcessing({
         commandCreator: replaceSectionItem,
@@ -27,6 +42,8 @@ export function useInsightListItemDropHandler() {
             const ref = event.payload.items[0].widget!.ref;
             dispatch(uiActions.selectWidget(ref));
             dispatch(uiActions.setConfigurationPanelOpened(true));
+            dispatch(uiActions.setWidgetLoadingAdditionalDataStarted(ref));
+            preselectDateDataset(ref, "default");
         },
     });
 

--- a/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/useKpiPlaceholderDropHandler.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/useKpiPlaceholderDropHandler.ts
@@ -24,10 +24,12 @@ export function useKpiPlaceholderDropHandler() {
         commandCreator: replaceSectionItem,
         errorEvent: "GDC.DASH/EVT.COMMAND.FAILED",
         successEvent: "GDC.DASH/EVT.FLUID_LAYOUT.ITEM_REPLACED",
-        onSuccess: () => {
+        onSuccess: (event) => {
+            const ref = event.payload.items[0].widget!.ref;
             dispatch(uiActions.selectWidget(idRef(KPI_PLACEHOLDER_WIDGET_ID)));
             dispatch(uiActions.setConfigurationPanelOpened(true));
             dispatch(uiActions.setKpiDateDatasetAutoOpen(true));
+            dispatch(uiActions.setWidgetLoadingAdditionalDataStarted(ref));
         },
     });
 

--- a/libs/sdk-ui-dashboard/src/presentation/widget/common/configuration/DateDatasetFilter.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/common/configuration/DateDatasetFilter.tsx
@@ -19,6 +19,7 @@ interface IDateDatasetFilterProps {
     dateFromVisualization?: ICatalogDateDataset;
     dateFilterCheckboxDisabled: boolean;
     shouldPickDateDataset?: boolean;
+    isLoadingAdditionalData?: boolean;
     onDateDatasetChanged?: (id: string) => void;
 }
 
@@ -31,6 +32,7 @@ export const DateDatasetFilter: React.FC<IDateDatasetFilterProps> = (props) => {
         isDatasetsLoading,
         shouldPickDateDataset,
         onDateDatasetChanged,
+        isLoadingAdditionalData,
     } = props;
 
     const catalogDatasetsMap = useDashboardSelector(selectAllCatalogDateDatasetsMap);
@@ -40,7 +42,7 @@ export const DateDatasetFilter: React.FC<IDateDatasetFilterProps> = (props) => {
         useIsSelectedDatasetHidden(selectedDateDataset?.dataSet.ref);
 
     const [isDateFilterEnabled, setIsDateFilterEnabled] = useState(
-        !!widget.dateDataSet || shouldPickDateDataset,
+        !!widget.dateDataSet || shouldPickDateDataset || isLoadingAdditionalData,
     );
 
     const {

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/configuration/InsightDateDataSetFilter.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/configuration/InsightDateDataSetFilter.tsx
@@ -27,12 +27,14 @@
 // } from "../../modules/Widgets";
 import React, { useEffect } from "react";
 import { DateDatasetFilter } from "../../common";
-import { IInsightWidget, isInsightWidget } from "@gooddata/sdk-model";
+import { IInsightWidget, isInsightWidget, widgetRef } from "@gooddata/sdk-model";
 import {
     MeasureDateDatasets,
     queryDateDatasetsForInsight,
     QueryInsightDateDatasets,
+    selectIsWidgetLoadingAdditionalDataByWidgetRef,
     useDashboardQueryProcessing,
+    useDashboardSelector,
 } from "../../../../model";
 
 export interface IConfigurationPanelProps {
@@ -52,6 +54,10 @@ export default function InsightDateDataSetFilter({ widget }: IConfigurationPanel
         queryCreator: queryDateDatasetsForInsight,
     });
 
+    const isLoadingAdditionalData = useDashboardSelector(
+        selectIsWidgetLoadingAdditionalDataByWidgetRef(widgetRef(widget)),
+    );
+
     useEffect(() => {
         queryDateDatasets(widget.insight);
     }, [queryDateDatasets, widget.insight]);
@@ -61,8 +67,9 @@ export default function InsightDateDataSetFilter({ widget }: IConfigurationPanel
             <DateDatasetFilter
                 widget={widget}
                 dateFilterCheckboxDisabled={false}
-                isDatasetsLoading={status === "running" || status === "pending"}
+                isDatasetsLoading={status === "running" || status === "pending" || isLoadingAdditionalData}
                 relatedDateDatasets={result?.dateDatasetsOrdered}
+                isLoadingAdditionalData={isLoadingAdditionalData}
             />
         );
     }

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insightMenu/DefaultDashboardInsightMenu/DashboardInsightMenu/index.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insightMenu/DefaultDashboardInsightMenu/DashboardInsightMenu/index.tsx
@@ -21,7 +21,7 @@ const DashboardInsightMenuBody: React.FC<IDashboardInsightMenuProps> = (props) =
             title={submenu.itemName}
             onBack={() => setSubmenu(null)}
         >
-            <DashboardInsightMenuSubmenu submenu={submenu} setSubmenu={setSubmenu} />
+            <submenu.SubmenuComponent widget={widget} />
         </DashboardInsightSubmenuContainer>
     ) : (
         <DashboardInsightMenuContainer onClose={onClose} widget={widget}>
@@ -78,12 +78,4 @@ const DashboardInsightMenuRoot: React.FC<DashboardInsightMenuRootProps> = ({ ite
             })}
         </>
     );
-};
-
-type DashboardInsightMenuSubmenuProps = {
-    submenu: IInsightMenuSubmenu;
-    setSubmenu: React.Dispatch<React.SetStateAction<IInsightMenuSubmenu | null>>;
-};
-const DashboardInsightMenuSubmenu: React.FC<DashboardInsightMenuSubmenuProps> = ({ submenu }) => {
-    return <>{submenu.renderSubmenu()}</>;
 };

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insightMenu/DefaultDashboardInsightMenu/getDefaultInsightEditMenuItems.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insightMenu/DefaultDashboardInsightMenu/getDefaultInsightEditMenuItems.ts
@@ -1,23 +1,15 @@
 // (C) 2021-2022 GoodData Corporation
 import { IntlShape } from "react-intl";
-import { IInsightWidget } from "@gooddata/sdk-model";
 import compact from "lodash/compact";
 
 import { IInsightMenuItem } from "../types";
-import { createInsightConfigurationScreen } from "../../insight/configuration/InsightConfiguration";
-import { createInsightInteractionsScreen } from "../../insight/configuration/InsightInteractions";
+import { InsightConfiguration } from "../../insight/configuration/InsightConfiguration";
+import { InsightInteractions } from "../../insight/configuration/InsightInteractions";
 
 /**
  * @internal
  */
-export function getDefaultInsightEditMenuItems(
-    intl: IntlShape,
-    config: {
-        widget: IInsightWidget;
-    },
-): IInsightMenuItem[] {
-    const { widget } = config;
-
+export function getDefaultInsightEditMenuItems(intl: IntlShape): IInsightMenuItem[] {
     return compact([
         {
             type: "submenu",
@@ -27,7 +19,7 @@ export function getDefaultInsightEditMenuItems(
             icon: "gd-icon-settings",
             disabled: false,
             className: "s-configuration-panel-submenu",
-            renderSubmenu: () => createInsightConfigurationScreen(widget),
+            SubmenuComponent: InsightConfiguration,
         },
         {
             type: "submenu",
@@ -37,7 +29,7 @@ export function getDefaultInsightEditMenuItems(
             icon: "gd-icon-settings",
             disabled: false,
             className: "s-configuration-panel-submenu",
-            renderSubmenu: () => createInsightInteractionsScreen(widget),
+            SubmenuComponent: InsightInteractions,
         },
     ]);
 }

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insightMenu/types.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insightMenu/types.ts
@@ -40,7 +40,7 @@ export interface IInsightMenuSubmenu {
     type: "submenu";
     itemId: string;
     itemName: string;
-    renderSubmenu: () => JSX.Element;
+    SubmenuComponent: ComponentType<{ widget: IInsightWidget }>;
     /**
      * If specified, the value is shown on hover of the item as a tooltip.
      */

--- a/libs/sdk-ui-dashboard/src/presentation/widget/widget/InsightWidget/useEditableInsightMenu.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/widget/InsightWidget/useEditableInsightMenu.ts
@@ -21,10 +21,8 @@ export const useEditableInsightMenu = (
 
     const { insightMenuItemsProvider } = useDashboardCustomizationsContext();
     const defaultMenuItems = useMemo<IInsightMenuItem[]>(() => {
-        return getDefaultInsightEditMenuItems(intl, {
-            widget,
-        });
-    }, [widget, intl]);
+        return getDefaultInsightEditMenuItems(intl);
+    }, [intl]);
 
     const menuItems = useMemo<IInsightMenuItem[]>(() => {
         return insightMenuItemsProvider


### PR DESCRIPTION
* Extend the FilterOpEnableDateFilter and related commands with the option to preselect the default date dataset.
* Use this new command to preselect the default date dataset after a widget is added (we are not using the autoResolveDateDataset flag because it would decrease the perceived speed of the UI: it would add a delay between dropping the widget and the widget actually appearing).
* Simplify submenu definition to make sure it is always rendered with up to date version of the widget object.
 
---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
