### PR TITLE
RELATED: RAIL-4170 Add support for customizing empty layout dropzone

### DIFF
--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -744,6 +744,9 @@ export type CustomDraggingComponent = ComponentType<ICustomDraggingComponentProp
 // @internal (undocumented)
 export type CustomEditModeButtonComponent = ComponentType<IEditButtonProps>;
 
+// @internal (undocumented)
+export type CustomEmptyLayoutDropZoneBodyComponent = ComponentType;
+
 // @alpha (undocumented)
 export type CustomFilterBarComponent = ComponentType<IFilterBarProps>;
 
@@ -2905,6 +2908,8 @@ export interface IDashboardCustomComponentProps {
     DashboardAttributeFilterComponentProvider?: OptionalAttributeFilterComponentProvider;
     // @alpha
     DashboardDateFilterComponentProvider?: OptionalDateFilterComponentProvider;
+    // @internal
+    EmptyLayoutDropZoneBodyComponent?: CustomEmptyLayoutDropZoneBodyComponent;
     // @alpha
     ErrorComponent?: ComponentType<IErrorProps>;
     // @alpha

--- a/libs/sdk-ui-dashboard/src/presentation/dashboard/components/DashboardRenderer.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/dashboard/components/DashboardRenderer.tsx
@@ -31,7 +31,11 @@ import { IDashboardProps } from "../types";
 import { DashboardLoading } from "./DashboardLoading";
 import { DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
-import { DragLayerComponent, LayoutResizeStateProvider } from "../../dragAndDrop";
+import {
+    DefaultEmptyLayoutDropZoneBody,
+    DragLayerComponent,
+    LayoutResizeStateProvider,
+} from "../../dragAndDrop";
 import { RenderModeAwareDashboardSidebar } from "../DashboardSidebar/RenderModeAwareDashboardSidebar";
 
 /**
@@ -114,6 +118,10 @@ export const DashboardRenderer: React.FC<IDashboardProps> = (props: IDashboardPr
                                         InsightWidgetComponentSet={insightWidgetComponentSet}
                                         KpiWidgetComponentSet={kpiWidgetComponentSet}
                                         AttributeFilterComponentSet={attributeFilterComponentSet}
+                                        EmptyLayoutDropZoneBodyComponent={
+                                            props.EmptyLayoutDropZoneBodyComponent ??
+                                            DefaultEmptyLayoutDropZoneBody
+                                        }
                                     >
                                         <DashboardConfigProvider menuButtonConfig={props.menuButtonConfig}>
                                             <DndProvider backend={HTML5Backend}>

--- a/libs/sdk-ui-dashboard/src/presentation/dashboard/types.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/dashboard/types.ts
@@ -13,7 +13,7 @@ import {
     DashboardState,
 } from "../../model";
 import { CustomFilterBarComponent } from "../filterBar";
-import { CustomDashboardLayoutComponent } from "../layout";
+import { CustomDashboardLayoutComponent, CustomEmptyLayoutDropZoneBodyComponent } from "../layout";
 import {
     CustomScheduledEmailDialogComponent,
     CustomScheduledEmailManagementDialogComponent,
@@ -47,7 +47,7 @@ import { InsightComponentSetProvider } from "../componentDefinition/types";
  *
  * @remarks
  * IMPORTANT: while this interface is marked as public, you also need to heed the maturity annotations
- * on each property. A lot of these properties are at this moment alpha level.
+ * on each property. A lot of these properties are at this moment alpha or internal level.
  *
  * @public
  */
@@ -299,6 +299,17 @@ export interface IDashboardCustomComponentProps {
      * @alpha
      */
     SidebarComponent?: CustomSidebarComponent;
+
+    /**
+     * Specify the component rendered as the body of the drop zone when the layout is empty.
+     *
+     * @internal
+     *
+     * @privateRemarks
+     * We would ideally replace the whole EmptyLayoutComponent, however integrating with the drop zone is currently too complicated.
+     *
+     */
+    EmptyLayoutDropZoneBodyComponent?: CustomEmptyLayoutDropZoneBodyComponent;
 }
 
 /**

--- a/libs/sdk-ui-dashboard/src/presentation/dashboardContexts/DashboardComponentsContext.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/dashboardContexts/DashboardComponentsContext.tsx
@@ -8,7 +8,7 @@ import {
     UnexpectedSdkError,
 } from "@gooddata/sdk-ui";
 
-import { CustomDashboardLayoutComponent } from "../layout/types";
+import { CustomDashboardLayoutComponent, CustomEmptyLayoutDropZoneBodyComponent } from "../layout/types";
 import {
     CustomButtonBarComponent,
     CustomMenuButtonComponent,
@@ -67,6 +67,7 @@ interface IDashboardComponentsContext {
     InsightWidgetComponentSet: InsightWidgetComponentSet;
     KpiWidgetComponentSet: KpiWidgetComponentSet;
     AttributeFilterComponentSet: AttributeFilterComponentSet;
+    EmptyLayoutDropZoneBodyComponent: CustomEmptyLayoutDropZoneBodyComponent;
 }
 
 const ThrowMissingComponentError = (componentName: string) => () => {
@@ -107,6 +108,7 @@ const DashboardComponentsContext = createContext<IDashboardComponentsContext>({
     InsightWidgetComponentSet: null as any, // TODO how to throw here
     KpiWidgetComponentSet: null as any, // TODO how to throw here
     AttributeFilterComponentSet: null as any, // TODO how to throw here
+    EmptyLayoutDropZoneBodyComponent: ThrowMissingComponentError("EmptyLayoutDropZoneBodyComponent"),
 });
 DashboardComponentsContext.displayName = "DashboardComponentsContext";
 

--- a/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/DefaultEmptyLayoutDropZoneBody.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/DefaultEmptyLayoutDropZoneBody.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { FormattedMessage } from "react-intl";
 import { Typography } from "@gooddata/sdk-ui-kit";
 
-export const EmptyDashboardDropZoneBox: React.FC = () => {
+export const DefaultEmptyLayoutDropZoneBody: React.FC = () => {
     return (
         <div className="drag-info-placeholder-box s-drag-info-placeholder-box">
             <Typography tagName="h2">

--- a/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/EmptyDashboardDropZone.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/EmptyDashboardDropZone.tsx
@@ -4,7 +4,6 @@ import { FormattedMessage } from "react-intl";
 import cx from "classnames";
 import { Typography } from "@gooddata/sdk-ui-kit";
 
-import { EmptyDashboardDropZoneBox } from "./EmptyDashboardDropZoneBox";
 import { useDashboardDrop } from "../useDashboardDrop";
 import {
     DraggableItemType,
@@ -16,6 +15,7 @@ import { useDashboardDispatch, useDashboardSelector, selectWidgetPlaceholder } f
 import { useInsightListItemDropHandler } from "./useInsightListItemDropHandler";
 import { useInsightPlaceholderDropHandler } from "./useInsightPlaceholderDropHandler";
 import { useKpiPlaceholderDropHandler } from "./useKpiPlaceholderDropHandler";
+import { useDashboardComponentsContext } from "../../dashboardContexts";
 
 const widgetCategoryMapping: Partial<{ [D in DraggableItemType]: string }> = {
     "insight-placeholder": "insight",
@@ -26,6 +26,8 @@ const widgetCategoryMapping: Partial<{ [D in DraggableItemType]: string }> = {
 export const EmptyDashboardDropZone: React.FC = () => {
     const dispatch = useDashboardDispatch();
     const widgetPlaceholder = useDashboardSelector(selectWidgetPlaceholder);
+
+    const { EmptyLayoutDropZoneBodyComponent } = useDashboardComponentsContext();
 
     const handleInsightListItemDrop = useInsightListItemDropHandler();
     const handleKpiPlaceholderDrop = useKpiPlaceholderDropHandler();
@@ -67,7 +69,7 @@ export const EmptyDashboardDropZone: React.FC = () => {
             ref={dropRef}
         >
             <div className={cx("drag-info-placeholder-inner", { "can-drop": canDrop, "is-over": isOver })}>
-                <EmptyDashboardDropZoneBox />
+                <EmptyLayoutDropZoneBodyComponent />
                 <div className="drag-info-placeholder-drop-target s-drag-info-placeholder-drop-target">
                     <div className="drop-target-inner">
                         <Typography tagName="p" className="drop-target-message kpi-drop-target">

--- a/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/index.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/index.ts
@@ -9,3 +9,4 @@ export * from "./EmptyDashboardDropZone";
 export * from "./useWidgetDragStartHandler";
 export * from "./useWidgetDragEndHandler";
 export * from "./DashboardLayoutSectionBorder";
+export * from "./DefaultEmptyLayoutDropZoneBody";

--- a/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayout.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayout.tsx
@@ -20,10 +20,8 @@ import {
     selectEnableWidgetCustomHeight,
     selectRenderMode,
 } from "../../model";
-import { useDashboardComponentsContext } from "../dashboardContexts";
 
 import { DashboardLayoutWidget } from "./DashboardLayoutWidget";
-import { EmptyDashboardError } from "./EmptyDashboardError";
 import { IDashboardLayoutProps } from "./types";
 import {
     DashboardLayout,
@@ -34,8 +32,9 @@ import {
 import { RenderModeAwareDashboardLayoutSectionRenderer } from "./DefaultDashboardLayoutRenderer/RenderModeAwareDashboardLayoutSectionRenderer";
 import { RenderModeAwareDashboardLayoutSectionHeaderRenderer } from "./DefaultDashboardLayoutRenderer/RenderModeAwareDashboardLayoutSectionHeaderRenderer";
 import { getMemoizedWidgetSanitizer } from "./DefaultDashboardLayoutUtils";
-import { EmptyDashboardDropZone, SectionHotspot } from "../dragAndDrop";
+import { SectionHotspot } from "../dragAndDrop";
 import { isInitialPlaceholderWidget } from "../../widgets";
+import { EmptyDashboardLayout } from "./EmptyDashboardLayout";
 
 /**
  * Get dashboard layout for exports.
@@ -86,9 +85,7 @@ const itemKeyGetter: IDashboardLayoutItemKeyGetter<ExtendedDashboardWidget> = (k
  * @alpha
  */
 export const DefaultDashboardLayout = (props: IDashboardLayoutProps): JSX.Element => {
-    const { onFiltersChange, onDrill, onError, ErrorComponent: CustomError } = props;
-
-    const { ErrorComponent } = useDashboardComponentsContext({ ErrorComponent: CustomError });
+    const { onFiltersChange, onDrill, onError } = props;
 
     const layout = useDashboardSelector(selectLayout);
     const isLayoutEmpty = useDashboardSelector(selectIsLayoutEmpty);
@@ -137,11 +134,7 @@ export const DefaultDashboardLayout = (props: IDashboardLayoutProps): JSX.Elemen
     );
 
     if (isLayoutEmpty) {
-        return renderMode === "edit" ? (
-            <EmptyDashboardDropZone />
-        ) : (
-            <EmptyDashboardError ErrorComponent={ErrorComponent} />
-        );
+        return <EmptyDashboardLayout />;
     }
 
     // do not render the tailing section hotspot if there is only one section in the layout and it has only initial placeholders in it

--- a/libs/sdk-ui-dashboard/src/presentation/layout/EmptyDashboardError.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/layout/EmptyDashboardError.tsx
@@ -1,14 +1,11 @@
 // (C) 2020-2022 GoodData Corporation
 import React from "react";
 import { useIntl } from "react-intl";
-import { IErrorProps } from "@gooddata/sdk-ui";
+import { useDashboardComponentsContext } from "../dashboardContexts";
 
-interface IEmptyDashboardErrorProps {
-    ErrorComponent: React.ComponentType<IErrorProps>;
-}
-
-export const EmptyDashboardError: React.FC<IEmptyDashboardErrorProps> = ({ ErrorComponent }) => {
+export const EmptyDashboardError: React.FC = () => {
     const intl = useIntl();
+    const { ErrorComponent } = useDashboardComponentsContext();
     return (
         <ErrorComponent
             className="s-layout-error"

--- a/libs/sdk-ui-dashboard/src/presentation/layout/EmptyDashboardLayout.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/layout/EmptyDashboardLayout.ts
@@ -1,0 +1,9 @@
+// (C) 2022 GoodData Corporation
+import { renderModeAware } from "../componentDefinition";
+import { EmptyDashboardDropZone } from "../dragAndDrop";
+import { EmptyDashboardError } from "./EmptyDashboardError";
+
+export const EmptyDashboardLayout = renderModeAware({
+    view: EmptyDashboardError,
+    edit: EmptyDashboardDropZone,
+});

--- a/libs/sdk-ui-dashboard/src/presentation/layout/types.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/layout/types.ts
@@ -20,3 +20,8 @@ export interface IDashboardLayoutProps {
  * @alpha
  */
 export type CustomDashboardLayoutComponent = ComponentType<IDashboardLayoutProps>;
+
+/**
+ * @internal
+ */
+export type CustomEmptyLayoutDropZoneBodyComponent = ComponentType;


### PR DESCRIPTION
Also simplify the empty layout handling.

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
