### PR TITLE
RELATED: SD-2384 Return ContractExpired error rather than throwing it, so that the handler for the error can be invoked

### DIFF
--- a/libs/sdk-backend-tiger/src/utils/errorHandling.ts
+++ b/libs/sdk-backend-tiger/src/utils/errorHandling.ts
@@ -29,7 +29,7 @@ export function convertApiError(error: Error): AnalyticalBackendError {
     const contractExpired = createContractExpiredError(error);
 
     if (contractExpired) {
-        throw contractExpired;
+        return contractExpired;
     }
 
     return new UnexpectedError("An unexpected error has occurred", error);


### PR DESCRIPTION
JIRA: SD-2384

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
