### PR TITLE
RELATED: RAIL-4459 Make loading of the catalog groups optional

### DIFF
--- a/libs/sdk-backend-base/api/sdk-backend-base.api.md
+++ b/libs/sdk-backend-base/api/sdk-backend-base.api.md
@@ -465,6 +465,8 @@ export abstract class DecoratedWorkspaceCatalogFactory implements IWorkspaceCata
     // (undocumented)
     options: IWorkspaceCatalogFactoryOptions;
     // (undocumented)
+    withGroups(loadGroups: boolean): IWorkspaceCatalogFactory;
+    // (undocumented)
     withOptions(options: IWorkspaceCatalogFactoryOptions): IWorkspaceCatalogFactory;
     // (undocumented)
     workspace: string;

--- a/libs/sdk-backend-base/src/decoratedBackend/catalog.ts
+++ b/libs/sdk-backend-base/src/decoratedBackend/catalog.ts
@@ -57,6 +57,10 @@ export abstract class DecoratedWorkspaceCatalogFactory implements IWorkspaceCata
         return this.createNew(this.decorated.withOptions(options));
     }
 
+    public withGroups(loadGroups: boolean): IWorkspaceCatalogFactory {
+        return this.createNew(this.decorated.withGroups(loadGroups));
+    }
+
     public async load(): Promise<IWorkspaceCatalog> {
         const catalog = await this.decorated.load();
 

--- a/libs/sdk-backend-base/src/dummyBackend/index.ts
+++ b/libs/sdk-backend-base/src/dummyBackend/index.ts
@@ -393,6 +393,7 @@ class DummyWorkspaceCatalogFactory implements IWorkspaceCatalogFactory {
             types: ["attribute", "measure", "fact", "dateDataset"],
             excludeTags: [],
             includeTags: [],
+            loadGroups: true,
         },
     ) {}
 
@@ -425,6 +426,12 @@ class DummyWorkspaceCatalogFactory implements IWorkspaceCatalogFactory {
     public excludeTags(tags: ObjRef[]): IWorkspaceCatalogFactory {
         return this.withOptions({
             excludeTags: tags,
+        });
+    }
+
+    public withGroups(loadGroups: boolean): IWorkspaceCatalogFactory {
+        return this.withOptions({
+            loadGroups,
         });
     }
 

--- a/libs/sdk-backend-bear/src/backend/workspace/catalog/availableItemsFactory.ts
+++ b/libs/sdk-backend-bear/src/backend/workspace/catalog/availableItemsFactory.ts
@@ -68,6 +68,7 @@ export class BearWorkspaceCatalogAvailableItemsFactory implements IWorkspaceCata
             types: ["attribute", "measure", "fact", "dateDataset"],
             excludeTags: [],
             includeTags: [],
+            loadGroups: true,
         },
         private readonly mappings: IUriMappings,
     ) {}
@@ -111,6 +112,10 @@ export class BearWorkspaceCatalogAvailableItemsFactory implements IWorkspaceCata
 
     public forInsight(insight: IInsightDefinition): IWorkspaceCatalogAvailableItemsFactory {
         return this.withOptions({ insight });
+    }
+
+    public withGroups(loadGroups: boolean): IWorkspaceCatalogAvailableItemsFactory {
+        return this.withOptions({ loadGroups });
     }
 
     public async load(): Promise<BearWorkspaceCatalogWithAvailableItems> {

--- a/libs/sdk-backend-bear/src/backend/workspace/catalog/factory.ts
+++ b/libs/sdk-backend-bear/src/backend/workspace/catalog/factory.ts
@@ -110,6 +110,7 @@ export class BearWorkspaceCatalogFactory implements IWorkspaceCatalogFactory {
             types: ["attribute", "measure", "fact", "dateDataset"],
             excludeTags: [],
             includeTags: [],
+            loadGroups: true,
         },
     ) {}
 
