### PR TITLE
RELATED: RAIL-4515 handle hiddenElements by value on bear

### DIFF
--- a/libs/sdk-backend-bear/src/backend/workspace/attributes/elements/limitingAfmFactory.ts
+++ b/libs/sdk-backend-bear/src/backend/workspace/attributes/elements/limitingAfmFactory.ts
@@ -1,4 +1,4 @@
-// (C) 2020-2021 GoodData Corporation
+// (C) 2020-2022 GoodData Corporation
 import { GdcExecuteAFM, Uri, Identifier, GdcMetadata } from "@gooddata/api-model-bear";
 import {
     ObjRef,
@@ -116,7 +116,7 @@ export class LimitingAfmFactory {
 
                     if (!isAttributeElementsByRef(filterElements)) {
                         throw new NotSupported(
-                            "Only attribute elements by ref are supported in elements attribute filter",
+                            "Only attribute elements by ref are supported in elements attribute filter on the bear backend",
                         );
                     }
                     const elementsString = filterElements.uris

--- a/libs/sdk-ui-filters/src/AttributeFilterHandler/internal/callbacks.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilterHandler/internal/callbacks.ts
@@ -3,7 +3,7 @@ import {
     actions,
     selectInvertableCommittedSelection,
     selectInvertableWorkingSelection,
-    AttributeFilterHanderEventListener,
+    AttributeFilterHandlerEventListener,
 } from "./redux";
 import {
     Callback,
@@ -112,7 +112,7 @@ export const newAttributeFilterCallbacks = () => {
     const { registerCallback, registrations, unsubscribeAll } =
         newCallbackRegistrationsWithGlobalUnsubscribe();
 
-    const eventListener: AttributeFilterHanderEventListener = (action, select) => {
+    const eventListener: AttributeFilterHandlerEventListener = (action, select) => {
         // Init
         if (actions.initStart.match(action)) {
             registrations.initStart.invoke(action.payload);

--- a/libs/sdk-ui-filters/src/AttributeFilterHandler/internal/callbacks.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilterHandler/internal/callbacks.ts
@@ -33,6 +33,7 @@ import {
     OnSelectionChangedCallbackPayload,
     OnSelectionCommittedCallbackPayload,
 } from "../types";
+import { GoodDataSdkError } from "@gooddata/sdk-ui";
 
 const newCallbackRegistrations = () => {
     return {
@@ -105,6 +106,13 @@ const newCallbackRegistrationsWithGlobalUnsubscribe = () => {
     };
 };
 
+function logError(activity: string, error: GoodDataSdkError): void {
+    const cause = error.getCause();
+    const formattedCause = cause ? `\nInner error: ${cause}` : "";
+    // eslint-disable-next-line no-console
+    console.error(`Error while ${activity}: ${error.getMessage()}${formattedCause}`);
+}
+
 /**
  * @internal
  */
@@ -119,6 +127,7 @@ export const newAttributeFilterCallbacks = () => {
         } else if (actions.initSuccess.match(action)) {
             registrations.initSuccess.invoke(action.payload);
         } else if (actions.initError.match(action)) {
+            logError("initializing", action.payload.error);
             registrations.initError.invoke(action.payload);
         } else if (actions.initCancel.match(action)) {
             registrations.initCancel.invoke(action.payload);
@@ -130,6 +139,7 @@ export const newAttributeFilterCallbacks = () => {
         } else if (actions.loadAttributeSuccess.match(action)) {
             registrations.loadAttributeSuccess.invoke(action.payload);
         } else if (actions.loadAttributeError.match(action)) {
+            logError("loading attribute", action.payload.error);
             registrations.loadAttributeError.invoke(action.payload);
         } else if (actions.loadAttributeCancel.match(action)) {
             registrations.loadAttributeCancel.invoke(action.payload);
@@ -141,6 +151,7 @@ export const newAttributeFilterCallbacks = () => {
         } else if (actions.loadInitialElementsPageSuccess.match(action)) {
             registrations.loadInitialElementsPageSuccess.invoke(action.payload);
         } else if (actions.loadInitialElementsPageError.match(action)) {
+            logError("loading initial elements page", action.payload.error);
             registrations.loadInitialElementsPageError.invoke(action.payload);
         } else if (actions.loadInitialElementsPageCancel.match(action)) {
             registrations.loadInitialElementsPageCancel.invoke(action.payload);
@@ -152,6 +163,7 @@ export const newAttributeFilterCallbacks = () => {
         } else if (actions.loadNextElementsPageSuccess.match(action)) {
             registrations.loadNextElementsPageSuccess.invoke(action.payload);
         } else if (actions.loadNextElementsPageError.match(action)) {
+            logError("loading next elements page", action.payload.error);
             registrations.loadNextElementsPageError.invoke(action.payload);
         } else if (actions.loadNextElementsPageCancel.match(action)) {
             registrations.loadNextElementsPageCancel.invoke(action.payload);
@@ -163,6 +175,7 @@ export const newAttributeFilterCallbacks = () => {
         } else if (actions.loadCustomElementsSuccess.match(action)) {
             registrations.loadCustomElementsSuccess.invoke(action.payload);
         } else if (actions.loadCustomElementsError.match(action)) {
+            logError("loading custom elements", action.payload.error);
             registrations.loadCustomElementsError.invoke(action.payload);
         } else if (actions.loadCustomElementsCancel.match(action)) {
             registrations.loadCustomElementsCancel.invoke(action.payload);

--- a/libs/sdk-ui-filters/src/AttributeFilterHandler/internal/redux/index.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilterHandler/internal/redux/index.ts
@@ -1,7 +1,7 @@
 // (C) 2022 GoodData Corporation
 export {
     AttributeFilterHandlerStore,
-    AttributeFilterHanderEventListener,
+    AttributeFilterHandlerEventListener,
     AttributeFilterHandlerStoreContext,
 } from "./store/types";
 export { createAttributeFilterHandlerStore } from "./store/createStore";

--- a/libs/sdk-ui-filters/src/AttributeFilterHandler/internal/redux/store/types.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilterHandler/internal/redux/store/types.ts
@@ -9,7 +9,7 @@ import { AttributeFilterState } from "./state";
  *
  * @internal
  */
-export type AttributeFilterHanderEventListener = (
+export type AttributeFilterHandlerEventListener = (
     action: Action,
     selectFromNextState: <T>(selector: (state: AttributeFilterState) => T) => T,
 ) => void;
@@ -38,5 +38,5 @@ export interface AttributeFilterHandlerStoreContext {
     attributeFilter: IAttributeFilter;
     hiddenElements?: string[];
     staticElements?: IAttributeElement[];
-    eventListener: AttributeFilterHanderEventListener;
+    eventListener: AttributeFilterHandlerEventListener;
 }


### PR DESCRIPTION
Since this is not supported on bear, we error. This PR makes sure the error is surfaced into the console to make debugging easier and improves the related error message. Also a small typo in one of the type names was fixed.

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
