### PR TITLE
RELATED: RAIL-4439 - Make cachingBackend decorator public

### DIFF
--- a/common/changes/@gooddata/sdk-ui-all/MAP-RAIL-4439-caching-backend_2022-09-22-11-54.json
+++ b/common/changes/@gooddata/sdk-ui-all/MAP-RAIL-4439-caching-backend_2022-09-22-11-54.json
@@ -2,7 +2,7 @@
     "changes": [
         {
             "packageName": "@gooddata/sdk-ui-all",
-            "comment": "Default backend caching configuration is no longer provided automatically. The configuration must be specified while using the withCaching backend decorator. To keep caching working the same as before, use RecommendedCachingConfiguration from @gooddata/sdk-backend-base package.",
+            "comment": "The withCaching backend decorator has been made public. RecommendedCachingConfiguration from @gooddata/sdk-backend-base can be use to configure backend caching.",
             "type": "none"
         }
     ],

--- a/common/changes/@gooddata/sdk-ui-all/MAP-RAIL-4439-caching-backend_2022-09-22-11-54.json
+++ b/common/changes/@gooddata/sdk-ui-all/MAP-RAIL-4439-caching-backend_2022-09-22-11-54.json
@@ -2,7 +2,7 @@
     "changes": [
         {
             "packageName": "@gooddata/sdk-ui-all",
-            "comment": "The withCaching backend decorator has been made public. RecommendedCachingConfiguration from @gooddata/sdk-backend-base can be use to configure backend caching.",
+            "comment": "The withCaching backend decorator has been made public. RecommendedCachingConfiguration from @gooddata/sdk-backend-base can be used to configure backend caching.",
             "type": "none"
         }
     ],

--- a/common/changes/@gooddata/sdk-ui-all/MAP-RAIL-4439-caching-backend_2022-09-22-11-54.json
+++ b/common/changes/@gooddata/sdk-ui-all/MAP-RAIL-4439-caching-backend_2022-09-22-11-54.json
@@ -1,0 +1,10 @@
+{
+    "changes": [
+        {
+            "packageName": "@gooddata/sdk-ui-all",
+            "comment": "Default backend caching configuration is no longer provided automatically. The configuration must be specified while using the withCaching backend decorator. To keep caching working the same as before, use RecommendedCachingConfiguration from @gooddata/sdk-backend-base package.",
+            "type": "none"
+        }
+    ],
+    "packageName": "@gooddata/sdk-ui-all"
+}

--- a/examples/sdk-examples/src/context/auth/context.tsx
+++ b/examples/sdk-examples/src/context/auth/context.tsx
@@ -2,7 +2,7 @@
 import React, { createContext, useContext, useEffect } from "react";
 import bearFactory from "@gooddata/sdk-backend-bear";
 import { IAnalyticalBackend } from "@gooddata/sdk-backend-spi";
-import { withCaching } from "@gooddata/sdk-backend-base";
+import { withCaching, RecommendedCachingConfiguration } from "@gooddata/sdk-backend-base";
 
 import { GoodDataAuthProvider } from "./GoodDataAuthProvider";
 import { AuthStatus, IAuthContext, IAuthState } from "./types";
@@ -12,7 +12,7 @@ const noop = () => undefined;
 
 const authProvider = new GoodDataAuthProvider();
 
