### PR TITLE
RELATED: RAIL-4418 Add getAttributeByDisplayForm caching

### DIFF
--- a/libs/sdk-backend-base/api/sdk-backend-base.api.md
+++ b/libs/sdk-backend-base/api/sdk-backend-base.api.md
@@ -238,6 +238,7 @@ export type CachingConfiguration = {
     maxSecuritySettingsOrgUrlsAge?: number;
     maxAttributeWorkspaces?: number;
     maxAttributeDisplayFormsPerWorkspace?: number;
+    maxAttributesPerWorkspace?: number;
     maxWorkspaceSettings?: number;
 };
 

--- a/libs/sdk-backend-base/src/dummyBackend/index.ts
+++ b/libs/sdk-backend-base/src/dummyBackend/index.ts
@@ -746,8 +746,32 @@ class DummyWorkspaceAttributesService implements IWorkspaceAttributesService {
     getAttribute(_ref: ObjRef): Promise<IAttributeMetadataObject> {
         throw new NotSupported("not supported");
     }
-    getAttributeByDisplayForm(_ref: ObjRef): Promise<IAttributeMetadataObject> {
-        throw new NotSupported("not supported");
+    async getAttributeByDisplayForm(ref: ObjRef): Promise<IAttributeMetadataObject> {
+        return {
+            deprecated: false,
+            description: "Dummy attribute",
+            displayForms: [
+                {
+                    attribute: idRef("dummyAttribute"),
+                    deprecated: false,
+                    description: "Dummy attribute",
+                    id: isIdentifierRef(ref) ? ref.identifier : "dummyDisplayForm",
+                    production: true,
+                    ref,
+                    title: "Dummy display form",
+                    type: "displayForm",
+                    unlisted: false,
+                    uri: isUriRef(ref) ? ref.uri : `/gdc/md/${ref.identifier}`,
+                },
+            ],
+            id: "dummyAttribute",
+            production: true,
+            ref: idRef("dummyAttribute"),
+            title: "Dummy attribute",
+            type: "attribute",
+            unlisted: false,
+            uri: "/gdc/md/dummyAttribute",
+        };
     }
     getAttributes(_refs: ObjRef[]): Promise<IAttributeMetadataObject[]> {
         throw new NotSupported("not supported");


### PR DESCRIPTION
JIRA: RAIL-4418

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
