### PR TITLE
RELATED: FET-1116 Remove node-sass and node-sass-magic-importer

### DIFF
--- a/common/config/rush/browser-approved-packages.json
+++ b/common/config/rush/browser-approved-packages.json
@@ -835,14 +835,6 @@
       "allowedCategories": [ "production" ]
     },
     {
-      "name": "node-sass",
-      "allowedCategories": [ "production", "tools" ]
-    },
-    {
-      "name": "node-sass-magic-importer",
-      "allowedCategories": [ "production", "tools" ]
-    },
-    {
       "name": "normalize.css",
       "allowedCategories": [ "production" ]
     },

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -6433,17 +6433,6 @@ packages:
       - supports-color
     dev: false
 
-  /agentkeepalive/4.2.1:
-    resolution: {integrity: sha512-Zn4cw2NEqd+9fiSVWMscnjyQ1a8Yfoc5oBajLeo5w+YBHgDUcEBY2hS4YpTz6iN5f/2zQiktcuM6tS8x1p9dpA==}
-    engines: {node: '>= 8.0.0'}
-    dependencies:
-      debug: 4.3.4
-      depd: 1.1.2
-      humanize-ms: 1.2.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
   /aggregate-error/3.1.0:
     resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}
     engines: {node: '>=8'}
@@ -6687,14 +6676,6 @@ packages:
       readable-stream: 3.6.0
     dev: false
 
-  /are-we-there-yet/3.0.0:
-    resolution: {integrity: sha512-0GWpv50YSOcLXaN6/FAKY3vfRbllXWV2xvfA/oKJF8pzFhWXPV+yjhJXDBbjscDYowv7Yw1A3uigpzn5iEGTyw==}
-    engines: {node: ^12.13.0 || ^14.15.0 || >=16}
-    dependencies:
-      delegates: 1.0.0
-      readable-stream: 3.6.0
-    dev: false
-
   /arg/4.1.3:
     resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
     dev: false
@@ -6924,10 +6905,6 @@ packages:
     resolution: {integrity: sha512-oVmpzk0eaqZ022vPnkYHS/GaZO0y1B2DwB6rInNYg/1Rc+2hs0oUushzYFkizUyDpBY0PbEJ/RoCkJyAbrNluw==}
     dependencies:
       rimraf: 2.7.1
-    dev: false
-
-  /async-foreach/0.1.3:
-    resolution: {integrity: sha512-VUeSMD8nEGBWaZK4lizI1sf3yEC7pnAQ/mrI7pC2fBz2s/tq5jWWEngTwaf0Gruu/OoXRGLGg1XFqpYBiGTYJA==}
     dev: false
 
   /async-limiter/1.0.1:
@@ -7806,13 +7783,6 @@ packages:
     engines: {node: '>=6'}
     dev: false
 
-  /camel-case/3.0.0:
-    resolution: {integrity: sha512-+MbKztAYHXPr1jNTSKQF52VpcFjwY5RkR7fxksV8Doo4KAYc5Fl4UJRgthBbTmEx8C54DqahhbLJkDwjI3PI/w==}
-    dependencies:
-      no-case: 2.3.2
-      upper-case: 1.1.3
-    dev: false
-
   /camel-case/4.1.2:
     resolution: {integrity: sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==}
     dependencies:
@@ -7930,29 +7900,6 @@ packages:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
-    dev: false
-
-  /change-case/3.1.0:
-    resolution: {integrity: sha512-2AZp7uJZbYEzRPsFoa+ijKdvp9zsrnnt6+yFokfwEpeJm0xuJDVoxiRCAaTzyJND8GJkofo2IcKWaUZ/OECVzw==}
-    dependencies:
-      camel-case: 3.0.0
-      constant-case: 2.0.0
-      dot-case: 2.1.1
-      header-case: 1.0.1
-      is-lower-case: 1.1.3
-      is-upper-case: 1.1.2
-      lower-case: 1.1.4
-      lower-case-first: 1.0.2
-      no-case: 2.3.2
-      param-case: 2.1.1
-      pascal-case: 2.0.1
-      path-case: 2.1.1
-      sentence-case: 2.1.1
-      snake-case: 2.1.0
-      swap-case: 1.1.2
-      title-case: 2.1.1
-      upper-case: 1.1.3
-      upper-case-first: 1.1.2
     dev: false
 
   /char-regex/1.0.2:
@@ -8588,13 +8535,6 @@ packages:
       easy-table: 1.1.0
     dev: false
 
-  /constant-case/2.0.0:
-    resolution: {integrity: sha512-eS0N9WwmjTqrOmR3o83F5vW8Z+9R1HnVz3xmzT2PMFug9ly+Au/fxRWlEBSb6LcZwspSsEn9Xs1uw9YgzAg1EQ==}
-    dependencies:
-      snake-case: 2.1.0
-      upper-case: 1.1.3
-    dev: false
-
   /constants-browserify/1.0.0:
     resolution: {integrity: sha512-xFxOwqIzR/e1k1gLiWEophSCMqXcwVHIH7akf7b/vxcUeGunlj3hvZaaqxwHsTgn+IndtkQJgSztIDWeumWJDQ==}
     dev: false
@@ -8912,13 +8852,6 @@ packages:
     resolution: {integrity: sha512-COtn4EROW5dBGlE/4PiKnh6rZpAPxDeFLaEEwt4i10jpDMFt2EhQGS79QmmrO+iKCHv0PU/HrOWEhijFd1x99Q==}
     dev: false
 
-  /css-node-extract/2.1.3:
-    resolution: {integrity: sha512-E7CzbC0I4uAs2dI8mPCVe+K37xuja5kjIugOotpwICFL7vzhmFMAPHvS/MF9gFrmv8DDUANsxrgyT/I3OLukcw==}
-    dependencies:
-      change-case: 3.1.0
-      postcss: 6.0.23
-    dev: false
-
   /css-select/4.3.0:
     resolution: {integrity: sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==}
     dependencies:
@@ -8927,12 +8860,6 @@ packages:
       domhandler: 4.3.1
       domutils: 2.8.0
       nth-check: 2.0.1
-    dev: false
-
-  /css-selector-extract/3.3.6:
-    resolution: {integrity: sha512-bBI8ZJKKyR9iHvxXb4t3E6WTMkis94eINopVg7y2FmmMjLXUVduD7mPEcADi4i9FX4wOypFMFpySX+0keuefxg==}
-    dependencies:
-      postcss: 6.0.23
     dev: false
 
   /css-tree/1.1.3:
@@ -9463,11 +9390,6 @@ packages:
       repeat-string: 1.6.1
     dev: false
 
-  /detect-file/1.0.0:
-    resolution: {integrity: sha512-DtCOLG98P007x7wiiOmfI0fi3eIKyWiLTGJ2MDnVi/E04lWGbf+JzrRHMm0rgIIZJGtHpKpbVgLWHrv8xXpc3Q==}
-    engines: {node: '>=0.10.0'}
-    dev: false
-
   /detect-newline/3.1.0:
     resolution: {integrity: sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==}
     engines: {node: '>=8'}
@@ -9656,12 +9578,6 @@ packages:
       domhandler: 4.3.1
     dev: false
 
-  /dot-case/2.1.1:
-    resolution: {integrity: sha512-HnM6ZlFqcajLsyudHq7LeeLDr2rFAVYtDv/hV5qchQEidSck8j9OPUsXY9KwJv/lHMtYlX4DjRQqwFYa+0r8Ug==}
-    dependencies:
-      no-case: 2.3.2
-    dev: false
-
   /dot-case/3.0.4:
     resolution: {integrity: sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==}
     dependencies:
@@ -9823,14 +9739,6 @@ packages:
     engines: {node: '>= 0.8'}
     dev: false
 
-  /encoding/0.1.13:
-    resolution: {integrity: sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==}
-    requiresBuild: true
-    dependencies:
-      iconv-lite: 0.6.3
-    dev: false
-    optional: true
-
   /end-of-stream/1.4.4:
     resolution: {integrity: sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==}
     dependencies:
@@ -9890,11 +9798,6 @@ packages:
 
   /entities/2.2.0:
     resolution: {integrity: sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==}
-    dev: false
-
-  /env-paths/2.2.1:
-    resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
-    engines: {node: '>=6'}
     dev: false
 
   /envinfo/7.8.1:
@@ -9957,10 +9860,6 @@ packages:
       raf: 3.4.1
       rst-selector-parser: 2.2.3
       string.prototype.trim: 1.2.5
-    dev: false
-
-  /err-code/2.0.3:
-    resolution: {integrity: sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==}
     dev: false
 
   /errno/0.1.8:
@@ -10575,13 +10474,6 @@ packages:
       to-regex: 3.0.2
     dev: false
 
