### PR TITLE
Support for text values on Bear in AttributeFilterHandler

### DIFF
--- a/libs/sdk-ui-filters/src/AttributeFilterHandler/internal/redux/elements/InMemoryPaging.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilterHandler/internal/redux/elements/InMemoryPaging.ts
@@ -1,0 +1,52 @@
+// (C) 2022 GoodData Corporation
+import { IElementsQueryResult } from "@gooddata/sdk-backend-spi";
+import { IAttributeElement } from "@gooddata/sdk-model";
+import invariant from "ts-invariant";
+
+// inspired by the same thing in sdk-backend-base, copied here to avoid the dependency
+export class InMemoryPaging implements IElementsQueryResult {
+    public readonly items: IAttributeElement[];
+    public readonly limit: number;
+    public readonly offset: number;
+    public readonly totalCount: number;
+
+    constructor(protected readonly allItems: IAttributeElement[], limit = 50, offset = 0) {
+        invariant(offset >= 0, `paging offset must be non-negative, got: ${offset}`);
+        invariant(limit > 0, `limit must be a positive number, got: ${limit}`);
+
+        // this will naturally return empty items if at the end of data; limit will always be positive
+        this.items = allItems.slice(offset, offset + limit);
+        // offset is at most at the end of all available elements
+        this.offset = Math.min(offset, allItems.length);
+        // limit is always kept as-requested
+        this.limit = limit;
+
+        this.totalCount = allItems.length;
+    }
+
+    public async next(): Promise<IElementsQueryResult> {
+        if (this.items.length === 0) {
+            return this;
+        }
+
+        return new InMemoryPaging(this.allItems, this.limit, this.offset + this.items.length);
+    }
+
+    public async goTo(pageIndex: number): Promise<IElementsQueryResult> {
+        if (this.items.length === 0) {
+            return this;
+        }
+
+        return new InMemoryPaging(this.allItems, this.limit, pageIndex * this.items.length);
+    }
+
+    public async all(): Promise<IAttributeElement[]> {
+        return [...this.allItems];
+    }
+
+    public async allSorted(
+        compareFn: (a: IAttributeElement, b: IAttributeElement) => number,
+    ): Promise<IAttributeElement[]> {
+        return [...this.allItems].sort(compareFn);
+    }
+}

--- a/libs/sdk-ui-filters/src/AttributeFilterHandler/internal/redux/elements/loadElementsFromStaticElements.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilterHandler/internal/redux/elements/loadElementsFromStaticElements.ts
@@ -12,59 +12,11 @@ import {
     IAttributeElements,
     isAttributeElementsByRef,
 } from "@gooddata/sdk-model";
-import invariant from "ts-invariant";
 import flow from "lodash/flow";
 
 import { ILoadElementsOptions } from "../../../types";
+import { InMemoryPaging } from "./InMemoryPaging";
 import { IHiddenElementsInfo } from "./types";
-
-// inspired by the same thing in sdk-backend-base, copied here to avoid the dependency
-class InMemoryPaging implements IElementsQueryResult {
-    public readonly items: IAttributeElement[];
-    public readonly limit: number;
-    public readonly offset: number;
-    public readonly totalCount: number;
-
-    constructor(protected readonly allItems: IAttributeElement[], limit = 50, offset = 0) {
-        invariant(offset >= 0, `paging offset must be non-negative, got: ${offset}`);
-        invariant(limit > 0, `limit must be a positive number, got: ${limit}`);
-
-        // this will naturally return empty items if at the end of data; limit will always be positive
-        this.items = allItems.slice(offset, offset + limit);
-        // offset is at most at the end of all available elements
-        this.offset = Math.min(offset, allItems.length);
-        // limit is always kept as-requested
-        this.limit = limit;
-
-        this.totalCount = allItems.length;
-    }
-
-    public async next(): Promise<IElementsQueryResult> {
-        if (this.items.length === 0) {
-            return this;
-        }
-
-        return new InMemoryPaging(this.allItems, this.limit, this.offset + this.items.length);
-    }
-
-    public async goTo(pageIndex: number): Promise<IElementsQueryResult> {
-        if (this.items.length === 0) {
-            return this;
-        }
-
-        return new InMemoryPaging(this.allItems, this.limit, pageIndex * this.items.length);
-    }
-
-    public async all(): Promise<IAttributeElement[]> {
-        return [...this.allItems];
-    }
-
-    public async allSorted(
-        compareFn: (a: IAttributeElement, b: IAttributeElement) => number,
-    ): Promise<IAttributeElement[]> {
-        return [...this.allItems].sort(compareFn);
-    }
-}
 
 const resolveHiddenElements =
     (hiddenElements: IAttributeElements) =>


### PR DESCRIPTION
- Bear validElements API does not support loading elements by values, but it's possible to load them with execution API.
- This is necessary to load the initial selection.

JIRA: RAIL-4290

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
