### PR TITLE
BUGFIX: RAIL-4440 Handle offset reset to get proper searched elements

### DIFF
--- a/libs/sdk-ui-filters/src/AttributeFilterHandler/internal/redux/loadInitialElementsPage/loadInitialElementsPageReducers.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilterHandler/internal/redux/loadInitialElementsPage/loadInitialElementsPageReducers.ts
@@ -16,6 +16,7 @@ const loadInitialElementsPageStart: AttributeFilterReducer<PayloadAction<{ corre
     state.elements.initialPageLoad.status = "loading";
     state.elements.initialPageLoad.error = undefined;
     state.elements.currentOptions.offset = 0;
+    state.elements.lastLoadedOptions.offset = 0;
     state.elements.data = [];
 };
 

--- a/libs/sdk-ui-filters/src/AttributeFilterHandler/internal/redux/store/state.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilterHandler/internal/redux/store/state.ts
@@ -80,6 +80,7 @@ export const initialState: Omit<AttributeFilterState, "displayFormRef" | "elemen
             status: "pending",
         },
         limitingAttributeFiltersAttributes: [],
+        lastLoadedOptions: {},
     },
     config: {},
     selection: {

--- a/libs/sdk-ui-filters/src/AttributeFilterHandler/test/resetLoadOptionsOnSearch.test.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilterHandler/test/resetLoadOptionsOnSearch.test.ts
@@ -1,0 +1,32 @@
+// (C) 2022 GoodData Corporation
+import { newTestAttributeFilterHandler } from "./fixtures";
+import { waitForAsync } from "./testUtils";
+
+describe("AttributeFilterHandler", () => {
+    it("scroll and search to reset offset", async () => {
+        const onLoadNextElementsPageStart = jest.fn();
+        const onLoadNextElementsPageSuccess = jest.fn();
+
+        const attributeFilterHandler = newTestAttributeFilterHandler("negative");
+
+        attributeFilterHandler.setLimit(2);
+        attributeFilterHandler.init();
+
+        await waitForAsync();
+
+        attributeFilterHandler.onLoadNextElementsPageStart(onLoadNextElementsPageStart);
+        attributeFilterHandler.onLoadNextElementsPageSuccess(onLoadNextElementsPageSuccess);
+
+        attributeFilterHandler.loadNextElementsPage("start");
+
+        await waitForAsync();
+
+        expect(attributeFilterHandler.getOffset()).toBe(2);
+
+        attributeFilterHandler.loadInitialElementsPage("start");
+
+        await waitForAsync();
+
+        expect(attributeFilterHandler.getOffset()).toBe(0);
+    });
+});


### PR DESCRIPTION
JIRA: RAIL-4440

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