-  /expand-tilde/2.0.2:
-    resolution: {integrity: sha512-A5EmesHW6rfnZ9ysHQjPdJRni0SRar0tjtG5MNtm9n5TUvsYU8oozprtRD4AqHxcZWWlVuAmQo2nWKfN9oyjTw==}
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      homedir-polyfill: 1.0.3
-    dev: false
-
   /expect/27.5.1:
     resolution: {integrity: sha512-E1q5hSUG2AmYQwQJ041nvgpkODHQvB+RKlB4IYdru6uJsyFTRyZAP463M+1lINorwbqAmUggi6+WwkD8lCS/Dw==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
@@ -10978,16 +10870,6 @@ packages:
       path-exists: 4.0.0
     dev: false
 
-  /findup-sync/3.0.0:
-    resolution: {integrity: sha512-YbffarhcicEhOrm4CtrwdKBdCuz576RLdhJDsIfvNtxUuhdRet1qZcsMjqbePtAseKdAnDyM/IyXbu7PRPRLYg==}
-    engines: {node: '>= 0.10'}
-    dependencies:
-      detect-file: 1.0.0
-      is-glob: 4.0.3
-      micromatch: 3.1.10
-      resolve-dir: 1.0.1
-    dev: false
-
   /fixed-data-table-2/1.2.6_react-dom@17.0.2+react@17.0.2:
     resolution: {integrity: sha512-fieKB2SXIJil4WSXEW6+5C58zOsDq6PdghYr13urIhgog0gncePuanoYyr/z7ZJepeGDrF6cU9Tmai8YyXa4Tw==}
     peerDependencies:
@@ -11372,27 +11254,6 @@ packages:
       wide-align: 1.1.5
     dev: false
 
-  /gauge/4.0.4:
-    resolution: {integrity: sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==}
-    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
-    dependencies:
-      aproba: 2.0.0
-      color-support: 1.1.3
-      console-control-strings: 1.1.0
-      has-unicode: 2.0.1
-      signal-exit: 3.0.7
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-      wide-align: 1.1.5
-    dev: false
-
-  /gaze/1.1.3:
-    resolution: {integrity: sha512-BRdNm8hbWzFzWHERTrejLqwHDfS4GibPoq5wjTPIoJHoBtKGPg3xAFfxmM+9ztbXelxcf2hwQcaz1PtmFeue8g==}
-    engines: {node: '>= 4.0.0'}
-    dependencies:
-      globule: 1.3.3
-    dev: false
-
   /gensync/1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
@@ -11551,17 +11412,6 @@ packages:
       path-is-absolute: 1.0.1
     dev: false
 
-  /glob/7.1.7:
-    resolution: {integrity: sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==}
-    dependencies:
-      fs.realpath: 1.0.0
-      inflight: 1.0.6
-      inherits: 2.0.4
-      minimatch: 3.1.2
-      once: 1.4.0
-      path-is-absolute: 1.0.1
-    dev: false
-
   /glob/7.2.0:
     resolution: {integrity: sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==}
     dependencies:
@@ -11591,31 +11441,11 @@ packages:
       ini: 2.0.0
     dev: false
 
-  /global-modules/1.0.0:
-    resolution: {integrity: sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==}
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      global-prefix: 1.0.2
-      is-windows: 1.0.2
-      resolve-dir: 1.0.1
-    dev: false
-
   /global-modules/2.0.0:
     resolution: {integrity: sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==}
     engines: {node: '>=6'}
     dependencies:
       global-prefix: 3.0.0
-    dev: false
-
-  /global-prefix/1.0.2:
-    resolution: {integrity: sha512-5lsx1NUDHtSjfg0eHlmYvZKv8/nVqX4ckFbM+FrGcQ+04KWcWFo9P5MxPZYSzUvyzmdTbI7Eix8Q4IbELDqzKg==}
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      expand-tilde: 2.0.2
-      homedir-polyfill: 1.0.3
-      ini: 1.3.8
-      is-windows: 1.0.2
-      which: 1.3.1
     dev: false
 
   /global-prefix/3.0.0:
@@ -11719,15 +11549,6 @@ packages:
     resolution: {integrity: sha512-xYfnw62CKG8nLkZBfWbhWwDw02CHty86jfPcc2cr3ZfeuK9ysoVPPEUxf21bAD/rWAgk52SuBrLJlefNy8mvFg==}
     dev: false
 
-  /globule/1.3.3:
-    resolution: {integrity: sha512-mb1aYtDbIjTu4ShMB85m3UzjX9BVKe9WCzsnfMSZk+K5GpIbBOexgg4PPCt5eHDEG5/ZQAUX2Kct02zfiPLsKg==}
-    engines: {node: '>= 0.10'}
-    dependencies:
-      glob: 7.1.7
-      lodash: 4.17.21
-      minimatch: 3.0.8
-    dev: false
-
   /gonzales-pe/4.3.0:
     resolution: {integrity: sha512-otgSPpUmdWJ43VXyiNgEYE4luzHCL2pz4wQ0OnDluC6Eg4Ko3Vexy/SrSynglw/eR+OhkzmqFCZa/OFa/RgAOQ==}
     engines: {node: '>=0.6.0'}
@@ -11820,20 +11641,6 @@ packages:
       wordwrap: 1.0.0
     optionalDependencies:
       uglify-js: 3.15.3
-    dev: false
-
-  /har-schema/2.0.0:
-    resolution: {integrity: sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==}
-    engines: {node: '>=4'}
-    dev: false
-
-  /har-validator/5.1.5:
-    resolution: {integrity: sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==}
-    engines: {node: '>=6'}
-    deprecated: this library is no longer supported
-    dependencies:
-      ajv: 6.12.6
-      har-schema: 2.0.0
     dev: false
 
   /hard-rejection/2.1.0:
@@ -12021,13 +11828,6 @@ packages:
     hasBin: true
     dev: false
 
-  /header-case/1.0.1:
-    resolution: {integrity: sha512-i0q9mkOeSuhXw6bGgiQCCBgY/jlZuV/7dZXyZ9c6LcBrqwvT8eT719E9uxE5LiZftdl+z81Ugbg/VvXV4OJOeQ==}
-    dependencies:
-      no-case: 2.3.2
-      upper-case: 1.1.3
-    dev: false
-
   /here/0.0.2:
     resolution: {integrity: sha1-acGvPwISHz2HiOAuhNyLOQXXEZU=}
     dev: false
@@ -12172,13 +11972,6 @@ packages:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
     dependencies:
       react-is: 16.13.1
-    dev: false
-
-  /homedir-polyfill/1.0.3:
-    resolution: {integrity: sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==}
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      parse-passwd: 1.0.0
     dev: false
 
   /hosted-git-info/2.8.9:
@@ -12447,15 +12240,6 @@ packages:
       - debug
     dev: false
 
-  /http-signature/1.2.0:
-    resolution: {integrity: sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==}
-    engines: {node: '>=0.8', npm: '>=1.3.7'}
-    dependencies:
-      assert-plus: 1.0.0
-      jsprim: 1.4.2
-      sshpk: 1.17.0
-    dev: false
-
   /http-signature/1.3.6:
     resolution: {integrity: sha512-3adrsD6zqo4GsTqtO7FyrejHNv+NgiIfAfv68+jVlFmSr9OGy7zrxONceFRLKvnnZA5jbxQBX1u9PpB6Wi32Gw==}
     engines: {node: '>=0.10'}
@@ -12495,12 +12279,6 @@ packages:
 
   /humanize-duration/3.27.1:
     resolution: {integrity: sha512-jCVkMl+EaM80rrMrAPl96SGG4NRac53UyI1o/yAzebDntEY6K6/Fj2HOjdPg8omTqIe5Y0wPBai2q5xXrIbarA==}
-    dev: false
-
-  /humanize-ms/1.2.1:
-    resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
-    dependencies:
-      ms: 2.1.3
     dev: false
 
   /hyperlinker/1.0.0:
@@ -13087,16 +12865,6 @@ packages:
     resolution: {integrity: sha512-18toSebUVF7y717dgw/Dzn6djOCqrkiDp3MhB8P6TdKyCVkbD1ZwE7Uz8Hwx6hUPTvKjbyYH9ncXT4ts4qLaSA==}
     dev: false
 
-  /is-lambda/1.0.1:
-    resolution: {integrity: sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==}
-    dev: false
-
-  /is-lower-case/1.1.3:
-    resolution: {integrity: sha512-+5A1e/WJpLLXZEDlgz4G//WYSHyQBD32qa4Jd3Lw06qQlv3fJHnp3YIHjTQSGzHMgzmVKz2ZP3rBxTHkPw/lxA==}
-    dependencies:
-      lower-case: 1.1.4
-    dev: false
-
   /is-map/2.0.2:
     resolution: {integrity: sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg==}
     dev: false
@@ -13287,12 +13055,6 @@ packages:
   /is-unicode-supported/0.1.0:
     resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
     engines: {node: '>=10'}
-    dev: false
-
-  /is-upper-case/1.1.2:
-    resolution: {integrity: sha512-GQYSJMgfeAmVwh9ixyk888l7OIhNAGKtY6QA+IrWlu9MDTCaXmeozOZ2S9Knj7bQwBO/H6J2kb+pbyTUiMNbsw==}
-    dependencies:
-      upper-case: 1.1.3
     dev: false
 
   /is-url/1.2.4:
@@ -14007,10 +13769,6 @@ packages:
       '@sideway/pinpoint': 2.0.0
     dev: false
 
-  /js-base64/2.6.4:
-    resolution: {integrity: sha512-pZe//GGmwJndub7ZghVHz7vjb2LgC1m8B07Au3eYqeqv9emhESByMXxaEgkUkEqJe87oBbSniGYoQNIBklc7IQ==}
-    dev: false
-
   /js-object-pretty-print/0.2.0:
     resolution: {integrity: sha512-hMmBRDYcWQ1Kq2qa+Q8eFEtEOvop+Il1ZEoYDkbk+hcb24Cx0QudI/IJf76Tuv9Wli9pGj5MmvKh2inrdD7C3g==}
     dev: false
@@ -14224,16 +13982,6 @@ packages:
       lodash.once: 4.1.1
       ms: 2.1.3
       semver: 5.7.1
-    dev: false
-
-  /jsprim/1.4.2:
-    resolution: {integrity: sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==}
-    engines: {node: '>=0.6.0'}
-    dependencies:
-      assert-plus: 1.0.0
-      extsprintf: 1.3.0
-      json-schema: 0.4.0
-      verror: 1.10.0
     dev: false
 
   /jsprim/2.0.2:
@@ -14750,16 +14498,6 @@ packages:
       signal-exit: 3.0.7
     dev: false
 
-  /lower-case-first/1.0.2:
-    resolution: {integrity: sha512-UuxaYakO7XeONbKrZf5FEgkantPf5DUqDayzP5VXZrtRPdH86s4kN47I8B3TW10S4QKiE3ziHNf3kRN//okHjA==}
-    dependencies:
-      lower-case: 1.1.4
-    dev: false
-
-  /lower-case/1.1.4:
-    resolution: {integrity: sha512-2Fgx1Ycm599x+WGpIYwJOvsjmXFzTSc34IwDWALRA/8AopUKAVPwfJ+h5+f85BCp0PWmmJcWzEpxOpoXycMpdA==}
-    dev: false
-
   /lower-case/2.0.2:
     resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
     dependencies:
@@ -14838,30 +14576,6 @@ packages:
 
   /make-error/1.3.6:
     resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
-    dev: false
-
-  /make-fetch-happen/9.1.0:
-    resolution: {integrity: sha512-+zopwDy7DNknmwPQplem5lAZX/eCOzSvSNNcSKm5eVwTkOBzoktEfXsa9L23J/GIRhxRsaxzkPEhrJEpE2F4Gg==}
-    engines: {node: '>= 10'}
-    dependencies:
-      agentkeepalive: 4.2.1
-      cacache: 15.3.0
-      http-cache-semantics: 4.1.0
-      http-proxy-agent: 4.0.1
-      https-proxy-agent: 5.0.0
-      is-lambda: 1.0.1
-      lru-cache: 6.0.0
-      minipass: 3.1.6
-      minipass-collect: 1.0.2
-      minipass-fetch: 1.4.1
-      minipass-flush: 1.0.5
-      minipass-pipeline: 1.2.4
-      negotiator: 0.6.3
-      promise-retry: 2.0.1
-      socks-proxy-agent: 6.1.1
-      ssri: 8.0.1
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /makeerror/1.0.12:
@@ -15270,12 +14984,6 @@ packages:
     resolution: {integrity: sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==}
     dev: false
 
-  /minimatch/3.0.8:
-    resolution: {integrity: sha512-6FsRAQsxQ61mw+qP1ZzbL9Bc78x2p5OqNgNpnoAFLTrX8n5Kxph0CsnhmKKNXTWjXqU5L0pGPR7hYk+XWZr60Q==}
-    dependencies:
-      brace-expansion: 1.1.11
-    dev: false
-
   /minimatch/3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
     dependencies:
@@ -15309,17 +15017,6 @@ packages:
       minipass: 3.1.6
     dev: false
 
-  /minipass-fetch/1.4.1:
-    resolution: {integrity: sha512-CGH1eblLq26Y15+Azk7ey4xh0J/XfJfrCox5LDJiKqI2Q2iwOLOKrlmIaODiSQS8d18jalF6y2K2ePUm0CmShw==}
-    engines: {node: '>=8'}
-    dependencies:
-      minipass: 3.1.6
-      minipass-sized: 1.0.3
-      minizlib: 2.1.2
-    optionalDependencies:
-      encoding: 0.1.13
-    dev: false
-
   /minipass-flush/1.0.5:
     resolution: {integrity: sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==}
     engines: {node: '>= 8'}
@@ -15329,13 +15026,6 @@ packages:
 
   /minipass-pipeline/1.2.4:
     resolution: {integrity: sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==}
-    engines: {node: '>=8'}
-    dependencies:
-      minipass: 3.1.6
-    dev: false
-
-  /minipass-sized/1.0.3:
-    resolution: {integrity: sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==}
     engines: {node: '>=8'}
     dependencies:
       minipass: 3.1.6
@@ -15496,6 +15186,7 @@ packages:
   /nan/2.15.0:
     resolution: {integrity: sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==}
     dev: false
+    optional: true
 
   /nanoclone/0.2.1:
     resolution: {integrity: sha512-wynEP02LmIbLpcYw8uBKpcfF6dmg2vcpKqxeH5UcoKEYdExslsdUA4ugFauuaeYdTB76ez6gJW8XAZ6CgkXYxA==}
@@ -15577,12 +15268,6 @@ packages:
     resolution: {integrity: sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==}
     dev: false
 
-  /no-case/2.3.2:
-    resolution: {integrity: sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==}
-    dependencies:
-      lower-case: 1.1.4
-    dev: false
-
   /no-case/3.0.4:
     resolution: {integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==}
     dependencies:
@@ -15617,25 +15302,6 @@ packages:
   /node-forge/1.3.1:
     resolution: {integrity: sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==}
     engines: {node: '>= 6.13.0'}
-    dev: false
-
-  /node-gyp/8.4.1:
-    resolution: {integrity: sha512-olTJRgUtAb/hOXG0E93wZDs5YiJlgbXxTwQAFHyNlRsXQnYzUaF2aGgujZbw+hR8aF4ZG/rST57bWMWD16jr9w==}
-    engines: {node: '>= 10.12.0'}
-    hasBin: true
-    dependencies:
-      env-paths: 2.2.1
-      glob: 7.2.0
-      graceful-fs: 4.2.10
-      make-fetch-happen: 9.1.0
-      nopt: 5.0.0
-      npmlog: 6.0.1
-      rimraf: 3.0.2
-      semver: 7.3.6
-      tar: 6.1.11
-      which: 2.0.2
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /node-int64/0.4.0:
@@ -15695,58 +15361,12 @@ packages:
     resolution: {integrity: sha512-XxYDdcQ6eKqp/YjI+tb2C5WM2LgjnZrfYg4vgQt49EK268b6gYCHsBLrK2qvJo4FmCtqmKezb0WZFK4fkrZNsg==}
     dev: false
 
-  /node-sass-magic-importer/5.3.2:
-    resolution: {integrity: sha512-T3wTUdUoXQE3QN+EsyPpUXRI1Gj1lEsrySQ9Kzlzi15QGKi+uRa9fmvkcSy2y3BKgoj//7Mt9+s+7p0poMpg6Q==}
-    engines: {node: '>=6.11.1', npm: '>=3.0.0'}
-    dependencies:
-      css-node-extract: 2.1.3
-      css-selector-extract: 3.3.6
-      findup-sync: 3.0.0
-      glob: 7.2.0
-      object-hash: 1.3.1
-      postcss-scss: 2.1.1
-      resolve: 1.22.0
-    dev: false
-
-  /node-sass/7.0.1:
-    resolution: {integrity: sha512-uMy+Xt29NlqKCFdFRZyXKOTqGt+QaKHexv9STj2WeLottnlqZEEWx6Bj0MXNthmFRRdM/YwyNo/8Tr46TOM0jQ==}
-    engines: {node: '>=12'}
-    hasBin: true
-    requiresBuild: true
-    dependencies:
-      async-foreach: 0.1.3
-      chalk: 4.1.2
-      cross-spawn: 7.0.3
-      gaze: 1.1.3
-      get-stdin: 4.0.1
-      glob: 7.2.0
-      lodash: 4.17.21
-      meow: 9.0.0
-      nan: 2.15.0
-      node-gyp: 8.4.1
-      npmlog: 5.0.1
-      request: 2.88.2
-      sass-graph: 4.0.0
-      stdout-stream: 1.4.1
-      true-case-path: 1.0.3
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
   /nopt/4.0.3:
     resolution: {integrity: sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==}
     hasBin: true
     dependencies:
       abbrev: 1.1.1
       osenv: 0.1.5
-    dev: false
-
-  /nopt/5.0.0:
-    resolution: {integrity: sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==}
-    engines: {node: '>=6'}
-    hasBin: true
-    dependencies:
-      abbrev: 1.1.1
     dev: false
 
   /normalize-package-data/2.5.0:
@@ -15854,16 +15474,6 @@ packages:
       set-blocking: 2.0.0
     dev: false
 
-  /npmlog/6.0.1:
-    resolution: {integrity: sha512-BTHDvY6nrRHuRfyjt1MAufLxYdVXZfd099H4+i1f0lPywNQyI4foeNXJRObB/uy+TYqUW0vAD9gbdSOXPst7Eg==}
-    engines: {node: ^12.13.0 || ^14.15.0 || >=16}
-    dependencies:
-      are-we-there-yet: 3.0.0
-      console-control-strings: 1.1.0
-      gauge: 4.0.4
-      set-blocking: 2.0.0
-    dev: false
-
   /nth-check/2.0.1:
     resolution: {integrity: sha512-it1vE95zF6dTT9lBsYbxvqh0Soy4SPowchj0UBGj/V6cTPnXXtQOPUbhZ6CmGzAD/rW22LQK6E96pcdJXk4A4w==}
     dependencies:
@@ -15883,10 +15493,6 @@ packages:
     resolution: {integrity: sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==}
     dev: false
 
-  /oauth-sign/0.9.0:
-    resolution: {integrity: sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==}
-    dev: false
-
   /object-assign/4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -15899,11 +15505,6 @@ packages:
       copy-descriptor: 0.1.1
       define-property: 0.2.5
       kind-of: 3.2.2
-    dev: false
-
-  /object-hash/1.3.1:
-    resolution: {integrity: sha512-OSuu/pU4ENM9kmREg0BdNrUDIl1heYa4mBZacJc+vVWz4GtAwu7jO8s4AIt2aGRUTqxykpWzI3Oqnsm13tTMDA==}
-    engines: {node: '>= 0.10.0'}
     dev: false
 
   /object-hash/2.2.0:
@@ -16318,12 +15919,6 @@ packages:
       readable-stream: 2.3.7
     dev: false
 
-  /param-case/2.1.1:
-    resolution: {integrity: sha512-eQE845L6ot89sk2N8liD8HAuH4ca6Vvr7VWAWwt7+kvvG5aBcPmmphQ68JsEG2qa9n1TykS2DLeMt363AAH8/w==}
-    dependencies:
-      no-case: 2.3.2
-    dev: false
-
   /param-case/3.0.4:
     resolution: {integrity: sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==}
     dependencies:
@@ -16385,11 +15980,6 @@ packages:
       lines-and-columns: 1.2.4
     dev: false
 
-  /parse-passwd/1.0.0:
-    resolution: {integrity: sha512-1Y1A//QUXEZK7YKz+rD9WydcE1+EuPr6ZBgKecAB8tmoW6UFv0NREVJe1p+jRxtThkcbbKkfwIbWJe/IeE6m2Q==}
-    engines: {node: '>=0.10.0'}
-    dev: false
-
   /parse5-htmlparser2-tree-adapter/6.0.1:
     resolution: {integrity: sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==}
     dependencies:
@@ -16411,13 +16001,6 @@ packages:
   /parseurl/1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
-    dev: false
-
-  /pascal-case/2.0.1:
-    resolution: {integrity: sha512-qjS4s8rBOJa2Xm0jmxXiyh1+OFf6ekCWOvUaRgAQSktzlTbMotS0nmG9gyYAybCWBcuP4fsBeRCKNwGBnMe2OQ==}
-    dependencies:
-      camel-case: 3.0.0
-      upper-case-first: 1.1.2
     dev: false
 
   /pascal-case/3.1.2:
@@ -16445,12 +16028,6 @@ packages:
 
   /path-browserify/1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
-    dev: false
-
-  /path-case/2.1.1:
-    resolution: {integrity: sha512-Ou0N05MioItesaLr9q8TtHVWmJ6fxWdqKB2RohFmNWVyJ+2zeKIeDNWAN6B/Pe7wpzWChhZX6nONYmOnMeJQ/Q==}
-    dependencies:
-      no-case: 2.3.2
     dev: false
 
   /path-dirname/1.0.2:
@@ -16886,15 +16463,6 @@ packages:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
     dev: false
 
-  /postcss/6.0.23:
-    resolution: {integrity: sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==}
-    engines: {node: '>=4.0.0'}
-    dependencies:
-      chalk: 2.4.2
-      source-map: 0.6.1
-      supports-color: 5.5.0
-    dev: false
-
   /postcss/7.0.39:
     resolution: {integrity: sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==}
     engines: {node: '>=6.0.0'}
@@ -17038,14 +16606,6 @@ packages:
 
   /promise-inflight/1.0.1:
     resolution: {integrity: sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==}
-    dev: false
-
-  /promise-retry/2.0.1:
-    resolution: {integrity: sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==}
-    engines: {node: '>=10'}
-    dependencies:
-      err-code: 2.0.3
-      retry: 0.12.0
     dev: false
 
   /promise.allsettled/1.0.5:
@@ -18298,33 +17858,6 @@ packages:
       throttleit: 1.0.0
     dev: false
 
-  /request/2.88.2:
-    resolution: {integrity: sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==}
-    engines: {node: '>= 6'}
-    deprecated: request has been deprecated, see https://github.com/request/request/issues/3142
-    dependencies:
-      aws-sign2: 0.7.0
-      aws4: 1.11.0
-      caseless: 0.12.0
-      combined-stream: 1.0.8
-      extend: 3.0.2
-      forever-agent: 0.6.1
-      form-data: 2.3.3
-      har-validator: 5.1.5
-      http-signature: 1.2.0
-      is-typedarray: 1.0.0
-      isstream: 0.1.2
-      json-stringify-safe: 5.0.1
-      mime-types: 2.1.35
-      oauth-sign: 0.9.0
-      performance-now: 2.1.0
-      qs: 6.5.3
-      safe-buffer: 5.2.1
-      tough-cookie: 2.5.0
-      tunnel-agent: 0.6.0
-      uuid: 3.4.0
-    dev: false
-
   /require-directory/2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
@@ -18368,14 +17901,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       resolve-from: 5.0.0
-    dev: false
-
-  /resolve-dir/1.0.1:
-    resolution: {integrity: sha512-R7uiTjECzvOsWSfdM0QKFNBVFcK27aHOUwdvK53BcW8zqnGdYp0Fbj82cy54+2A4P2tFM22J5kRfe1R+lM/1yg==}
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      expand-tilde: 2.0.2
-      global-modules: 1.0.0
     dev: false
 
   /resolve-from/2.0.0:
@@ -18467,11 +17992,6 @@ packages:
   /ret/0.1.15:
     resolution: {integrity: sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==}
     engines: {node: '>=0.12'}
-    dev: false
-
-  /retry/0.12.0:
-    resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
-    engines: {node: '>= 4'}
     dev: false
 
   /retry/0.13.1:
@@ -18602,17 +18122,6 @@ packages:
       truncate-utf8-bytes: 1.0.2
     dev: false
 
-  /sass-graph/4.0.0:
-    resolution: {integrity: sha512-WSO/MfXqKH7/TS8RdkCX3lVkPFQzCgbqdGsmSKq6tlPU+GpGEsa/5aW18JqItnqh+lPtcjifqdZ/VmiILkKckQ==}
-    engines: {node: '>=12'}
-    hasBin: true
-    dependencies:
-      glob: 7.2.0
-      lodash: 4.17.21
-      scss-tokenizer: 0.3.0
-      yargs: 17.4.0
-    dev: false
-
   /sass-loader/10.2.1:
     resolution: {integrity: sha512-RRvWl+3K2LSMezIsd008ErK4rk6CulIMSwrcc2aZvjymUgKo/vjXGp1rSWmfTUX7bblEOz8tst4wBwWtCGBqKA==}
     engines: {node: '>= 10.13.0'}
@@ -18634,32 +18143,6 @@ packages:
       neo-async: 2.6.2
       schema-utils: 3.1.1
       semver: 7.3.6
-    dev: false
-
-  /sass-loader/10.2.1_89732cc13ea2438c8063d0d8ede18dbd:
-    resolution: {integrity: sha512-RRvWl+3K2LSMezIsd008ErK4rk6CulIMSwrcc2aZvjymUgKo/vjXGp1rSWmfTUX7bblEOz8tst4wBwWtCGBqKA==}
-    engines: {node: '>= 10.13.0'}
-    peerDependencies:
-      fibers: '>= 3.1.0'
-      node-sass: ^4.0.0 || ^5.0.0 || ^6.0.0
-      sass: ^1.3.0
-      webpack: ^4.36.0 || ^5.0.0
-    peerDependenciesMeta:
-      fibers:
-        optional: true
-      node-sass:
-        optional: true
-      sass:
-        optional: true
-    dependencies:
-      klona: 2.0.5
-      loader-utils: 2.0.2
-      neo-async: 2.6.2
-      node-sass: 7.0.1
-      sass: 1.53.0
-      schema-utils: 3.1.1
-      semver: 7.3.6
-      webpack: 5.72.0_webpack-cli@4.9.2
     dev: false
 
   /sass-loader/10.2.1_sass@1.53.0+webpack@5.72.0:
@@ -18769,13 +18252,6 @@ packages:
       regexpp: 3.2.0
     dev: false
 
-  /scss-tokenizer/0.3.0:
-    resolution: {integrity: sha512-14Zl9GcbBvOT9057ZKjpz5yPOyUWG2ojd9D5io28wHRYsOrs7U95Q+KNL87+32p8rc+LvDpbu/i9ZYjM9Q+FsQ==}
-    dependencies:
-      js-base64: 2.6.4
-      source-map: 0.7.3
-    dev: false
-
   /select-hose/2.0.0:
     resolution: {integrity: sha512-mEugaLK+YfkijB4fx0e6kImuJdCIt2LxCRcbEYPqRGCs4F2ogyfZU5IAZRdjCP8JPq2AtdNoC/Dux63d9Kiryg==}
     dev: false
@@ -18844,13 +18320,6 @@ packages:
       on-finished: 2.3.0
       range-parser: 1.2.1
       statuses: 1.5.0
-    dev: false
-
-  /sentence-case/2.1.1:
-    resolution: {integrity: sha512-ENl7cYHaK/Ktwk5OTD+aDbQ3uC8IByu/6Bkg+HDv8Mm+XnBnppVNalcfJTNsp1ibstKh030/JKQQWglDvtKwEQ==}
-    dependencies:
-      no-case: 2.3.2
-      upper-case-first: 1.1.2
     dev: false
 
   /serialize-javascript/4.0.0:
@@ -19044,23 +18513,12 @@ packages:
       is-fullwidth-code-point: 3.0.0
     dev: false
 
-  /smart-buffer/4.2.0:
-    resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
-    engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
-    dev: false
-
   /smooth-progress/1.1.0:
     resolution: {integrity: sha512-3+v5J4HzdBTcC0RLU6mxVa4t7lojUOxwRZu6f2XngR9u4d6sWDaOc909fCj7gnpf6NV0spJYPIBQYzZUQzG0iA==}
     engines: {node: '>= 4.0.0'}
     dependencies:
       ansi-escapes: 1.4.0
       chalk: 1.1.3
-    dev: false
-
-  /snake-case/2.1.0:
-    resolution: {integrity: sha512-FMR5YoPFwOLuh4rRz92dywJjyKYZNLpMn1R5ujVpIYkbA9p01fq8RMg0FkO4M+Yobt4MjHeLTJVm5xFFBHSV2Q==}
-    dependencies:
-      no-case: 2.3.2
     dev: false
 
   /snapdragon-node/2.1.1:
@@ -19099,25 +18557,6 @@ packages:
       faye-websocket: 0.11.4
       uuid: 8.3.2
       websocket-driver: 0.7.4
-    dev: false
-
-  /socks-proxy-agent/6.1.1:
-    resolution: {integrity: sha512-t8J0kG3csjA4g6FTbsMOWws+7R7vuRC8aQ/wy3/1OWmsgwA68zs/+cExQ0koSitUDXqhufF/YJr9wtNMZHw5Ew==}
-    engines: {node: '>= 10'}
-    dependencies:
-      agent-base: 6.0.2
-      debug: 4.3.4
-      socks: 2.6.2
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /socks/2.6.2:
-    resolution: {integrity: sha512-zDZhHhZRY9PxRruRMR7kMhnf3I8hDs4S3f9RecfnGxvcBHQcKcIH/oUcEWffsfl1XxdYlA7nnlGbbTvPz9D8gA==}
-    engines: {node: '>= 10.13.0', npm: '>= 3.0.0'}
-    dependencies:
-      ip: 1.1.5
-      smart-buffer: 4.2.0
     dev: false
 
   /sort-keys/2.0.0:
@@ -19417,12 +18856,6 @@ packages:
   /statuses/1.5.0:
     resolution: {integrity: sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==}
     engines: {node: '>= 0.6'}
-    dev: false
-
-  /stdout-stream/1.4.1:
-    resolution: {integrity: sha512-j4emi03KXqJWcIeF8eIXkjMFN1Cmb8gUlDYGeBALLPo5qdyTfA9bOtl8m33lRoC+vFMkP3gl0WsDr6+gzxbbTA==}
-    dependencies:
-      readable-stream: 2.3.7
     dev: false
 
   /store2/2.13.2:
@@ -19967,13 +19400,6 @@ packages:
       stable: 0.1.8
     dev: false
 
-  /swap-case/1.1.2:
-    resolution: {integrity: sha512-BAmWG6/bx8syfc6qXPprof3Mn5vQgf5dwdUNJhsNqU9WdPt5P+ES/wQ5bxfijy8zwZgZZHslC3iAsxsuQMCzJQ==}
-    dependencies:
-      lower-case: 1.1.4
-      upper-case: 1.1.3
-    dev: false
-
   /symbol-tree/3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
     dev: false
@@ -20467,13 +19893,6 @@ packages:
     resolution: {integrity: sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA==}
     dev: false
 
-  /title-case/2.1.1:
-    resolution: {integrity: sha512-EkJoZ2O3zdCz3zJsYCsxyq2OC5hrxR9mfdd5I+w8h/tmFfeOxJ+vvkxsKxdmN0WtS9zLdHEgfgVOiMVgv+Po4Q==}
-    dependencies:
-      no-case: 2.3.2
-      upper-case: 1.1.3
-    dev: false
-
   /tmp-promise/1.1.0:
     resolution: {integrity: sha512-8+Ah9aB1IRXCnIOxXZ0uFozV1nMU5xiu7hhFVUSxZ3bYu+psD4TzagCzVbexUCgNNGJnsmNDQlS4nG3mTyoNkw==}
     dependencies:
@@ -20646,12 +20065,6 @@ packages:
 
   /trough/1.0.5:
     resolution: {integrity: sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==}
-    dev: false
-
-  /true-case-path/1.0.3:
-    resolution: {integrity: sha512-m6s2OdQe5wgpFMC+pAJ+q9djG82O2jcHPOI6RNg1yy9rCYR+WD6Nbpl32fDpfC56nirdRy+opFa/Vk7HYhqaew==}
-    dependencies:
-      glob: 7.2.0
     dev: false
 
   /true-myth/2.2.3:
@@ -21200,16 +20613,6 @@ packages:
     engines: {node: '>=4'}
     dev: false
     optional: true
-
-  /upper-case-first/1.1.2:
-    resolution: {integrity: sha512-wINKYvI3Db8dtjikdAqoBbZoP6Q+PZUyfMR7pmwHzjC2quzSkUq5DmPrTtPEqHaz8AGtmsB4TqwapMTM1QAQOQ==}
-    dependencies:
-      upper-case: 1.1.3
-    dev: false
-
-  /upper-case/1.1.3:
-    resolution: {integrity: sha512-WRbjgmYzgXkCV7zNVpy5YgrHgbBv126rMALQQMrmzOVC4GM2waQ9x7xtm8VU+1yF2kWyPzI9zbZ48n4vSxwfSA==}
-    dev: false
 
   /uri-js/4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
@@ -22326,11 +21729,6 @@ packages:
     engines: {node: '>=10'}
     dev: false
 
-  /yargs-parser/21.0.1:
-    resolution: {integrity: sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==}
-    engines: {node: '>=12'}
-    dev: false
-
   /yargs/16.2.0:
     resolution: {integrity: sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==}
     engines: {node: '>=10'}
@@ -22342,19 +21740,6 @@ packages:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 20.2.9
-    dev: false
-
-  /yargs/17.4.0:
-    resolution: {integrity: sha512-WJudfrk81yWFSOkZYpAZx4Nt7V4xp7S/uJkX0CnxovMCt1wCE8LNftPpNuF9X/u9gN5nsD7ycYtRcDf2pL3UiA==}
-    engines: {node: '>=12'}
-    dependencies:
-      cliui: 7.0.4
-      escalade: 3.1.1
-      get-caller-file: 2.0.5
-      require-directory: 2.1.1
-      string-width: 4.2.3
-      y18n: 5.0.8
-      yargs-parser: 21.0.1
     dev: false
 
   /yarn/1.22.18:
@@ -22411,7 +21796,7 @@ packages:
     dev: false
 
   file:projects/api-client-bear.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-MPpc3o3l544SZDOKyfXKPZxUUguhVGrZRI90zJe8K8mLyDsGUS17BgICOcVOylJwpzo7AYXPi8kC2HLgrDTARg==, tarball: file:projects/api-client-bear.tgz}
+    resolution: {integrity: sha512-RdwSArq76LsOldTkj+61DacuKAMBtxOPr6HTeqgo6xjGQTLvPzRMzVe7FjKE9ycdUTkFhfW69Vt17w8gHE44OQ==, tarball: file:projects/api-client-bear.tgz}
     id: file:projects/api-client-bear.tgz
     name: '@rush-temp/api-client-bear'
     version: 0.0.0
@@ -22479,7 +21864,7 @@ packages:
     dev: false
 
   file:projects/api-client-tiger.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-g9CaZwSWq3oFd+sozK/LMVO+7Ckk/xvCPV6Uqwz3StqjYain3X4t6ktrVrblLNvFvjt3gmItDeYvXSDT7eiBJA==, tarball: file:projects/api-client-tiger.tgz}
+    resolution: {integrity: sha512-zVpCzYDUjV3Hy8bs/ekDA6E7h005F15ZPTv9JfGSVo5r6YFW5R4Mqi62BxfvyyGTOhZt2/ProaJ9/pdDVuEuoA==, tarball: file:projects/api-client-tiger.tgz}
     id: file:projects/api-client-tiger.tgz
     name: '@rush-temp/api-client-tiger'
     version: 0.0.0
@@ -22632,7 +22017,7 @@ packages:
     dev: false
 
   file:projects/catalog-export.tgz:
-    resolution: {integrity: sha512-alBRhIQEZWYWkSu7E4L0ufLu4g9k27vSEjb44/t8B05Lcqcspsiw726dR2kLky60vgL5oZOIBlt4oHUgnXfApQ==, tarball: file:projects/catalog-export.tgz}
+    resolution: {integrity: sha512-3HCtuvOIqOOWRpTFMuOo02wyvLj3LB/3JFc8bWWodQSUgf+pcx0KEqCZrOleHUyh1v/SyFfboqON9C9CLRgGfw==, tarball: file:projects/catalog-export.tgz}
     name: '@rush-temp/catalog-export'
     version: 0.0.0
     dependencies:
@@ -22687,7 +22072,7 @@ packages:
     dev: false
 
   file:projects/dashboard-plugin-template.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-VD1Wvuv7eXl1vJu9mglXt6wQHKG8z/Ew13evOTaPG09vaAiSe8QkWNoTjQRSegiBxpM5oJNX7fmLr2zRImBb3Q==, tarball: file:projects/dashboard-plugin-template.tgz}
+    resolution: {integrity: sha512-7jBM81hGDkBObyO3u9nsl7zro9iATYRLJNAB0Eb9LWdGcH6vpgE8CQ1qyfOCWdjuhcl8hLjGcQVRUXq20sjCCQ==, tarball: file:projects/dashboard-plugin-template.tgz}
     id: file:projects/dashboard-plugin-template.tgz
     name: '@rush-temp/dashboard-plugin-template'
     version: 0.0.0
@@ -22766,7 +22151,7 @@ packages:
     dev: false
 
   file:projects/dashboard-plugin-tests.tgz:
-    resolution: {integrity: sha512-tPo6P35D3Z5EJNqudDmeRlN16CkGK4/F1YmkjQ1T4eN9guf4kcziG6K8sRct/w1rH1Wn1kYodUn3vZ7gwiNlTw==, tarball: file:projects/dashboard-plugin-tests.tgz}
+    resolution: {integrity: sha512-2dazOAb3SYGlYm4PKqxrZOnlHUyVmej770jTvmW2PkCXTgaKUNrnwZOK51/ZLmH8TqdxqvAMTgrF135Bnj/gFQ==, tarball: file:projects/dashboard-plugin-tests.tgz}
     name: '@rush-temp/dashboard-plugin-tests'
     version: 0.0.0
     dependencies:
@@ -22824,8 +22209,6 @@ packages:
       jest-enzyme: 7.1.2_4c874ea13312c50d8c9b996ca71028db
       jest-junit: 3.7.0
       lodash: 4.17.21
-      node-sass: 7.0.1
-      node-sass-magic-importer: 5.3.2
       prettier: 2.5.1
       raf: 3.4.1
       react: 17.0.2
@@ -22859,7 +22242,7 @@ packages:
     dev: false
 
   file:projects/experimental-workspace.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-LonuTcpq0yR2G70snlkCwdr3pJVpNqocJgMSUNmybTDndHMs/NVexKFaPuxHDdC1A2uv67YuBOv31hgEadSPaQ==, tarball: file:projects/experimental-workspace.tgz}
+    resolution: {integrity: sha512-iSULcnFOJAagZ9hZluLyE1uOov30vzv1ir4vU8GM37Ri910fExs8ZIeGYbGPVJsHCBvKwUqSKePq9du64Mg4Wg==, tarball: file:projects/experimental-workspace.tgz}
     id: file:projects/experimental-workspace.tgz
     name: '@rush-temp/experimental-workspace'
     version: 0.0.0
@@ -22957,7 +22340,7 @@ packages:
     dev: false
 
   file:projects/live-examples-workspace.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-I11OguUKYMCyr2A20mErfAch77JnwxEcd/CDv7DKaEQ1xxiLZU4gN8GWC60KAVBepZoX6uCRVOXlFgiFAaFV1g==, tarball: file:projects/live-examples-workspace.tgz}
+    resolution: {integrity: sha512-i/uvrz4A4YIdknhJV5rLeKIuim9+kIENJazSKoNtWsSs09ih1Llvqy9rdulP8bjwagpssTzejSYy4FB4L/K+YA==, tarball: file:projects/live-examples-workspace.tgz}
     id: file:projects/live-examples-workspace.tgz
     name: '@rush-temp/live-examples-workspace'
     version: 0.0.0
@@ -22999,7 +22382,7 @@ packages:
     dev: false
 
   file:projects/mock-handling.tgz:
-    resolution: {integrity: sha512-TCignnPdks+kyi/Ue8btpXFkDfokvAb9egGDjEDotmDzuIZv0ccakJdJ9VIx/wRTqA1xQzlqFaV511gepgcLUg==, tarball: file:projects/mock-handling.tgz}
+    resolution: {integrity: sha512-9Wt6liBd0N5L5wvmyUaF1+rp8g36w/yZBVtW349xXoQj1Kz//zWeKNz068gic3aJkBqADSlnzLyCT99u54TwxQ==, tarball: file:projects/mock-handling.tgz}
     name: '@rush-temp/mock-handling'
     version: 0.0.0
     dependencies:
@@ -23054,7 +22437,7 @@ packages:
     dev: false
 
   file:projects/playground.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-ip5mW4zMlui4BykaSwUVqyllSg1X9sLSiWQ6QQfJuw3k+2aUq8cRE+Uia03vHFpq8oGP96djBmzwsPG3pf7Yzg==, tarball: file:projects/playground.tgz}
+    resolution: {integrity: sha512-WNMHTGxTe+cXOsPOxfFCfrDjMTerjRQbqsM7CmROPPch16jmTHMjo3BnVuQERrD/z5THBQra/QRtqpTqLYxzNw==, tarball: file:projects/playground.tgz}
     id: file:projects/playground.tgz
     name: '@rush-temp/playground'
     version: 0.0.0
@@ -23140,7 +22523,7 @@ packages:
     dev: false
 
   file:projects/plugin-toolkit.tgz:
-    resolution: {integrity: sha512-P6cN1aVyysy9SST3Li1ADuV+yxOwEBj5xlLTS2D8vlM7b/rmFbYh/xRQLf2eFpiVSZhR86ciVkZv+p7W++FkWQ==, tarball: file:projects/plugin-toolkit.tgz}
+    resolution: {integrity: sha512-II/WWYp/2pYJ4YZhPwNeI4hNp09Hai5xtC5kMvagcRljz38kqyp0hFIbltQHqcJFhOx1VDxjZ2z9TPF91vrNWQ==, tarball: file:projects/plugin-toolkit.tgz}
     name: '@rush-temp/plugin-toolkit'
     version: 0.0.0
     dependencies:
@@ -23205,7 +22588,7 @@ packages:
     dev: false
 
   file:projects/reference-workspace-mgmt.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-1/RGZ0EGSCIeY39GmyCoZY5i7SFbNPUHTJz/Kzm8d9zGKwwDaa+8Yzn8FAawa4yzQDMEIcqRNch4D+fhFZRLlw==, tarball: file:projects/reference-workspace-mgmt.tgz}
