### PR TITLE
Fix security advisory for moment in gooddata-ui-sdk

### DIFF
--- a/examples/sdk-examples/package.json
+++ b/examples/sdk-examples/package.json
@@ -107,7 +107,7 @@
         "history": "^4.7.2",
         "isomorphic-fetch": "^3.0.0",
         "lodash": "^4.17.19",
-        "moment": "^2.24.0",
+        "moment": "^2.29.4",
         "classnames": "^2.3.1",
         "react": "^17.0.2",
         "react-datepicker": "^4.8.0",

--- a/libs/sdk-ui-filters/package.json
+++ b/libs/sdk-ui-filters/package.json
@@ -75,7 +75,7 @@
         "intersection-observer": "^0.12.2",
         "json-stable-stringify": "^1.0.1",
         "lodash": "^4.17.19",
-        "moment": "^2.24.0",
+        "moment": "^2.29.4",
         "react-day-picker": "^8.0.1",
         "react-intl": "^5.23.0",
         "react-responsive": "^8.2.0",

--- a/libs/sdk-ui-kit/package.json
+++ b/libs/sdk-ui-kit/package.json
@@ -80,7 +80,7 @@
         "fixed-data-table-2": "^1.2.0",
         "lodash": "^4.17.19",
         "moment-timezone": "^0.5.35",
-        "moment": "^2.24.0",
+        "moment": "^2.29.4",
         "react-content-loader": "^6.2.0",
         "react-day-picker": "^8.0.1",
         "react-helmet": "^6.1.0",

--- a/libs/sdk-ui-tests/package.json
+++ b/libs/sdk-ui-tests/package.json
@@ -84,7 +84,7 @@
         "jest-junit": "^3.0.0",
         "json-stable-stringify": "^1.0.1",
         "lodash": "^4.17.19",
-        "moment": "^2.24.0",
+        "moment": "^2.29.4",
         "react-intl": "^5.23.0",
         "react-responsive": "^8.2.0",
         "spark-md5": "^3.0.0",


### PR DESCRIPTION
JIRA: FET-1134

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
