### PR TITLE
Temporarily fix parent filters in view mode

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/dashboardDropdownBody/configuration/hooks/useParentsConfiguration.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/dashboardDropdownBody/configuration/hooks/useParentsConfiguration.ts
@@ -52,7 +52,7 @@ export function useParentsConfiguration(
 
             return connectingAttributes
                 ? connectingAttributes[0]
-                : connectingAttributesMatrix![currentFilterIndex][neighborFilterIndex][0]?.ref;
+                : connectingAttributesMatrix![currentFilterIndex]?.[neighborFilterIndex][0]?.ref;
         },
         [connectingAttributesMatrix, filterElementsBy, idToIndexMap],
     );


### PR DESCRIPTION
- After integration of new AttributeFilter and removing connectingAttributesMatrix in view mode (https://github.com/gooddata/gooddata-ui-sdk/pull/2991) it's touching non-existing indexes in connectingAttributesMatrix

JIRA: RAIL-4390

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
