### PR TITLE
RELATED: RAIL-4455 Remove filter decorator API

### DIFF
--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -2759,7 +2759,6 @@ export type IAttributeFilterDraggingComponentProps = {
 
 // @public
 export interface IAttributeFiltersCustomizer {
-    withCustomDecorator(providerFactory: (next: AttributeFilterComponentProvider) => OptionalAttributeFilterComponentProvider): IAttributeFiltersCustomizer;
     withCustomProvider(provider: OptionalAttributeFilterComponentProvider): IAttributeFiltersCustomizer;
 }
 
@@ -3277,7 +3276,6 @@ export interface IDashboardWidgetProps {
 
 // @public
 export interface IDateFiltersCustomizer {
-    withCustomDecorator(providerFactory: (next: DateFilterComponentProvider) => OptionalDateFilterComponentProvider): IDateFiltersCustomizer;
     withCustomProvider(provider: OptionalDateFilterComponentProvider): IDateFiltersCustomizer;
 }
 

--- a/libs/sdk-ui-dashboard/src/plugins/customizationApis/attributeFiltersCustomizer.ts
+++ b/libs/sdk-ui-dashboard/src/plugins/customizationApis/attributeFiltersCustomizer.ts
@@ -142,33 +142,6 @@ export class DefaultAttributeFiltersCustomizer implements IAttributeFiltersCusto
         return this;
     };
 
-    public withCustomDecorator = (
-        providerFactory: (next: AttributeFilterComponentProvider) => OptionalAttributeFilterComponentProvider,
-    ): IAttributeFiltersCustomizer => {
-        // snapshot current root provider
-        const rootSnapshot = this.state.getRootProvider();
-        // call user's factory in order to obtain the actual provider - pass the current root so that user's
-        // code can use it to obtain component to decorate
-        const decoratorProvider = providerFactory(rootSnapshot);
-        // construct new root provider; this will be using user's provider with a fallback to root provider
-        // in case user's code does not return anything
-        const newRootProvider: AttributeFilterComponentProvider = (attributeFilter) => {
-            const Component = decoratorProvider(attributeFilter);
-
-            if (Component) {
-                return Component;
-            }
-
-            return rootSnapshot(attributeFilter);
-        };
-
-        // finally modify the root provider; next time someone registers decorator, it will be on top of
-        // this currently registered one
-        this.state.switchRootProvider(newRootProvider);
-
-        return this;
-    };
-
     public getAttributeFilterProvider = (): AttributeFilterComponentProvider => {
         return this.state.getRootProvider();
     };

--- a/libs/sdk-ui-dashboard/src/plugins/customizationApis/dateFiltersCustomizer.ts
+++ b/libs/sdk-ui-dashboard/src/plugins/customizationApis/dateFiltersCustomizer.ts
@@ -140,33 +140,6 @@ export class DefaultDateFiltersCustomizer implements IDateFiltersCustomizer {
         return this;
     };
 
-    public withCustomDecorator = (
-        providerFactory: (next: DateFilterComponentProvider) => OptionalDateFilterComponentProvider,
-    ): IDateFiltersCustomizer => {
-        // snapshot current root provider
-        const rootSnapshot = this.state.getRootProvider();
-        // call user's factory in order to obtain the actual provider - pass the current root so that user's
-        // code can use it to obtain component to decorate
-        const decoratorProvider = providerFactory(rootSnapshot);
-        // construct new root provider; this will be using user's provider with a fallback to root provider
-        // in case user's code does not return anything
-        const newRootProvider: DateFilterComponentProvider = (dateFilter) => {
-            const Component = decoratorProvider(dateFilter);
-
-            if (Component) {
-                return Component;
-            }
-
-            return rootSnapshot(dateFilter);
-        };
-
-        // finally modify the root provider; next time someone registers decorator, it will be on top of
-        // this currently registered one
-        this.state.switchRootProvider(newRootProvider);
-
-        return this;
-    };
-
     public getDateFilterProvider = (): DateFilterComponentProvider => {
         return this.state.getRootProvider();
     };

--- a/libs/sdk-ui-dashboard/src/plugins/customizer.ts
+++ b/libs/sdk-ui-dashboard/src/plugins/customizer.ts
@@ -8,9 +8,7 @@ import {
     OptionalInsightBodyComponentProvider,
     OptionalKpiComponentProvider,
     OptionalDateFilterComponentProvider,
-    DateFilterComponentProvider,
     OptionalAttributeFilterComponentProvider,
-    AttributeFilterComponentProvider,
 } from "../presentation";
 import {
     DashboardDispatch,
@@ -385,53 +383,6 @@ export interface IAttributeFiltersCustomizer {
      * @returns self, for call chaining sakes
      */
     withCustomProvider(provider: OptionalAttributeFilterComponentProvider): IAttributeFiltersCustomizer;
-
-    /**
-     * Register a factory for attribute filter decorator providers.
-     *
-     * @remarks
-     * Decorators are a way to add customizations or embellishments on top
-     * of an existing component. Decorators are more complex to write because they need to work with the component
-     * they should decorate and add 'something' on top of that component.
-     *
-     * This is best illustrated on an example:
-     *
-     * @example
-     * ```
-     * withCustomDecorator((next) => {
-     *     return (attributeFilter) => {
-     *         if (some_condition_to_prevent_decoration) {
-     *             return undefined;
-     *         }
-     *
-     *         function MyCustomDecorator(props) {
-     *              const Decorated = next(attributeFilter);
-     *
-     *              return (
-     *                  <div>
-     *                      <p>My Custom Decoration</p>
-     *                      <Decorated {...props}/>
-     *                  </div>
-     *              )
-     *         }
-     *
-     *         return MyCustomDecorator;
-     *     }
-     * })
-     * ```
-     *
-     * The above shows how to register a decorator that will use some condition to determine whether particular
-     * attribute filter is eligible for decoration. If yes, it will add some extra text in front of the attribute filter. Decorator
-     * defers rendering of the actual attribute filter to the underlying provider.
-     *
-     * Note: the factory function that you specify will be called immediately at the registration time. The
-     * provider that it returns will be called at render time.
-     *
-     * @param providerFactory - factory
-     */
-    withCustomDecorator(
-        providerFactory: (next: AttributeFilterComponentProvider) => OptionalAttributeFilterComponentProvider,
-    ): IAttributeFiltersCustomizer;
 }
 
 /**
@@ -459,53 +410,6 @@ export interface IDateFiltersCustomizer {
      * @returns self, for call chaining sakes
      */
     withCustomProvider(provider: OptionalDateFilterComponentProvider): IDateFiltersCustomizer;
-
-    /**
-     * Register a factory for date filter decorator providers.
-     *
-     * @remarks
-     * Decorators are a way to add customizations or embellishments on top
-     * of an existing component. Decorators are more complex to write because they need to work with the component
-     * they should decorate and add 'something' on top of that component.
-     *
-     * This is best illustrated on an example:
-     *
-     * @example
-     * ```
-     * withCustomDecorator((next) => {
-     *     return (dateFilter) => {
-     *         if (some_condition_to_prevent_decoration) {
-     *             return undefined;
-     *         }
-     *
-     *         function MyCustomDecorator(props) {
-     *              const Decorated = next(dateFilter);
-     *
-     *              return (
-     *                  <div>
-     *                      <p>My Custom Decoration</p>
-     *                      <Decorated {...props}/>
-     *                  </div>
-     *              )
-     *         }
-     *
-     *         return MyCustomDecorator;
-     *     }
-     * })
-     * ```
-     *
-     * The above shows how to register a decorator that will use some condition to determine whether particular
-     * date filter is eligible for decoration. If yes, it will add some extra text in front of the date filter. Decorator
-     * defers rendering of the actual date filter to the underlying provider.
-     *
-     * Note: the factory function that you specify will be called immediately at the registration time. The
-     * provider that it returns will be called at render time.
-     *
-     * @param providerFactory - factory
-     */
-    withCustomDecorator(
-        providerFactory: (next: DateFilterComponentProvider) => OptionalDateFilterComponentProvider,
-    ): IDateFiltersCustomizer;
 }
 
 /**


### PR DESCRIPTION
The API is hard to use correctly, we need to rethink the decorator APIs as a whole later.

JIRA: RAIL-4455

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
