### PR TITLE
RELATED: RAIL-4170, RAIL-4424, RAIL-4425 fix adding insights onto empty layouts

### DIFF
--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -5471,6 +5471,9 @@ export const selectIsDashboardSaving: OutputSelector<DashboardState, boolean, (r
 // @internal (undocumented)
 export const selectIsDeleteDialogOpen: OutputSelector<DashboardState, boolean, (res: UiState) => boolean>;
 
+// @internal (undocumented)
+export const selectIsDraggingWidget: OutputSelector<DashboardState, boolean, (res: UiState) => boolean>;
+
 // @public
 export const selectIsEmbedded: OutputSelector<DashboardState, boolean, (res: ResolvedDashboardConfig) => boolean>;
 
@@ -5844,6 +5847,10 @@ payload: number;
 type: string;
 }>;
 clearFilterIndexSelection: CaseReducer<UiState, AnyAction>;
+setIsDraggingWidget: CaseReducer<UiState, {
+payload: boolean;
+type: string;
+}>;
 }>;
 
 // @alpha (undocumented)
@@ -5862,6 +5869,8 @@ export interface UiState {
     };
     // (undocumented)
     insightListLastUpdateRequested: number;
+    // (undocumented)
+    isDraggingWidget: boolean;
     // (undocumented)
     kpiAlerts: {
         openedWidgetRef: ObjRef | undefined;

--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -3274,7 +3274,7 @@ export interface IDraggableCreatePanelItemProps {
     // (undocumented)
     onDragEnd?: (didDrop: boolean) => void;
     // (undocumented)
-    onDragStart?: () => void;
+    onDragStart?: (item: DraggableItem) => void;
 }
 
 // @alpha

--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -5095,6 +5095,9 @@ export const selectAccessibleDashboards: (state: DashboardState) => IListedDashb
 // @alpha
 export const selectAccessibleDashboardsMap: OutputSelector<DashboardState, ObjRefMap<IListedDashboard>, (res: IListedDashboard[]) => ObjRefMap<IListedDashboard>>;
 
+// @internal (undocumented)
+export const selectActiveSectionIndex: OutputSelector<DashboardState, number | undefined, (res: UiState) => number | undefined>;
+
 // @alpha
 export const selectAlertByRef: ((ref: ObjRef) => (state: DashboardState) => IWidgetAlert | undefined) & MemoizedFunction;
 
@@ -5859,10 +5862,17 @@ setIsDraggingWidget: CaseReducer<UiState, {
 payload: boolean;
 type: string;
 }>;
+setActiveSectionIndex: CaseReducer<UiState, {
+payload: number;
+type: string;
+}>;
+clearActiveSectionIndex: CaseReducer<UiState, AnyAction>;
 }>;
 
 // @alpha (undocumented)
 export interface UiState {
+    // (undocumented)
+    activeSectionIndex: number | undefined;
     // (undocumented)
     configurationPanelOpened: boolean;
     // (undocumented)

--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -4111,6 +4111,9 @@ export interface ISidebarProps {
     DefaultSidebar: ComponentType<ISidebarProps>;
 }
 
+// @internal
+export function isInitialPlaceholderWidget(obj: unknown): obj is PlaceholderWidget;
+
 // @internal (undocumented)
 export function isInsightDraggableListItem(item: any): item is InsightDraggableListItem;
 
@@ -4383,6 +4386,9 @@ export function newDisplayFormMap(items: ReadonlyArray<IAttributeDisplayFormMeta
 // @alpha
 export const newDrillToSameDashboardHandler: (dashboardRef: ObjRef) => DashboardEventHandler<DashboardDrillToDashboardResolved>;
 
+// @internal (undocumented)
+export function newInitialPlaceholderWidget(): PlaceholderWidget;
+
 // @alpha (undocumented)
 export function newInsightPlaceholderWidget(sectionIndex: number, itemIndex: number, isLastInSection: boolean): InsightPlaceholderWidget;
 
@@ -4390,7 +4396,7 @@ export function newInsightPlaceholderWidget(sectionIndex: number, itemIndex: num
 export function newKpiPlaceholderWidget(sectionIndex: number, itemIndex: number, isLastInSection: boolean): KpiPlaceholderWidget;
 
 // @alpha (undocumented)
-export function newPlaceholderWidget(sectionIndex: number, itemIndex: number, isLastInSection: boolean): InsightPlaceholderWidget;
+export function newPlaceholderWidget(sectionIndex: number, itemIndex: number, isLastInSection: boolean): PlaceholderWidget;
 
 // @public
 export interface ObjectAvailabilityConfig {
@@ -4521,6 +4527,8 @@ export const PLACEHOLDER_WIDGET_ID = "__placeholder__";
 export interface PlaceholderWidget extends ICustomWidget {
     // (undocumented)
     readonly customType: "gd-widget-placeholder";
+    // (undocumented)
+    readonly isInitial?: boolean;
     // (undocumented)
     readonly isLastInSection: boolean;
     // (undocumented)

--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -6573,6 +6573,12 @@ export function useShareButtonProps(): IShareButtonProps;
 // @alpha (undocumented)
 export const useTopBarProps: () => ITopBarProps;
 
+// @internal (undocumented)
+export function useWidgetDragEndHandler(): (didDrop: boolean) => void;
+
+// @internal (undocumented)
+export function useWidgetDragStartHandler(): (item: DraggableItem) => void;
+
 // @internal
 export function useWidgetExecutionsHandler(widgetRef: ObjRef): {
     onLoadingChanged: OnLoadingChanged;

--- a/libs/sdk-ui-dashboard/src/model/store/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/index.ts
@@ -230,6 +230,7 @@ export {
     selectIsFilterAttributeSelectionOpen,
     selectSelectedFilterIndex,
     selectIsDraggingWidget,
+    selectActiveSectionIndex,
 } from "./ui/uiSelectors";
 export { uiActions } from "./ui";
 export { RenderModeState } from "./renderMode/renderModeState";

--- a/libs/sdk-ui-dashboard/src/model/store/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/index.ts
@@ -229,6 +229,7 @@ export {
     selectIsWidgetLoadingAdditionalDataByWidgetRef,
     selectIsFilterAttributeSelectionOpen,
     selectSelectedFilterIndex,
+    selectIsDraggingWidget,
 } from "./ui/uiSelectors";
 export { uiActions } from "./ui";
 export { RenderModeState } from "./renderMode/renderModeState";

--- a/libs/sdk-ui-dashboard/src/model/store/ui/uiReducers.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/ui/uiReducers.ts
@@ -125,6 +125,10 @@ const selectFilterIndex: UiReducer<PayloadAction<number>> = (state, action) => {
 
 const clearFilterIndexSelection: UiReducer = (state) => {
     state.selectedFilterIndex = undefined;
+}
+
+const setIsDraggingWidget: UiReducer<PayloadAction<boolean>> = (state, action) => {
+    state.isDraggingWidget = action.payload;
 };
 
 export const uiReducers = {
@@ -157,4 +161,5 @@ export const uiReducers = {
     setFilterAttributeSelectionOpen,
     selectFilterIndex,
     clearFilterIndexSelection,
+    setIsDraggingWidget,
 };

--- a/libs/sdk-ui-dashboard/src/model/store/ui/uiReducers.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/ui/uiReducers.ts
@@ -131,6 +131,14 @@ const setIsDraggingWidget: UiReducer<PayloadAction<boolean>> = (state, action) =
     state.isDraggingWidget = action.payload;
 };
 
+const setActiveSectionIndex: UiReducer<PayloadAction<number>> = (state, action) => {
+    state.activeSectionIndex = action.payload;
+};
+
+const clearActiveSectionIndex: UiReducer = (state) => {
+    state.activeSectionIndex = undefined;
+};
+
 export const uiReducers = {
     openScheduleEmailDialog,
     closeScheduleEmailDialog,
@@ -162,4 +170,6 @@ export const uiReducers = {
     selectFilterIndex,
     clearFilterIndexSelection,
     setIsDraggingWidget,
+    setActiveSectionIndex,
+    clearActiveSectionIndex,
 };

--- a/libs/sdk-ui-dashboard/src/model/store/ui/uiReducers.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/ui/uiReducers.ts
@@ -125,7 +125,7 @@ const selectFilterIndex: UiReducer<PayloadAction<number>> = (state, action) => {
 
 const clearFilterIndexSelection: UiReducer = (state) => {
     state.selectedFilterIndex = undefined;
-}
+};
 
 const setIsDraggingWidget: UiReducer<PayloadAction<boolean>> = (state, action) => {
     state.isDraggingWidget = action.payload;

--- a/libs/sdk-ui-dashboard/src/model/store/ui/uiSelectors.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/ui/uiSelectors.ts
@@ -198,3 +198,8 @@ export const selectIsFilterAttributeSelectionOpen = createSelector(
  * @alpha
  */
 export const selectSelectedFilterIndex = createSelector(selectSelf, (state) => state.selectedFilterIndex);
+
+/**
+ * @internal
+ */
+export const selectIsDraggingWidget = createSelector(selectSelf, (state) => state.isDraggingWidget);

--- a/libs/sdk-ui-dashboard/src/model/store/ui/uiSelectors.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/ui/uiSelectors.ts
@@ -203,3 +203,8 @@ export const selectSelectedFilterIndex = createSelector(selectSelf, (state) => s
  * @internal
  */
 export const selectIsDraggingWidget = createSelector(selectSelf, (state) => state.isDraggingWidget);
+
+/**
+ * @internal
+ */
+export const selectActiveSectionIndex = createSelector(selectSelf, (state) => state.activeSectionIndex);

--- a/libs/sdk-ui-dashboard/src/model/store/ui/uiState.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/ui/uiState.ts
@@ -47,6 +47,7 @@ export interface UiState {
     filterAttributeSelectionOpen: boolean;
     selectedFilterIndex: number | undefined;
     isDraggingWidget: boolean;
+    activeSectionIndex: number | undefined;
 }
 
 export const uiInitialState: UiState = {
@@ -87,4 +88,5 @@ export const uiInitialState: UiState = {
     filterAttributeSelectionOpen: false,
     selectedFilterIndex: undefined,
     isDraggingWidget: false,
+    activeSectionIndex: undefined,
 };

--- a/libs/sdk-ui-dashboard/src/model/store/ui/uiState.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/ui/uiState.ts
@@ -46,6 +46,7 @@ export interface UiState {
     widgetsLoadingAdditionalData: ObjRef[];
     filterAttributeSelectionOpen: boolean;
     selectedFilterIndex: number | undefined;
+    isDraggingWidget: boolean;
 }
 
 export const uiInitialState: UiState = {
@@ -85,4 +86,5 @@ export const uiInitialState: UiState = {
     widgetsLoadingAdditionalData: [],
     filterAttributeSelectionOpen: false,
     selectedFilterIndex: undefined,
+    isDraggingWidget: false,
 };

--- a/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/DraggableCreatePanelItem.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/DraggableCreatePanelItem.tsx
@@ -1,5 +1,5 @@
 // (C) 2022 GoodData Corporation
-import React, { useEffect } from "react";
+import React from "react";
 import cx from "classnames";
 
 import { useDashboardDrag } from "./useDashboardDrag";
@@ -13,7 +13,7 @@ export interface IDraggableCreatePanelItemProps {
     Component: CustomCreatePanelItemComponent;
     disabled?: boolean;
     canDrag: boolean;
-    onDragStart?: () => void;
+    onDragStart?: (item: DraggableItem) => void;
     onDragEnd?: (didDrop: boolean) => void;
     dragItem: DraggableItem;
     hideDefaultPreview?: boolean;
@@ -39,15 +39,10 @@ export const DraggableCreatePanelItem: React.FC<IDraggableCreatePanelItemProps> 
             dragEnd: (_, monitor) => {
                 onDragEnd?.(monitor.didDrop());
             },
+            dragStart: onDragStart,
         },
         [canDrag, onDragEnd, hideDefaultPreview, dragItem],
     );
-
-    useEffect(() => {
-        if (isDragging && onDragStart) {
-            onDragStart();
-        }
-    }, [onDragStart, isDragging]);
 
     return (
         <div ref={dragRef} className={cx({ "is-dragging": isDragging })}>

--- a/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/DashboardLayoutSectionBorder/index.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/DashboardLayoutSectionBorder/index.ts
@@ -1,3 +1,4 @@
 // (C) 2022 GoodData Corporation
 export { DashboardLayoutSectionBorder } from "./DashboardLayoutSectionBorder";
 export { DashboardLayoutSectionBorderLine } from "./DashboardLayoutSectionBorderLine";
+export { DashboardLayoutSectionBorderStatus } from "./types";

--- a/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/DraggableInsightListItem.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/DraggableInsightListItem.tsx
@@ -1,5 +1,5 @@
 // (C) 2022 GoodData Corporation
-import React, { useEffect } from "react";
+import React, { useCallback } from "react";
 import classNames from "classnames";
 import { IInsight } from "@gooddata/sdk-model";
 
@@ -10,12 +10,15 @@ import {
     useWidgetSelection,
     eagerRemoveSectionItem,
     selectWidgetPlaceholder,
+    uiActions,
 } from "../../../model";
 import { useDashboardDrag } from "../useDashboardDrag";
 import {
     CustomDashboardInsightListItemComponent,
     CustomDashboardInsightListItemComponentProps,
+    DraggableItem,
 } from "../types";
+import { useAddInitialSectionHandler } from "./useAddInitialSectionHandler";
 
 /**
  * @internal
@@ -39,6 +42,17 @@ export function DraggableInsightListItem({
     const { deselectWidgets } = useWidgetSelection();
     const widgetPlaceholder = useDashboardSelector(selectWidgetPlaceholder);
 
+    const addInitialSectionHandler = useAddInitialSectionHandler();
+
+    const handleDragStart = useCallback(
+        (item: DraggableItem) => {
+            deselectWidgets();
+            addInitialSectionHandler(item);
+            dispatch(uiActions.setIsDraggingWidget(true));
+        },
+        [addInitialSectionHandler, deselectWidgets, dispatch],
+    );
+
     const [{ isDragging }, dragRef] = useDashboardDrag(
         {
             dragItem: {
@@ -53,17 +67,12 @@ export function DraggableInsightListItem({
                         eagerRemoveSectionItem(widgetPlaceholder.sectionIndex, widgetPlaceholder.itemIndex),
                     );
                 }
+                dispatch(uiActions.setIsDraggingWidget(false));
             },
+            dragStart: handleDragStart,
         },
         [isInEditMode, insight, widgetPlaceholder],
     );
-
-    // deselect all widgets when starting the drag
-    useEffect(() => {
-        if (isDragging) {
-            deselectWidgets();
-        }
-    }, [deselectWidgets, isDragging]);
 
     return (
         <div className={classNames({ "is-dragging": isDragging })} ref={dragRef}>

--- a/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/DraggableKpiCreatePanelItem.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/DraggableKpiCreatePanelItem.tsx
@@ -1,19 +1,12 @@
 // (C) 2022 GoodData Corporation
-import React, { useCallback } from "react";
+import React from "react";
 
-import {
-    selectIsInEditMode,
-    useDashboardDispatch,
-    useDashboardSelector,
-    useWidgetSelection,
-    eagerRemoveSectionItem,
-    selectWidgetPlaceholder,
-    uiActions,
-} from "../../../model";
+import { selectIsInEditMode, useDashboardSelector } from "../../../model";
 import { DraggableItem } from "../types";
-import { DraggableCreatePanelItem, IDraggableCreatePanelItemProps } from "../DraggableCreatePanelItem";
+import { DraggableCreatePanelItem } from "../DraggableCreatePanelItem";
 import { CustomCreatePanelItemComponent } from "../../componentDefinition";
-import { useAddInitialSectionHandler } from "./useAddInitialSectionHandler";
+import { useWidgetDragStartHandler } from "./useWidgetDragStartHandler";
+import { useWidgetDragEndHandler } from "./useWidgetDragEndHandler";
 
 interface IDraggableKpiCreatePanelItemProps {
     CreatePanelItemComponent: CustomCreatePanelItemComponent;
@@ -28,31 +21,10 @@ export const DraggableKpiCreatePanelItem: React.FC<IDraggableKpiCreatePanelItemP
     CreatePanelItemComponent,
     disabled,
 }) => {
-    const dispatch = useDashboardDispatch();
     const isInEditMode = useDashboardSelector(selectIsInEditMode);
-    const { deselectWidgets } = useWidgetSelection();
-    const widgetPlaceholder = useDashboardSelector(selectWidgetPlaceholder);
 
-    const addInitialSectionHandler = useAddInitialSectionHandler();
-
-    const handleDragStart = useCallback(
-        (item: DraggableItem) => {
-            deselectWidgets();
-            addInitialSectionHandler(item);
-            dispatch(uiActions.setIsDraggingWidget(true));
-        },
-        [addInitialSectionHandler, deselectWidgets, dispatch],
-    );
-
-    const handleDragEnd = useCallback<Required<IDraggableCreatePanelItemProps>["onDragEnd"]>(
-        (didDrop) => {
-            if (!didDrop && widgetPlaceholder) {
-                dispatch(eagerRemoveSectionItem(widgetPlaceholder.sectionIndex, widgetPlaceholder.itemIndex));
-            }
-            dispatch(uiActions.setIsDraggingWidget(false));
-        },
-        [dispatch, widgetPlaceholder],
-    );
+    const handleDragStart = useWidgetDragStartHandler();
+    const handleDragEnd = useWidgetDragEndHandler();
 
     return (
         <DraggableCreatePanelItem

--- a/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/DraggableKpiCreatePanelItem.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/DraggableKpiCreatePanelItem.tsx
@@ -8,10 +8,12 @@ import {
     useWidgetSelection,
     eagerRemoveSectionItem,
     selectWidgetPlaceholder,
+    uiActions,
 } from "../../../model";
 import { DraggableItem } from "../types";
 import { DraggableCreatePanelItem, IDraggableCreatePanelItemProps } from "../DraggableCreatePanelItem";
 import { CustomCreatePanelItemComponent } from "../../componentDefinition";
+import { useAddInitialSectionHandler } from "./useAddInitialSectionHandler";
 
 interface IDraggableKpiCreatePanelItemProps {
     CreatePanelItemComponent: CustomCreatePanelItemComponent;
@@ -31,11 +33,23 @@ export const DraggableKpiCreatePanelItem: React.FC<IDraggableKpiCreatePanelItemP
     const { deselectWidgets } = useWidgetSelection();
     const widgetPlaceholder = useDashboardSelector(selectWidgetPlaceholder);
 
+    const addInitialSectionHandler = useAddInitialSectionHandler();
+
+    const handleDragStart = useCallback(
+        (item: DraggableItem) => {
+            deselectWidgets();
+            addInitialSectionHandler(item);
+            dispatch(uiActions.setIsDraggingWidget(true));
+        },
+        [addInitialSectionHandler, deselectWidgets, dispatch],
+    );
+
     const handleDragEnd = useCallback<Required<IDraggableCreatePanelItemProps>["onDragEnd"]>(
         (didDrop) => {
             if (!didDrop && widgetPlaceholder) {
                 dispatch(eagerRemoveSectionItem(widgetPlaceholder.sectionIndex, widgetPlaceholder.itemIndex));
             }
+            dispatch(uiActions.setIsDraggingWidget(false));
         },
         [dispatch, widgetPlaceholder],
     );
@@ -48,7 +62,7 @@ export const DraggableKpiCreatePanelItem: React.FC<IDraggableKpiCreatePanelItemP
             dragItem={dragItem}
             hideDefaultPreview={false}
             onDragEnd={handleDragEnd}
-            onDragStart={deselectWidgets}
+            onDragStart={handleDragStart}
         />
     );
 };

--- a/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/EmptyDashboardDropZone.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/EmptyDashboardDropZone.tsx
@@ -1,8 +1,6 @@
 // (C) 2022 GoodData Corporation
 import React from "react";
-import { FormattedMessage } from "react-intl";
 import cx from "classnames";
-import { Typography } from "@gooddata/sdk-ui-kit";
 
 import { EmptyDashboardDropZoneBox } from "./EmptyDashboardDropZoneBox";
 import { useDashboardDrop } from "../useDashboardDrop";
@@ -67,7 +65,6 @@ export const EmptyDashboardDropZone: React.FC = () => {
         ],
     );
 
-    const message = <FormattedMessage id="newDashboard.dropInsight" />;
     const widgetCategory = widgetCategoryMapping[itemType];
 
     return (
@@ -80,16 +77,6 @@ export const EmptyDashboardDropZone: React.FC = () => {
         >
             <div className={cx("drag-info-placeholder-inner", { "can-drop": canDrop, "is-over": isOver })}>
                 <EmptyDashboardDropZoneBox />
-                <div className="drag-info-placeholder-drop-target s-drag-info-placeholder-drop-target">
-                    <div className="drop-target-inner">
-                        <Typography tagName="p" className="drop-target-message kpi-drop-target">
-                            {message}
-                        </Typography>
-                        <Typography tagName="p" className="drop-target-message visualization-drop-target">
-                            {message}
-                        </Typography>
-                    </div>
-                </div>
             </div>
         </div>
     );

--- a/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/EmptyDashboardDropZone.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/EmptyDashboardDropZone.tsx
@@ -1,6 +1,8 @@
 // (C) 2022 GoodData Corporation
 import React from "react";
+import { FormattedMessage } from "react-intl";
 import cx from "classnames";
+import { Typography } from "@gooddata/sdk-ui-kit";
 
 import { EmptyDashboardDropZoneBox } from "./EmptyDashboardDropZoneBox";
 import { useDashboardDrop } from "../useDashboardDrop";
@@ -10,15 +12,10 @@ import {
     isInsightPlaceholderDraggableItem,
     isKpiPlaceholderDraggableItem,
 } from "../types";
-import {
-    useDashboardDispatch,
-    useDashboardSelector,
-    selectWidgetPlaceholder,
-    eagerRemoveSectionItem,
-} from "../../../model";
-import { useNewSectionInsightListItemDropHandler } from "./useNewSectionInsightListItemDropHandler";
-import { useNewSectionInsightPlaceholderDropHandler } from "./useNewSectionInsightPlaceholderDropHandler";
-import { useNewSectionKpiPlaceholderDropHandler } from "./useNewSectionKpiPlaceholderDropHandler";
+import { useDashboardDispatch, useDashboardSelector, selectWidgetPlaceholder } from "../../../model";
+import { useInsightListItemDropHandler } from "./useInsightListItemDropHandler";
+import { useInsightPlaceholderDropHandler } from "./useInsightPlaceholderDropHandler";
+import { useKpiPlaceholderDropHandler } from "./useKpiPlaceholderDropHandler";
 
 const widgetCategoryMapping: Partial<{ [D in DraggableItemType]: string }> = {
     "insight-placeholder": "insight",
@@ -30,9 +27,9 @@ export const EmptyDashboardDropZone: React.FC = () => {
     const dispatch = useDashboardDispatch();
     const widgetPlaceholder = useDashboardSelector(selectWidgetPlaceholder);
 
-    const handleInsightListItemDrop = useNewSectionInsightListItemDropHandler(0);
-    const handleKpiPlaceholderDrop = useNewSectionKpiPlaceholderDropHandler(0);
-    const handleInsightPlaceholderDrop = useNewSectionInsightPlaceholderDropHandler(0);
+    const handleInsightListItemDrop = useInsightListItemDropHandler();
+    const handleKpiPlaceholderDrop = useKpiPlaceholderDropHandler();
+    const handleInsightPlaceholderDrop = useInsightPlaceholderDropHandler();
 
     const [{ canDrop, isOver, itemType }, dropRef] = useDashboardDrop(
         ["insightListItem", "kpi-placeholder", "insight-placeholder"],
@@ -42,17 +39,10 @@ export const EmptyDashboardDropZone: React.FC = () => {
                     handleInsightListItemDrop(item.insight);
                 }
                 if (isKpiPlaceholderDraggableItem(item)) {
-                    handleKpiPlaceholderDrop();
+                    handleKpiPlaceholderDrop(0, 0, true);
                 }
                 if (isInsightPlaceholderDraggableItem(item)) {
-                    handleInsightPlaceholderDrop();
-                }
-            },
-            hover: () => {
-                if (widgetPlaceholder) {
-                    dispatch(
-                        eagerRemoveSectionItem(widgetPlaceholder.sectionIndex, widgetPlaceholder.itemIndex),
-                    );
+                    handleInsightPlaceholderDrop(0, 0, true);
                 }
             },
         },
@@ -65,6 +55,7 @@ export const EmptyDashboardDropZone: React.FC = () => {
         ],
     );
 
+    const message = <FormattedMessage id="newDashboard.dropInsight" />;
     const widgetCategory = widgetCategoryMapping[itemType];
 
     return (
@@ -77,6 +68,16 @@ export const EmptyDashboardDropZone: React.FC = () => {
         >
             <div className={cx("drag-info-placeholder-inner", { "can-drop": canDrop, "is-over": isOver })}>
                 <EmptyDashboardDropZoneBox />
+                <div className="drag-info-placeholder-drop-target s-drag-info-placeholder-drop-target">
+                    <div className="drop-target-inner">
+                        <Typography tagName="p" className="drop-target-message kpi-drop-target">
+                            {message}
+                        </Typography>
+                        <Typography tagName="p" className="drop-target-message visualization-drop-target">
+                            {message}
+                        </Typography>
+                    </div>
+                </div>
             </div>
         </div>
     );

--- a/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/EmptyDashboardDropZone.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/EmptyDashboardDropZone.tsx
@@ -1,0 +1,96 @@
+// (C) 2022 GoodData Corporation
+import React from "react";
+import { FormattedMessage } from "react-intl";
+import cx from "classnames";
+import { Typography } from "@gooddata/sdk-ui-kit";
+
+import { EmptyDashboardDropZoneBox } from "./EmptyDashboardDropZoneBox";
+import { useDashboardDrop } from "../useDashboardDrop";
+import {
+    DraggableItemType,
+    isInsightDraggableListItem,
+    isInsightPlaceholderDraggableItem,
+    isKpiPlaceholderDraggableItem,
+} from "../types";
+import {
+    useDashboardDispatch,
+    useDashboardSelector,
+    selectWidgetPlaceholder,
+    eagerRemoveSectionItem,
+} from "../../../model";
+import { useNewSectionInsightListItemDropHandler } from "./useNewSectionInsightListItemDropHandler";
+import { useNewSectionInsightPlaceholderDropHandler } from "./useNewSectionInsightPlaceholderDropHandler";
+import { useNewSectionKpiPlaceholderDropHandler } from "./useNewSectionKpiPlaceholderDropHandler";
+
+const widgetCategoryMapping: Partial<{ [D in DraggableItemType]: string }> = {
+    "insight-placeholder": "insight",
+    insightListItem: "visualization",
+    "kpi-placeholder": "kpi",
+};
+
+export const EmptyDashboardDropZone: React.FC = () => {
+    const dispatch = useDashboardDispatch();
+    const widgetPlaceholder = useDashboardSelector(selectWidgetPlaceholder);
+
+    const handleInsightListItemDrop = useNewSectionInsightListItemDropHandler(0);
+    const handleKpiPlaceholderDrop = useNewSectionKpiPlaceholderDropHandler(0);
+    const handleInsightPlaceholderDrop = useNewSectionInsightPlaceholderDropHandler(0);
+
+    const [{ canDrop, isOver, itemType }, dropRef] = useDashboardDrop(
+        ["insightListItem", "kpi-placeholder", "insight-placeholder"],
+        {
+            drop: (item) => {
+                if (isInsightDraggableListItem(item)) {
+                    handleInsightListItemDrop(item.insight);
+                }
+                if (isKpiPlaceholderDraggableItem(item)) {
+                    handleKpiPlaceholderDrop();
+                }
+                if (isInsightPlaceholderDraggableItem(item)) {
+                    handleInsightPlaceholderDrop();
+                }
+            },
+            hover: () => {
+                if (widgetPlaceholder) {
+                    dispatch(
+                        eagerRemoveSectionItem(widgetPlaceholder.sectionIndex, widgetPlaceholder.itemIndex),
+                    );
+                }
+            },
+        },
+        [
+            dispatch,
+            widgetPlaceholder,
+            handleInsightListItemDrop,
+            handleKpiPlaceholderDrop,
+            handleInsightPlaceholderDrop,
+        ],
+    );
+
+    const message = <FormattedMessage id="newDashboard.dropInsight" />;
+    const widgetCategory = widgetCategoryMapping[itemType];
+
+    return (
+        <div
+            className={cx("drag-info-placeholder", "s-last-drop-position", "dash-item", {
+                [`type-${widgetCategory}`]: !!widgetCategory,
+                "type-none": !widgetCategory,
+            })}
+            ref={dropRef}
+        >
+            <div className={cx("drag-info-placeholder-inner", { "can-drop": canDrop, "is-over": isOver })}>
+                <EmptyDashboardDropZoneBox />
+                <div className="drag-info-placeholder-drop-target s-drag-info-placeholder-drop-target">
+                    <div className="drop-target-inner">
+                        <Typography tagName="p" className="drop-target-message kpi-drop-target">
+                            {message}
+                        </Typography>
+                        <Typography tagName="p" className="drop-target-message visualization-drop-target">
+                            {message}
+                        </Typography>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+};

--- a/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/EmptyDashboardDropZoneBox.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/EmptyDashboardDropZoneBox.tsx
@@ -9,15 +9,6 @@ export const EmptyDashboardDropZoneBox: React.FC = () => {
             <Typography tagName="h2">
                 <FormattedMessage id="newDashboard.title" />
             </Typography>
-            {/*<Typography tagName="p">
-                <FormattedMessage id="newDashboard.subtitle" />
-            </Typography>
-             <div className="drag-info-placeholder-box-insight">
-                <Typography tagName="p">
-                    <span className="gd-icon-insight" />
-                    <FormattedMessage id="newDashboard.subtitle.insight" />
-                </Typography>
-            </div> */}
         </div>
     );
 };

--- a/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/EmptyDashboardDropZoneBox.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/EmptyDashboardDropZoneBox.tsx
@@ -1,0 +1,23 @@
+// (C) 2022 GoodData Corporation
+import React from "react";
+import { FormattedMessage } from "react-intl";
+import { Typography } from "@gooddata/sdk-ui-kit";
+
+export const EmptyDashboardDropZoneBox: React.FC = () => {
+    return (
+        <div className="drag-info-placeholder-box s-drag-info-placeholder-box">
+            <Typography tagName="h2">
+                <FormattedMessage id="newDashboard.title" />
+            </Typography>
+            {/*<Typography tagName="p">
+                <FormattedMessage id="newDashboard.subtitle" />
+            </Typography>
+             <div className="drag-info-placeholder-box-insight">
+                <Typography tagName="p">
+                    <span className="gd-icon-insight" />
+                    <FormattedMessage id="newDashboard.subtitle.insight" />
+                </Typography>
+            </div> */}
+        </div>
+    );
+};

--- a/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/SectionDropZoneBox.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/SectionDropZoneBox.tsx
@@ -12,31 +12,33 @@ export interface ISectionDropZoneBoxProps {
 export const SectionDropZoneBox: React.FC<ISectionDropZoneBoxProps> = (props) => {
     const { isOver } = props;
     return (
-        <DashboardLayoutSectionBorder status={isOver ? "active" : "muted"}>
-            <div
-                className={cx(
-                    "drag-info-placeholder",
-                    "widget-dropzone-box",
-                    "s-last-drop-position",
-                    "type-kpi",
-                )}
-            >
-                <div className={cx("drag-info-placeholder-inner", "can-drop", { "is-over": isOver })}>
-                    <div className="drag-info-placeholder-drop-target">
-                        <div className="drop-target-inner">
-                            <Typography tagName="p" className="drop-target-message kpi-drop-target">
-                                <FormattedMessage
-                                    id="dropzone.new.row.desc"
-                                    values={{
-                                        b: (chunks: string) => <b>{chunks}</b>,
-                                        nbsp: <>&nbsp;</>,
-                                    }}
-                                />
-                            </Typography>
+        <div className="new-row-dropzone">
+            <DashboardLayoutSectionBorder status={isOver ? "active" : "muted"}>
+                <div
+                    className={cx(
+                        "drag-info-placeholder",
+                        "widget-dropzone-box",
+                        "s-last-drop-position",
+                        "type-kpi",
+                    )}
+                >
+                    <div className={cx("drag-info-placeholder-inner", "can-drop", { "is-over": isOver })}>
+                        <div className="drag-info-placeholder-drop-target">
+                            <div className="drop-target-inner">
+                                <Typography tagName="p" className="drop-target-message kpi-drop-target">
+                                    <FormattedMessage
+                                        id="dropzone.new.row.desc"
+                                        values={{
+                                            b: (chunks: string) => <b>{chunks}</b>,
+                                            nbsp: <>&nbsp;</>,
+                                        }}
+                                    />
+                                </Typography>
+                            </div>
                         </div>
                     </div>
                 </div>
-            </div>
-        </DashboardLayoutSectionBorder>
+            </DashboardLayoutSectionBorder>
+        </div>
     );
 };

--- a/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/SectionHotspot.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/SectionHotspot.tsx
@@ -10,7 +10,6 @@ import {
 } from "../../../model";
 import { useDashboardDrop } from "../useDashboardDrop";
 import { SectionDropZoneBox } from "./SectionDropZoneBox";
-import { DashboardLayoutSectionBorderLine } from "./DashboardLayoutSectionBorder";
 import {
     isInsightDraggableListItem,
     isInsightPlaceholderDraggableItem,
@@ -86,13 +85,7 @@ export const SectionHotspot: React.FC<ISectionHotspotProps> = (props) => {
             })}
         >
             <div className={cx("row-hotspot", { hidden: !canDrop })} style={{ ...debugStyle }} ref={dropRef}>
-                <div className="new-row-dropzone">
-                    {isOver ? (
-                        <SectionDropZoneBox isOver={isOver} />
-                    ) : (
-                        <DashboardLayoutSectionBorderLine position="top" status="muted" />
-                    )}
-                </div>
+                {!!isOver && <SectionDropZoneBox isOver={isOver} />}
             </div>
         </div>
     );

--- a/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/index.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/index.ts
@@ -6,3 +6,5 @@ export * from "./SectionHotspot";
 export * from "./Hotspot";
 export * from "./WidgetDropZone";
 export * from "./EmptyDashboardDropZone";
+export * from "./useWidgetDragStartHandler";
+export * from "./useWidgetDragEndHandler";

--- a/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/index.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/index.ts
@@ -5,3 +5,4 @@ export * from "./AddKpiWidgetButton";
 export * from "./SectionHotspot";
 export * from "./Hotspot";
 export * from "./WidgetDropZone";
+export * from "./EmptyDashboardDropZone";

--- a/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/index.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/index.ts
@@ -8,3 +8,4 @@ export * from "./WidgetDropZone";
 export * from "./EmptyDashboardDropZone";
 export * from "./useWidgetDragStartHandler";
 export * from "./useWidgetDragEndHandler";
+export * from "./DashboardLayoutSectionBorder";

--- a/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/useAddInitialSectionHandler.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/useAddInitialSectionHandler.ts
@@ -15,7 +15,7 @@ import {
     isInsightPlaceholderDraggableItem,
     isKpiPlaceholderDraggableItem,
 } from "../types";
-import { newPlaceholderWidget } from "../../../widgets";
+import { newInitialPlaceholderWidget } from "../../../widgets";
 import { getInsightPlaceholderSizeInfo, getSizeInfo } from "../../../_staging/layout/sizing";
 
 export function useAddInitialSectionHandler() {
@@ -39,7 +39,7 @@ export function useAddInitialSectionHandler() {
 
                 if (sizeInfo) {
                     dispatch(
-                        addLayoutSection(0, undefined, [
+                        addLayoutSection(0, {}, [
                             {
                                 type: "IDashboardLayoutItem",
                                 size: {
@@ -48,7 +48,7 @@ export function useAddInitialSectionHandler() {
                                         gridWidth: sizeInfo.width.default!,
                                     },
                                 },
-                                widget: newPlaceholderWidget(0, 0, false),
+                                widget: newInitialPlaceholderWidget(),
                             },
                         ]),
                     );

--- a/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/useAddInitialSectionHandler.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/useAddInitialSectionHandler.ts
@@ -1,0 +1,60 @@
+// (C) 2022 GoodData Corporation
+import { useCallback } from "react";
+import { IVisualizationSizeInfo } from "@gooddata/sdk-ui-ext";
+
+import {
+    useDashboardSelector,
+    useDashboardDispatch,
+    selectIsLayoutEmpty,
+    addLayoutSection,
+    selectSettings,
+} from "../../../model";
+import {
+    DraggableItem,
+    isInsightDraggableListItem,
+    isInsightPlaceholderDraggableItem,
+    isKpiPlaceholderDraggableItem,
+} from "../types";
+import { newPlaceholderWidget } from "../../../widgets";
+import { getInsightPlaceholderSizeInfo, getSizeInfo } from "../../../_staging/layout/sizing";
+
+export function useAddInitialSectionHandler() {
+    const dispatch = useDashboardDispatch();
+    const settings = useDashboardSelector(selectSettings);
+    const isLayoutEmpty = useDashboardSelector(selectIsLayoutEmpty);
+
+    return useCallback(
+        (item: DraggableItem) => {
+            if (isLayoutEmpty) {
+                let sizeInfo: IVisualizationSizeInfo | undefined;
+                if (isInsightDraggableListItem(item)) {
+                    sizeInfo = getSizeInfo(settings, "insight", item.insight);
+                }
+                if (isInsightPlaceholderDraggableItem(item)) {
+                    sizeInfo = getInsightPlaceholderSizeInfo(settings);
+                }
+                if (isKpiPlaceholderDraggableItem(item)) {
+                    sizeInfo = getSizeInfo(settings, "kpi");
+                }
+
+                if (sizeInfo) {
+                    dispatch(
+                        addLayoutSection(0, undefined, [
+                            {
+                                type: "IDashboardLayoutItem",
+                                size: {
+                                    xl: {
+                                        gridHeight: sizeInfo.height.default!,
+                                        gridWidth: sizeInfo.width.default!,
+                                    },
+                                },
+                                widget: newPlaceholderWidget(0, 0, false),
+                            },
+                        ]),
+                    );
+                }
+            }
+        },
+        [dispatch, isLayoutEmpty, settings],
+    );
+}

--- a/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/useNewSectionInsightListItemDropHandler.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/useNewSectionInsightListItemDropHandler.ts
@@ -1,0 +1,74 @@
+// (C) 2022 GoodData Corporation
+import { useCallback } from "react";
+import { IInsight, insightRef, insightTitle } from "@gooddata/sdk-model";
+
+import { getSizeInfo } from "../../../_staging/layout/sizing";
+import {
+    selectSettings,
+    useDashboardDispatch,
+    useDashboardSelector,
+    useDashboardCommandProcessing,
+    uiActions,
+    enableInsightWidgetDateFilter,
+    DashboardCommandFailed,
+    ChangeInsightWidgetFilterSettings,
+    addLayoutSection,
+} from "../../../model";
+
+export function useNewSectionInsightListItemDropHandler(sectionIndex: number) {
+    const dispatch = useDashboardDispatch();
+    const settings = useDashboardSelector(selectSettings);
+
+    const { run: preselectDateDataset } = useDashboardCommandProcessing({
+        commandCreator: enableInsightWidgetDateFilter,
+        errorEvent: "GDC.DASH/EVT.COMMAND.FAILED",
+        successEvent: "GDC.DASH/EVT.INSIGHT_WIDGET.FILTER_SETTINGS_CHANGED",
+        onSuccess: (event) => {
+            dispatch(uiActions.setWidgetLoadingAdditionalDataStopped(event.payload.ref));
+        },
+        onError: (event: DashboardCommandFailed<ChangeInsightWidgetFilterSettings>) => {
+            dispatch(uiActions.setWidgetLoadingAdditionalDataStopped(event.payload.command.payload.ref));
+        },
+    });
+
+    const { run: addNewSectionWithInsight } = useDashboardCommandProcessing({
+        commandCreator: addLayoutSection,
+        errorEvent: "GDC.DASH/EVT.COMMAND.FAILED",
+        successEvent: "GDC.DASH/EVT.FLUID_LAYOUT.SECTION_ADDED",
+        onSuccess: (event) => {
+            const ref = event.payload.section.items[0].widget!.ref;
+            dispatch(uiActions.selectWidget(ref));
+            dispatch(uiActions.setConfigurationPanelOpened(true));
+            dispatch(uiActions.setWidgetLoadingAdditionalDataStarted(ref));
+            preselectDateDataset(ref, "default");
+        },
+    });
+
+    return useCallback(
+        (insight: IInsight) => {
+            const sizeInfo = getSizeInfo(settings, "insight", insight);
+            addNewSectionWithInsight(sectionIndex, {}, [
+                {
+                    type: "IDashboardLayoutItem",
+                    widget: {
+                        type: "insight",
+                        insight: insightRef(insight),
+                        ignoreDashboardFilters: [],
+                        drills: [],
+                        title: insightTitle(insight),
+                        description: "",
+                        configuration: { hideTitle: false },
+                        properties: {},
+                    },
+                    size: {
+                        xl: {
+                            gridHeight: sizeInfo.height.default,
+                            gridWidth: sizeInfo.width.default!,
+                        },
+                    },
+                },
+            ]);
+        },
+        [addNewSectionWithInsight, sectionIndex, settings],
+    );
+}

--- a/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/useNewSectionInsightPlaceholderDropHandler.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/useNewSectionInsightPlaceholderDropHandler.ts
@@ -1,0 +1,45 @@
+// (C) 2022 GoodData Corporation
+import { useCallback } from "react";
+import { idRef } from "@gooddata/sdk-model";
+
+import { getInsightPlaceholderSizeInfo } from "../../../_staging/layout/sizing";
+import {
+    selectSettings,
+    useDashboardDispatch,
+    useDashboardSelector,
+    useDashboardCommandProcessing,
+    uiActions,
+    addLayoutSection,
+} from "../../../model";
+import { INSIGHT_PLACEHOLDER_WIDGET_ID, newInsightPlaceholderWidget } from "../../../widgets";
+
+export function useNewSectionInsightPlaceholderDropHandler(sectionIndex: number) {
+    const dispatch = useDashboardDispatch();
+    const settings = useDashboardSelector(selectSettings);
+
+    const { run: addNewSectionWithInsightPlaceholder } = useDashboardCommandProcessing({
+        commandCreator: addLayoutSection,
+        errorEvent: "GDC.DASH/EVT.COMMAND.FAILED",
+        successEvent: "GDC.DASH/EVT.FLUID_LAYOUT.SECTION_ADDED",
+        onSuccess: () => {
+            dispatch(uiActions.selectWidget(idRef(INSIGHT_PLACEHOLDER_WIDGET_ID)));
+            dispatch(uiActions.setConfigurationPanelOpened(true));
+        },
+    });
+
+    return useCallback(() => {
+        const sizeInfo = getInsightPlaceholderSizeInfo(settings);
+        addNewSectionWithInsightPlaceholder(sectionIndex, {}, [
+            {
+                type: "IDashboardLayoutItem",
+                size: {
+                    xl: {
+                        gridHeight: sizeInfo.height.default!,
+                        gridWidth: sizeInfo.width.default!,
+                    },
+                },
+                widget: newInsightPlaceholderWidget(sectionIndex, 0, true),
+            },
+        ]);
+    }, [addNewSectionWithInsightPlaceholder, sectionIndex, settings]);
+}

--- a/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/useNewSectionKpiPlaceholderDropHandler.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/useNewSectionKpiPlaceholderDropHandler.ts
@@ -1,0 +1,48 @@
+// (C) 2022 GoodData Corporation
+import { useCallback } from "react";
+import { idRef } from "@gooddata/sdk-model";
+
+import { getSizeInfo } from "../../../_staging/layout/sizing";
+import {
+    selectSettings,
+    useDashboardDispatch,
+    useDashboardSelector,
+    useDashboardCommandProcessing,
+    uiActions,
+    addLayoutSection,
+} from "../../../model";
+import { KPI_PLACEHOLDER_WIDGET_ID, newKpiPlaceholderWidget } from "../../../widgets";
+
+export function useNewSectionKpiPlaceholderDropHandler(sectionIndex: number) {
+    const dispatch = useDashboardDispatch();
+    const settings = useDashboardSelector(selectSettings);
+
+    const { run: addNewSectionWithKpiPlaceholder } = useDashboardCommandProcessing({
+        commandCreator: addLayoutSection,
+        errorEvent: "GDC.DASH/EVT.COMMAND.FAILED",
+        successEvent: "GDC.DASH/EVT.FLUID_LAYOUT.SECTION_ADDED",
+        onSuccess: (event) => {
+            const ref = event.payload.section.items[0].widget!.ref;
+            dispatch(uiActions.selectWidget(idRef(KPI_PLACEHOLDER_WIDGET_ID)));
+            dispatch(uiActions.setConfigurationPanelOpened(true));
+            dispatch(uiActions.setKpiDateDatasetAutoOpen(true));
+            dispatch(uiActions.setWidgetLoadingAdditionalDataStarted(ref));
+        },
+    });
+
+    return useCallback(() => {
+        const sizeInfo = getSizeInfo(settings, "kpi");
+        addNewSectionWithKpiPlaceholder(sectionIndex, {}, [
+            {
+                type: "IDashboardLayoutItem",
+                size: {
+                    xl: {
+                        gridHeight: sizeInfo.height.default!,
+                        gridWidth: sizeInfo.width.default!,
+                    },
+                },
+                widget: newKpiPlaceholderWidget(sectionIndex, 0, true),
+            },
+        ]);
+    }, [addNewSectionWithKpiPlaceholder, sectionIndex, settings]);
+}

--- a/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/useWidgetDragEndHandler.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/useWidgetDragEndHandler.ts
@@ -1,0 +1,28 @@
+// (C) 2022 GoodData Corporation
+import { useCallback } from "react";
+
+import {
+    useDashboardDispatch,
+    uiActions,
+    eagerRemoveSectionItem,
+    useDashboardSelector,
+    selectWidgetPlaceholder,
+} from "../../../model";
+
+/**
+ * @internal
+ */
+export function useWidgetDragEndHandler() {
+    const dispatch = useDashboardDispatch();
+    const widgetPlaceholder = useDashboardSelector(selectWidgetPlaceholder);
+
+    return useCallback(
+        (didDrop: boolean) => {
+            if (!didDrop && widgetPlaceholder) {
+                dispatch(eagerRemoveSectionItem(widgetPlaceholder.sectionIndex, widgetPlaceholder.itemIndex));
+            }
+            dispatch(uiActions.setIsDraggingWidget(false));
+        },
+        [dispatch, widgetPlaceholder],
+    );
+}

--- a/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/useWidgetDragStartHandler.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/useWidgetDragStartHandler.ts
@@ -1,0 +1,24 @@
+// (C) 2022 GoodData Corporation
+import { useCallback } from "react";
+
+import { useDashboardDispatch, useWidgetSelection, uiActions } from "../../../model";
+import { DraggableItem } from "../types";
+import { useAddInitialSectionHandler } from "./useAddInitialSectionHandler";
+
+/**
+ * @internal
+ */
+export function useWidgetDragStartHandler() {
+    const dispatch = useDashboardDispatch();
+    const { deselectWidgets } = useWidgetSelection();
+    const addInitialSectionHandler = useAddInitialSectionHandler();
+
+    return useCallback(
+        (item: DraggableItem) => {
+            deselectWidgets();
+            addInitialSectionHandler(item);
+            dispatch(uiActions.setIsDraggingWidget(true));
+        },
+        [addInitialSectionHandler, deselectWidgets, dispatch],
+    );
+}

--- a/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/useDashboardDrop.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/useDashboardDrop.ts
@@ -12,6 +12,7 @@ const basicDropCollect = (monitor: DropTargetMonitor) => ({
     isOver: monitor.isOver(),
     canDrop: monitor.canDrop(),
     itemType: monitor.getItemType() as DraggableItemType,
+    item: monitor.getItem(),
 });
 
 export function useDashboardDrop<

--- a/libs/sdk-ui-dashboard/src/presentation/index.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/index.ts
@@ -5,7 +5,12 @@ export * from "./dashboard";
 // only export the types for this, not the actual code
 export * from "./dashboardContexts/types";
 export * from "./dragAndDrop/types";
-export { DraggableCreatePanelItem, IDraggableCreatePanelItemProps } from "./dragAndDrop";
+export {
+    DraggableCreatePanelItem,
+    IDraggableCreatePanelItemProps,
+    useWidgetDragStartHandler,
+    useWidgetDragEndHandler,
+} from "./dragAndDrop";
 export * from "./drill";
 export * from "./filterBar";
 export * from "./layout";

--- a/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayout.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayout.tsx
@@ -34,6 +34,8 @@ import {
 import { RenderModeAwareDashboardLayoutSectionHeaderRenderer } from "./DefaultDashboardLayoutRenderer/RenderModeAwareDashboardLayoutSectionHeaderRenderer";
 import { getMemoizedWidgetSanitizer } from "./DefaultDashboardLayoutUtils";
 import { EmptyDashboardDropZone, SectionHotspot } from "../dragAndDrop";
+import { isPlaceholderWidget } from "../../widgets";
+import { DashboardLayoutSectionBorderLine } from "../dragAndDrop/draggableWidget/DashboardLayoutSectionBorder";
 
 /**
  * Get dashboard layout for exports.
@@ -142,6 +144,11 @@ export const DefaultDashboardLayout = (props: IDashboardLayoutProps): JSX.Elemen
         );
     }
 
+    // do not render the tailing section hotspot if there is only one section in the layout and it has only placeholders in it
+    const shouldRenderSectionHotspot =
+        transformedLayout.sections.length > 1 ||
+        transformedLayout.sections[0].items.some((i) => !isPlaceholderWidget(i.widget));
+
     return (
         <>
             <DashboardLayout
@@ -153,7 +160,11 @@ export const DefaultDashboardLayout = (props: IDashboardLayoutProps): JSX.Elemen
                 sectionHeaderRenderer={RenderModeAwareDashboardLayoutSectionHeaderRenderer}
                 renderMode={renderMode}
             />
-            <SectionHotspot index={transformedLayout.sections.length} targetPosition="below" />
+            {shouldRenderSectionHotspot ? (
+                <SectionHotspot index={transformedLayout.sections.length} targetPosition="below" />
+            ) : (
+                <DashboardLayoutSectionBorderLine position="top" status="muted" />
+            )}
         </>
     );
 };

--- a/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayout.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayout.tsx
@@ -33,7 +33,7 @@ import {
 } from "./DefaultDashboardLayoutRenderer";
 import { RenderModeAwareDashboardLayoutSectionHeaderRenderer } from "./DefaultDashboardLayoutRenderer/RenderModeAwareDashboardLayoutSectionHeaderRenderer";
 import { getMemoizedWidgetSanitizer } from "./DefaultDashboardLayoutUtils";
-import { SectionHotspot } from "../dragAndDrop";
+import { EmptyDashboardDropZone, SectionHotspot } from "../dragAndDrop";
 
 /**
  * Get dashboard layout for exports.
@@ -134,9 +134,15 @@ export const DefaultDashboardLayout = (props: IDashboardLayoutProps): JSX.Elemen
         [onError, onDrill, onFiltersChange],
     );
 
-    return isLayoutEmpty ? (
-        <EmptyDashboardError ErrorComponent={ErrorComponent} />
-    ) : (
+    if (isLayoutEmpty) {
+        return renderMode === "edit" ? (
+            <EmptyDashboardDropZone />
+        ) : (
+            <EmptyDashboardError ErrorComponent={ErrorComponent} />
+        );
+    }
+
+    return (
         <>
             <DashboardLayout
                 className={isExport ? "export-mode" : ""}

--- a/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayout.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayout.tsx
@@ -34,7 +34,7 @@ import {
 import { RenderModeAwareDashboardLayoutSectionHeaderRenderer } from "./DefaultDashboardLayoutRenderer/RenderModeAwareDashboardLayoutSectionHeaderRenderer";
 import { getMemoizedWidgetSanitizer } from "./DefaultDashboardLayoutUtils";
 import { EmptyDashboardDropZone, SectionHotspot } from "../dragAndDrop";
-import { isPlaceholderWidget } from "../../widgets";
+import { isInitialPlaceholderWidget } from "../../widgets";
 import { DashboardLayoutSectionBorderLine } from "../dragAndDrop/draggableWidget/DashboardLayoutSectionBorder";
 
 /**
@@ -144,10 +144,10 @@ export const DefaultDashboardLayout = (props: IDashboardLayoutProps): JSX.Elemen
         );
     }
 
-    // do not render the tailing section hotspot if there is only one section in the layout and it has only placeholders in it
+    // do not render the tailing section hotspot if there is only one section in the layout and it has only initial placeholders in it
     const shouldRenderSectionHotspot =
         transformedLayout.sections.length > 1 ||
-        transformedLayout.sections[0].items.some((i) => !isPlaceholderWidget(i.widget));
+        transformedLayout.sections[0].items.some((i) => !isInitialPlaceholderWidget(i.widget));
 
     return (
         <>

--- a/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayout.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayout.tsx
@@ -36,7 +36,6 @@ import { RenderModeAwareDashboardLayoutSectionHeaderRenderer } from "./DefaultDa
 import { getMemoizedWidgetSanitizer } from "./DefaultDashboardLayoutUtils";
 import { EmptyDashboardDropZone, SectionHotspot } from "../dragAndDrop";
 import { isInitialPlaceholderWidget } from "../../widgets";
-import { DashboardLayoutSectionBorderLine } from "../dragAndDrop/draggableWidget/DashboardLayoutSectionBorder";
 
 /**
  * Get dashboard layout for exports.
@@ -162,10 +161,8 @@ export const DefaultDashboardLayout = (props: IDashboardLayoutProps): JSX.Elemen
                 sectionHeaderRenderer={RenderModeAwareDashboardLayoutSectionHeaderRenderer}
                 renderMode={renderMode}
             />
-            {shouldRenderSectionHotspot ? (
+            {!!shouldRenderSectionHotspot && (
                 <SectionHotspot index={transformedLayout.sections.length} targetPosition="below" />
-            ) : (
-                <DashboardLayoutSectionBorderLine position="top" status="muted" />
             )}
         </>
     );

--- a/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayout.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayout.tsx
@@ -31,6 +31,7 @@ import {
     IDashboardLayoutItemKeyGetter,
     IDashboardLayoutWidgetRenderer,
 } from "./DefaultDashboardLayoutRenderer";
+import { RenderModeAwareDashboardLayoutSectionRenderer } from "./DefaultDashboardLayoutRenderer/RenderModeAwareDashboardLayoutSectionRenderer";
 import { RenderModeAwareDashboardLayoutSectionHeaderRenderer } from "./DefaultDashboardLayoutRenderer/RenderModeAwareDashboardLayoutSectionHeaderRenderer";
 import { getMemoizedWidgetSanitizer } from "./DefaultDashboardLayoutUtils";
 import { EmptyDashboardDropZone, SectionHotspot } from "../dragAndDrop";
@@ -157,6 +158,7 @@ export const DefaultDashboardLayout = (props: IDashboardLayoutProps): JSX.Elemen
                 itemKeyGetter={itemKeyGetter}
                 widgetRenderer={widgetRenderer}
                 enableCustomHeight={enableWidgetCustomHeight}
+                sectionRenderer={RenderModeAwareDashboardLayoutSectionRenderer}
                 sectionHeaderRenderer={RenderModeAwareDashboardLayoutSectionHeaderRenderer}
                 renderMode={renderMode}
             />

--- a/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayoutRenderer/DashboardLayoutEditSectionHeaderRenderer.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayoutRenderer/DashboardLayoutEditSectionHeaderRenderer.tsx
@@ -6,12 +6,18 @@ import { IDashboardLayoutSectionHeaderRenderProps } from "./interfaces";
 import { SectionHeaderEditable } from "./EditableHeader/SectionHeaderEditable";
 import { emptyItemFacadeWithFullSize } from "./utils/emptyFacade";
 import { SectionHotspot } from "../../dragAndDrop";
+import { isPlaceholderWidget } from "../../../widgets";
+import { DashboardLayoutSectionBorderLine } from "../../dragAndDrop/draggableWidget/DashboardLayoutSectionBorder";
 
 export function DashboardLayoutEditSectionHeaderRenderer(
     props: IDashboardLayoutSectionHeaderRenderProps<any>,
 ): JSX.Element | null {
     const { section, screen } = props;
     const sectionHeader = section.header();
+
+    // do not render the section hotspot if there is only one section in the layout and it has only placeholders in it
+    const shouldRenderHotspot =
+        section.index() > 0 || section.items().some((i) => !isPlaceholderWidget(i.widget()));
 
     return (
         <DashboardLayoutItemRenderer
@@ -22,7 +28,13 @@ export function DashboardLayoutEditSectionHeaderRenderer(
             <DashboardLayoutSectionHeader
                 title={sectionHeader?.title}
                 description={sectionHeader?.description}
-                renderBeforeHeader={<SectionHotspot index={section.index()} targetPosition="above" />}
+                renderBeforeHeader={
+                    shouldRenderHotspot ? (
+                        <SectionHotspot index={section.index()} targetPosition="above" />
+                    ) : (
+                        <DashboardLayoutSectionBorderLine position="top" status="muted" />
+                    )
+                }
                 renderHeader={
                     <SectionHeaderEditable
                         title={sectionHeader?.title || ""}

--- a/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayoutRenderer/DashboardLayoutEditSectionHeaderRenderer.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayoutRenderer/DashboardLayoutEditSectionHeaderRenderer.tsx
@@ -6,8 +6,7 @@ import { IDashboardLayoutSectionHeaderRenderProps } from "./interfaces";
 import { SectionHeaderEditable } from "./EditableHeader/SectionHeaderEditable";
 import { emptyItemFacadeWithFullSize } from "./utils/emptyFacade";
 import { SectionHotspot } from "../../dragAndDrop";
-import { isPlaceholderWidget } from "../../../widgets";
-import { DashboardLayoutSectionBorderLine } from "../../dragAndDrop/draggableWidget/DashboardLayoutSectionBorder";
+import { isInitialPlaceholderWidget } from "../../../widgets";
 
 export function DashboardLayoutEditSectionHeaderRenderer(
     props: IDashboardLayoutSectionHeaderRenderProps<any>,
@@ -15,9 +14,8 @@ export function DashboardLayoutEditSectionHeaderRenderer(
     const { section, screen } = props;
     const sectionHeader = section.header();
 
-    // do not render the section hotspot if there is only one section in the layout and it has only placeholders in it
-    const shouldRenderHotspot =
-        section.index() > 0 || section.items().some((i) => !isPlaceholderWidget(i.widget()));
+    const isInitialDropzone =
+        section.index() === 0 && section.items().every((i) => isInitialPlaceholderWidget(i.widget()));
 
     return (
         <DashboardLayoutItemRenderer
@@ -29,18 +27,16 @@ export function DashboardLayoutEditSectionHeaderRenderer(
                 title={sectionHeader?.title}
                 description={sectionHeader?.description}
                 renderBeforeHeader={
-                    shouldRenderHotspot ? (
-                        <SectionHotspot index={section.index()} targetPosition="above" />
-                    ) : (
-                        <DashboardLayoutSectionBorderLine position="top" status="muted" />
-                    )
+                    !isInitialDropzone && <SectionHotspot index={section.index()} targetPosition="above" />
                 }
                 renderHeader={
-                    <SectionHeaderEditable
-                        title={sectionHeader?.title || ""}
-                        description={sectionHeader?.description || ""}
-                        index={section.index()}
-                    />
+                    !isInitialDropzone && (
+                        <SectionHeaderEditable
+                            title={sectionHeader?.title || ""}
+                            description={sectionHeader?.description || ""}
+                            index={section.index()}
+                        />
+                    )
                 }
             />
         </DashboardLayoutItemRenderer>

--- a/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayoutRenderer/DashboardLayoutSectionRenderer.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayoutRenderer/DashboardLayoutSectionRenderer.tsx
@@ -4,26 +4,29 @@ import { IDashboardLayoutSectionRenderer } from "./interfaces";
 import cx from "classnames";
 import { DashboardLayoutSectionBorder } from "../../dragAndDrop/draggableWidget/DashboardLayoutSectionBorder";
 import { DashboardLayoutSectionBorderStatus } from "../../dragAndDrop/draggableWidget/DashboardLayoutSectionBorder/types";
-import { selectIsDraggingWidget, useDashboardSelector } from "../../../model";
+import { selectActiveSectionIndex, selectIsDraggingWidget, useDashboardSelector } from "../../../model";
 import { RenderMode } from "../../../types";
 
 const isHiddenStyle = { height: 0, width: 0, overflow: "hidden", flex: 0 };
 const defaultStyle = {};
 
-function useBorderStatus(renderMode: RenderMode): DashboardLayoutSectionBorderStatus {
+function useBorderStatus(renderMode: RenderMode, sectionIndex: number): DashboardLayoutSectionBorderStatus {
     const isDraggingWidget = useDashboardSelector(selectIsDraggingWidget);
-    if (!isDraggingWidget || renderMode === "view") {
+    const activeSectionIndex = useDashboardSelector(selectActiveSectionIndex);
+    const isActive = activeSectionIndex === sectionIndex;
+
+    if ((!isDraggingWidget && !isActive) || renderMode === "view") {
         return "invisible";
     }
 
-    return "muted"; // TODO activation by editable header activation, maybe split this component into two?
+    return "muted";
 }
 
 export const DashboardLayoutSectionRenderer: IDashboardLayoutSectionRenderer<unknown> = (props) => {
-    const { children, className, debug, isHidden, renderMode } = props;
+    const { children, className, debug, isHidden, renderMode, section } = props;
 
     const style = isHidden ? isHiddenStyle : defaultStyle;
-    const status = useBorderStatus(renderMode);
+    const status = useBorderStatus(renderMode, section.index());
 
     return (
         <div

--- a/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayoutRenderer/DashboardLayoutSectionRenderer.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayoutRenderer/DashboardLayoutSectionRenderer.tsx
@@ -2,14 +2,28 @@
 import React from "react";
 import { IDashboardLayoutSectionRenderer } from "./interfaces";
 import cx from "classnames";
+import { DashboardLayoutSectionBorder } from "../../dragAndDrop/draggableWidget/DashboardLayoutSectionBorder";
+import { DashboardLayoutSectionBorderStatus } from "../../dragAndDrop/draggableWidget/DashboardLayoutSectionBorder/types";
+import { selectIsDraggingWidget, useDashboardSelector } from "../../../model";
+import { RenderMode } from "../../../types";
 
 const isHiddenStyle = { height: 0, width: 0, overflow: "hidden", flex: 0 };
 const defaultStyle = {};
 
+function useBorderStatus(renderMode: RenderMode): DashboardLayoutSectionBorderStatus {
+    const isDraggingWidget = useDashboardSelector(selectIsDraggingWidget);
+    if (!isDraggingWidget || renderMode === "view") {
+        return "invisible";
+    }
+
+    return "muted"; // TODO activation by editable header activation, maybe split this component into two?
+}
+
 export const DashboardLayoutSectionRenderer: IDashboardLayoutSectionRenderer<unknown> = (props) => {
-    const { children, className, debug, isHidden } = props;
+    const { children, className, debug, isHidden, renderMode } = props;
 
     const style = isHidden ? isHiddenStyle : defaultStyle;
+    const status = useBorderStatus(renderMode);
 
     return (
         <div
@@ -18,7 +32,7 @@ export const DashboardLayoutSectionRenderer: IDashboardLayoutSectionRenderer<unk
             })}
             style={style}
         >
-            {children}
+            <DashboardLayoutSectionBorder status={status}>{children}</DashboardLayoutSectionBorder>
         </div>
     );
 };

--- a/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayoutRenderer/DashboardLayoutSectionRenderer.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayoutRenderer/DashboardLayoutSectionRenderer.tsx
@@ -2,31 +2,14 @@
 import React from "react";
 import { IDashboardLayoutSectionRenderer } from "./interfaces";
 import cx from "classnames";
-import { DashboardLayoutSectionBorder } from "../../dragAndDrop/draggableWidget/DashboardLayoutSectionBorder";
-import { DashboardLayoutSectionBorderStatus } from "../../dragAndDrop/draggableWidget/DashboardLayoutSectionBorder/types";
-import { selectActiveSectionIndex, selectIsDraggingWidget, useDashboardSelector } from "../../../model";
-import { RenderMode } from "../../../types";
 
 const isHiddenStyle = { height: 0, width: 0, overflow: "hidden", flex: 0 };
 const defaultStyle = {};
 
-function useBorderStatus(renderMode: RenderMode, sectionIndex: number): DashboardLayoutSectionBorderStatus {
-    const isDraggingWidget = useDashboardSelector(selectIsDraggingWidget);
-    const activeSectionIndex = useDashboardSelector(selectActiveSectionIndex);
-    const isActive = activeSectionIndex === sectionIndex;
-
-    if ((!isDraggingWidget && !isActive) || renderMode === "view") {
-        return "invisible";
-    }
-
-    return "muted";
-}
-
 export const DashboardLayoutSectionRenderer: IDashboardLayoutSectionRenderer<unknown> = (props) => {
-    const { children, className, debug, isHidden, renderMode, section } = props;
+    const { children, className, debug, isHidden } = props;
 
     const style = isHidden ? isHiddenStyle : defaultStyle;
-    const status = useBorderStatus(renderMode, section.index());
 
     return (
         <div
@@ -35,7 +18,7 @@ export const DashboardLayoutSectionRenderer: IDashboardLayoutSectionRenderer<unk
             })}
             style={style}
         >
-            <DashboardLayoutSectionBorder status={status}>{children}</DashboardLayoutSectionBorder>
+            {children}
         </div>
     );
 };

--- a/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayoutRenderer/EditableDashboardLayoutSectionRenderer.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayoutRenderer/EditableDashboardLayoutSectionRenderer.tsx
@@ -1,0 +1,36 @@
+// (C) 2007-2022 GoodData Corporation
+import React from "react";
+import { IDashboardLayoutSectionRenderer } from "./interfaces";
+import cx from "classnames";
+import { DashboardLayoutSectionBorder } from "../../dragAndDrop/draggableWidget/DashboardLayoutSectionBorder";
+import { DashboardLayoutSectionBorderStatus } from "../../dragAndDrop/draggableWidget/DashboardLayoutSectionBorder/types";
+import { selectActiveSectionIndex, selectIsDraggingWidget, useDashboardSelector } from "../../../model";
+
+const isHiddenStyle = { height: 0, width: 0, overflow: "hidden", flex: 0 };
+const defaultStyle = {};
+
+function useBorderStatus(sectionIndex: number): DashboardLayoutSectionBorderStatus {
+    const isDraggingWidget = useDashboardSelector(selectIsDraggingWidget);
+    const activeSectionIndex = useDashboardSelector(selectActiveSectionIndex);
+    const isActive = activeSectionIndex === sectionIndex;
+
+    return !isDraggingWidget && !isActive ? "invisible" : "muted";
+}
+
+export const EditableDashboardLayoutSectionRenderer: IDashboardLayoutSectionRenderer<unknown> = (props) => {
+    const { children, className, debug, isHidden, section } = props;
+
+    const style = isHidden ? isHiddenStyle : defaultStyle;
+    const status = useBorderStatus(section.index());
+
+    return (
+        <div
+            className={cx(["gd-fluidlayout-row", "s-fluid-layout-row", className], {
+                "gd-fluidlayout-row-debug": debug,
+            })}
+            style={style}
+        >
+            <DashboardLayoutSectionBorder status={status}>{children}</DashboardLayoutSectionBorder>
+        </div>
+    );
+};

--- a/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayoutRenderer/EditableDashboardLayoutSectionRenderer.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayoutRenderer/EditableDashboardLayoutSectionRenderer.tsx
@@ -2,8 +2,7 @@
 import React from "react";
 import { IDashboardLayoutSectionRenderer } from "./interfaces";
 import cx from "classnames";
-import { DashboardLayoutSectionBorder } from "../../dragAndDrop/draggableWidget/DashboardLayoutSectionBorder";
-import { DashboardLayoutSectionBorderStatus } from "../../dragAndDrop/draggableWidget/DashboardLayoutSectionBorder/types";
+import { DashboardLayoutSectionBorder, DashboardLayoutSectionBorderStatus } from "../../dragAndDrop";
 import { selectActiveSectionIndex, selectIsDraggingWidget, useDashboardSelector } from "../../../model";
 
 const isHiddenStyle = { height: 0, width: 0, overflow: "hidden", flex: 0 };

--- a/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayoutRenderer/EditableHeader/SectionHeaderEditable.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayoutRenderer/EditableHeader/SectionHeaderEditable.tsx
@@ -13,22 +13,13 @@ import {
 } from "./sectionHeaderHelper";
 import { changeLayoutSectionHeader, uiActions, useDashboardDispatch } from "../../../../model";
 
-export interface ISectionHeaderEditOwnProps {
+export interface ISectionHeaderEditableProps {
     title: string;
     description: string;
     index: number;
 }
 
-export interface ISectionHeaderEditDispatchProps {
-    rowHeaderTitleChanged: (rowId: string, title: string) => void;
-    rowHeaderDescriptionChanged: (rowId: string, description: string) => void;
-    rowHeaderFocused: (rowId: string) => void;
-    rowHeaderBlurred: (rowId: string) => void;
-}
-
-export type ISectionHeaderEditableProps = ISectionHeaderEditOwnProps & ISectionHeaderEditDispatchProps;
-
-export function SectionHeaderEditable(props: ISectionHeaderEditOwnProps): JSX.Element {
+export function SectionHeaderEditable(props: ISectionHeaderEditableProps): JSX.Element {
     const description = getDescription(props.description);
     const title = getTitle(props.title);
     const { index } = props;

--- a/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayoutRenderer/EditableHeader/SectionHeaderEditable.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayoutRenderer/EditableHeader/SectionHeaderEditable.tsx
@@ -11,7 +11,7 @@ import {
     MAX_DESCRIPTION_LENGTH,
     DESCRIPTION_LENGTH_WARNING_LIMIT,
 } from "./sectionHeaderHelper";
-import { changeLayoutSectionHeader, useDashboardDispatch } from "../../../../model";
+import { changeLayoutSectionHeader, uiActions, useDashboardDispatch } from "../../../../model";
 
 export interface ISectionHeaderEditOwnProps {
     title: string;
@@ -44,18 +44,28 @@ export function SectionHeaderEditable(props: ISectionHeaderEditOwnProps): JSX.El
         [dispatch, index],
     );
 
+    const onEditingStart = useCallback(() => {
+        dispatch(uiActions.setActiveSectionIndex(index));
+    }, [dispatch, index]);
+
+    const onEditingEnd = useCallback(() => {
+        dispatch(uiActions.clearActiveSectionIndex());
+    }, [dispatch]);
+
     const onTitleSubmit = useCallback(
         (title: string) => {
             changeTitle(title);
+            onEditingEnd();
         },
-        [changeTitle],
+        [changeTitle, onEditingEnd],
     );
 
     const onDescriptionSubmit = useCallback(
         (description: string) => {
             changeDescription(description);
+            onEditingEnd();
         },
-        [changeDescription],
+        [changeDescription, onEditingEnd],
     );
 
     return (
@@ -70,6 +80,8 @@ export function SectionHeaderEditable(props: ISectionHeaderEditOwnProps): JSX.El
                     placeholderMessage={intl.formatMessage({ id: "layout.header.add.title.placeholder" })}
                     alignTo={`.gd-title-for-${index}`}
                     onSubmit={onTitleSubmit}
+                    onEditingStart={onEditingStart}
+                    onCancel={onEditingEnd}
                 />
             </div>
             <div className="gd-editable-label-container gd-row-header-description-wrapper">
@@ -84,6 +96,8 @@ export function SectionHeaderEditable(props: ISectionHeaderEditOwnProps): JSX.El
                         id: "layout.header.add.description.placeholder",
                     })}
                     onSubmit={onDescriptionSubmit}
+                    onEditingStart={onEditingStart}
+                    onCancel={onEditingEnd}
                 />
             </div>
         </div>

--- a/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayoutRenderer/RenderModeAwareDashboardLayoutSectionRenderer.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayoutRenderer/RenderModeAwareDashboardLayoutSectionRenderer.tsx
@@ -1,0 +1,14 @@
+// (C) 2022 GoodData Corporation
+
+import { renderModeAware } from "../../componentDefinition";
+import { DashboardLayoutSectionRenderer } from "./DashboardLayoutSectionRenderer";
+import { EditableDashboardLayoutSectionRenderer } from "./EditableDashboardLayoutSectionRenderer";
+import { IDashboardLayoutSectionRenderer } from "./interfaces";
+
+/**
+ * @internal
+ */
+export const RenderModeAwareDashboardLayoutSectionRenderer = renderModeAware({
+    view: DashboardLayoutSectionRenderer,
+    edit: EditableDashboardLayoutSectionRenderer,
+}) as IDashboardLayoutSectionRenderer<unknown>;

--- a/libs/sdk-ui-dashboard/src/presentation/localization/bundles/en-US.json
+++ b/libs/sdk-ui-dashboard/src/presentation/localization/bundles/en-US.json
@@ -1793,5 +1793,27 @@
         "value": "Delete",
         "comment": "",
         "limit": 0
+    },
+    "newDashboard.title|insight": {
+        "value": "Drag insight here",
+        "comment": "",
+        "limit": 0
+    },
+    "newDashboard.title|report": {
+        "value": "Drag report here",
+        "comment": "",
+        "translate": false,
+        "limit": 0
+    },
+    "newDashboard.dropInsight|insight": {
+        "value": "Drop insight",
+        "comment": "A placeholder showed when user drags new insight into a dashboard canvas by cursor (drag and drop).",
+        "limit": 0
+    },
+    "newDashboard.dropInsight|report": {
+        "value": "Drop report",
+        "comment": "A placeholder showed when user drags new report into a dashboard canvas by cursor (drag and drop).",
+        "translate": false,
+        "limit": 0
     }
 }

--- a/libs/sdk-ui-dashboard/src/presentation/topBar/buttonBar/button/saveButton/DefaultSaveButton.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/topBar/buttonBar/button/saveButton/DefaultSaveButton.tsx
@@ -11,7 +11,6 @@ import {
     saveDashboard,
     selectEnableAnalyticalDashboardPermissions,
     selectIsDashboardDirty,
-    selectIsNewDashboard,
     selectIsDashboardSaving,
     selectIsLayoutEmpty,
     selectIsInEditMode,
@@ -39,13 +38,12 @@ export function useSaveButtonProps(): ISaveButtonProps {
     const isSaving = useDashboardSelector(selectIsDashboardSaving);
     const arePermissionsEnabled = useDashboardSelector(selectEnableAnalyticalDashboardPermissions);
     const isPrivateDashboard = useDashboardSelector(selectIsPrivateDashboard);
-    const isNewDashboard = useDashboardSelector(selectIsNewDashboard);
     const isEmptyDashboard = useDashboardSelector(selectIsLayoutEmpty);
     const canSaveDashboard = useDashboardSelector(selectCanSaveDashboard);
     const isDashboardDirty = useDashboardSelector(selectIsDashboardDirty);
 
     const isVisible = isEditing;
-    const isEnabled = isNewDashboard ? !isEmptyDashboard : isDashboardDirty;
+    const isEnabled = isDashboardDirty;
 
     const buttonValue = arePermissionsEnabled
         ? messages.controlButtonsSaveValue

--- a/libs/sdk-ui-dashboard/src/presentation/widget/kpi/EditModeDashboardKpi/EditModeDashboardKpi.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/kpi/EditModeDashboardKpi/EditModeDashboardKpi.tsx
@@ -17,6 +17,7 @@ import {
     selectFilterContextFilters,
     uiActions,
     useWidgetSelection,
+    selectIsDashboardSaving,
 } from "../../../../model";
 import { DashboardItemHeadline, DashboardItemKpi } from "../../../presentationComponents";
 import { useDashboardComponentsContext } from "../../../dashboardContexts";
@@ -63,6 +64,8 @@ export const EditModeDashboardKpi = (props: IDashboardKpiProps) => {
     const separators = useDashboardSelector(selectSeparators);
     const disableDrillUnderline = useDashboardSelector(selectDisableKpiDashboardHeadlineUnderline);
     const isDrillable = kpiWidget.drills.length > 0;
+    const isSaving = useDashboardSelector(selectIsDashboardSaving);
+    const isEditable = !isSaving;
 
     const dispatch = useDashboardDispatch();
     const coordinates = useDashboardSelector(selectWidgetCoordinatesByRef(widgetRef(kpiWidget)));
@@ -120,7 +123,9 @@ export const EditModeDashboardKpi = (props: IDashboardKpiProps) => {
                 "kpi-with-pop": kpiWidget.kpi.comparisonType !== "none",
                 "content-loading": isLoading,
                 "content-loaded": !isLoading,
+                "is-editable": isEditable,
             })}
+            contentClassName={cx({ "is-editable": isEditable })}
             renderBeforeContent={renderBeforeContent}
             renderAfterContent={() => {
                 if (isSelected) {

--- a/libs/sdk-ui-dashboard/src/presentation/widget/widget/DashboardWidget.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/widget/DashboardWidget.tsx
@@ -5,8 +5,13 @@ import { extendedWidgetDebugStr } from "../../../model";
 import { DefaultDashboardWidget } from "./DefaultDashboardWidget";
 import { isDashboardWidget } from "@gooddata/sdk-model";
 import { CustomDashboardWidgetComponent, IDashboardWidgetProps } from "./types";
-import { WidgetDropZone } from "../../dragAndDrop";
-import { isInsightPlaceholderWidget, isKpiPlaceholderWidget, isPlaceholderWidget } from "../../../widgets";
+import { EmptyDashboardDropZone, WidgetDropZone } from "../../dragAndDrop";
+import {
+    isInitialPlaceholderWidget,
+    isInsightPlaceholderWidget,
+    isKpiPlaceholderWidget,
+    isPlaceholderWidget,
+} from "../../../widgets";
 
 const BadWidgetType: React.FC = () => {
     return <div>Missing renderer</div>;
@@ -42,6 +47,10 @@ export const DashboardWidget = (props: IDashboardWidgetProps): JSX.Element => {
         // the default WidgetComponentProvider always returns something, DefaultDashboardWidget by default
         if (Component && Component !== DefaultDashboardWidget) {
             return Component;
+        }
+
+        if (isInitialPlaceholderWidget(widget)) {
+            return EmptyDashboardDropZone;
         }
 
         if (isPlaceholderWidget(widget)) {

--- a/libs/sdk-ui-dashboard/src/presentation/widget/widget/InsightWidget/EditableDashboardInsightWidget.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/widget/InsightWidget/EditableDashboardInsightWidget.tsx
@@ -12,7 +12,7 @@ import {
 } from "../../../presentationComponents";
 import { DashboardInsight } from "../../insight";
 import { useDashboardComponentsContext } from "../../../dashboardContexts";
-import { useWidgetSelection } from "../../../../model";
+import { selectIsDashboardSaving, useDashboardSelector, useWidgetSelection } from "../../../../model";
 import { useEditableInsightMenu } from "./useEditableInsightMenu";
 import { IDefaultDashboardInsightWidgetProps } from "./types";
 import { DashboardWidgetInsightGuard } from "./DashboardWidgetInsightGuard";
@@ -44,6 +44,9 @@ const EditableDashboardInsightWidgetCore: React.FC<
         () => InsightMenuComponentProvider(insight, widget),
         [InsightMenuComponentProvider, insight, widget],
     );
+
+    const isSaving = useDashboardSelector(selectIsDashboardSaving);
+    const isEditable = !isSaving;
 
     return (
         <DashboardItem
@@ -87,6 +90,8 @@ const EditableDashboardInsightWidgetCore: React.FC<
                         </>
                     );
                 }}
+                contentClassName={cx({ "is-editable": isEditable })}
+                visualizationClassName={cx({ "is-editable": isEditable })}
             >
                 {({ clientHeight, clientWidth }) => (
                     <DashboardInsight

--- a/libs/sdk-ui-dashboard/src/widgets/placeholders/types.ts
+++ b/libs/sdk-ui-dashboard/src/widgets/placeholders/types.ts
@@ -90,6 +90,7 @@ export interface PlaceholderWidget extends ICustomWidget {
     readonly sectionIndex: number;
     readonly itemIndex: number;
     readonly isLastInSection: boolean;
+    readonly isInitial?: boolean;
 }
 
 /**
@@ -100,6 +101,16 @@ export interface PlaceholderWidget extends ICustomWidget {
  */
 export function isPlaceholderWidget(obj: unknown): obj is PlaceholderWidget {
     return !isEmpty(obj) && (obj as PlaceholderWidget).customType === "gd-widget-placeholder";
+}
+
+/**
+ * Tests whether an object is a {@link PlaceholderWidget} and is initial.
+ *
+ * @param obj - object to test
+ * @internal
+ */
+export function isInitialPlaceholderWidget(obj: unknown): obj is PlaceholderWidget {
+    return isPlaceholderWidget(obj) && !!obj.isInitial;
 }
 
 /**
@@ -114,12 +125,24 @@ export function newPlaceholderWidget(
     sectionIndex: number,
     itemIndex: number,
     isLastInSection: boolean,
-): InsightPlaceholderWidget {
+): PlaceholderWidget {
     return newCustomWidget(PLACEHOLDER_WIDGET_ID, "gd-widget-placeholder", {
         sectionIndex,
         itemIndex,
         isLastInSection,
-    }) as InsightPlaceholderWidget;
+    }) as PlaceholderWidget;
+}
+
+/**
+ * @internal
+ */
+export function newInitialPlaceholderWidget(): PlaceholderWidget {
+    return newCustomWidget(PLACEHOLDER_WIDGET_ID, "gd-widget-placeholder", {
+        sectionIndex: 0,
+        itemIndex: 0,
+        isLastInSection: true,
+        isInitial: true,
+    }) as PlaceholderWidget;
 }
 
 /**

--- a/libs/sdk-ui-dashboard/styles/scss/dragAndDrop.scss
+++ b/libs/sdk-ui-dashboard/styles/scss/dragAndDrop.scss
@@ -293,8 +293,9 @@
     }
 
     &.last {
+        top: 16px;
         height: 100px;
-        margin: -8px 0 0;
+        margin: 0;
     }
 }
 
@@ -490,7 +491,10 @@
     }
 
     &.bottom {
-        bottom: -23px;
+        bottom: -18px;
+        &.active {
+            bottom: -23px;
+        }
     }
 
     &.active {

--- a/libs/sdk-ui-dashboard/styles/scss/dragAndDrop.scss
+++ b/libs/sdk-ui-dashboard/styles/scss/dragAndDrop.scss
@@ -492,9 +492,6 @@
 
     &.bottom {
         bottom: -18px;
-        &.active {
-            bottom: -23px;
-        }
     }
 
     &.active {


### PR DESCRIPTION
* support adding widgets onto an empty layout
* handle section activation (using the editing of header title or subtitle)
* add missing "is-editable" css classes

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
