### PR TITLE
BUGFIX: RAIL-4319 Fix gitlab pipeline definition

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,9 +26,10 @@ stages:
   # package.json in every release anyway.
   # Commit message condition is needed to avoid creating a new Docker image on
   # every single merge commit to master - that would be a waste.
-  if: '$CI_COMMIT_BRANCH == "master" && $CI_COMMIT_MESSAGE =~ /^Release .+$/'
-  changes:
-    - libs/sdk-ui-components/**/*
+  rules:
+    - if: '$CI_COMMIT_BRANCH == "master" && $CI_COMMIT_MESSAGE =~ /^Release .+$/'
+      changes:
+        - libs/sdk-ui-components/**/*
 
 .with-buildx:
   before_script:
@@ -40,6 +41,8 @@ stages:
       --driver-opt="namespace=gitlab-managed-apps,nodeselector=role=ci,qemu.install=true,replicas=3"
 
 build-web-components:
+  extends:
+    - .release
   image: node:16
   stage: build
   cache:
@@ -59,11 +62,10 @@ build-web-components:
   artifacts:
     paths:
       - ${CI_PROJECT_DIR}/libs/sdk-ui-web-components/web-components.tar.gz
-  rules:
-    - <<: *.release
 
 docker-build-web-components:
   extends:
+    - .release
     - .with-buildx
   stage: artifacts
   variables:
@@ -75,15 +77,13 @@ docker-build-web-components:
       -t $IMAGE_ID -t $CI_REGISTRY_IMAGE:$CI_COMMIT_REF_SLUG -f Dockerfile .
   dependencies:
     - build-web-components
-  rules:
-    - <<: *.release
 
 generate-update:
+  extends:
+    - .release
   stage: generate-update
   variables:
     KUBERNETES_MEMORY_REQUEST: 100Mi
   script:
     - /scripts/update-ext-image-version.rb web-components
   dependencies: []
-  rules:
-    - <<: *.release


### PR DESCRIPTION
The previous structure had invalid YAML anchors. Changing
to more modern `extends` approach.

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
