### PR TITLE
RELATED: RAIL-4494 Remove connecting attributes loading on dashboard init

### DIFF
--- a/common/scripts/ci/docker_rush.sh
+++ b/common/scripts/ci/docker_rush.sh
@@ -33,7 +33,7 @@ docker run \
   --env HOME="/workspace" \
   --env EXAMPLES_BUILD_TYPE \
   --env EXAMPLE_MAPBOX_ACCESS_TOKEN \
-  --env BROWSERSLIST_IGNORE_OLD_DATA \
+  --env BROWSERSLIST_IGNORE_OLD_DATA=true \
   --rm \
   ${net_param} \
   --volume ${ROOT_DIR}:/workspace:Z \

--- a/common/scripts/ci/docker_rushx.sh
+++ b/common/scripts/ci/docker_rushx.sh
@@ -35,7 +35,7 @@ docker run \
   --env WIREMOCK_NET \
   --env EXAMPLES_BUILD_TYPE \
   --env EXAMPLE_MAPBOX_ACCESS_TOKEN \
-  --env BROWSERSLIST_IGNORE_OLD_DATA \
+  --env BROWSERSLIST_IGNORE_OLD_DATA=true \
   --env HOME="/workspace" \
   --rm \
   ${net_param} \

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/common/stateInitializers.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/common/stateInitializers.ts
@@ -37,7 +37,6 @@ import { PromiseFnReturnType } from "../../../types/sagas";
 import update from "lodash/fp/update";
 import isEmpty from "lodash/isEmpty";
 import { loadFiltersToIndexMapping } from "../initializeDashboardHandler/loadFiltersToIndexMapping";
-import { loadConnectingAttributesMatrix } from "../initializeDashboardHandler/loadConnectingAttributesMatrix";
 
 export const EmptyDashboardLayout: IDashboardLayout<IWidget> = {
     type: "IDashboardLayout",
@@ -161,13 +160,7 @@ export function* actionsToInitializeExistingDashboard(
         loadFiltersToIndexMapping,
         attributeFilters,
     );
-    const connectingAttributesMatrix: PromiseFnReturnType<typeof loadConnectingAttributesMatrix> = yield call(
-        loadConnectingAttributesMatrix,
-        ctx.backend,
-        ctx.workspace,
-        attributeFilters,
-        Array.from(attributeFilterDisplayForms),
-    );
+
     /*
      * NOTE: cannot do without the cast here. The layout in IDashboard is parameterized with IDashboardWidget
      * which also includes KPI and Insight widget definitions = those without identity. That is however
@@ -188,7 +181,7 @@ export function* actionsToInitializeExistingDashboard(
             filterContextIdentity,
             attributeFilterDisplayForms,
             filterToIndexMap,
-            connectingAttributesMatrix,
+            connectingAttributesMatrix: [],
         }),
         layoutActions.setLayout(dashboardLayout),
         metaActions.setMeta({


### PR DESCRIPTION
- Remove loading of the `connectingAttributeMatrix` on the dashboard component initialisation. This will cause the attribute filter configuration not to work in the new editMode currently being developed. The follow-up task will move the loading of the matrix on demand while opening the attribute filter configuration, if the data were not loaded before.

JIRA: RAIL-4494

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