-const backend = withCaching(bearFactory().withAuthentication(authProvider));
+const backend = withCaching(bearFactory().withAuthentication(authProvider), RecommendedCachingConfiguration);
 
 const initialState: IAuthState = {
     authStatus: AuthStatus.AUTHORIZING,

--- a/libs/sdk-backend-base/README.md
+++ b/libs/sdk-backend-base/README.md
@@ -75,22 +75,23 @@ critical requirement, then this decorator can speed your application immensely.
 
 ```typescript
 import {IAnalyticalBackend} from "@gooddata/sdk-backend-spi";
-import {withCaching} from "@gooddata/sdk-backend-base";
+import {withCaching, RecommendedCachingConfiguration} from "@gooddata/sdk-backend-base";
 
 const realBackendImplementation = ...;
-const enhancedBackend: IAnalyticalBackend = withCaching(realBackendImplementation);
+const enhancedBackend: IAnalyticalBackend = withCaching(realBackendImplementation, RecommendedCachingConfiguration);
 ```
 
-The withCaching optionally accepts configuration which you can use to tweak the size of the different caches.
+The withCaching accepts configuration which you need to use to tweak the size of the different caches. You can use RecommendedCachingConfiguration
+available in this package.
 
 The caching plays well with normalization:
 
 ```typescript
 import {IAnalyticalBackend} from "@gooddata/sdk-backend-spi";
-import {withCaching, withNormalization} from "@gooddata/sdk-backend-base";
+import {withCaching, withNormalization, RecommendedCachingConfiguration} from "@gooddata/sdk-backend-base";
 
 const realBackendImplementation = ...;
-const enhancedBackend: IAnalyticalBackend = withNormalization(withCaching(realBackendImplementation));
+const enhancedBackend: IAnalyticalBackend = withNormalization(withCaching(realBackendImplementation, RecommendedCachingConfiguration));
 ```
 
 This way the normalization first wipes any differences that are unimportant for the backend, effectively dispatching

--- a/libs/sdk-backend-base/api/sdk-backend-base.api.md
+++ b/libs/sdk-backend-base/api/sdk-backend-base.api.md
@@ -216,7 +216,7 @@ export function builderFactory<TItem, TBuilder extends Builder<TItem>, TBuilderC
 // @beta
 export type BuilderModifications<TBuilder extends IBuilder<TItem>, TItem = ExtractBuilderType<TBuilder>> = (builder: TBuilder) => TBuilder;
 
-// @beta
+// @public
 export type CacheControl = {
     resetExecutions: () => void;
     resetCatalogs: () => void;
@@ -226,19 +226,19 @@ export type CacheControl = {
     resetAll: () => void;
 };
 
-// @beta
+// @public
 export type CachingConfiguration = {
-    maxExecutions: number | undefined;
-    maxResultWindows: number | undefined;
-    maxCatalogs: number | undefined;
-    maxCatalogOptions: number | undefined;
+    maxExecutions?: number;
+    maxResultWindows?: number;
+    maxCatalogs?: number;
+    maxCatalogOptions?: number;
     onCacheReady?: (cacheControl: CacheControl) => void;
-    maxSecuritySettingsOrgs: number | undefined;
-    maxSecuritySettingsOrgUrls: number | undefined;
-    maxSecuritySettingsOrgUrlsAge: number | undefined;
-    maxAttributeWorkspaces: number | undefined;
-    maxAttributeDisplayFormsPerWorkspace: number | undefined;
-    maxWorkspaceSettings: number | undefined;
+    maxSecuritySettingsOrgs?: number;
+    maxSecuritySettingsOrgUrls?: number;
+    maxSecuritySettingsOrgUrlsAge?: number;
+    maxAttributeWorkspaces?: number;
+    maxAttributeDisplayFormsPerWorkspace?: number;
+    maxWorkspaceSettings?: number;
 };
 
 // @beta
@@ -559,9 +559,6 @@ export type DecoratorFactories = {
     attributes?: AttributesDecoratorFactory;
     dashboards?: DashboardsDecoratorFactory;
 };
-
-// @beta (undocumented)
-export const DefaultCachingConfiguration: CachingConfiguration;
 
 // @internal (undocumented)
 export class Denormalizer {
@@ -903,6 +900,9 @@ export class Normalizer {
 // @alpha (undocumented)
 export type PreparedExecutionWrapper = (execution: IPreparedExecution) => IPreparedExecution;
 
+// @public (undocumented)
+export const RecommendedCachingConfiguration: CachingConfiguration;
+
 // @alpha
 export const resolveValueOrUpdateCallback: <TValue>(valueOrUpdateCallback: ValueOrUpdateCallback<TValue>, valueToUpdate: TValue) => TValue;
 
@@ -993,7 +993,7 @@ export class WidgetBaseBuilder<T extends IWidget> extends Builder<T> implements 
     uri: (valueOrUpdateCallback: ValueOrUpdateCallback<string>) => this;
 }
 
-// @beta
+// @public
 export function withCaching(realBackend: IAnalyticalBackend, config?: CachingConfiguration): IAnalyticalBackend;
 
 // @beta

--- a/libs/sdk-backend-base/api/sdk-backend-base.api.md
+++ b/libs/sdk-backend-base/api/sdk-backend-base.api.md
@@ -900,7 +900,7 @@ export class Normalizer {
 // @alpha (undocumented)
 export type PreparedExecutionWrapper = (execution: IPreparedExecution) => IPreparedExecution;
 
-// @public (undocumented)
+// @public
 export const RecommendedCachingConfiguration: CachingConfiguration;
 
 // @alpha
@@ -994,7 +994,7 @@ export class WidgetBaseBuilder<T extends IWidget> extends Builder<T> implements 
 }
 
 // @public
-export function withCaching(realBackend: IAnalyticalBackend, config?: CachingConfiguration): IAnalyticalBackend;
+export function withCaching(realBackend: IAnalyticalBackend, config: CachingConfiguration): IAnalyticalBackend;
 
 // @beta
 export function withCustomWorkspaceSettings(realBackend: IAnalyticalBackend, config: WorkspaceSettingsConfiguration): IAnalyticalBackend;

--- a/libs/sdk-backend-base/src/cachingBackend/index.ts
+++ b/libs/sdk-backend-base/src/cachingBackend/index.ts
@@ -89,7 +89,7 @@ type CachingContext = {
         workspaceAttributes?: LRUCache<AttributeCacheEntry>;
         workspaceSettings?: LRUCache<WorkspaceSettingsCacheEntry>;
     };
-    config: CachingConfiguration;
+    config: CachingConfiguration | undefined;
     capabilities: IBackendCapabilities;
 };
 
@@ -193,8 +193,8 @@ class WithExecutionResultCaching extends DecoratedExecutionResult {
     ) {
         super(decorated, wrapper);
 
-        if (cachingEnabled(this.ctx.config.maxResultWindows)) {
-            this.windows = new LRUCache({ maxSize: this.ctx.config.maxResultWindows });
+        if (cachingEnabled(this.ctx.config?.maxResultWindows)) {
+            this.windows = new LRUCache({ maxSize: this.ctx.config?.maxResultWindows });
         }
     }
 
@@ -273,7 +273,7 @@ class WithCatalogCaching extends DecoratedWorkspaceCatalogFactory {
         if (!cacheEntry) {
             cacheEntry = {
                 catalogForOptions: new LRUCache<Promise<IWorkspaceCatalog>>({
-                    maxSize: this.ctx.config.maxCatalogOptions,
+                    maxSize: this.ctx.config?.maxCatalogOptions,
                 }),
             };
             cache.set(workspace, cacheEntry);
@@ -337,8 +337,8 @@ class WithSecuritySettingsCaching extends DecoratedSecuritySettingsService {
         if (!cacheEntry) {
             cacheEntry = {
                 valid: new LRUCache<Promise<boolean>>({
-                    maxSize: this.ctx.config.maxSecuritySettingsOrgUrls,
-                    maxAge: this.ctx.config.maxSecuritySettingsOrgUrlsAge,
+                    maxSize: this.ctx.config?.maxSecuritySettingsOrgUrls,
+                    maxAge: this.ctx.config?.maxSecuritySettingsOrgUrlsAge,
                 }),
             };
             cache.set(scope, cacheEntry);
@@ -404,10 +404,10 @@ class WithWorkspaceSettingsCaching extends DecoratedWorkspaceSettingsService {
         if (!cacheEntry) {
             cacheEntry = {
                 userWorkspaceSettings: new LRUCache<Promise<IUserWorkspaceSettings>>({
-                    maxSize: this.ctx.config.maxWorkspaceSettings,
+                    maxSize: this.ctx.config?.maxWorkspaceSettings,
                 }),
                 workspaceSettings: new LRUCache<Promise<IWorkspaceSettings>>({
-                    maxSize: this.ctx.config.maxWorkspaceSettings,
+                    maxSize: this.ctx.config?.maxWorkspaceSettings,
                 }),
             };
             cache.set(workspace, cacheEntry);
@@ -534,7 +534,7 @@ class WithAttributesCaching extends DecoratedWorkspaceAttributesService {
         if (!cacheEntry) {
             cacheEntry = {
                 displayForms: new LRUCache<Promise<IAttributeDisplayFormMetadataObject>>({
-                    maxSize: this.ctx.config.maxAttributeDisplayFormsPerWorkspace,
+                    maxSize: this.ctx.config?.maxAttributeDisplayFormsPerWorkspace,
                 }),
             };
             cache.set(workspace, cacheEntry);
@@ -843,30 +843,30 @@ export const RecommendedCachingConfiguration: CachingConfiguration = {
  */
 export function withCaching(
     realBackend: IAnalyticalBackend,
-    config: CachingConfiguration = RecommendedCachingConfiguration,
+    config?: CachingConfiguration,
 ): IAnalyticalBackend {
-    assertPositiveOrUndefined(config.maxCatalogOptions, "maxCatalogOptions");
-    assertPositiveOrUndefined(config.maxSecuritySettingsOrgUrls, "maxSecuritySettingsOrgUrls");
-    assertPositiveOrUndefined(config.maxSecuritySettingsOrgUrlsAge, "maxSecuritySettingsOrgUrlsAge");
+    assertPositiveOrUndefined(config?.maxCatalogOptions, "maxCatalogOptions");
+    assertPositiveOrUndefined(config?.maxSecuritySettingsOrgUrls, "maxSecuritySettingsOrgUrls");
+    assertPositiveOrUndefined(config?.maxSecuritySettingsOrgUrlsAge, "maxSecuritySettingsOrgUrlsAge");
 
-    const execCaching = cachingEnabled(config.maxExecutions);
-    const catalogCaching = cachingEnabled(config.maxCatalogs);
-    const securitySettingsCaching = cachingEnabled(config.maxSecuritySettingsOrgs);
-    const attributeCaching = cachingEnabled(config.maxAttributeWorkspaces);
-    const workspaceSettingsCaching = cachingEnabled(config.maxWorkspaceSettings);
+    const execCaching = cachingEnabled(config?.maxExecutions);
+    const catalogCaching = cachingEnabled(config?.maxCatalogs);
+    const securitySettingsCaching = cachingEnabled(config?.maxSecuritySettingsOrgs);
+    const attributeCaching = cachingEnabled(config?.maxAttributeWorkspaces);
+    const workspaceSettingsCaching = cachingEnabled(config?.maxWorkspaceSettings);
 
     const ctx: CachingContext = {
         caches: {
-            execution: execCaching ? new LRUCache({ maxSize: config.maxExecutions }) : undefined,
-            workspaceCatalogs: catalogCaching ? new LRUCache({ maxSize: config.maxCatalogs }) : undefined,
+            execution: execCaching ? new LRUCache({ maxSize: config?.maxExecutions }) : undefined,
+            workspaceCatalogs: catalogCaching ? new LRUCache({ maxSize: config?.maxCatalogs }) : undefined,
             securitySettings: securitySettingsCaching
-                ? new LRUCache({ maxSize: config.maxSecuritySettingsOrgs })
+                ? new LRUCache({ maxSize: config?.maxSecuritySettingsOrgs })
                 : undefined,
             workspaceAttributes: attributeCaching
-                ? new LRUCache({ maxSize: config.maxAttributeWorkspaces })
+                ? new LRUCache({ maxSize: config?.maxAttributeWorkspaces })
                 : undefined,
             workspaceSettings: workspaceSettingsCaching
-                ? new LRUCache({ maxSize: config.maxWorkspaceSettings })
+                ? new LRUCache({ maxSize: config?.maxWorkspaceSettings })
                 : undefined,
         },
         config,
@@ -879,7 +879,7 @@ export function withCaching(
     const attributes = attributeCaching ? cachedAttributes(ctx) : identity;
     const workspaceSettings = workspaceSettingsCaching ? cachedWorkspaceSettings(ctx) : identity;
 
-    if (config.onCacheReady) {
+    if (config?.onCacheReady) {
         config.onCacheReady(cacheControl(ctx));
     }
 

--- a/libs/sdk-backend-base/src/cachingBackend/index.ts
+++ b/libs/sdk-backend-base/src/cachingBackend/index.ts
@@ -615,7 +615,7 @@ function cacheControl(ctx: CachingContext): CacheControl {
  * Cache control can be used to interact with the caching layer - at the moment to reset the contents of the
  * different top-level caches.
  *
- * @beta
+ * @public
  */
 export type CacheControl = {
     /**
@@ -655,7 +655,7 @@ export type CacheControl = {
 /**
  * Specifies where should the caching decorator apply and to what size should caches grow.
  *
- * @beta
+ * @public
  */
 export type CachingConfiguration = {
     /**
@@ -671,7 +671,7 @@ export type CachingConfiguration = {
      *
      * When non-positive number is specified, then no caching will be done.
      */
-    maxExecutions: number | undefined;
+    maxExecutions?: number;
 
     /**
      * Maximum number of execution result's pages to cache PER result. The window offset and limit are used as cache key.
@@ -685,7 +685,7 @@ export type CachingConfiguration = {
      *
      * Note: this option has no effect if execution caching is disabled.
      */
-    maxResultWindows: number | undefined;
+    maxResultWindows?: number;
 
     /**
      * Maximum number of workspaces for which to cache catalogs. The workspace identifier is used as cache key. For
@@ -699,7 +699,7 @@ export type CachingConfiguration = {
      *
      * When non-positive number is specified, then no caching of result windows will be done.
      */
-    maxCatalogs: number | undefined;
+    maxCatalogs?: number;
 
     /**
      * Catalog can be viewed in many different ways - determined by the options specified during load. This option
@@ -714,7 +714,7 @@ export type CachingConfiguration = {
      *
      * Setting non-positive number here is invalid. If you want to turn off catalog caching, tweak the `maxCatalogs`.
      */
-    maxCatalogOptions: number | undefined;
+    maxCatalogOptions?: number;
 
     /**
      * Specify function to call once the caching is set up. If present, the function will be called
@@ -736,7 +736,7 @@ export type CachingConfiguration = {
      *
      * When non-positive number is specified, then no caching will be done.
      */
-    maxSecuritySettingsOrgs: number | undefined;
+    maxSecuritySettingsOrgs?: number;
 
     /**
      * Maximum number of URLs per organization that will have its validation result cached. The URL
@@ -751,7 +751,7 @@ export type CachingConfiguration = {
      * Setting non-positive number here is invalid. If you want to turn off organization security settings caching,
      * tweak the `maxSecuritySettingsOrgs`.
      */
-    maxSecuritySettingsOrgUrls: number | undefined;
+    maxSecuritySettingsOrgUrls?: number;
 
     /**
      * Maximum age of cached organization's URL validation results. The value is in milliseconds.
@@ -764,7 +764,7 @@ export type CachingConfiguration = {
      * Setting non-positive number here is invalid. If you want to turn off organization security settings
      * caching, tweak the `maxSecuritySettingsOrgs`.
      */
-    maxSecuritySettingsOrgUrlsAge: number | undefined;
+    maxSecuritySettingsOrgUrlsAge?: number;
 
     /**
      * Maximum number of workspaces for which to cache selected {@link @gooddata/sdk-backend-spi#IWorkspaceAttributesService} calls.
@@ -779,7 +779,7 @@ export type CachingConfiguration = {
      *
      * When non-positive number is specified, then no caching will be done.
      */
-    maxAttributeWorkspaces: number | undefined;
+    maxAttributeWorkspaces?: number;
 
     /**
      * Maximum number of attribute display forms to cache per workspace.
@@ -793,7 +793,7 @@ export type CachingConfiguration = {
      * Setting non-positive number here is invalid. If you want to turn off attribute display form
      * caching, tweak the `maxAttributeWorkspaces` value.
      */
-    maxAttributeDisplayFormsPerWorkspace: number | undefined;
+    maxAttributeDisplayFormsPerWorkspace?: number;
 
     /**
      * Maximum number of settings for a workspace and for a user to cache per workspace.
@@ -806,7 +806,7 @@ export type CachingConfiguration = {
      *
      * When non-positive number is specified, then no caching of result windows will be done.
      */
-    maxWorkspaceSettings: number | undefined;
+    maxWorkspaceSettings?: number;
 };
 
 function assertPositiveOrUndefined(value: number | undefined, valueName: string) {
@@ -817,9 +817,9 @@ function assertPositiveOrUndefined(value: number | undefined, valueName: string)
 }
 
 /**
- * @beta
+ * @public
  */
-export const DefaultCachingConfiguration: CachingConfiguration = {
+export const RecommendedCachingConfiguration: CachingConfiguration = {
     maxExecutions: 10,
     maxResultWindows: 5,
     maxCatalogs: 1,
@@ -839,11 +839,11 @@ export const DefaultCachingConfiguration: CachingConfiguration = {
  * @remarks see {@link CachingConfiguration} properties for more information.
  * @param realBackend - real backend to decorate with caching
  * @param config - caching configuration
- * @beta
+ * @public
  */
 export function withCaching(
     realBackend: IAnalyticalBackend,
-    config: CachingConfiguration = DefaultCachingConfiguration,
+    config: CachingConfiguration = RecommendedCachingConfiguration,
 ): IAnalyticalBackend {
     assertPositiveOrUndefined(config.maxCatalogOptions, "maxCatalogOptions");
     assertPositiveOrUndefined(config.maxSecuritySettingsOrgUrls, "maxSecuritySettingsOrgUrls");

--- a/libs/sdk-backend-base/src/cachingBackend/index.ts
+++ b/libs/sdk-backend-base/src/cachingBackend/index.ts
@@ -89,7 +89,7 @@ type CachingContext = {
         workspaceAttributes?: LRUCache<AttributeCacheEntry>;
         workspaceSettings?: LRUCache<WorkspaceSettingsCacheEntry>;
     };
-    config: CachingConfiguration | undefined;
+    config: CachingConfiguration;
     capabilities: IBackendCapabilities;
 };
 
@@ -193,8 +193,8 @@ class WithExecutionResultCaching extends DecoratedExecutionResult {
     ) {
         super(decorated, wrapper);
 
-        if (cachingEnabled(this.ctx.config?.maxResultWindows)) {
-            this.windows = new LRUCache({ maxSize: this.ctx.config?.maxResultWindows });
+        if (cachingEnabled(this.ctx.config.maxResultWindows)) {
+            this.windows = new LRUCache({ maxSize: this.ctx.config.maxResultWindows });
         }
     }
 
@@ -273,7 +273,7 @@ class WithCatalogCaching extends DecoratedWorkspaceCatalogFactory {
         if (!cacheEntry) {
             cacheEntry = {
                 catalogForOptions: new LRUCache<Promise<IWorkspaceCatalog>>({
-                    maxSize: this.ctx.config?.maxCatalogOptions,
+                    maxSize: this.ctx.config.maxCatalogOptions,
                 }),
             };
             cache.set(workspace, cacheEntry);
@@ -337,8 +337,8 @@ class WithSecuritySettingsCaching extends DecoratedSecuritySettingsService {
         if (!cacheEntry) {
             cacheEntry = {
                 valid: new LRUCache<Promise<boolean>>({
-                    maxSize: this.ctx.config?.maxSecuritySettingsOrgUrls,
-                    maxAge: this.ctx.config?.maxSecuritySettingsOrgUrlsAge,
+                    maxSize: this.ctx.config.maxSecuritySettingsOrgUrls,
+                    maxAge: this.ctx.config.maxSecuritySettingsOrgUrlsAge,
                 }),
             };
             cache.set(scope, cacheEntry);
@@ -404,10 +404,10 @@ class WithWorkspaceSettingsCaching extends DecoratedWorkspaceSettingsService {
         if (!cacheEntry) {
             cacheEntry = {
                 userWorkspaceSettings: new LRUCache<Promise<IUserWorkspaceSettings>>({
-                    maxSize: this.ctx.config?.maxWorkspaceSettings,
+                    maxSize: this.ctx.config.maxWorkspaceSettings,
                 }),
                 workspaceSettings: new LRUCache<Promise<IWorkspaceSettings>>({
-                    maxSize: this.ctx.config?.maxWorkspaceSettings,
+                    maxSize: this.ctx.config.maxWorkspaceSettings,
                 }),
             };
             cache.set(workspace, cacheEntry);
@@ -534,7 +534,7 @@ class WithAttributesCaching extends DecoratedWorkspaceAttributesService {
         if (!cacheEntry) {
             cacheEntry = {
                 displayForms: new LRUCache<Promise<IAttributeDisplayFormMetadataObject>>({
-                    maxSize: this.ctx.config?.maxAttributeDisplayFormsPerWorkspace,
+                    maxSize: this.ctx.config.maxAttributeDisplayFormsPerWorkspace,
                 }),
             };
             cache.set(workspace, cacheEntry);
@@ -843,35 +843,35 @@ export const RecommendedCachingConfiguration: CachingConfiguration = {
  *
  * @remarks see {@link CachingConfiguration} properties for more information.
  * @param realBackend - real backend to decorate with caching
- * @param config - caching configuration
+ * @param config - caching configuration. {@link RecommendedCachingConfiguration} can be used
  * @public
  */
 export function withCaching(
     realBackend: IAnalyticalBackend,
     config: CachingConfiguration,
 ): IAnalyticalBackend {
-    assertPositiveOrUndefined(config?.maxCatalogOptions, "maxCatalogOptions");
-    assertPositiveOrUndefined(config?.maxSecuritySettingsOrgUrls, "maxSecuritySettingsOrgUrls");
-    assertPositiveOrUndefined(config?.maxSecuritySettingsOrgUrlsAge, "maxSecuritySettingsOrgUrlsAge");
+    assertPositiveOrUndefined(config.maxCatalogOptions, "maxCatalogOptions");
+    assertPositiveOrUndefined(config.maxSecuritySettingsOrgUrls, "maxSecuritySettingsOrgUrls");
+    assertPositiveOrUndefined(config.maxSecuritySettingsOrgUrlsAge, "maxSecuritySettingsOrgUrlsAge");
 
-    const execCaching = cachingEnabled(config?.maxExecutions);
-    const catalogCaching = cachingEnabled(config?.maxCatalogs);
-    const securitySettingsCaching = cachingEnabled(config?.maxSecuritySettingsOrgs);
-    const attributeCaching = cachingEnabled(config?.maxAttributeWorkspaces);
-    const workspaceSettingsCaching = cachingEnabled(config?.maxWorkspaceSettings);
+    const execCaching = cachingEnabled(config.maxExecutions);
+    const catalogCaching = cachingEnabled(config.maxCatalogs);
+    const securitySettingsCaching = cachingEnabled(config.maxSecuritySettingsOrgs);
+    const attributeCaching = cachingEnabled(config.maxAttributeWorkspaces);
+    const workspaceSettingsCaching = cachingEnabled(config.maxWorkspaceSettings);
 
     const ctx: CachingContext = {
         caches: {
-            execution: execCaching ? new LRUCache({ maxSize: config?.maxExecutions }) : undefined,
-            workspaceCatalogs: catalogCaching ? new LRUCache({ maxSize: config?.maxCatalogs }) : undefined,
+            execution: execCaching ? new LRUCache({ maxSize: config.maxExecutions }) : undefined,
+            workspaceCatalogs: catalogCaching ? new LRUCache({ maxSize: config.maxCatalogs }) : undefined,
             securitySettings: securitySettingsCaching
-                ? new LRUCache({ maxSize: config?.maxSecuritySettingsOrgs })
+                ? new LRUCache({ maxSize: config.maxSecuritySettingsOrgs })
                 : undefined,
             workspaceAttributes: attributeCaching
-                ? new LRUCache({ maxSize: config?.maxAttributeWorkspaces })
+                ? new LRUCache({ maxSize: config.maxAttributeWorkspaces })
                 : undefined,
             workspaceSettings: workspaceSettingsCaching
-                ? new LRUCache({ maxSize: config?.maxWorkspaceSettings })
+                ? new LRUCache({ maxSize: config.maxWorkspaceSettings })
                 : undefined,
         },
         config,
@@ -884,7 +884,7 @@ export function withCaching(
     const attributes = attributeCaching ? cachedAttributes(ctx) : identity;
     const workspaceSettings = workspaceSettingsCaching ? cachedWorkspaceSettings(ctx) : identity;
 
-    if (config?.onCacheReady) {
+    if (config.onCacheReady) {
         config.onCacheReady(cacheControl(ctx));
     }
 

--- a/libs/sdk-backend-base/src/cachingBackend/index.ts
+++ b/libs/sdk-backend-base/src/cachingBackend/index.ts
@@ -817,6 +817,11 @@ function assertPositiveOrUndefined(value: number | undefined, valueName: string)
 }
 
 /**
+ * These are the recommended settings for the backend caching.
+ *
+ * @remarks
+ * For more information on what the options mean see {@link CachingConfiguration}.
+ *
  * @public
  */
 export const RecommendedCachingConfiguration: CachingConfiguration = {
@@ -843,7 +848,7 @@ export const RecommendedCachingConfiguration: CachingConfiguration = {
  */
 export function withCaching(
     realBackend: IAnalyticalBackend,
-    config?: CachingConfiguration,
+    config: CachingConfiguration,
 ): IAnalyticalBackend {
     assertPositiveOrUndefined(config?.maxCatalogOptions, "maxCatalogOptions");
     assertPositiveOrUndefined(config?.maxSecuritySettingsOrgUrls, "maxSecuritySettingsOrgUrls");

--- a/libs/sdk-backend-base/src/index.ts
+++ b/libs/sdk-backend-base/src/index.ts
@@ -45,7 +45,7 @@ export { withEventing, AnalyticalBackendCallbacks } from "./eventingBackend";
 export {
     withCaching,
     CachingConfiguration,
-    DefaultCachingConfiguration,
+    RecommendedCachingConfiguration,
     CacheControl,
 } from "./cachingBackend";
 export {

--- a/libs/sdk-backend-bear/src/backend/workspace/execution/test/executionFactory.test.ts
+++ b/libs/sdk-backend-bear/src/backend/workspace/execution/test/executionFactory.test.ts
@@ -1,4 +1,4 @@
-// (C) 2020-2021 GoodData Corporation
+// (C) 2020-2022 GoodData Corporation
 
 import { BearExecution } from "../executionFactory";
 import { BearAuthenticatedCallGuard } from "../../../../types/auth";
@@ -6,7 +6,7 @@ import { NotSupported } from "@gooddata/sdk-backend-spi";
 import { ReferenceMd, ReferenceRecordings } from "@gooddata/reference-workspace";
 import { recordedInsight } from "@gooddata/sdk-backend-mockingbird";
 import { newAttributeSort } from "@gooddata/sdk-model";
-import { withCaching } from "@gooddata/sdk-backend-base";
+import { withCaching, RecommendedCachingConfiguration } from "@gooddata/sdk-backend-base";
 import bearFactory from "../../../../index";
 
 const UnsupportedAuthCall: BearAuthenticatedCallGuard = () => {
@@ -29,7 +29,7 @@ describe("execution factory", () => {
         /*
          * This is here to confirm that the shenanigans related to execute-by-ref play well with the decorators
          */
-        const cachingBackend = withCaching(bearFactory());
+        const cachingBackend = withCaching(bearFactory(), RecommendedCachingConfiguration);
         const initialExecution = cachingBackend
             .workspace("test-workspace")
             .execution()


### PR DESCRIPTION
- optimize CachingConfiguration interface
- make the cachingBacken decorator and all related types public

JIRA: RAIL-4439

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
