### PR TITLE
RELATED: TNT-971 Added setLocale support

### DIFF
--- a/libs/sdk-backend-base/api/sdk-backend-base.api.md
+++ b/libs/sdk-backend-base/api/sdk-backend-base.api.md
@@ -542,6 +542,8 @@ export abstract class DecoratedWorkspaceSettingsService implements IWorkspaceSet
     getSettings(): Promise<IWorkspaceSettings>;
     // (undocumented)
     getSettingsForCurrentUser(): Promise<IUserWorkspaceSettings>;
+    // (undocumented)
+    setLocale(locale: string): Promise<void>;
 }
 
 // @alpha

--- a/libs/sdk-backend-base/src/cachingBackend/index.ts
+++ b/libs/sdk-backend-base/src/cachingBackend/index.ts
@@ -393,6 +393,10 @@ class WithWorkspaceSettingsCaching extends DecoratedWorkspaceSettingsService {
         return userWorkspaceSettings;
     }
 
+    public async setLocale(locale: string): Promise<void> {
+        return super.setLocale(locale);
+    }
+
     private getOrCreateWorkspaceEntry = (workspace: string): WorkspaceSettingsCacheEntry => {
         const cache = this.ctx.caches.workspaceSettings!;
         let cacheEntry = cache.get(workspace);

--- a/libs/sdk-backend-base/src/decoratedBackend/workspaceSettings.ts
+++ b/libs/sdk-backend-base/src/decoratedBackend/workspaceSettings.ts
@@ -1,4 +1,4 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 import {
     IUserWorkspaceSettings,
     IWorkspaceSettings,
@@ -17,5 +17,9 @@ export abstract class DecoratedWorkspaceSettingsService implements IWorkspaceSet
 
     async getSettingsForCurrentUser(): Promise<IUserWorkspaceSettings> {
         return this.decorated.getSettingsForCurrentUser();
+    }
+
+    async setLocale(locale: string): Promise<void> {
+        return this.decorated.setLocale(locale);
     }
 }

--- a/libs/sdk-backend-base/src/dummyBackend/index.ts
+++ b/libs/sdk-backend-base/src/dummyBackend/index.ts
@@ -509,6 +509,7 @@ class DummyOrganization implements IOrganization {
     settings(): IOrganizationSettingsService {
         return {
             setWhiteLabeling: () => Promise.resolve(),
+            setLocale: () => Promise.resolve(),
         };
     }
 }
@@ -533,6 +534,10 @@ class DummyWorkspaceSettingsService implements IWorkspaceSettingsService {
                 decimal: ".",
             },
         });
+    }
+
+    setLocale(_locale: string): Promise<void> {
+        return Promise.resolve();
     }
 }
 

--- a/libs/sdk-backend-bear/src/backend/user/settings.ts
+++ b/libs/sdk-backend-bear/src/backend/user/settings.ts
@@ -1,5 +1,5 @@
-// (C) 2020 GoodData Corporation
-import { IUserSettingsService, IUserSettings } from "@gooddata/sdk-backend-spi";
+// (C) 2020-2022 GoodData Corporation
+import { IUserSettingsService, IUserSettings, NotSupported } from "@gooddata/sdk-backend-spi";
 import { userLoginMd5FromAuthenticatedPrincipalWithAnonymous } from "../../utils/api";
 import { BearAuthenticatedCallGuard } from "../../types/auth";
 import { ANONYMOUS_USER_SETTINGS } from "../constants";
@@ -31,5 +31,9 @@ export class BearUserSettingsService implements IUserSettingsService {
                 ...flags,
             };
         });
+    }
+
+    public setLocale(_locale: string): Promise<void> {
+        throw new NotSupported("Backend does not support user locale setup");
     }
 }

--- a/libs/sdk-backend-bear/src/backend/workspace/settings/settings.ts
+++ b/libs/sdk-backend-bear/src/backend/workspace/settings/settings.ts
@@ -3,6 +3,7 @@ import {
     IWorkspaceSettings,
     IWorkspaceSettingsService,
     IUserWorkspaceSettings,
+    NotSupported,
 } from "@gooddata/sdk-backend-spi";
 import { ISettings } from "@gooddata/sdk-model";
 import { IFeatureFlags } from "@gooddata/api-client-bear";
@@ -82,5 +83,9 @@ export class BearWorkspaceSettings implements IWorkspaceSettingsService {
                 ...mergeWorkspaceAndUserSettings(workspaceFeatureFlags, userFeatureFlags),
             };
         });
+    }
+
+    public setLocale(_locale: string): Promise<void> {
+        throw new NotSupported("Backend does not support workspace locale setup");
     }
 }

--- a/libs/sdk-backend-mockingbird/src/recordedBackend/index.ts
+++ b/libs/sdk-backend-mockingbird/src/recordedBackend/index.ts
@@ -205,6 +205,9 @@ function recordedWorkspace(
                         ...(implConfig.globalSettings ?? {}),
                     };
                 },
