### PR TITLE
RELATED: RAIL-4488 improve the perceived KPI performance when changing measure, make KPI title editable

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/widget/common/EditableHeadline.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/common/EditableHeadline.tsx
@@ -1,0 +1,35 @@
+// (C) 2007-2022 GoodData Corporation
+import React from "react";
+import noop from "lodash/noop";
+import { EditableLabel } from "@gooddata/sdk-ui-kit";
+
+interface IEditableHeadlineProps {
+    text: string;
+    maxLength: number;
+    originalTitle: string;
+    onTitleEditingStart?: () => void;
+    onTitleEditingCancel?: () => void;
+    onTitleChange: (title: string) => void;
+}
+
+export const EditableHeadline: React.FC<IEditableHeadlineProps> = ({
+    maxLength,
+    originalTitle,
+    text,
+    onTitleChange,
+    onTitleEditingCancel = noop,
+    onTitleEditingStart = noop,
+}) => (
+    <EditableLabel
+        className="s-editable-label s-headline"
+        maxRows={2}
+        value={text}
+        maxLength={maxLength}
+        placeholder={originalTitle}
+        onEditingStart={onTitleEditingStart}
+        onSubmit={onTitleChange}
+        onCancel={onTitleEditingCancel}
+    >
+        <span>{text}</span>
+    </EditableLabel>
+);

--- a/libs/sdk-ui-dashboard/src/presentation/widget/kpi/DefaultKpiConfigurationPanel/KpiMetricDropdown/KpiMetricDropdown.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/kpi/DefaultKpiConfigurationPanel/KpiMetricDropdown/KpiMetricDropdown.tsx
@@ -1,7 +1,9 @@
 // (C) 2022 GoodData Corporation
-import React, { useCallback, useMemo } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { IKpiWidget, IMeasureMetadataObject, ObjRef } from "@gooddata/sdk-model";
 import { useWorkspaceStrict } from "@gooddata/sdk-ui";
+
+import { safeSerializeObjRef } from "../../../../../_staging/metadata/safeSerializeObjRef";
 
 import { MetricDropdown } from "./MetricDropdown";
 