+    resolution: {integrity: sha512-idJsO6GRBqwv4tZcdvw2wyn0GkQDwmpvsb396to49JnE1R5MQ1uIRwRcHTciPAJePNe8mgZxYplrIqsk6Nsnqg==, tarball: file:projects/reference-workspace-mgmt.tgz}
     id: file:projects/reference-workspace-mgmt.tgz
     name: '@rush-temp/reference-workspace-mgmt'
     version: 0.0.0
@@ -23246,7 +22629,7 @@ packages:
     dev: false
 
   file:projects/reference-workspace.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-ORT6tgHkDHD/SzzSchkbUuqqkzdmFMDueaUaELF0GC7HHsGVfz55GeVrQUX/nhn5r38ADS2gaWZWHOCaztfzbw==, tarball: file:projects/reference-workspace.tgz}
+    resolution: {integrity: sha512-XheiRHR5QLMUv2TLoqUyDKHKDgCWzSoD2M3PfV/voioUQ6QLQ5mmDgofn6x6BXafpO2qC26KjcI4tdrA345Xew==, tarball: file:projects/reference-workspace.tgz}
     id: file:projects/reference-workspace.tgz
     name: '@rush-temp/reference-workspace'
     version: 0.0.0
@@ -23288,7 +22671,7 @@ packages:
     dev: false
 
   file:projects/sdk-backend-base.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-nHtLGk+WYQvDlSmih0UhGtMxYtF7DywLos6Iv0FtJoOKHdF/IVIuvCyJfSoyuvW1Um+TJWc0ZDJ/6VRSOGWB9Q==, tarball: file:projects/sdk-backend-base.tgz}
