### PR TITLE
MED-209: Added feature flag to support new SQL and data explain in metric editor

### DIFF
--- a/libs/sdk-backend-tiger/src/backend/features/feature.ts
+++ b/libs/sdk-backend-tiger/src/backend/features/feature.ts
@@ -58,6 +58,13 @@ export function mapFeatures(features: FeaturesMap): Partial<ITigerFeatureFlags> 
             "BOOLEAN",
             FeatureFlagsValues.enableTheming,
         ),
+        ...loadFeature(
+            features,
+            TigerFeaturesNames.EnableMetricSqlAndDataExplain,
+            "enableMetricSqlAndDataExplain",
+            "BOOLEAN",
+            FeatureFlagsValues.enableMetricSqlAndDataExplain,
+        ),
     };
 }
 

--- a/libs/sdk-backend-tiger/src/backend/features/test/static.test.ts
+++ b/libs/sdk-backend-tiger/src/backend/features/test/static.test.ts
@@ -22,6 +22,8 @@ describe("static features", () => {
                 [TigerFeaturesNames.EnableMultipleDates]: "ENABLED",
                 [TigerFeaturesNames.EnableKPIDashboardDeleteFilterButton]: "ENABLED",
                 [TigerFeaturesNames.DashboardEditModeDevRollout]: "ENABLED",
+                [TigerFeaturesNames.EnableTheming]: "ENABLED",
+                [TigerFeaturesNames.EnableMetricSqlAndDataExplain]: "ENABLED",
             }),
         );
         expect(results).toEqual({
@@ -30,6 +32,8 @@ describe("static features", () => {
             enableKPIDashboardDeleteFilterButton: true,
             enableMultipleDates: true,
             enableSortingByTotalGroup: true,
+            enableTheming: true,
+            enableMetricSqlAndDataExplain: true,
         });
     });
 
@@ -42,6 +46,8 @@ describe("static features", () => {
                     [TigerFeaturesNames.EnableMultipleDates]: "ENABLED",
                     [TigerFeaturesNames.EnableKPIDashboardDeleteFilterButton]: "ENABLED",
                     [TigerFeaturesNames.DashboardEditModeDevRollout]: "ENABLED",
+                    [TigerFeaturesNames.EnableTheming]: "ENABLED",
+                    [TigerFeaturesNames.EnableMetricSqlAndDataExplain]: "ENABLED",
                 },
                 "beta",
             ),
@@ -52,6 +58,8 @@ describe("static features", () => {
             enableKPIDashboardDeleteFilterButton: true,
             enableMultipleDates: true,
             enableSortingByTotalGroup: true,
+            enableTheming: true,
+            enableMetricSqlAndDataExplain: true,
         });
     });
 });

--- a/libs/sdk-backend-tiger/src/backend/uiFeatures.ts
+++ b/libs/sdk-backend-tiger/src/backend/uiFeatures.ts
@@ -18,6 +18,8 @@ export enum TigerFeaturesNames {
     DashboardEditModeDevRollout = "dashboardEditModeDevRollout",
     //boolean + possible values: enabled, disabled
     EnableTheming = "enableTheming",
+    //boolean + possible values: enabled, disabled
+    EnableMetricSqlAndDataExplain = "enableMetricSqlAndDataExplain",
 }
 
 export type ITigerFeatureFlags = {
@@ -27,6 +29,7 @@ export type ITigerFeatureFlags = {
     enableKPIDashboardDeleteFilterButton: typeof FeatureFlagsValues["enableKPIDashboardDeleteFilterButton"][number];
     dashboardEditModeDevRollout: typeof FeatureFlagsValues["dashboardEditModeDevRollout"][number];
     enableTheming: typeof FeatureFlagsValues["enableTheming"][number];
+    enableMetricSqlAndDataExplain: typeof FeatureFlagsValues["enableMetricSqlAndDataExplain"][number];
 };
 
 export const DefaultFeatureFlags: ITigerFeatureFlags = {
@@ -37,6 +40,7 @@ export const DefaultFeatureFlags: ITigerFeatureFlags = {
     // disable edit mode in gdc-dashboards during development
     dashboardEditModeDevRollout: false,
     enableTheming: true,
+    enableMetricSqlAndDataExplain: false,
 };
 
 export const FeatureFlagsValues = {
@@ -50,4 +54,5 @@ export const FeatureFlagsValues = {
     enableKPIDashboardDeleteFilterButton: [true, false] as const,
     dashboardEditModeDevRollout: [true, false] as const,
     enableTheming: [true, false] as const,
+    enableMetricSqlAndDataExplain: [true, false] as const,
 };


### PR DESCRIPTION
JIRA: MED-209

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
