### PR TITLE
RELATED: RAIL-4492 Remove harmful z-index setting

### DIFF
--- a/libs/sdk-ui-dashboard/styles/scss/filterBar.scss
+++ b/libs/sdk-ui-dashboard/styles/scss/filterBar.scss
@@ -49,7 +49,6 @@ $attribute-filter-drag-handle-left: 10px;
     }
 
     .dash-nav {
-        z-index: 1;
         width: $sidebar-width;
     }
 }


### PR DESCRIPTION
This caused an invisible element to overlay actual useful elements, which in turned complicated e2e tests.

JIRA: RAIL-4492

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
