### PR TITLE
RELATED: RAIL-4431 fix focus issues in dashboard edit mode

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/dashboard/DashboardSidebar/CreationPanel.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/dashboard/DashboardSidebar/CreationPanel.tsx
@@ -10,6 +10,7 @@ import {
     selectSupportsKpiWidgetCapability,
     selectIsAnalyticalDesignerEnabled,
     useDashboardSelector,
+    selectIsNewDashboard,
 } from "../../../model";
 import { useDashboardComponentsContext } from "../../dashboardContexts";
 import cx from "classnames";
@@ -20,6 +21,7 @@ interface ICreationPanelProps {
 export const CreationPanel: React.FC<ICreationPanelProps> = ({ className }) => {
     const supportsKpis = useDashboardSelector(selectSupportsKpiWidgetCapability);
     const isAnalyticalDesignerEnabled = useDashboardSelector(selectIsAnalyticalDesignerEnabled);
+    const isNewDashboard = useDashboardSelector(selectIsNewDashboard);
 
     const { KpiWidgetComponentSet, AttributeFilterComponentSet, InsightWidgetComponentSet } =
         useDashboardComponentsContext();
@@ -53,7 +55,10 @@ export const CreationPanel: React.FC<ICreationPanelProps> = ({ className }) => {
                         <Typography tagName="h3">
                             <FormattedMessage id="visualizationsList.savedVisualizations" />
                         </Typography>
-                        <DraggableInsightList recalculateSizeReference={className} />
+                        <DraggableInsightList
+                            recalculateSizeReference={className}
+                            searchAutofocus={!isNewDashboard}
+                        />
                     </div>
                 )}
             </div>

--- a/libs/sdk-ui-kit/src/EditableLabel/EditableLabel.tsx
+++ b/libs/sdk-ui-kit/src/EditableLabel/EditableLabel.tsx
@@ -37,6 +37,7 @@ export class EditableLabelInner extends Component<IEditableLabelInnerProps, IEdi
     };
     private readonly root: RefObject<any>;
     private readonly textarea: RefObject<HTMLTextAreaElement>;
+    private focusTimeout: number = 0;
 
     constructor(props: IEditableLabelInnerProps) {
         super(props);
@@ -74,6 +75,7 @@ export class EditableLabelInner extends Component<IEditableLabelInnerProps, IEdi
         rootNode.removeEventListener("dragstart", this.onSelectStart);
         rootNode.removeEventListener("selectstart", this.onSelectStart);
         this.removeListeners();
+        clearTimeout(this.focusTimeout);
     }
 
     onDocumentClick = (e: MouseEvent): void => {
@@ -189,17 +191,21 @@ export class EditableLabelInner extends Component<IEditableLabelInnerProps, IEdi
         const { scrollToEndOnEditingStart, textareaInOverlay } = this.props;
 
         if (componentElement) {
-            componentElement.focus();
+            window.clearTimeout(this.focusTimeout);
+            // without the timeout the focus sometimes got stolen by the previously active item for some reason
+            this.focusTimeout = window.setTimeout(() => {
+                componentElement.focus();
 
-            if (scrollToEndOnEditingStart && this.isMultiLine()) {
-                componentElement.scrollTop = componentElement.scrollHeight;
-            }
+                if (scrollToEndOnEditingStart && this.isMultiLine()) {
+                    componentElement.scrollTop = componentElement.scrollHeight;
+                }
 
-            componentElement.select();
+                componentElement.select();
 
-            if (textareaInOverlay) {
-                this.measureRootDimensions();
-            }
+                if (textareaInOverlay) {
+                    this.measureRootDimensions();
+                }
+            }, 1);
         }
     };
 


### PR DESCRIPTION
* fix title autofocus for new dashboards
* focus insight list search for existing dashboards

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
