### PR TITLE
RAIL-4460: Date filter calendar broken with SDK v8.10 plugin

### DIFF
--- a/libs/sdk-ui-filters/styles/scss/components/DateRangePicker.scss
+++ b/libs/sdk-ui-filters/styles/scss/components/DateRangePicker.scss
@@ -122,6 +122,17 @@ $gd-day-picker-width: 267px;
         }
     }
 
+    //CSS for old RANGE PICKER due to RAIL-4460
+    &:not(.datetime) {
+        display: flex;
+        flex-direction: row;
+        justify-content: space-between;
+        align-items: center;
+    }
+    &-input-wrapper {
+        position: relative;
+    }
+
     &-picker {
         --rdp-cell-size: 32px;
         --rdp-background-color: none;
@@ -139,6 +150,8 @@ $gd-day-picker-width: 267px;
             var(--gd-shadow-color, transparentize($gd-date-range-picker-shadow-color, 0.85));
         background: $gd-color-white;
         user-select: none;
+
+        //CSS for new RANGE PICKER
 
         .rdp-months {
             display: flex;
@@ -257,6 +270,169 @@ $gd-day-picker-width: 267px;
             &:hover {
                 cursor: pointer;
             }
+        }
+
+        //CSS for old RANGE PICKER due to RAIL-4460
+
+        .DayPicker {
+            position: relative;
+            display: flex;
+            justify-content: center;
+            flex-wrap: wrap;
+            user-select: none;
+        }
+
+        .DayPicker-Month {
+            display: table;
+            border-spacing: 0;
+            border-collapse: collapse;
+            margin-top: 0;
+            user-select: none;
+        }
+
+        .DayPicker-NavBar {
+            position: absolute;
+            right: 0;
+            left: 0;
+            padding: 0 0.5rem;
+        }
+
+        .DayPicker-NavButton {
+            position: absolute;
+            top: -0.25em;
+            box-sizing: content-box;
+            width: 1.5rem;
+            height: 1.5rem;
+            text-align: center;
+            background-image: none;
+            cursor: pointer;
+
+            &::before {
+                display: block;
+                padding-top: 0.15em;
+                font-family: $gd-font-indigo;
+                font-size: 18px;
+                color: $gd-palette-primary-base;
+            }
+
+            &:hover {
+                color: $gd-palette-primary-base;
+                cursor: pointer;
+            }
+
+            &:hover::before {
+                color: $gd-color-state-blank;
+            }
+
+            &--prev {
+                left: 0.15em;
+
+                &::before {
+                    content: "\e630";
+                }
+            }
+
+            &--next {
+                right: 0.35em;
+
+                &::before {
+                    content: "\e631";
+                }
+            }
+        }
+
+        .DayPicker-Caption {
+            display: table-caption;
+            margin-left: 0.25em;
+            margin-right: 0.25em;
+            margin-bottom: 1em;
+            font-family: $gd-font-primary;
+            font-weight: 400;
+            font-size: 17px;
+            text-align: center;
+            color: $gd-color-dark;
+            cursor: default;
+        }
+
+        .DayPicker-Weekdays {
+            display: table-header-group;
+        }
+
+        .DayPicker-WeekdaysRow {
+            display: table-row;
+        }
+
+        .DayPicker-Weekday {
+            display: table-cell;
+            padding-bottom: 0.5em;
+            font-family: $gd-font-primary;
+            font-weight: 400;
+            font-size: 13px;
+            text-align: center;
+            color: var(--gd-palette-complementary-8, $default-gd-color-state-blank);
+            cursor: help;
+
+            abbr {
+                text-decoration: none;
+                border-bottom: none;
+            }
+        }
+
+        .DayPicker-Body {
+            display: table-row-group;
+        }
+
+        .DayPicker-Week {
+            display: table-row;
+        }
+
+        .DayPicker-Day {
+            display: table-cell;
+            padding: 0.3125em 0.55em;
+            font-family: $gd-font-primary;
+            font-size: 14px;
+            font-weight: 700;
+            text-align: center;
+            color: $gd-color-text;
+            border-radius: 0;
+
+            &:hover {
+                background: $gd-date-range-picker-hover-bgcolor;
+                cursor: pointer;
+            }
+
+            &--disabled {
+                font-weight: 400;
+                color: $gd-color-disabled;
+
+                &:hover {
+                    background: transparent;
+                    cursor: default;
+                }
+            }
+
+            &--outside {
+                font-weight: normal;
+                color: $gd-color-disabled;
+            }
+        }
+
+        .DayPicker--interactionDisabled .DayPicker-Day {
+            cursor: default;
+        }
+
+        .DayPicker-NavButton--interactionDisabled {
+            display: none;
+        }
+
+        .DayPicker-Day--selected:not(.DayPicker-Day--disabled) {
+            color: $gd-color-text-light;
+            background: $gd-palette-primary-base;
+        }
+
+        .DayPicker-Day--selected:not(.DayPicker-Day--start):not(.DayPicker-Day--end) {
+            color: $gd-color-text;
+            background: $gd-date-range-picker-interval-bgcolor;
         }
     }
 

