### PR TITLE
Display comparison for static range on KPI's

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/widget/kpi/common/KpiContent/KpiContent.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/kpi/common/KpiContent/KpiContent.tsx
@@ -5,7 +5,6 @@ import Measure from "react-measure";
 import { GoodDataSdkError, isGoodDataSdkError, ErrorCodes, ISeparators } from "@gooddata/sdk-ui";
 import {
     IFilter,
-    isAbsoluteDateFilter,
     isAllTimeDateFilter,
     isDateFilter,
     IKpiWidget,
@@ -53,13 +52,12 @@ class KpiContent extends Component<IKpiContentProps & WrappedComponentProps> {
 
         const { kpiResult, enableCompactSize } = this.props;
         const isDateFilterNotRelevant = isDateFilterIrrelevant(this.props.kpi);
-        const isDateFilterAbsolute = this.props.filters!.some(isAbsoluteDateFilter);
         const isDateFilterAllTime = this.props.filters!.every(
             (f) => !isDateFilter(f) || isAllTimeDateFilter(f),
         );
         const dateFilter = this.props.filters!.find(isDateFilter); // for now we use the first date filter available for this
         const popLabel = getKpiPopLabel(dateFilter, this.props.kpi.kpi.comparisonType, this.props.intl);
-        const popDisabled = isDateFilterAllTime || isDateFilterNotRelevant || isDateFilterAbsolute;
+        const popDisabled = isDateFilterAllTime || isDateFilterNotRelevant;
         const isSdkError = isGoodDataSdkError(this.props.error);
         const isNoData = isSdkError && this.props.error!.message === ErrorCodes.NO_DATA;
 


### PR DESCRIPTION
Remove check for `absoluteDateFilter` for KPI's, so is able to display previous periods comparison when static range is selected, same as with headlines.

JIRA: TNT-447

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