+    resolution: {integrity: sha512-SUCDbRkqnhclf3Swktn3Wcp78KD66ExDibVvDJdYHCpVBj3NOGseXZtsnb8xx6eQyXCvb1EhCRkQ8qoiu6WpJA==, tarball: file:projects/sdk-backend-base.tgz}
     id: file:projects/sdk-backend-base.tgz
     name: '@rush-temp/sdk-backend-base'
     version: 0.0.0
@@ -23340,7 +22723,7 @@ packages:
     dev: false
 
   file:projects/sdk-backend-bear.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-61bBfxZuKX3qgNDcGjTRHAGE6F1I6/LbxE1ySFr0eejD9dVKoTjE30jkk9rKMBkrV08mdsHhB5k3Z0bqoRsrKw==, tarball: file:projects/sdk-backend-bear.tgz}
+    resolution: {integrity: sha512-ZxtEaiVKiVJ3awyOWpdD1mdye4ARqpJnod/5twTw03MdGesnEQb1fZw7LdtDQSzNXau/7ETgEeYu/TdBVDiNlA==, tarball: file:projects/sdk-backend-bear.tgz}
     id: file:projects/sdk-backend-bear.tgz
     name: '@rush-temp/sdk-backend-bear'
     version: 0.0.0
@@ -23394,7 +22777,7 @@ packages:
     dev: false
 
   file:projects/sdk-backend-mockingbird.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-id+7FXlSzUdvBoy7tQp6Erd6zRTHF8Z2HvSP0LRrnkViOjb6akOSYCNffKRMfq9cnXtZIZZLVJ2GwJo2v4bMgQ==, tarball: file:projects/sdk-backend-mockingbird.tgz}
