### PR TITLE
Latest insight in saved insights list isn't displayed

### DIFF
--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -4107,6 +4107,7 @@ export interface ISharingProperties {
 
 // @alpha (undocumented)
 export interface ISidebarProps {
+    configurationPanelClassName?: string;
     DefaultSidebar: ComponentType<ISidebarProps>;
 }
 
@@ -5744,7 +5745,7 @@ export const ShareDialog: (props: IShareDialogProps) => JSX.Element;
 export const ShareStatusIndicator: (props: IShareStatusProps) => JSX.Element;
 
 // @internal (undocumented)
-export const SidebarConfigurationPanel: () => JSX.Element;
+export const SidebarConfigurationPanel: React_2.FC<Omit<ISidebarProps, "DefaultSidebar">>;
 
 // @public
 export class SingleDashboardStoreAccessor {

--- a/libs/sdk-ui-dashboard/src/presentation/dashboard/DashboardSidebar/CreationPanel.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/dashboard/DashboardSidebar/CreationPanel.tsx
@@ -4,17 +4,17 @@ import { Typography } from "@gooddata/sdk-ui-kit";
 import compact from "lodash/compact";
 import sortBy from "lodash/sortBy";
 import { FormattedMessage } from "react-intl";
-import cx from "classnames";
 
 import { DraggableInsightList } from "./DraggableInsightList";
 import { selectSupportsKpiWidgetCapability, useDashboardSelector } from "../../../model";
 import { useDashboardComponentsContext } from "../../dashboardContexts";
+import cx from "classnames";
 
 interface ICreationPanelProps {
-    isSticky: boolean;
+    className?: string;
 }
 
-export const CreationPanel: React.FC<ICreationPanelProps> = ({ isSticky = false }) => {
+export const CreationPanel: React.FC<ICreationPanelProps> = ({ className }) => {
     const supportsKpis = useDashboardSelector(selectSupportsKpiWidgetCapability);
 
     const { KpiWidgetComponentSet, AttributeFilterComponentSet, InsightWidgetComponentSet } =
@@ -33,12 +33,8 @@ export const CreationPanel: React.FC<ICreationPanelProps> = ({ isSticky = false 
     }, [AttributeFilterComponentSet, KpiWidgetComponentSet, InsightWidgetComponentSet, supportsKpis]);
 
     return (
-        <div className="configuration-panel creation-panel">
-            <div
-                className={cx("flex-panel-full-vh-height", {
-                    "sticky-panel": isSticky,
-                })}
-            >
+        <div className={cx("configuration-panel creation-panel", className)}>
+            <div className="configuration-panel-content">
                 <Typography tagName="h2" className="flex-panel-item-nostretch">
                     <FormattedMessage id="visualizationsList.dragToAdd" />
                 </Typography>
@@ -52,7 +48,7 @@ export const CreationPanel: React.FC<ICreationPanelProps> = ({ isSticky = false 
                     <Typography tagName="h3">
                         <FormattedMessage id="visualizationsList.savedVisualizations" />
                     </Typography>
-                    <DraggableInsightList />
+                    <DraggableInsightList recalculateSizeReference={className} />
                 </div>
             </div>
         </div>

--- a/libs/sdk-ui-dashboard/src/presentation/dashboard/DashboardSidebar/DraggableInsightList/DraggableInsightList.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/dashboard/DashboardSidebar/DraggableInsightList/DraggableInsightList.tsx
@@ -5,18 +5,18 @@ import { FlexDimensions } from "@gooddata/sdk-ui-kit";
 import { DraggableInsightListCore } from "./DraggableInsightListCore";
 
 interface IDraggableInsightListProps {
-    isSticky?: boolean;
+    recalculateSizeReference?: string;
     searchAutofocus?: boolean;
 }
 
 export const DraggableInsightList: React.FC<IDraggableInsightListProps> = (props) => {
-    const { isSticky, searchAutofocus } = props;
+    const { recalculateSizeReference, searchAutofocus } = props;
 
     const flexRef = useRef<FlexDimensions>(null);
 
     useEffect(() => {
         flexRef.current?.updateSize();
-    }, [isSticky]);
+    }, [recalculateSizeReference]);
 
     return (
         <div className="gd-visualizations-list gd-flex-item-stretch gd-flex-row-container">

--- a/libs/sdk-ui-dashboard/src/presentation/dashboard/DashboardSidebar/SidebarConfigurationPanel.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/dashboard/DashboardSidebar/SidebarConfigurationPanel.tsx
@@ -3,16 +3,19 @@ import React from "react";
 import { DeleteDropZone } from "../../dragAndDrop";
 import { useWidgetSelection } from "../../../model";
 import { CreationPanel } from "./CreationPanel";
+import { ISidebarProps } from "./types";
 
 /**
  * @internal
  */
-export const SidebarConfigurationPanel = (): JSX.Element => {
+export const SidebarConfigurationPanel: React.FC<Omit<ISidebarProps, "DefaultSidebar">> = ({
+    configurationPanelClassName,
+}): JSX.Element => {
     const { deselectWidgets } = useWidgetSelection();
     return (
         <div className="col gd-flex-item gd-sidebar-container" onClick={deselectWidgets}>
             <div className="flex-panel-full-vh-height">
-                <CreationPanel isSticky={false} />
+                <CreationPanel className={configurationPanelClassName} />
             </div>
             <DeleteDropZone />
         </div>

--- a/libs/sdk-ui-dashboard/src/presentation/dashboard/DashboardSidebar/types.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/dashboard/DashboardSidebar/types.ts
@@ -10,6 +10,11 @@ export interface ISidebarProps {
      * sidebar that decorates default side bar, then use this component to render the default sidebar.
      */
     DefaultSidebar: ComponentType<ISidebarProps>;
+
+    /**
+     * Specify className for configurationPanel.
+     */
+    configurationPanelClassName?: string;
 }
 
 /**

--- a/libs/sdk-ui-dashboard/styles/scss/configurationPanel.scss
+++ b/libs/sdk-ui-dashboard/styles/scss/configurationPanel.scss
@@ -9,6 +9,7 @@ $dialog-background: var(--gd-palette-complementary-0, #fcfcfd);
 
 .configuration-panel {
     width: 100%;
+    height: 100%;
     padding: 10px 0;
     background-color: $dialog-background;
 
@@ -447,4 +448,10 @@ $dialog-background: var(--gd-palette-complementary-0, #fcfcfd);
     .input-checkbox-label {
         display: inline-block;
     }
+}
+
+.configuration-panel-content {
+    display: flex;
+    height: 100%;
+    flex-direction: column;
 }


### PR DESCRIPTION
Latest insight in saved insights list isn't displayed

RAIL-4427

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
