### PR TITLE
RELATED: RAIL-4448 Prevent invariant error in attribute filter loader

### DIFF
--- a/libs/sdk-ui-filters/src/AttributeFilter@next/types.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilter@next/types.ts
@@ -124,6 +124,22 @@ export interface IAttributeFilterCoreProps {
      * @remarks
      * The meaning of the items is determined by the way the filter is specified: if the filter uses URIs,
      * then these are also interpreted as URIs, analogously with values.
+     *
+     * If using `hiddenElements`, make sure your input filter excludes the hidden elements, otherwise it could lead to
+     * non-intuitive behavior.
+     * So, for positive filters, make sure their elements do NOT contain any of the `hiddenElements`.
+     * Inversely for negative filters, make sure their elements do contain all of the `hiddenElements`.
+     *
+     * @example
+     * This is how to correctly create a filter that has some items hidden but is set to All:
+     *
+     * ```tsx
+     * const hiddenUris: ["uri1", "uri2"];
+     * // make sure to use the uris both in the filter...
+     * const filter = newNegativeAttributeFilter("displayForm", { uris: hiddenUris });
+     * // ...and also in the prop
+     * return <AttributeFilter filter={filter} hiddenElements={hiddenUris} />
+     * ```
      */
     hiddenElements?: string[];
 

--- a/libs/sdk-ui-filters/src/AttributeFilterHandler/factory.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilterHandler/factory.ts
@@ -22,6 +22,22 @@ export interface IAttributeFilterHandlerOptionsBase {
      * @remarks
      * The meaning of the items is determined by the way the filter is specified: if the filter uses URIs,
      * then these are also interpreted as URIs, analogously with values.
+     *
+     * If using hiddenElements, make sure your input filter excludes the hidden elements, otherwise it could lead to
+     * non-intuitive behavior.
+     * So, for positive filters, make sure their elements do NOT contain any of the `hiddenElements`.
+     * Inversely for negative filters, make sure their elements do contain all of the `hiddenElements`.
+     *
+     * @example
+     * This is how to correctly create a filter that has some items hidden but is set to All:
+     *
+     * ```tsx
+     * const hiddenUris: ["uri1", "uri2"];
+     * // make sure to use the uris both in the filter...
+     * const filter = newNegativeAttributeFilter("displayForm", { uris: hiddenUris });
+     * // ...and also in the config
+     * const handler = newAttributeFilterHandler(backend, workspace, filter, { hiddenElements: hiddenUris });
+     * ```
      */
     hiddenElements?: string[];
 

--- a/libs/sdk-ui-filters/src/AttributeFilterHandler/internal/loader.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilterHandler/internal/loader.ts
@@ -41,6 +41,7 @@ import {
 } from "../types";
 import { AttributeFilterReduxBridge } from "./bridge";
 import { AttributeFilterHandlerConfig } from "./types";
+import { sanitizeInputFilter } from "./utils/sanitizeInputFilter";
 
 /**
  * @internal
@@ -50,8 +51,10 @@ export class AttributeFilterLoader implements IAttributeFilterLoader {
     protected config: AttributeFilterHandlerConfig;
 
     protected constructor(config: AttributeFilterHandlerConfig) {
-        this.config = config;
-        this.bridge = new AttributeFilterReduxBridge(config);
+        const { attributeFilter, hiddenElements } = config;
+        this.config = { ...config };
+        this.config.attributeFilter = sanitizeInputFilter(attributeFilter, hiddenElements);
+        this.bridge = new AttributeFilterReduxBridge(this.config);
     }
 
     private validateStaticElementsLoad = () => {

--- a/libs/sdk-ui-filters/src/AttributeFilterHandler/internal/utils/sanitizeInputFilter.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilterHandler/internal/utils/sanitizeInputFilter.ts
@@ -1,0 +1,39 @@
+// (C) 2022 GoodData Corporation
+import difference from "lodash/difference";
+import {
+    filterAttributeElements,
+    filterObjRef,
+    IAttributeElements,
+    IAttributeFilter,
+    isAttributeElementsByRef,
+    isNegativeAttributeFilter,
+    newNegativeAttributeFilter,
+    newPositiveAttributeFilter,
+} from "@gooddata/sdk-model";
+
+/**
+ * Removes the elements specified in hidden elements from the input filter: they are handled down the line.
+ *
+ * @param attributeFilter - filter to sanitize
+ * @param hiddenElements - hidden elements to use
+ * @internal
+ */
+export function sanitizeInputFilter<T extends IAttributeFilter>(
+    attributeFilter: T,
+    hiddenElements: string[] | undefined,
+): T {
+    if (!hiddenElements?.length) {
+        return attributeFilter;
+    }
+
+    const selection = filterAttributeElements(attributeFilter);
+    const rawSelection = isAttributeElementsByRef(selection) ? selection.uris : selection.values;
+    const sanitizedRawSelection = difference(rawSelection, hiddenElements);
+    const sanitizedSelection: IAttributeElements = isAttributeElementsByRef(selection)
+        ? { uris: sanitizedRawSelection }
+        : { values: sanitizedRawSelection };
+
+    return isNegativeAttributeFilter(attributeFilter)
+        ? (newNegativeAttributeFilter(filterObjRef(attributeFilter), sanitizedSelection) as T)
+        : (newPositiveAttributeFilter(filterObjRef(attributeFilter), sanitizedSelection) as T);
+}


### PR DESCRIPTION
When a user hides an element and uses it in the input filter, it would previously throw an invariant. Thus, we sanitize the input because we know that the hidden elements will be resolved in the output filter later anyway.

Also mention `hiddenElements` correct usage.

JIRA: RAIL-4448

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