@@ -142,6 +143,12 @@ export class BearWorkspaceCatalogFactory implements IWorkspaceCatalogFactory {
     public excludeTags(tags: ObjRef[]): IWorkspaceCatalogFactory {
         return this.withOptions({
             excludeTags: tags,
+        });
+    }
+
+    public withGroups(loadGroups: boolean): IWorkspaceCatalogFactory {
+        return this.withOptions({
+            loadGroups,
         });
     }
 
@@ -286,8 +293,8 @@ export class BearWorkspaceCatalogFactory implements IWorkspaceCatalogFactory {
     };
 
     private loadCatalogGroups = async (): Promise<ICatalogGroup[]> => {
-        const { types } = this.options;
-        const shouldLoadGroups = types.some(isGroupableCatalogItemType);
+        const { types, loadGroups } = this.options;
+        const shouldLoadGroups = loadGroups && types.some(isGroupableCatalogItemType);
         if (!shouldLoadGroups) {
             return [];
         }

--- a/libs/sdk-backend-bear/tests/integrated/__snapshots__/catalog.test.ts.snap
+++ b/libs/sdk-backend-bear/tests/integrated/__snapshots__/catalog.test.ts.snap
@@ -20718,6 +20718,7 @@ BearWorkspaceCatalog {
   "options": Object {
     "excludeTags": Array [],
     "includeTags": Array [],
+    "loadGroups": true,
     "types": Array [
       "attribute",
       "measure",
@@ -37574,6 +37575,7 @@ BearWorkspaceCatalog {
       "GDC.time.quarter_in_year",
     ],
     "includeTags": Array [],
+    "loadGroups": true,
     "production": true,
     "types": Array [
       "dateDataset",

--- a/libs/sdk-backend-mockingbird/src/recordedBackend/catalog.ts
+++ b/libs/sdk-backend-mockingbird/src/recordedBackend/catalog.ts
@@ -40,6 +40,7 @@ export class RecordedCatalogFactory implements IWorkspaceCatalogFactory {
             types: ["attribute", "measure", "fact", "dateDataset"],
             excludeTags: [],
             includeTags: [],
+            loadGroups: true,
         },
     ) {}
 
@@ -75,6 +76,12 @@ export class RecordedCatalogFactory implements IWorkspaceCatalogFactory {
         };
         return new RecordedCatalogFactory(this.workspace, this.recordings, this.config, newOptions);
     };
+
+    public withGroups(loadGroups: boolean): IWorkspaceCatalogFactory {
+        return this.withOptions({
+            loadGroups,
+        });
+    }
 
     public load = async (): Promise<IWorkspaceCatalog> => {
         const catalog = this.recordings.metadata?.catalog;
@@ -146,6 +153,7 @@ class RecordedAvailableCatalogFactory implements IWorkspaceCatalogAvailableItems
             types: ["attribute", "measure", "fact", "dateDataset"],
             excludeTags: [],
             includeTags: [],
+            loadGroups: true,
         },
     ) {}
 
@@ -203,6 +211,13 @@ class RecordedAvailableCatalogFactory implements IWorkspaceCatalogAvailableItems
         // availability not implemented yet
         return this;
     };
+
+    // eslint-disable-next-line sonarjs/no-identical-functions
+    public withGroups(loadGroups: boolean): IWorkspaceCatalogAvailableItemsFactory {
+        return this.withOptions({
+            loadGroups,
+        });
+    }
 
     public load = async (): Promise<IWorkspaceCatalogWithAvailableItems> => {
         return new RecordedAvailableCatalog(this.workspace, this.config, this.groups, this.items);

--- a/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
+++ b/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
@@ -1607,6 +1607,7 @@ export interface IWorkspaceCatalogFactoryMethods<TFactory, TOptions> {
     forDataset(dataset: ObjRef): TFactory;
     forTypes(types: CatalogItemType_2[]): TFactory;
     includeTags(tags: ObjRef[]): TFactory;
+    withGroups(loadGroups: boolean): TFactory;
     withOptions(options: Partial<TOptions>): TFactory;
 }
 
@@ -1616,6 +1617,7 @@ export interface IWorkspaceCatalogFactoryOptions {
     excludeTags: ObjRef[];
     includeDateGranularities?: string[];
     includeTags: ObjRef[];
+    loadGroups?: boolean;
     production?: boolean;
     types: CatalogItemType_2[];
 }

--- a/libs/sdk-backend-spi/src/workspace/ldm/catalog.ts
+++ b/libs/sdk-backend-spi/src/workspace/ldm/catalog.ts
@@ -55,6 +55,12 @@ export interface IWorkspaceCatalogFactoryOptions {
      * Default: undefined
      */
     includeDateGranularities?: string[];
+
+    /**
+     * Should catalog fetch groups?
+     * Default: true
+     */
+    loadGroups?: boolean;
 }
 
 /**
@@ -233,6 +239,15 @@ export interface IWorkspaceCatalogFactoryMethods<TFactory, TOptions> {
      * @returns catalog factory
      */
     excludeTags(tags: ObjRef[]): TFactory;
+
+    /**
+     * Setup whether catalog should fetch groups.
+     * Default: true
+     *
+     * @param loadGroups - should fetch groups
+     * @returns catalog factory
+     */
+    withGroups(loadGroups: boolean): TFactory;
 
     /**
      * Setup catalog to fetch only items for specific options

--- a/libs/sdk-backend-tiger/src/backend/workspace/catalog/availableItemsFactory.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/catalog/availableItemsFactory.ts
@@ -80,6 +80,7 @@ export class TigerWorkspaceCatalogAvailableItemsFactory implements IWorkspaceCat
             types: ["attribute", "measure", "fact", "dateDataset"],
             excludeTags: [],
             includeTags: [],
+            loadGroups: true,
         },
     ) {}
 
@@ -121,6 +122,12 @@ export class TigerWorkspaceCatalogAvailableItemsFactory implements IWorkspaceCat
 
     public forInsight(insight: IInsightDefinition): IWorkspaceCatalogAvailableItemsFactory {
         return this.withOptions({ insight });
+    }
+
+    public withGroups(loadGroups: boolean): IWorkspaceCatalogAvailableItemsFactory {
+        return this.withOptions({
+            loadGroups,
+        });
     }
 
     public async load(): Promise<TigerWorkspaceCatalogWithAvailableItems> {

--- a/libs/sdk-backend-tiger/src/backend/workspace/catalog/factory.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/catalog/factory.ts
@@ -36,6 +36,7 @@ export class TigerWorkspaceCatalogFactory implements IWorkspaceCatalogFactory {
             types: ["attribute", "measure", "fact", "dateDataset"],
             excludeTags: [],
             includeTags: [],
+            loadGroups: true,
         },
     ) {}
 
@@ -70,6 +71,12 @@ export class TigerWorkspaceCatalogFactory implements IWorkspaceCatalogFactory {
             excludeTags: tags,
         });
     };
+
+    public withGroups(loadGroups: boolean): IWorkspaceCatalogFactory {
+        return this.withOptions({
+            loadGroups,
+        });
+    }
 
     public load = async (): Promise<IWorkspaceCatalog> => {
         const promises: Promise<CatalogItem[]>[] = [];

--- a/libs/sdk-backend-tiger/tests/integrated/__snapshots__/catalog.test.ts.snap
+++ b/libs/sdk-backend-tiger/tests/integrated/__snapshots__/catalog.test.ts.snap
@@ -10763,6 +10763,7 @@ TigerWorkspaceCatalog {
   "options": Object {
     "excludeTags": Array [],
     "includeTags": Array [],
+    "loadGroups": true,
     "types": Array [
       "attribute",
       "measure",
@@ -13814,6 +13815,7 @@ TigerWorkspaceCatalog {
       "GDC.time.quarter_in_year",
     ],
     "includeTags": Array [],
+    "loadGroups": true,
     "production": true,
     "types": Array [
       "dateDataset",

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/initializeDashboardHandler/loadCatalog.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/initializeDashboardHandler/loadCatalog.ts
@@ -1,4 +1,4 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 import { DashboardContext } from "../../../types/commonTypes";
 import { IWorkspaceCatalog, IWorkspaceCatalogFactoryOptions } from "@gooddata/sdk-backend-spi";
 import { DateAttributeGranularity } from "@gooddata/sdk-model";
@@ -23,6 +23,7 @@ export function loadCatalog(ctx: DashboardContext): Promise<IWorkspaceCatalog> {
         includeTags: [],
         types: ["attribute", "fact", "measure", "dateDataset"],
         includeDateGranularities: SupportedCatalogGranularity,
+        loadGroups: false,
     };
 
     return backend.workspace(workspace).catalog().withOptions(options).load();

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/drill/common/filterValuesResolver.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/drill/common/filterValuesResolver.ts
@@ -97,6 +97,7 @@ async function resolveRelativeDateFilterValues(
             ?.workspace(workspace)
             .catalog()
             .forDataset(filter.relativeDateFilter.dataSet)
+            .withGroups(false)
             .load();
 
         if (dataSet.dateDatasets) {

--- a/libs/sdk-ui-dashboard/src/presentation/widget/common/configuration/useIsSelectedDatasetHidden.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/common/configuration/useIsSelectedDatasetHidden.ts
@@ -28,6 +28,7 @@ export function useIsSelectedDatasetHidden(selectedDateDatasetRef: ObjRef | unde
                       const catalog = await backend
                           .workspace(workspace)
                           .catalog()
+                          .withGroups(false)
                           .forTypes(["dateDataset"])
                           .excludeTags(
                               (objectAvailability.excludeObjectsWithTags ?? []).map((tag) => idRef(tag)),


### PR DESCRIPTION
- Make loading of the catalog groups optional
- For now, default to true (for backward compatibility)

JIRA: RAIL-4459

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
