### PR TITLE
RELATED: RAIL-4410 Show original plugin parameters when prompt while updating

### DIFF
--- a/tools/plugin-toolkit/src/_base/terminal/prompts.ts
+++ b/tools/plugin-toolkit/src/_base/terminal/prompts.ts
@@ -170,13 +170,14 @@ export async function promptLanguage(): Promise<TargetAppLanguage> {
     return response.language;
 }
 
-export async function promptPluginParameters(): Promise<string> {
+export async function promptPluginParameters(originalParameters?: string): Promise<string> {
     const question: DistinctQuestion = {
         message:
             "A text editor specified will now open and let you enter parameters for the plugin." +
             "This is how you can configure how your plugin behaves on the workspace. Save and exit editor when done.",
         name: "parameters",
         type: "editor",
+        default: originalParameters,
     };
 
     const response = await prompt(question);


### PR DESCRIPTION
- while updating dashboard plugin parameter and prompted to enter the new value, the original value is in the editor as well for easier handling its update or typo fixes.

JIRA: RAIL-4410

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