@@ -13,16 +15,23 @@ interface IKpiMetricDropdownProps {
 export const KpiMetricDropdown: React.FC<IKpiMetricDropdownProps> = (props) => {
     const { widget, onMeasureChange } = props;
     const workspace = useWorkspaceStrict();
-
     const measureRef = widget?.kpi.metric;
-    const selectedItems = useMemo(() => (measureRef ? [measureRef] : []), [measureRef]);
+
+    const [selectedMeasure, setSelectedMeasure] = useState<ObjRef | undefined>(measureRef);
+
+    const selectedItems = useMemo(() => (selectedMeasure ? [selectedMeasure] : []), [selectedMeasure]);
 
     const handleMeasureChanged = useCallback(
         (measure: IMeasureMetadataObject) => {
             onMeasureChange(measure.ref);
+            setSelectedMeasure(measure.ref);
         },
         [onMeasureChange],
     );
+
+    useEffect(() => {
+        setSelectedMeasure(measureRef);
+    }, [safeSerializeObjRef(measureRef)]);
 
     return (
         <MetricDropdown

--- a/libs/sdk-ui-dashboard/src/presentation/widget/kpi/EditModeDashboardKpi/EditModeDashboardKpi.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/kpi/EditModeDashboardKpi/EditModeDashboardKpi.tsx
@@ -18,14 +18,17 @@ import {
     uiActions,
     useWidgetSelection,
     selectIsDashboardSaving,
+    changeKpiWidgetHeader,
+    selectAllCatalogMeasuresMap,
 } from "../../../../model";
-import { DashboardItemHeadline, DashboardItemKpi } from "../../../presentationComponents";
+import { DashboardItemKpi } from "../../../presentationComponents";
 import { useDashboardComponentsContext } from "../../../dashboardContexts";
 
 import { ConfigurationBubble } from "../../common";
 import { getKpiResult, KpiRenderer, useKpiData, useKpiExecutionDataView } from "../common";
 import { IDashboardKpiProps } from "../types";
 import { useOptimisticMeasureUpdate } from "./useOptimisticMeasureUpdate";
+import { EditableKpiHeadline } from "./EditModeKpiHeadline";
 
 export const EditModeDashboardKpi = (props: IDashboardKpiProps) => {
     const {
@@ -75,6 +78,20 @@ export const EditModeDashboardKpi = (props: IDashboardKpiProps) => {
     const onWidgetDelete = useCallback(() => {
         dispatch(uiActions.openKpiDeleteDialog(coordinates));
     }, [dispatch, coordinates]);
+
+    const measures = useDashboardSelector(selectAllCatalogMeasuresMap);
+    const currentMeasure = measures.get(kpiWidget.kpi.metric);
+
+    const onWidgetTitleChanged = useCallback(
+        (newTitle: string) => {
+            if (newTitle) {
+                dispatch(changeKpiWidgetHeader(kpiWidget.ref, { title: newTitle }));
+            } else if (currentMeasure) {
+                dispatch(changeKpiWidgetHeader(kpiWidget.ref, { title: currentMeasure.measure.title }));
+            }
+        },
+        [currentMeasure, dispatch, kpiWidget.ref],
+    );
 
     const { error, result, status } = useKpiExecutionDataView({
         backend,
@@ -143,7 +160,11 @@ export const EditModeDashboardKpi = (props: IDashboardKpiProps) => {
                 return null;
             }}
             renderHeadline={(clientHeight) => (
-                <DashboardItemHeadline title={titleToShow} clientHeight={clientHeight} />
+                <EditableKpiHeadline
+                    title={titleToShow}
+                    clientHeight={clientHeight}
+                    onTitleChange={onWidgetTitleChanged}
+                />
             )}
             isSelectable={isSelectable}
             isSelected={isSelected}

--- a/libs/sdk-ui-dashboard/src/presentation/widget/kpi/EditModeDashboardKpi/EditModeKpiHeadline.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/kpi/EditModeDashboardKpi/EditModeKpiHeadline.tsx
@@ -1,0 +1,38 @@
+// (C) 2007-2022 GoodData Corporation
+import React from "react";
+
+import { DashboardItemHeadlineContainer } from "../../../presentationComponents";
+import { EditableHeadline } from "../../common/EditableHeadline";
+
+interface IEditableKpiHeadlineProps {
+    title: string;
+    onTitleChange: (title: string) => void;
+    onTitleEditingEnd?: () => void;
+    onTitleEditingStart?: () => void;
+    clientHeight?: number;
+}
+
+const MAX_KPI_TITLE_LENGTH = 35;
+
+export const EditableKpiHeadline: React.FC<IEditableKpiHeadlineProps> = ({
+    title,
+    onTitleChange,
+    onTitleEditingEnd,
+    onTitleEditingStart,
+    clientHeight,
+}) => {
+    const maxLength = Math.max(title.length, MAX_KPI_TITLE_LENGTH);
+
+    return (
+        <DashboardItemHeadlineContainer clientHeight={clientHeight}>
+            <EditableHeadline
+                text={title}
+                originalTitle={title}
+                maxLength={maxLength}
+                onTitleChange={onTitleChange}
+                onTitleEditingStart={onTitleEditingStart}
+                onTitleEditingCancel={onTitleEditingEnd}
+            />
+        </DashboardItemHeadlineContainer>
+    );
+};

--- a/libs/sdk-ui-dashboard/src/presentation/widget/kpi/EditModeDashboardKpi/useOptimisticMeasureUpdate.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/kpi/EditModeDashboardKpi/useOptimisticMeasureUpdate.ts
@@ -1,0 +1,76 @@
+// (C) 2022 GoodData Corporation
+import { useEffect, useState } from "react";
+import { areObjRefsEqual, IKpiWidget, ObjRef } from "@gooddata/sdk-model";
+
+import {
+    useDashboardSelector,
+    useDashboardEventsContext,
+    isDashboardCommandStarted,
+    isDashboardKpiWidgetMeasureChanged,
+    DashboardEventHandler,
+    isDashboardCommandFailed,
+    selectAllCatalogMeasuresMap,
+    DashboardCommandStarted,
+    ChangeKpiWidgetMeasure,
+} from "../../../../model";
+
+export function useOptimisticMeasureUpdate(kpiWidget: IKpiWidget) {
+    // ref of the measure the KPI is being updated to
+    const [updatingMeasureRef, setUpdatingMeasureRef] = useState<ObjRef | undefined>();
+
+    const measures = useDashboardSelector(selectAllCatalogMeasuresMap);
+    const currentMeasure = measures.get(kpiWidget.kpi.metric);
+    const updatingMeasure = updatingMeasureRef && measures.get(updatingMeasureRef);
+
+    const { registerHandler, unregisterHandler } = useDashboardEventsContext();
+    useEffect(() => {
+        const onMeasureChangingStarted: DashboardEventHandler = {
+            eval: (evt: any) => {
+                return (
+                    isDashboardCommandStarted(evt) &&
+                    evt.payload.command.type === "GDC.DASH/CMD.KPI_WIDGET.CHANGE_MEASURE" &&
+                    areObjRefsEqual(evt.payload.command.payload.ref, kpiWidget.ref)
+                );
+            },
+            handler: (e: DashboardCommandStarted<ChangeKpiWidgetMeasure>) => {
+                setUpdatingMeasureRef(e.payload.command.payload.measureRef);
+            },
+        };
+        const onMeasureChangingEnded: DashboardEventHandler = {
+            eval: (evt: any) => {
+                return (
+                    (isDashboardKpiWidgetMeasureChanged(evt) &&
+                        areObjRefsEqual(evt.payload.ref, kpiWidget.ref)) ||
+                    (isDashboardCommandFailed(evt) &&
+                        evt.payload.command.type === "GDC.DASH/CMD.KPI_WIDGET.CHANGE_MEASURE" &&
+                        areObjRefsEqual(evt.payload.command.payload.ref, kpiWidget.ref))
+                );
+            },
+            handler: () => {
+                setUpdatingMeasureRef(undefined);
+            },
+        };
+
+        registerHandler(onMeasureChangingStarted);
+        registerHandler(onMeasureChangingEnded);
+
+        return () => {
+            unregisterHandler(onMeasureChangingStarted);
+            unregisterHandler(onMeasureChangingEnded);
+        };
+    }, [kpiWidget.ref, registerHandler, unregisterHandler]);
+
+    const isChangingMeasure = !!updatingMeasureRef;
+
+    // if the current title of the KPI is the same as the title of the current measure, after the update is done,
+    // it will take on the title of the new measure, otherwise the title is untouched
+    const titleToShow =
+        isChangingMeasure && kpiWidget.title === currentMeasure?.measure.title && updatingMeasure
+            ? updatingMeasure.measure.title
+            : kpiWidget.title;
+
+    return {
+        isChangingMeasure,
+        titleToShow,
+    };
+}


### PR DESCRIPTION
Use optimistic updates when changing the measure of a KPI widget. This makes the switch seem instantaneous even though there are some async operations running in the background.

Also, make the KPI title editable.

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