+    resolution: {integrity: sha512-bC7uQqCAEXJkUHymqusaVNkD+0EHRBFfwuEW0n41oU19KaOWDR71VnHpva3Q2ywGWrToAxgP1byvtilzdusB0g==, tarball: file:projects/sdk-backend-mockingbird.tgz}
     id: file:projects/sdk-backend-mockingbird.tgz
     name: '@rush-temp/sdk-backend-mockingbird'
     version: 0.0.0
@@ -23441,7 +22824,7 @@ packages:
     dev: false
 
   file:projects/sdk-backend-spi.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-9JiXLLMMbU9X19oJ6Hv78aVwGuSSz4QyrpyQTH87pdJxenIWupQ1ASrUnW5lKYMzwA4fsKZeRKjLNe/1isWUaw==, tarball: file:projects/sdk-backend-spi.tgz}
+    resolution: {integrity: sha512-K4SyHyl+sSPsEnNVS/1Wuoh8zmalMoAhgSgwJuj8Hj2nnsuJVwKUQXTj01271gf91KKv02IDSDKYiBU4li1LJw==, tarball: file:projects/sdk-backend-spi.tgz}
     id: file:projects/sdk-backend-spi.tgz
     name: '@rush-temp/sdk-backend-spi'
     version: 0.0.0