+                async setLocale(): Promise<void> {
+                    return Promise.resolve();
+                },
             };
         },
         styling(): IWorkspaceStylingService {
@@ -323,6 +326,7 @@ function recordedOrganization(organizationId: string, implConfig: RecordedBacken
         settings(): IOrganizationSettingsService {
             return {
                 setWhiteLabeling: () => Promise.resolve(),
+                setLocale: () => Promise.resolve(),
             };
         },
     };
@@ -359,6 +363,7 @@ function recordedUserService(implConfig: RecordedBackendConfig): IUserService {
                     separators,
                     ...(implConfig.globalSettings ?? {}),
                 }),
+                setLocale: () => Promise.resolve(),
             };
         },
     };

--- a/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
+++ b/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
@@ -989,6 +989,7 @@ export interface IOrganizations {
 
 // @public
 export interface IOrganizationSettingsService {
+    setLocale(locale: string): Promise<void>;
     setWhiteLabeling(whiteLabeling: IWhiteLabeling): Promise<void>;
 }
 
@@ -1521,6 +1522,7 @@ export interface IUserSettings extends ISettings_2 {
 // @public
 export interface IUserSettingsService {
     getSettings(): Promise<IUserSettings>;
+    setLocale(locale: string): Promise<void>;
 }
 
 // @public
@@ -1758,6 +1760,7 @@ export interface IWorkspaceSettings extends ISettings_2 {
 export interface IWorkspaceSettingsService {
     getSettings(): Promise<IWorkspaceSettings>;
     getSettingsForCurrentUser(): Promise<IUserWorkspaceSettings>;
+    setLocale(locale: string): Promise<void>;
 }
 
 // @public

--- a/libs/sdk-backend-spi/src/organization/settings/index.ts
+++ b/libs/sdk-backend-spi/src/organization/settings/index.ts
@@ -9,9 +9,20 @@ import { IWhiteLabeling } from "@gooddata/sdk-model";
  */
 export interface IOrganizationSettingsService {
     /**
-     * Set whiteLabeling in organization.
+     * Sets whiteLabeling for organization.
+     *
+     * @param whiteLabeling - describes whitelabeling setting for logoUrl, faviconUrl etc.
      *
      * @returns promise
      */
     setWhiteLabeling(whiteLabeling: IWhiteLabeling): Promise<void>;
+
+    /**
+     * Sets locale for current workspace.
+     *
+     * @param locale - IETF BCP 47 Code locale ID, for example "en-US", "cs-CZ", etc.
+     *
+     * @returns promise
+     */
+    setLocale(locale: string): Promise<void>;
 }

--- a/libs/sdk-backend-spi/src/user/settings/index.ts
+++ b/libs/sdk-backend-spi/src/user/settings/index.ts
@@ -1,4 +1,4 @@
-// (C) 2020 GoodData Corporation
+// (C) 2020-2022 GoodData Corporation
 import { IUserSettings } from "../../common/settings";
 
 /**
@@ -13,4 +13,13 @@ export interface IUserSettingsService {
      * @returns promise of the feature flags of the current user
      */
     getSettings(): Promise<IUserSettings>;
+
+    /**
+     * Set locale for the current user
+     *
+     * @param locale - IETF BCP 47 Code locale ID, for example "en-US", "cs-CZ", etc.
+     *
+     * @returns promise
+     */
+    setLocale(locale: string): Promise<void>;
 }

--- a/libs/sdk-backend-spi/src/workspace/settings/index.ts
+++ b/libs/sdk-backend-spi/src/workspace/settings/index.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2020 GoodData Corporation
+// (C) 2019-2022 GoodData Corporation
 import { IWorkspaceSettings, IUserWorkspaceSettings } from "../../common/settings";
 
 /**
@@ -20,4 +20,13 @@ export interface IWorkspaceSettingsService {
      * @returns promise of user/workspace settings
      */
     getSettingsForCurrentUser(): Promise<IUserWorkspaceSettings>;
+
+    /**
+     * Sets locale for current workspace.
+     *
+     * @param locale - IETF BCP 47 Code locale ID, for example "en-US", "cs-CZ", etc.
+     *
+     * @returns promise
+     */
+    setLocale(locale: string): Promise<void>;
 }

--- a/libs/sdk-backend-tiger/src/backend/organization/settings.ts
+++ b/libs/sdk-backend-tiger/src/backend/organization/settings.ts
@@ -8,10 +8,14 @@ export class OrganizationSettingsService implements IOrganizationSettingsService
     constructor(public readonly authCall: TigerAuthenticatedCallGuard) {}
 
     public async setWhiteLabeling(whiteLabeling: IWhiteLabeling): Promise<void> {
-        this.setSetting("whiteLabeling", whiteLabeling);
+        return this.setSetting("whiteLabeling", whiteLabeling);
     }
 
-    private async setSetting(id: string, content: any): Promise<void> {
+    public async setLocale(locale: string): Promise<void> {
+        return this.setSetting("locale", { value: locale });
+    }
+
+    private async setSetting(id: string, content: any): Promise<any> {
         // Currently it is necessary to check existence of required setting
         // since PUT does not support creation of non-existing setting.
         // It can be simplified to Update method once NAS-4291 is implemented
@@ -29,15 +33,15 @@ export class OrganizationSettingsService implements IOrganizationSettingsService
     }
 
     private async getSetting(id: string): Promise<any> {
-        await this.authCall((client) =>
+        return this.authCall((client) =>
             client.entities.getEntityOrganizationSettings({
                 id,
             }),
         );
     }
 
-    private async updateSetting(id: string, content: any): Promise<void> {
-        await this.authCall((client) =>
+    private async updateSetting(id: string, content: any): Promise<any> {
+        return this.authCall((client) =>
             client.entities.updateEntityOrganizationSettings({
                 id,
                 jsonApiOrganizationSettingInDocument: {
@@ -53,8 +57,8 @@ export class OrganizationSettingsService implements IOrganizationSettingsService
         );
     }
 
-    private async createSetting(id: string, content: any): Promise<void> {
-        await this.authCall((client) =>
+    private async createSetting(id: string, content: any): Promise<any> {
+        return this.authCall((client) =>
             client.entities.createEntityOrganizationSettings({
                 jsonApiOrganizationSettingInDocument: {
                     data: {

--- a/libs/sdk-backend-tiger/src/backend/user/settings.ts
+++ b/libs/sdk-backend-tiger/src/backend/user/settings.ts
@@ -1,5 +1,6 @@
 // (C) 2020-2022 GoodData Corporation
-import { IUserSettingsService, IUserSettings } from "@gooddata/sdk-backend-spi";
+import { IUserSettingsService, IUserSettings, isUnexpectedError } from "@gooddata/sdk-backend-spi";
+import { convertApiError } from "../../utils/errorHandling";
 import { TigerAuthenticatedCallGuard } from "../../types";
 import { TigerFeaturesService } from "../features";
 import { DefaultUserSettings } from "../uiSettings";
@@ -16,6 +17,74 @@ export class TigerUserSettingsService implements IUserSettingsService {
                 ...features,
                 userId: profile.userId,
             };
+        });
+    }
+
+    public async setLocale(locale: string): Promise<void> {
+        return this.setSetting("locale", { value: locale });
+    }
+
+    private async setSetting(id: string, content: any): Promise<void> {
+        // Currently it is necessary to check existence of required setting
+        // since PUT does not support creation of non-existing setting.
+        // It can be simplified to Update method once NAS-4291 is implemented
+        try {
+            await this.getSetting(id);
+            await this.updateSetting(id, content);
+        } catch (error: any) {
+            if (isUnexpectedError(error)) {
+                // if such settings is not defined
+                await this.createSetting(id, content);
+                return;
+            }
+            throw convertApiError(error);
+        }
+    }
+
+    private async getSetting(id: string): Promise<any> {
+        return this.authCall(async (client) => {
+            const profile = await client.profile.getCurrent();
+            return client.entities.getEntityUserSettings({
+                userId: profile.userId,
+                id,
+            });
+        });
+    }
+
+    private async updateSetting(id: string, content: any): Promise<any> {
+        return this.authCall(async (client) => {
+            const profile = await client.profile.getCurrent();
+            return client.entities.updateEntityUserSettings({
+                id,
+                userId: profile.userId,
+                jsonApiUserSettingInDocument: {
+                    data: {
+                        type: "userSetting",
+                        id,
+                        attributes: {
+                            content,
+                        },
+                    },
+                },
+            });
+        });
+    }
+
+    private async createSetting(id: string, content: any): Promise<any> {
+        return this.authCall(async (client) => {
+            const profile = await client.profile.getCurrent();
+            return client.entities.createEntityUserSettings({
+                userId: profile.userId,
+                jsonApiUserSettingInDocument: {
+                    data: {
+                        type: "userSetting",
+                        id,
+                        attributes: {
+                            content,
+                        },
+                    },
+                },
+            });
         });
     }
 }

--- a/libs/sdk-ui-ext/src/dataLoaders/test/UserWorkspaceSettingsDataLoader.test.ts
+++ b/libs/sdk-ui-ext/src/dataLoaders/test/UserWorkspaceSettingsDataLoader.test.ts
@@ -1,4 +1,4 @@
-// (C) 2020-2021 GoodData Corporation
+// (C) 2020-2022 GoodData Corporation
 import noop from "lodash/noop";
 import { dummyBackendEmptyData } from "@gooddata/sdk-backend-mockingbird";
 import { IAnalyticalBackend, IUserWorkspaceSettings } from "@gooddata/sdk-backend-spi";
@@ -18,6 +18,7 @@ describe("UserWorkspaceSettingsDataLoader", () => {
             settings: () => ({
                 getSettingsForCurrentUser,
                 getSettings: noop as any,
+                setLocale: (_locale: string) => Promise.resolve(),
             }),
         }),
     });


### PR DESCRIPTION
Set locale support for user, workspace and organization.

JIRA: TNT-971

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
