### PR TITLE
FEATURE: SD-2357 Update WorkspaceConverter in sdk-backend-tiger to use description field returned from BE

### DIFF
--- a/libs/sdk-backend-tiger/src/convertors/fromBackend/WorkspaceConverter.ts
+++ b/libs/sdk-backend-tiger/src/convertors/fromBackend/WorkspaceConverter.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2021 GoodData Corporation
+// (C) 2019-2022 GoodData Corporation
 import { JsonApiWorkspaceOut, JsonApiWorkspaceOutWithLinks } from "@gooddata/api-client-tiger";
 import { IWorkspaceDescriptor } from "@gooddata/sdk-backend-spi";
 
@@ -9,7 +9,7 @@ export const workspaceConverter = ({
 }: JsonApiWorkspaceOut | JsonApiWorkspaceOutWithLinks): IWorkspaceDescriptor => {
     const parentWorkspace = relationships?.parent?.data?.id;
     return {
-        description: attributes?.name || id,
+        description: attributes?.description || attributes?.name || id,
         title: attributes?.name || id,
         id: id,
         parentWorkspace,


### PR DESCRIPTION
<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
