### PR TITLE
Minimize BootstrapResource usage in Bear backend

### DIFF
--- a/libs/api-client-bear/src/gooddata.ts
+++ b/libs/api-client-bear/src/gooddata.ts
@@ -13,6 +13,7 @@ import { sanitizeConfig, IConfigStorage, ConfigModule } from "./config";
 import { CatalogueModule } from "./catalogue";
 import { AttributesMapLoaderModule } from "./utils/attributesMapLoader";
 import { LdmModule } from "./ldm";
+import { OrganizationModule } from "./organization";
 
 /**
  * This package provides low-level functions for communication with the GoodData platform.
@@ -53,6 +54,7 @@ export class SDK {
     public catalogue: CatalogueModule;
     public ldm: LdmModule;
     public configStorage: IConfigStorage;
+    public organization: OrganizationModule;
     public utils: {
         loadAttributesMap: any;
         getAttributesDisplayForms: any;
@@ -72,6 +74,7 @@ export class SDK {
         this.dashboard = new DashboardModule(this.xhr);
         this.catalogue = new CatalogueModule(this.xhr, this.execution);
         this.ldm = new LdmModule(this.xhr);
+        this.organization = new OrganizationModule(this.xhr);
 
         const attributesMapLoaderModule = new AttributesMapLoaderModule(this.md);
         this.utils = {

--- a/libs/api-client-bear/src/organization.ts
+++ b/libs/api-client-bear/src/organization.ts
@@ -1,0 +1,16 @@
+// (C) 2022 GoodData Corporation
+
+import { XhrModule } from "./xhr";
+import { GdcOrganization } from "@gooddata/api-model-bear";
+
+export class OrganizationModule {
+    constructor(private xhr: XhrModule) {}
+
+    /**
+     * Get current user's organization
+     * @returns resolves with current user's organization
+     */
+    public getCurrentOrganization(): Promise<GdcOrganization.IOrganization> {
+        return this.xhr.getParsed<GdcOrganization.IOrganization>("/gdc/app/organization/current");
+    }
+}

--- a/libs/api-client-bear/src/tests/project.test.ts
+++ b/libs/api-client-bear/src/tests/project.test.ts
@@ -1,4 +1,4 @@
-// (C) 2007-2020 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 import "isomorphic-fetch";
 import fetchMock from "fetch-mock";
 import noop from "lodash/noop";