@@ -23486,7 +22869,7 @@ packages:
     dev: false
 
   file:projects/sdk-backend-tiger.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-cn8SMkI5yMcl1EKPcF2Oy7fflSE1AX4CJIhlDv62wA7flgaWUosDYvaiBZQpURBhBslgsu5iTpIaMF4tmsxsSg==, tarball: file:projects/sdk-backend-tiger.tgz}
+    resolution: {integrity: sha512-9Ztr6pOppR4Wp2nEKLY07syTKqUwSw19Pw/bPpOMrdPsDgPSEQjo3757KpqI+RBUlJY1+7AENPy/2cwMO6QCVg==, tarball: file:projects/sdk-backend-tiger.tgz}
     id: file:projects/sdk-backend-tiger.tgz
     name: '@rush-temp/sdk-backend-tiger'
     version: 0.0.0
@@ -23539,7 +22922,7 @@ packages:
     dev: false
 
   file:projects/sdk-embedding.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-ql7ukwiKb0LxXJ/rjSYjGK9M4SjXa60uO2mw49lKakC0YbTLhaqoZ/Fk+ZlLbuVyp/RteHIzKFstaDONGspvww==, tarball: file:projects/sdk-embedding.tgz}
+    resolution: {integrity: sha512-SbiQMqMVQGc6QaHcQSDh8tBK26So7EFTl6f8il0gHOo/fnSRQ8Czg9RZ8UQd4WRSIlZ4yKZyc7jEBnPT17Tb2Q==, tarball: file:projects/sdk-embedding.tgz}
     id: file:projects/sdk-embedding.tgz
     name: '@rush-temp/sdk-embedding'
     version: 0.0.0
@@ -23584,7 +22967,7 @@ packages:
     dev: false
 
   file:projects/sdk-examples.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-VZA7cR03sdCVxEncGzHCIVXKlue+1l2OLKQjuq/ycIJjplrLEvc8Sw99MJmZvufPuizlph+9ZljaS/OlZleDzg==, tarball: file:projects/sdk-examples.tgz}
+    resolution: {integrity: sha512-zsRtWr1ppHMlJFX5R95MIdZJUhM9ojYuKNGPLMSusR9D0zJSUsmbX70HAkRTS+J3FQlM7kAftb/mnm6/goZHNg==, tarball: file:projects/sdk-examples.tgz}
     id: file:projects/sdk-examples.tgz
     name: '@rush-temp/sdk-examples'
     version: 0.0.0
@@ -23795,7 +23178,7 @@ packages:
     dev: false
 
   file:projects/sdk-skel-tsx.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-fqITTLPNO0lUwCA5QX+FJOA9GUb0cJP8w48d7qYvHHUMbkz9pbuJRG4Wq4IfKKQ5iQn3ws46JfqGxGtlwR9mgA==, tarball: file:projects/sdk-skel-tsx.tgz}
+    resolution: {integrity: sha512-9OKMQ+P3Ff3m9rq1FUEzRSFoREs9ZrDFe/oRuTKN6sBRUPuIUbQPhtKxFHeoevIdsk9TkiWu/p4SaoUF+UjEaA==, tarball: file:projects/sdk-skel-tsx.tgz}
     id: file:projects/sdk-skel-tsx.tgz
     name: '@rush-temp/sdk-skel-tsx'
     version: 0.0.0
