### PR TITLE
RELATED: RAIL-4508 Fix attribute filter hierarchies

### DIFF
--- a/libs/sdk-ui-filters/src/AttributeFilter@next/hooks/useAttributeFilterController.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilter@next/hooks/useAttributeFilterController.ts
@@ -149,15 +149,7 @@ function useInitOrReload(
     }, [handler]);
 
     useEffect(() => {
-        if (!isEqual(filter, handler.getFilter())) {
-            const elements = filterAttributeElements(filter);
-            const keys = isAttributeElementsByValue(elements) ? elements.values : elements.uris;
-            const isInverted = isNegativeAttributeFilter(filter);
-
-            handler.changeSelection({ keys, isInverted });
-            handler.commitSelection();
-            handler.init();
-        } else if (!isEqual(limitingAttributeFilters, handler.getLimitingAttributeFilters())) {
+        if (!isEqual(limitingAttributeFilters, handler.getLimitingAttributeFilters())) {
             handler.changeSelection({ keys: [], isInverted: true });
             handler.setLimitingAttributeFilters(limitingAttributeFilters);
             handler.loadInitialElementsPage(PARENT_FILTERS_CORRELATION);
@@ -170,6 +162,14 @@ function useInitOrReload(
 
             setConnectedPlaceholderValue(nextFilter);
             onApply?.(nextFilter, isInverted);
+        } else if (!isEqual(filter, handler.getFilter())) {
+            const elements = filterAttributeElements(filter);
+            const keys = isAttributeElementsByValue(elements) ? elements.values : elements.uris;
+            const isInverted = isNegativeAttributeFilter(filter);
+
+            handler.changeSelection({ keys, isInverted });
+            handler.commitSelection();
+            handler.init();
         }
     }, [filter, limitingAttributeFilters, handler, onApply, setConnectedPlaceholderValue]);
 }


### PR DESCRIPTION
In case both limiting filters and the filter itself changes at the same time, we need to handle the limiting filter change first. That way the new limited elements load before the new selection is applied and the filter gets re-initialized.

JIRA: RAIL-4508

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