--- a/libs/sdk-ui-kit/styles/scss/datepicker.scss
+++ b/libs/sdk-ui-kit/styles/scss/datepicker.scss
@@ -90,6 +90,8 @@
         0 2px 5px 0 var(--gd-shadow-color, transparentize($gd-datepicker-shadow-color, 0.85))
     );
 
+    //CSS for new DATEPICKER
+
     .rdp-nav {
         position: absolute;
         top: 1.05em;
@@ -195,6 +197,164 @@
     }
 
     .rdp-day_selected:not(.rdp-day_disabled):not(.rdp-day_outside) {
+        color: $gd-color-text-light;
+        background: $gd-palette-primary-base;
+    }
+
+    //CSS for old DATEPICKER due to RAIL-4460
+
+    .DayPicker {
+        position: relative;
+        display: flex;
+        justify-content: center;
+        flex-wrap: wrap;
+        user-select: none;
+    }
+
+    .DayPicker-Month {
+        display: table;
+        border-spacing: 0;
+        border-collapse: collapse;
+        user-select: none;
+    }
+
+    .DayPicker-NavBar {
+        position: absolute;
+        right: 0;
+        left: 0;
+        padding: 0 0.5rem;
+    }
+
+    .DayPicker-NavButton {
+        position: absolute;
+        width: 1.5rem;
+        height: 1.5rem;
+        cursor: pointer;
+        background-repeat: no-repeat;
+        background-position: center;
+        background-size: contain;
+    }
+
+    .DayPicker-NavButton--prev,
+    .DayPicker-NavButton--next {
+        position: absolute;
+        top: -0.25em;
+        box-sizing: content-box;
+        width: 2em;
+        height: 2em;
+        text-align: center;
+
+        &::before {
+            display: block;
+            color: $gd-palette-primary-base;
+            padding-top: 0.15em;
+            font-family: $gd-font-indigo;
+            font-size: 18px;
+        }
+
+        &:hover::before {
+            color: $gd-color-state-blank;
+        }
+    }
+
+    .DayPicker-NavButton--prev {
+        left: 0.15em;
+
+        &::before {
+            content: "\e630";
+        }
+    }
+
+    .DayPicker-NavButton--next {
+        right: 0.35em;
+
+        &::before {
+            content: "\e631";
+        }
+    }
+
+    .DayPicker-NavButton--next:hover,
+    .DayPicker-NavButton--prev:hover {
+        color: $gd-palette-primary-base;
+        cursor: pointer;
+    }
+
+    .DayPicker-Caption {
+        display: table-caption;
+        color: $gd-color-dark;
+        cursor: default;
+        margin-left: 0.25em;
+        margin-right: 0.25em;
+        margin-bottom: 1em;
+        font-family: $gd-font-primary;
+        font-size: 17px;
+        text-align: center;
+    }
+
+    .DayPicker-Weekdays {
+        display: table-header-group;
+    }
+
+    .DayPicker-WeekdaysRow {
+        display: table-row;
+    }
+
+    .DayPicker-Weekday {
+        display: table-cell;
+        color: var(--gd-palette-complementary-8, $default-gd-color-state-blank);
+        cursor: help;
+        padding-bottom: 0.5em;
+        font-family: $gd-font-primary;
+        font-weight: 400;
+        font-size: 13px;
+        text-align: center;
+
+        abbr {
+            text-decoration: none;
+            border-bottom: none;
+        }
+    }
+
+    .DayPicker-Body {
+        display: table-row-group;
+    }
+
+    .DayPicker-Week {
+        display: table-row;
+    }
+
+    .DayPicker-Day {
+        display: table-cell;
+        padding: 0.3125em 0.55em;
+        color: $gd-color-text;
+        font-family: $gd-font-primary;
+        font-size: 14px;
+        font-weight: 700;
+        text-align: center;
+
+        &:hover {
+            background: $gd-datepicker-hover-bgcolor;
+            cursor: pointer;
+        }
+    }
+
+    .DayPicker--interactionDisabled .DayPicker-Day {
+        cursor: default;
+    }
+
+    .DayPicker-Day--disabled {
+        color: $gd-color-disabled;
+        cursor: default;
+        font-weight: 400;
+    }
+
+    .DayPicker-Day--outside {
+        color: $gd-color-disabled;
+        cursor: default;
+        font-weight: 400;
+    }
+
+    .DayPicker-Day--selected:not(.DayPicker-Day--disabled):not(.DayPicker-Day--outside) {
         color: $gd-color-text-light;
         background: $gd-palette-primary-base;
     }


### PR DESCRIPTION
Due to be able to use plugins with older version of SDK we need to keep css also for old definition of DatePicker. This is because plugins has not bundled css and uses parent css from dashboards.

This needs to be solved in future systematics way because can cause lots of problems ... :(

JIRA: RAIL-4460

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
