### PR TITLE
RELATED: RAIL-4465 Add sdk-ui-filters to plugin peerDeps

### DIFF
--- a/tools/dashboard-plugin-template/package.json
+++ b/tools/dashboard-plugin-template/package.json
@@ -60,6 +60,7 @@
         "@gooddata/sdk-ui": "^8.11.0-alpha.77",
         "@gooddata/sdk-ui-charts": "^8.11.0-alpha.77",
         "@gooddata/sdk-ui-ext": "^8.11.0-alpha.77",
+        "@gooddata/sdk-ui-filters": "^8.11.0-alpha.77",
         "@gooddata/sdk-ui-geo": "^8.11.0-alpha.77",
         "@gooddata/sdk-ui-pivot": "^8.11.0-alpha.77",
         "react": "^16.10.0 || ^17.0.0",


### PR DESCRIPTION
This is needed so that sdk-ui-filters can accept singleton instance from KD and thus use the correct contexts for react-intl. This issue is very similar to the one fixed in RAIL-3937 but from the plugin's side.

JIRA: RAIL-4465

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
