### PR TITLE
Improve AttributeFilter error messages, expose useParentFilters hook

### DIFF
--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -34,6 +34,7 @@ import { IAnalyticalBackend } from '@gooddata/sdk-backend-spi';
 import { IAttributeDisplayFormMetadataObject } from '@gooddata/sdk-model';
 import { IAttributeElements } from '@gooddata/sdk-model';
 import { IAttributeFilter } from '@gooddata/sdk-model';
+import { IAttributeFilterBaseProps } from '@gooddata/sdk-ui-filters';
 import { IAttributeMetadataObject } from '@gooddata/sdk-model';
 import { IAvailableDrillTargets } from '@gooddata/sdk-ui';
 import { IBackendCapabilities } from '@gooddata/sdk-backend-spi';
@@ -6582,6 +6583,12 @@ export function useInsightWidgetDataView(config: IUseInsightWidgetDataView & Use
 
 // @public
 export type UseInsightWidgetInsightDataViewCallbacks = UseCancelablePromiseCallbacks<DataViewFacade, GoodDataSdkError>;
+
+// @public
+export const useParentFilters: (filter: IDashboardAttributeFilter) => UseParentFiltersResult;
+
+// @public
+export type UseParentFiltersResult = Pick<IAttributeFilterBaseProps, "parentFilters" | "parentFilterOverAttribute">;
 
 // @alpha (undocumented)
 export type UserInteractionPayload = UserInteractionPayloadWithData | BareUserInteractionPayload;

--- a/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/index.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/index.tsx
@@ -5,3 +5,4 @@ export { CreatableAttributeFilter } from "./CreatableAttributeFilter";
 export { DefaultDashboardAttributeFilterComponentSetFactory } from "./DefaultDashboardAttributeFilterComponentSetFactory";
 export * from "./addAttributeFilter";
 export * from "./types";
+export * from "./useParentFilters";

--- a/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/useParentFilters.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/useParentFilters.ts
@@ -5,16 +5,24 @@ import { IAttributeFilter, ObjRef, IDashboardAttributeFilter } from "@gooddata/s
 
 import { dashboardAttributeFilterToAttributeFilter } from "../../../_staging/dashboard/dashboardFilterConverter";
 import { selectFilterContextAttributeFilters, useDashboardSelector } from "../../../model";
-import { IAttributeFilterButtonProps } from "@gooddata/sdk-ui-filters";
+import { IAttributeFilterBaseProps } from "@gooddata/sdk-ui-filters";
 
-type UseParentFiltersResult = Pick<
-    IAttributeFilterButtonProps,
+/**
+ * Result of the {@link useParentFilters} hook, that can be used as parent filtering input props for {@link @gooddata/sdk-ui-filters#AttributeFilter}.
+ *
+ * @public
+ */
+export type UseParentFiltersResult = Pick<
+    IAttributeFilterBaseProps,
     "parentFilters" | "parentFilterOverAttribute"
 >;
 
 /**
- * Returns parent filter-related data to use as AttributeFilterButton props.
- * @param filter - filter to get the parent filter-related data
+ * Returns parent filtering input props for {@link @gooddata/sdk-ui-filters#AttributeFilter} for particular dashboard attribute filter.
+ *
+ * @param filter - dashboard filter to get the parent filter-related data
+ *
+ * @public
  */
 export const useParentFilters = (filter: IDashboardAttributeFilter): UseParentFiltersResult => {
     const allAttributeFilters = useDashboardSelector(selectFilterContextAttributeFilters);

--- a/libs/sdk-ui-filters/src/AttributeFilter@next/AttributeFilterBase.tsx
+++ b/libs/sdk-ui-filters/src/AttributeFilter@next/AttributeFilterBase.tsx
@@ -1,5 +1,6 @@
 // (C) 2021-2022 GoodData Corporation
 import React from "react";
+import { useBackend } from "@gooddata/sdk-ui";
 import { AttributeFilterRenderer } from "./Components/AttributeFilterRenderer";
 import { IAttributeFilterBaseProps } from "./types";
 import { validateAttributeFilterProps } from "./utils";
@@ -9,7 +10,9 @@ import { AttributeFilterProviders } from "./AttributeFilterProviders";
  * @internal
  */
 export const AttributeFilterBase: React.FC<IAttributeFilterBaseProps> = (props) => {
-    validateAttributeFilterProps(props);
+    const backend = useBackend(props.backend);
+
+    validateAttributeFilterProps({ backend, ...props });
 
     return (
         <AttributeFilterProviders {...props}>

--- a/libs/sdk-ui-filters/src/AttributeFilter@next/utils.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilter@next/utils.ts
@@ -68,7 +68,16 @@ export function getElementKey(element: IAttributeElement) {
  * @internal
  */
 export function validateAttributeFilterProps(props: IAttributeFilterBaseProps) {
-    const { connectToPlaceholder, filter, identifier, onApply } = props;
+    const {
+        connectToPlaceholder,
+        filter,
+        identifier,
+        onApply,
+        parentFilters,
+        hiddenElements,
+        staticElements,
+        backend,
+    } = props;
 
     invariant(
         !(filter && connectToPlaceholder),
@@ -100,6 +109,20 @@ export function validateAttributeFilterProps(props: IAttributeFilterBaseProps) {
     invariant(
         identifier || filter || connectToPlaceholder,
         "No identifier, filter or placeholer provided. Provide one of the properties: 'filter', 'connectToPlaceholder' or 'identifier' (note that identifier is deprecated).",
+    );
+
+    invariant(
+        !(!backend?.capabilities?.supportsElementsQueryParentFiltering && !isEmpty(parentFilters)),
+        "Parent filtering is not supported by the current backend implementation.",
+    );
+
+    invariant(
+        !(
+            !backend?.capabilities?.supportsElementsQueryParentFiltering &&
+            !isEmpty(hiddenElements) &&
+            isEmpty(staticElements)
+        ),
+        "Hidden elements are not supported by the current backend implementation.",
     );
 
     if (identifier) {


### PR DESCRIPTION
- Expose useParentFilters hook, so it can be used by dashboard plugins for custom attribute filter implementations
- Parent filtering / hidden elements are not supported on tiger - provide better error messages

JIRA: RAIL-4464, RAIL-4452
<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