@@ -210,16 +210,10 @@ describe("project", () => {
 
         describe("getCurrentProjectId", () => {
             it("should resolve with project id", () => {
-                fetchMock.mock("/gdc/app/account/bootstrap", {
+                fetchMock.mock("/gdc/app/account/bootstrap/projectId", {
                     status: 200,
                     body: JSON.stringify({
-                        bootstrapResource: {
-                            current: {
-                                project: {
-                                    links: { self: "/gdc/project/project_hash" },
-                                },
-                            },
-                        },
+                        projectId: "project_hash",
                     }),
                 });
 
@@ -231,9 +225,11 @@ describe("project", () => {
             });
 
             it("should resolve with null if current project not set", () => {
-                fetchMock.mock("/gdc/app/account/bootstrap", {
+                fetchMock.mock("/gdc/app/account/bootstrap/projectId", {
                     status: 200,
-                    body: JSON.stringify({ bootstrapResource: { current: { project: null } } }),
+                    body: JSON.stringify({
+                        projectId: null,
+                    }),
                 });
 
                 return createProject()
@@ -245,24 +241,17 @@ describe("project", () => {
         });
 
         describe("getTimezone", () => {
-            it("should return timezone using bootstrap", () => {
-                const bootstrapUrl = "/gdc/app/account/bootstrap?projectId=prjId";
+            it("should return timezone using its own api", () => {
+                const timezoneApiUrl = "/gdc/app/projects/prjId/timezone";
                 const timezoneMock = {
                     id: "Europe/Prague",
                     displayName: "Central European Time",
                     currentOffsetMs: 3600000,
                 };
-                const bootstrap = {
-                    bootstrapResource: {
-                        current: {
-                            timezone: timezoneMock,
-                        },
-                    },
-                };
 
-                fetchMock.mock(bootstrapUrl, {
+                fetchMock.mock(timezoneApiUrl, {
                     status: 200,
-                    body: JSON.stringify(bootstrap),
+                    body: JSON.stringify({ timezone: timezoneMock }),
                 });
 
                 return createProject()

--- a/libs/api-client-bear/src/tests/user.test.ts
+++ b/libs/api-client-bear/src/tests/user.test.ts
@@ -185,15 +185,11 @@ describe("user", () => {
 
                 fetchMock.mock("/gdc/account/token", 200);
 
-                fetchMock.mock("/gdc/app/account/bootstrap", {
+                fetchMock.mock("/gdc/app/account/bootstrap/account", {
                     status: 200,
                     body: JSON.stringify({
-                        bootstrapResource: {
-                            accountSetting: {
-                                links: {
-                                    self: `/gdc/account/profile/${userId}`,
-                                },
-                            },
+                        accountInfo: {
+                            logoutUri: `/gdc/account/login/${userId}`,
                         },
                     }),
                 });
@@ -258,24 +254,16 @@ describe("user", () => {
                 const organizationName = "ORG_NAME";
                 const profileUri = "PROFILE_URI";
 
-                fetchMock.mock("/gdc/app/account/bootstrap", {
+                fetchMock.mock("/gdc/app/account/bootstrap/account", {
                     status: 200,
                     body: JSON.stringify({
-                        bootstrapResource: {
-                            accountSetting: {
-                                login,
-                                firstName,
-                                lastName,
-                                links: {
-                                    self: profileUri,
-                                },
-                            },
-                            current: {
-                                loginMD5,
-                            },
-                            settings: {
-                                organizationName,
-                            },
+                        accountInfo: {
+                            login,
+                            firstName,
+                            lastName,
+                            profileUri,
+                            loginMD5,
+                            organizationName,
                         },
                     }),
                 });

--- a/libs/api-model-bear/api/api-model-bear.api.md
+++ b/libs/api-model-bear/api/api-model-bear.api.md
@@ -1818,6 +1818,18 @@ export namespace GdcMetadataObject {
     export type WrappedObject = GdcMetadata.IWrappedAttribute | GdcMetadata.IWrappedMetric | GdcMetadata.IWrappedFact | GdcMetadata.IWrappedAttributeDisplayForm | GdcMetadata.IWrappedKpiAlert | GdcMetadata.IWrappedDataSet | GdcMetadata.IWrappedPrompt | GdcMetadata.IWrappedTheme | GdcDashboard.IWrappedAnalyticalDashboard | GdcFilterContext.IWrappedFilterContext | GdcFilterContext.IWrappedTempFilterContext | GdcKpi.IWrappedKPI | GdcScheduledMail.IWrappedScheduledMail | GdcProjectDashboard.IWrappedProjectDashboard | GdcExtendedDateFilters.IWrappedDateFilterConfig | GdcVisualizationWidget.IWrappedVisualizationWidget | GdcVisualizationObject.IVisualization | GdcVisualizationClass.IVisualizationClassWrapped | GdcDataSets.IWrappedDataSet | GdcReport.IWrappedReport | GdcReport.IWrappedReportDefinition | GdcDashboardPlugin.IWrappedDashboardPlugin;
 }
 
+// @public (undocumented)
+export namespace GdcOrganization {
+    // (undocumented)
+    export interface IOrganization {
+        // (undocumented)
+        organization: {
+            id: string;
+            name: string;
+        };
+    }
+}
+
 // @public
 export namespace GdcPaging {
     // (undocumented)
@@ -1838,6 +1850,31 @@ export namespace GdcPaging {
 
 // @public (undocumented)
 export namespace GdcProject {
+    // (undocumented)
+    export interface IProjectId {
+        // (undocumented)
+        projectId: string;
+    }
+    // (undocumented)
+    export interface IProjectLcmIdentifiers {
+        // (undocumented)
+        projectLcm: {
+            projectId?: string;
+            dataProductId?: string;
+            clientId?: string;
+            segmentId?: string;
+        };
+    }
+    // (undocumented)
+    export interface ITimezone {
+        // (undocumented)
+        timezone: {
+            id: string;
+            displayName: string;
+            shortDisplayName: string;
+            currentOffsetMs: number;
+        };
+    }
     // (undocumented)
     export interface IUserProject {
         // (undocumented)
@@ -2124,6 +2161,28 @@ export namespace GdcUser {
     // (undocumented)
     export type DataUploadStatus = "PREPARED" | "RUNNING" | "OK" | "ERROR" | "WARNING";
     // (undocumented)
+    export interface IAccountInfo {
+        // (undocumented)
+        firstName: string;
+        // (undocumented)
+        lastName: string;
+        // (undocumented)
+        login: string;
+        // (undocumented)
+        loginMD5: string;
+        // (undocumented)
+        logoutUri: string;
+        // (undocumented)
+        organizationName: string;
+        // (undocumented)
+        profileUri: string;
+    }
+    // (undocumented)
+    export interface IAccountInfoResponse {
+        // (undocumented)
+        accountInfo: IAccountInfo;
+    }
+    // (undocumented)
     export interface IAccountSetting {
         // (undocumented)
         authenticationModes?: Array<"SSO" | "PASSWORD">;
@@ -2172,6 +2231,11 @@ export namespace GdcUser {
         updated?: Timestamp;
         // (undocumented)
         verifyPassword?: string;
+    }
+    // (undocumented)
+    export interface IAssociatedProjectPermissions {
+        // (undocumented)
+        associatedPermissions: IProjectPermissions;
     }
     // (undocumented)
     export interface IBootstrapResource {
@@ -2510,6 +2574,11 @@ export namespace GdcUser {
         walkMe?: string;
         // (undocumented)
         walkMeEnvironment?: string;
+    }
+    // (undocumented)
+    export interface IUserFeatureFlags {
+        // (undocumented)
+        featureFlags: IFeatureFlags;
     }
     // (undocumented)
     export interface IUserListItem {

--- a/libs/api-model-bear/src/index.ts
+++ b/libs/api-model-bear/src/index.ts
@@ -1,4 +1,4 @@
-// (C) 2007-2021 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 /**
  * This package provides TypeScript definitions for the types of the REST API requests and responses on the GoodData platform.
  * It also provides functions that operate on those objects directly.
@@ -35,6 +35,7 @@ export { GdcPaging } from "./base/GdcPaging";
 export { GdcReport } from "./report/GdcReport";
 export { GdcUserGroup } from "./userGroup/GdcUserGroup";
 export { GdcAccessControl } from "./accessControl/GdcAccessControl";
+export { GdcOrganization } from "./organization/GdcOrganization";
 export {
     BooleanAsString,
     DateString,

--- a/libs/api-model-bear/src/organization/GdcOrganization.ts
+++ b/libs/api-model-bear/src/organization/GdcOrganization.ts
@@ -1,0 +1,13 @@
+// (C) 2022 GoodData Corporation
+
+/**
+ * @public
+ */
+export namespace GdcOrganization {
+    export interface IOrganization {
+        organization: {
+            id: string;
+            name: string;
+        };
+    }
+}

--- a/libs/api-model-bear/src/project/GdcProject.ts
+++ b/libs/api-model-bear/src/project/GdcProject.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2020 GoodData Corporation
+// (C) 2019-2022 GoodData Corporation
 import { GdcPaging } from "../base/GdcPaging";
 import { Uri } from "../aliases";
 
@@ -34,6 +34,28 @@ export namespace GdcProject {
         userProjects: {
             items: IUserProject[];
             paging: GdcPaging.IBearPagingWithTotalCount;
+        };
+    }
+
+    export interface IProjectLcmIdentifiers {
+        projectLcm: {
+            projectId?: string;
+            dataProductId?: string;
+            clientId?: string;
+            segmentId?: string;
+        };
+    }
+
+    export interface IProjectId {
+        projectId: string;
+    }
+
+    export interface ITimezone {
+        timezone: {
+            id: string;
+            displayName: string;
+            shortDisplayName: string;
+            currentOffsetMs: number;
         };
     }
 }

--- a/libs/api-model-bear/src/user/GdcUser.ts
+++ b/libs/api-model-bear/src/user/GdcUser.ts
@@ -1,4 +1,4 @@
-// (C) 2007-2021 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 import { BooleanAsString, Timestamp, Email, Uri, TimeIso8601, DateString } from "../aliases";
 import { GdcMetadata } from "../meta/GdcMetadata";
 
@@ -205,6 +205,10 @@ export namespace GdcUser {
         [key: string]: number | boolean | string;
     }
 
+    export interface IUserFeatureFlags {
+        featureFlags: IFeatureFlags;
+    }
+
     export interface IProjectPermissions {
         permissions: {
             [permission in ProjectPermission]?: BooleanAsString;
@@ -213,6 +217,10 @@ export namespace GdcUser {
             project: Uri;
             user: Uri;
         };
+    }
+
+    export interface IAssociatedProjectPermissions {
+        associatedPermissions: IProjectPermissions;
     }
 
     export interface IProject {
@@ -479,5 +487,19 @@ export namespace GdcUser {
             permissions?: Uri;
             projectRelUri?: Uri;
         };
+    }
+
+    export interface IAccountInfoResponse {
+        accountInfo: IAccountInfo;
+    }
+
+    export interface IAccountInfo {
+        login: string;
+        loginMD5: string;
+        firstName: string;
+        lastName: string;
+        organizationName: string;
+        profileUri: string;
+        logoutUri: string;
     }
 }

--- a/libs/sdk-backend-bear/src/backend/index.ts
+++ b/libs/sdk-backend-bear/src/backend/index.ts
@@ -74,6 +74,8 @@ const CAPABILITIES: IBackendCapabilities = {
     supportsHierarchicalWorkspaces: false,
     supportsCustomColorPalettes: true,
     supportsOrganizationSettings: false,
+    supportsInlineMeasures: false,
+    supportsBootstrapResource: true,
 };
 
 /**
@@ -104,6 +106,7 @@ type BearLegacyFunctions = {
         projectId?: string;
         productId?: string;
         clientId?: string;
+        loadAnalyticalDashboards?: boolean;
     }): Promise<GdcUser.IBootstrapResource>;
     ajaxSetup?(setup: any): void;
     log?(uri: string, logMessages: string[]): Promise<any>;

--- a/libs/sdk-backend-bear/src/backend/organization/index.ts
+++ b/libs/sdk-backend-bear/src/backend/organization/index.ts
@@ -9,7 +9,6 @@ import {
     NotSupported,
 } from "@gooddata/sdk-backend-spi";
 import { IOrganizationDescriptor } from "@gooddata/sdk-model";
-import invariant from "ts-invariant";
 
 import { SecuritySettingsService } from "./securitySettings";
 import { BearAuthenticatedCallGuard } from "../../types/auth";
@@ -56,21 +55,9 @@ export class BearOrganizations implements IOrganizations {
     constructor(private readonly authCall: BearAuthenticatedCallGuard) {}
 
     public async getCurrentOrganization(): Promise<IOrganization> {
-        const bootstrap = await this.authCall((sdk) => sdk.user.getBootstrapResource());
-        const organizationId = this.getDomainIdFromDomainUri(
-            bootstrap.bootstrapResource.accountSetting.links?.domain,
-        );
-        return new BearOrganization(
-            this.authCall,
-            organizationId,
-            bootstrap.bootstrapResource.settings?.organizationName,
-        );
-    }
-
-    private getDomainIdFromDomainUri(domainUri: string | undefined): string {
-        invariant(domainUri, "Current user has no domain uri");
-
-        const lastIndexOfSlash = domainUri.lastIndexOf("/");
-        return domainUri.substr(lastIndexOfSlash + 1);
+        const {
+            organization: { id, name },
+        } = await this.authCall((sdk) => sdk.organization.getCurrentOrganization());
+        return new BearOrganization(this.authCall, id, name);
     }
 }

--- a/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
+++ b/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
@@ -371,6 +371,7 @@ export interface IBackendCapabilities {
     hasTypeScopedIdentifiers?: boolean;
     maxDimensions?: number;
     supportsAccessControl?: boolean;
+    supportsBootstrapResource?: boolean;
     supportsCsvUploader?: boolean;
     supportsCustomColorPalettes?: boolean;
     supportsElementsQueryParentFiltering?: boolean;

--- a/libs/sdk-backend-spi/src/backend/capabilities.ts
+++ b/libs/sdk-backend-spi/src/backend/capabilities.ts
@@ -173,6 +173,11 @@ export interface IBackendCapabilities {
     supportsInlineMeasures?: boolean;
 
     /**
+     * Indicates whether backend supports bootstrap resource that returns initial app data.
+     */
+    supportsBootstrapResource?: boolean;
+
+    /**
      * Catchall for additional capabilities
      */
     [key: string]: undefined | boolean | number | string;

--- a/libs/sdk-backend-tiger/src/backend/index.ts
+++ b/libs/sdk-backend-tiger/src/backend/index.ts
@@ -76,6 +76,7 @@ const CAPABILITIES: IBackendCapabilities = {
     supportsCustomColorPalettes: true,
     supportsOrganizationSettings: true,
     supportsInlineMeasures: true,
+    supportsBootstrapResource: false,
 };
 
 /**

--- a/libs/sdk-ui/api/sdk-ui.api.md
+++ b/libs/sdk-ui/api/sdk-ui.api.md
@@ -1585,7 +1585,7 @@ export const removeAllWordingTranslationsWithSpecialSuffix: (translations: Recor
 export const ResolvedClientWorkspaceProvider: React_2.FC<IClientWorkspaceIdentifiers>;
 
 // @alpha
-export function resolveLCMWorkspaceIdentifiers(backend: any, clientWorkspace: IClientWorkspaceIdentifiers): Promise<IClientWorkspaceIdentifiers>;
+export function resolveLCMWorkspaceIdentifiers(backend: any, { client, dataProduct, workspace }: IClientWorkspaceIdentifiers): Promise<IClientWorkspaceIdentifiers>;
 
 // @internal
 export const resolveLocale: (locale: unknown) => ILocale;

--- a/tools/applink/README.md
+++ b/tools/applink/README.md
@@ -56,6 +56,8 @@ The application supports several global hotkeys:
 
 ### autoBuild
 
+Start `npm run applink autoBuild`.
+
 The autoBuild mode is a special mode of the devConsole suitable for automation of incremental SDK library builds. In
 this mode the dev console will not work towards updating some target application with latest build artifacts.
 


### PR DESCRIPTION
The BootstrapResource API no longer loads analytical dashboards list to optimize call duration.

New APIs are called instead of BootstrapResource when possible. Ideally, BootstrapResource call should not be used by any internal Bear API in the future and new API should be created when some part of its response is needed by any new or existing API.

JIRA: TNT-1065

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
