### PR TITLE
RELATED: RAIL-4455 Improve the filter decorator example

### DIFF
--- a/libs/sdk-ui-dashboard/src/plugins/customizer.ts
+++ b/libs/sdk-ui-dashboard/src/plugins/customizer.ts
@@ -398,24 +398,36 @@ export interface IAttributeFiltersCustomizer {
      *
      * @example
      * ```
+     * // outside of the register function
+     * // define your decorator in form of a factory that takes the decorated component as a parameter
+     * // that way we can later memoize the resulting component and improve the UX
+     * function MyCustomAttributeFilterDecoratorFactory(
+     *     Decorated: CustomDashboardAttributeFilterComponent,
+     * ): CustomDashboardAttributeFilterComponent {
+     *     return (props) => {
+     *         return (
+     *             <div>
+     *                 <b>My Custom Decoration</b>
+     *                 <Decorated {...props} />
+     *             </div>
+     *         );
+     *     };
+     * }
+     *
+     * // in the register function
      * withCustomDecorator((next) => {
      *     return (attributeFilter) => {
+     *         const Decorated = next(attributeFilter);
+     *         // memoize the result of the factory in order to improve performance
+     *         // and prevent unnecessary reloads of the decorated component
+     *         const WithCustomDecorator = useMemo(
+     *             () => MyCustomAttributeFilterDecoratorFactory(Decorated),
+     *             [Decorated],
+     *         );
      *         if (some_condition_to_prevent_decoration) {
      *             return undefined;
      *         }
-     *
-     *         function MyCustomDecorator(props) {
-     *              const Decorated = next(attributeFilter);
-     *
-     *              return (
-     *                  <div>
-     *                      <p>My Custom Decoration</p>
-     *                      <Decorated {...props}/>
-     *                  </div>
-     *              )
-     *         }
-     *
-     *         return MyCustomDecorator;
+     *         return WithCustomDecorator;
      *     }
      * })
      * ```


### PR DESCRIPTION
Now it shows the best practice that prevents unwanted unmounting of the decorated component (and thus reloading of the elements).

JIRA: RAIL-4455

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
