### PR TITLE
SD-2393: Allow passing dynamic value to useToastMessage in SDK

### DIFF
--- a/libs/sdk-ui-kit/src/Messages/useToastMessage.ts
+++ b/libs/sdk-ui-kit/src/Messages/useToastMessage.ts
@@ -35,7 +35,7 @@ export const useToastMessage = (): UseToastMessageType => {
     const addMessageBase =
         (type: MessageType): AddMessageType =>
         (message, options) => {
-            if (options.values) {
+            if (options?.values) {
                 return addMessage({ ...options, type, node: intl.formatMessage(message, options.values) });
             }
             return addMessage({ ...options, type, text: intl.formatMessage(message) });


### PR DESCRIPTION
JIRA: SD-2393


---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
