### PR TITLE
Fix attribute filter parent change during init

### DIFF
--- a/libs/sdk-ui-filters/src/AttributeFilter@next/hooks/useAttributeFilterController.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilter@next/hooks/useAttributeFilterController.ts
@@ -152,8 +152,6 @@ function useInitOrReload(
         if (!isEqual(limitingAttributeFilters, handler.getLimitingAttributeFilters())) {
             handler.changeSelection({ keys: [], isInverted: true });
             handler.setLimitingAttributeFilters(limitingAttributeFilters);
-            handler.loadInitialElementsPage(PARENT_FILTERS_CORRELATION);
-
             // the next lines are to apply selection to the state of the parent component to make the
             // new attribute filter state persistent
             handler.commitSelection();
@@ -162,6 +160,12 @@ function useInitOrReload(
 
             setConnectedPlaceholderValue(nextFilter);
             onApply?.(nextFilter, isInverted);
+
+            if (handler.getInitStatus() !== "success") {
+                handler.init();
+            } else {
+                handler.loadInitialElementsPage(PARENT_FILTERS_CORRELATION);
+            }
         } else if (!isEqual(filter, handler.getFilter())) {
             const elements = filterAttributeElements(filter);
             const keys = isAttributeElementsByValue(elements) ? elements.values : elements.uris;


### PR DESCRIPTION
- When attribute filter initialization is not finished yet, do not load initial elements page, but trigger fresh init

JIRA: RAIL-4521

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