@@ -23830,8 +23213,6 @@ packages:
       jest-enzyme: 7.1.2_4c874ea13312c50d8c9b996ca71028db
       jest-junit: 3.7.0
       lodash: 4.17.21
-      node-sass: 7.0.1
-      node-sass-magic-importer: 5.3.2
       prettier: 2.5.1
       raf: 3.4.1
       react: 17.0.2
@@ -23854,7 +23235,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-all.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-nXBf60ToY1LaGWTgx0+c5J4p5O7ioDhDFMx1X3Z5J21Q4YJaalzvuufdcbgWiUqrUl1Q6ryleYKMotzyDFuqug==, tarball: file:projects/sdk-ui-all.tgz}
+    resolution: {integrity: sha512-+NCYMYeFb5U6VeJzUTmfBV3xiyZ2gQewM+hOgQphPA4v4OOlQOCvbBK9vyO6zMQyY4Y39JCKG5bU1OFG1LSePw==, tarball: file:projects/sdk-ui-all.tgz}
     id: file:projects/sdk-ui-all.tgz
     name: '@rush-temp/sdk-ui-all'
     version: 0.0.0
@@ -23896,7 +23277,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-charts.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-lG2sx0k+NTf8WDiBhvbA/DvEYF5FEbWV6j0VSdpeOL91JXnpgZp3kOHz/5KU00zg/vc2Bmg3Kfd3TKTJOZpZMg==, tarball: file:projects/sdk-ui-charts.tgz}
+    resolution: {integrity: sha512-tz8Z/ck3QI/e9geR3kU1ekKFGfSYTbv7ttUTsV2kldUysug9WpiQgcPb2I8VqT7tkFBPw/DOxyX9fRQS3iaENQ==, tarball: file:projects/sdk-ui-charts.tgz}
     id: file:projects/sdk-ui-charts.tgz
     name: '@rush-temp/sdk-ui-charts'
     version: 0.0.0
@@ -23942,8 +23323,6 @@ packages:
       jest-enzyme: 7.1.2_4c874ea13312c50d8c9b996ca71028db
       jest-junit: 3.7.0
       lodash: 4.17.21
-      node-sass: 7.0.1
-      node-sass-magic-importer: 5.3.2
       polished: 3.7.2
       prettier: 2.5.1
       raf: 3.4.1
@@ -23975,7 +23354,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-dashboard.tgz_a7e570fd5a4985262571d64f4bc94b86:
-    resolution: {integrity: sha512-4RkFWYOofl+pnHhFAYoH1m3VIVF2BCWuDBHHihu8MVQWbo4c1LlULOdG9kW4Nr00RUMKmvywEZpB7mxbLwoEkA==, tarball: file:projects/sdk-ui-dashboard.tgz}
+    resolution: {integrity: sha512-btqQOLz7K7yEggY55UGnEK/3SXew5sqnyyy44cUDikW7SdILNlKe+oVQANMrRvAegEGWI57dGx13FewFOvJyew==, tarball: file:projects/sdk-ui-dashboard.tgz}
     id: file:projects/sdk-ui-dashboard.tgz
     name: '@rush-temp/sdk-ui-dashboard'
     version: 0.0.0
@@ -24023,8 +23402,6 @@ packages:
       jest-junit: 3.7.0
       json-stable-stringify: 1.0.1
       lodash: 4.17.21
-      node-sass: 7.0.1
-      node-sass-magic-importer: 5.3.2
       normalize.css: 8.0.1
       prettier: 2.5.1
       raf: 3.4.1
@@ -24069,7 +23446,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-ext.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-8HOgj+SL9zVZ5nVNWCZbBr9KKrNH13q+L0U3olEHDqzpFWtW+rCimq2UqVoKtVEtS9Q61MCINVe192t5aDOtpA==, tarball: file:projects/sdk-ui-ext.tgz}
+    resolution: {integrity: sha512-USDIvskPotohq/bbIUXwzeOM6gkJg1zOrzpFghQdB5h8g0Mvm2wWkIbeCPloA9RPWnCTECOxGeIh8a0TJlgikw==, tarball: file:projects/sdk-ui-ext.tgz}
     id: file:projects/sdk-ui-ext.tgz
     name: '@rush-temp/sdk-ui-ext'
     version: 0.0.0
@@ -24122,8 +23499,6 @@ packages:
       jest-enzyme: 7.1.2_4c874ea13312c50d8c9b996ca71028db
       jest-junit: 3.7.0
       lodash: 4.17.21
-      node-sass: 7.0.1
-      node-sass-magic-importer: 5.3.2
       prettier: 2.5.1
       raf: 3.4.1
       react: 17.0.2
@@ -24158,7 +23533,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-filters.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-jneltyTEt36udRzmSltNcqMkKRCwBBqoggWwa9IPZC8VsxAOT1nu11yMUnTE2/LFgFHLTQKmxM51se7imiXAQw==, tarball: file:projects/sdk-ui-filters.tgz}
+    resolution: {integrity: sha512-nLtUxlpd9aFP6i4hvwIwAFeXDH84aVPP4Cdk9jrbtjQArl8CXglCdl5ZpU6zlqkockknuAMws0m9uvBdko7P/w==, tarball: file:projects/sdk-ui-filters.tgz}
     id: file:projects/sdk-ui-filters.tgz
     name: '@rush-temp/sdk-ui-filters'
     version: 0.0.0
@@ -24207,8 +23582,6 @@ packages:
       json-stable-stringify: 1.0.1
       lodash: 4.17.21
       moment: 2.29.2
-      node-sass: 7.0.1
-      node-sass-magic-importer: 5.3.2
       prettier: 2.5.1
       raf: 3.4.1
       react: 17.0.2
@@ -24243,7 +23616,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-geo.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-szFgMDYNMjs4Wj7XgcPLzmcJ9wfuOWiitPRyZzfsLHSfebre1J7dUG1nVUsRHO6B5Knw8xbBmbqy2a8+GSA7mg==, tarball: file:projects/sdk-ui-geo.tgz}
+    resolution: {integrity: sha512-eqiB/UFqVEdZlAQhktwxWylTAHPaM3jJVb0b5d6FrP9PYKb6BDL9gQH1fYhqjG5tQCOs6SaufJ6zkG06EZOHBA==, tarball: file:projects/sdk-ui-geo.tgz}
     id: file:projects/sdk-ui-geo.tgz
     name: '@rush-temp/sdk-ui-geo'
     version: 0.0.0
@@ -24285,8 +23658,6 @@ packages:
       jest-junit: 3.7.0
       lodash: 4.17.21
       mapbox-gl: 2.8.0
-      node-sass: 7.0.1
-      node-sass-magic-importer: 5.3.2
       prettier: 2.5.1
       raf: 3.4.1
       react: 17.0.2
@@ -24316,7 +23687,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-kit.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-DVd62bEONF6FGZ9IUz0eTnvZEqqmGnzjl9ul5SUZST2A+0j6ceK+6i8cYbKfzy/KePfJNutK0msZ3aez9S5gKg==, tarball: file:projects/sdk-ui-kit.tgz}
+    resolution: {integrity: sha512-4Ww2lNItOACyuBFJW5wdNbzP6QfKsIPhXyKUGOOFBk+tDp3S6VJAq4sbQD4ETY+7jf6d0L5tTuCAAQ7JRqv1/w==, tarball: file:projects/sdk-ui-kit.tgz}
     id: file:projects/sdk-ui-kit.tgz
     name: '@rush-temp/sdk-ui-kit'
     version: 0.0.0
@@ -24381,8 +23752,6 @@ packages:
       lodash: 4.17.21
       moment: 2.29.2
       moment-timezone: 0.5.34
-      node-sass: 7.0.1
-      node-sass-magic-importer: 5.3.2
       prettier: 2.5.1
       raf: 3.4.1
       react: 17.0.2
@@ -24423,7 +23792,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-loaders.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-ENYHKjHGjMDBMxiTAcFTe9CTUU8qRd69r/r626rmzM1/2BGIIDufaSy6xbCO79IKxPinAyux3B8BK8jf9Wbqqg==, tarball: file:projects/sdk-ui-loaders.tgz}
+    resolution: {integrity: sha512-CluR1cEsfMWrhjUSRI2tYUpR/jLJ665yr+D9ZmTPA0sZhsJq4nljAgHJp2rZF5HP152KbTPDf+MYqN21IKqdfA==, tarball: file:projects/sdk-ui-loaders.tgz}
     id: file:projects/sdk-ui-loaders.tgz
     name: '@rush-temp/sdk-ui-loaders'
     version: 0.0.0
@@ -24459,8 +23828,6 @@ packages:
       jest-enzyme: 7.1.2_4c874ea13312c50d8c9b996ca71028db
       jest-junit: 3.7.0
       lodash: 4.17.21
-      node-sass: 7.0.1
-      node-sass-magic-importer: 5.3.2
       prettier: 2.5.1
       raf: 3.4.1
       react: 17.0.2
@@ -24485,7 +23852,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-pivot.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-Y7N7ClSEcy8AMfWcsEg5bOEvxFa9qB1UEJ7nqVLO3zIQoLQqp/X8ONTmL7Ywpf7lQFTwt5rA39RuXHFYzC9O8w==, tarball: file:projects/sdk-ui-pivot.tgz}
+    resolution: {integrity: sha512-fxNVGtgMCfBq9BsYEMC3NY2Mj3XeW7aWLQBZKKGwxPFG3rNlbCl1OjVeKPp9uMhSKqvLd3zTdfjM4z1W1agHQg==, tarball: file:projects/sdk-ui-pivot.tgz}
     id: file:projects/sdk-ui-pivot.tgz
     name: '@rush-temp/sdk-ui-pivot'
     version: 0.0.0
@@ -24530,8 +23897,6 @@ packages:
       jest-enzyme: 7.1.2_4c874ea13312c50d8c9b996ca71028db
       jest-junit: 3.7.0
       lodash: 4.17.21
-      node-sass: 7.0.1
-      node-sass-magic-importer: 5.3.2
       prettier: 2.5.1
       raf: 3.4.1
       react: 17.0.2
@@ -24561,7 +23926,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-tests-e2e.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-mxf7lDh6XezozwNSo3zzmcxGmwJPRBqGwX+1p/fcPGINa/+qVtMuMRMLSobvaQ3570kSk84XY2rSwUFWm4W1RA==, tarball: file:projects/sdk-ui-tests-e2e.tgz}
+    resolution: {integrity: sha512-ShBJvg/1i9pAYspET4JXorbA7iaR/hfeVTXkMh13Qz4fYc7t7vdDuLCpSoly2tESKb2AWuoTJ6aUjzgA3njewA==, tarball: file:projects/sdk-ui-tests-e2e.tgz}
     id: file:projects/sdk-ui-tests-e2e.tgz
     name: '@rush-temp/sdk-ui-tests-e2e'
     version: 0.0.0
@@ -24620,8 +23985,6 @@ packages:
       jest: 27.5.1_ts-node@10.7.0
       jest-junit: 3.7.0
       lodash: 4.17.21
-      node-sass: 7.0.1
-      node-sass-magic-importer: 5.3.2
       npm-run-all: 4.1.5
       prettier: 2.5.1
       prettier-loader: 3.3.0_prettier@2.5.1+webpack@5.72.0
@@ -24632,7 +23995,7 @@ packages:
       react-intl: 5.24.8_react@17.0.2+typescript@4.0.2
       react-router-dom: 5.3.0_react@17.0.2
       sass: 1.53.0
-      sass-loader: 10.2.1_89732cc13ea2438c8063d0d8ede18dbd
+      sass-loader: 10.2.1_sass@1.53.0+webpack@5.72.0
       source-map-loader: 2.0.2_webpack@5.72.0
       speed-measure-webpack-plugin: 1.5.0_webpack@5.72.0
       style-loader: 3.3.1_webpack@5.72.0
@@ -24655,6 +24018,7 @@ packages:
       - eslint-config-prettier
       - fibers
       - node-notifier
+      - node-sass
       - supports-color
       - ts-node
       - uglify-js
@@ -24664,7 +24028,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-tests.tgz:
-    resolution: {integrity: sha512-sjmK+jPQeiBOMhYVSAbmS66VskPSJcOodKWlWqGXLPErxN8/S7Epgx8jg9F7UTHLoEQdwRQLx6PTXyowM92ULA==, tarball: file:projects/sdk-ui-tests.tgz}
+    resolution: {integrity: sha512-vi2z+fOb6ofnfV+uvzXA607D3gNPgBbp8n+NGB6ApNr8FSQcSQzJ6a6MvRDOeWs3IidU7bj3YlCNE1q0puBhlg==, tarball: file:projects/sdk-ui-tests.tgz}
     name: '@rush-temp/sdk-ui-tests'
     version: 0.0.0
     dependencies:
@@ -24776,7 +24140,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-theme-provider.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-P+l91wm+BJ9ucgmdRadtqI00IQhsGlBHxOiq9GszzV2IxCGLen+Nf5FYYlZza/e082630xsBdGQXGMmvPs3R6w==, tarball: file:projects/sdk-ui-theme-provider.tgz}
+    resolution: {integrity: sha512-BoAwDpx05hpI0Z868tOy27EJ0SKZjT6Wg6NWHWOugvRf6h05ZfkkOAZQK7S+9x6ba9OXFoXICuTX22UeXGsx+Q==, tarball: file:projects/sdk-ui-theme-provider.tgz}
     id: file:projects/sdk-ui-theme-provider.tgz
     name: '@rush-temp/sdk-ui-theme-provider'
     version: 0.0.0
@@ -24811,8 +24175,6 @@ packages:
       jest-enzyme: 7.1.2_4c874ea13312c50d8c9b996ca71028db
       jest-junit: 3.7.0
       lodash: 4.17.21
-      node-sass: 7.0.1
-      node-sass-magic-importer: 5.3.2
       polished: 3.7.2
       prettier: 2.5.1
       raf: 3.4.1
@@ -24836,7 +24198,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-vis-commons.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-fBPKof0KUKbVRLM35RFJEeAd3arxfe1e9sAnbU/HzvsjCVMEcF7WLaWg2HbUYA42JoTzx+2gw+qpV1a/So6ghA==, tarball: file:projects/sdk-ui-vis-commons.tgz}
+    resolution: {integrity: sha512-czcp4XY1pLuwYly87qkKFQdIHXd9RZBiN2jf8a4iZS1kG0vmByA9Uix2OHszFUigg3crcthR53EGnOF4i7pX5A==, tarball: file:projects/sdk-ui-vis-commons.tgz}
     id: file:projects/sdk-ui-vis-commons.tgz
     name: '@rush-temp/sdk-ui-vis-commons'
     version: 0.0.0
@@ -24874,8 +24236,6 @@ packages:
       jest-enzyme: 7.1.2_4c874ea13312c50d8c9b996ca71028db
       jest-junit: 3.7.0
       lodash: 4.17.21
-      node-sass: 7.0.1
-      node-sass-magic-importer: 5.3.2
       prettier: 2.5.1
       raf: 3.4.1
       react: 17.0.2
@@ -24903,7 +24263,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-web-components.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-ziTFzR4ORGcJgaVaktic0rNU+kMnRcY0spPTufWX/DpF57DMDt3pXbMQWqlzKdsTI9rXeGzZG4319MraHuchEw==, tarball: file:projects/sdk-ui-web-components.tgz}
+    resolution: {integrity: sha512-jLVHDdIxBySfjGdFJ75mkPjKU/ZOHZ9VdSA31pHRUmMobsGUBiqm+l2pxCPNIwK7N06ydy2YYlO1WbgP64xnwQ==, tarball: file:projects/sdk-ui-web-components.tgz}
     id: file:projects/sdk-ui-web-components.tgz
     name: '@rush-temp/sdk-ui-web-components'
     version: 0.0.0
@@ -24943,8 +24303,6 @@ packages:
       jest-junit: 3.7.0
       lodash: 4.17.21
       mini-css-extract-plugin: 2.6.1_webpack@5.72.0
-      node-sass: 7.0.1
-      node-sass-magic-importer: 5.3.2
       prettier: 2.5.1
       raf: 3.4.1
       react: 17.0.2
@@ -24979,7 +24337,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-1aeaDYyl84a9GOMXgbg4lCP7geOqkzb5kmlKd5vd/1esPbBjVd4sAbbPP4Y0xDtFYDVp8oADjHQTrfnwJKLxDg==, tarball: file:projects/sdk-ui.tgz}
+    resolution: {integrity: sha512-IO/aTN3QqopC/KPKGqOloklaFIvhhoZCf6azFwKoyvloY2Fbqz3HketaoJH9UvJhLGtufj/79eXuyVyIWBne3w==, tarball: file:projects/sdk-ui.tgz}
     id: file:projects/sdk-ui.tgz
     name: '@rush-temp/sdk-ui'
     version: 0.0.0

--- a/libs/sdk-ui-loaders/package.json
+++ b/libs/sdk-ui-loaders/package.json
@@ -100,8 +100,6 @@
         "jest": "^27.5.1",
         "jest-enzyme": "^7.1.2",
         "jest-junit": "^3.0.0",
-        "node-sass": "^7.0.1",
-        "node-sass-magic-importer": "^5.3.2",
         "prettier": "~2.5.0",
         "raf": "^3.4.1",
         "react": "^17.0.2",

--- a/libs/sdk-ui-tests-e2e/package.json
+++ b/libs/sdk-ui-tests-e2e/package.json
@@ -136,8 +136,6 @@
         "html-webpack-plugin": "^5.3.1",
         "jest": "^27.5.1",
         "jest-junit": "^3.0.0",
-        "node-sass": "^7.0.1",
-        "node-sass-magic-importer": "^5.3.2",
         "npm-run-all": "^4.1.5",
         "prettier": "~2.5.0",
         "prettier-loader": "^3.3.0",

--- a/libs/sdk-ui-theme-provider/package.json
+++ b/libs/sdk-ui-theme-provider/package.json
@@ -93,8 +93,6 @@
         "jest": "^27.5.1",
         "jest-enzyme": "^7.1.2",
         "jest-junit": "^3.0.0",
-        "node-sass": "^7.0.1",
-        "node-sass-magic-importer": "^5.3.2",
         "prettier": "~2.5.0",
         "raf": "^3.4.1",
         "react": "^17.0.2",

--- a/libs/sdk-ui-web-components/package.json
+++ b/libs/sdk-ui-web-components/package.json
@@ -110,8 +110,6 @@
         "jest": "^27.5.1",
         "jest-enzyme": "^7.1.2",
         "jest-junit": "^3.0.0",
-        "node-sass": "^7.0.1",
-        "node-sass-magic-importer": "^5.3.2",
         "prettier": "~2.5.0",
         "raf": "^3.4.1",
         "react": "^17.0.2",

--- a/skel/sdk-skel-tsx/package.json
+++ b/skel/sdk-skel-tsx/package.json
@@ -93,8 +93,6 @@
         "jest": "^27.5.1",
         "jest-enzyme": "^7.1.2",
         "jest-junit": "^3.0.0",
-        "node-sass": "^7.0.1",
-        "node-sass-magic-importer": "^5.3.2",
         "prettier": "~2.5.0",
         "raf": "^3.4.1",
         "react": "^17.0.2",

--- a/tools/dashboard-plugin-tests/package.json
+++ b/tools/dashboard-plugin-tests/package.json
@@ -142,8 +142,6 @@
         "jest": "^27.5.1",
         "jest-enzyme": "^7.1.2",
         "jest-junit": "^3.0.0",
-        "node-sass": "^7.0.1",
-        "node-sass-magic-importer": "^5.3.2",
         "prettier": "~2.5.0",
         "raf": "^3.4.1",
         "react": "^17.0.2",


### PR DESCRIPTION
They are no longer wanted or needed, so neither allow nor install them.

JIRA: FET-1116

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
