### PR TITLE
RELATED: RAIL-4518 fix drills on empty values

### DIFF
--- a/libs/sdk-ui-charts/src/charts/_base/BaseChart.tsx
+++ b/libs/sdk-ui-charts/src/charts/_base/BaseChart.tsx
@@ -2,7 +2,6 @@
 import React from "react";
 import { ICoreChartProps, OnLegendReady } from "../../interfaces";
 import { getValidColorPalette, ChartTransformation } from "../../highcharts";
-import { fixEmptyHeaderItems } from "@gooddata/sdk-ui-vis-commons";
 import noop from "lodash/noop";
 import { defaultCoreChartProps } from "../_commons/defaultProps";
 import {
@@ -104,9 +103,6 @@ class StatelessBaseChart extends React.Component<Props> {
                 <IntlWrapper locale={locale}>
                     <IntlTranslationsProvider>
                         {(translationProps: ITranslationsComponentProps) => {
-                            // TODO: this is evil; mutating the items of readonly array; need to find a conceptual way to do this
-                            fixEmptyHeaderItems(dataView, translationProps.emptyHeaderString);
-
                             return (
                                 <ChartTransformation
                                     height={height}

--- a/libs/sdk-ui-charts/src/charts/headline/CoreHeadline.tsx
+++ b/libs/sdk-ui-charts/src/charts/headline/CoreHeadline.tsx
@@ -1,11 +1,8 @@
-// (C) 2007-2018 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 import React from "react";
-import { fixEmptyHeaderItems } from "@gooddata/sdk-ui-vis-commons";
 import {
     newErrorMapping,
     IErrorDescriptors,
-    IntlTranslationsProvider,
-    ITranslationsComponentProps,
     IntlWrapper,
     ErrorCodes,
     ILoadingInjectedProps,
@@ -55,22 +52,13 @@ export class HeadlineStateless extends React.Component<Props> {
 
         return (
             <IntlWrapper locale={locale}>
-                <IntlTranslationsProvider>
-                    {(props: ITranslationsComponentProps) => {
-                        // TODO: evil; fix this conceptually
-                        fixEmptyHeaderItems(dataView, `(${props.emptyHeaderString})`);
-
-                        return (
-                            <HeadlineTransformation
-                                dataView={dataView}
-                                onAfterRender={afterRender}
-                                onDrill={onDrill}
-                                drillableItems={drillableItems}
-                                config={config}
-                            />
-                        );
-                    }}
-                </IntlTranslationsProvider>
+                <HeadlineTransformation
+                    dataView={dataView}
+                    onAfterRender={afterRender}
+                    onDrill={onDrill}
+                    drillableItems={drillableItems}
+                    config={config}
+                />
             </IntlWrapper>
         );
     }

--- a/libs/sdk-ui-charts/src/charts/xirr/CoreXirr.tsx
+++ b/libs/sdk-ui-charts/src/charts/xirr/CoreXirr.tsx
@@ -1,11 +1,8 @@
-// (C) 2007-2018 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 import React from "react";
-import { fixEmptyHeaderItems } from "@gooddata/sdk-ui-vis-commons";
 import {
     newErrorMapping,
     IErrorDescriptors,
-    IntlTranslationsProvider,
-    ITranslationsComponentProps,
     IntlWrapper,
     ErrorCodes,
     ILoadingInjectedProps,
@@ -55,22 +52,13 @@ export class XirrStateless extends React.Component<Props> {
 
         return (
             <IntlWrapper locale={locale}>
-                <IntlTranslationsProvider>
-                    {(props: ITranslationsComponentProps) => {
-                        // TODO: evil; fix this conceptually
-                        fixEmptyHeaderItems(dataView, `(${props.emptyHeaderString})`);
-
-                        return (
-                            <XirrTransformation
-                                dataView={dataView}
-                                onAfterRender={afterRender}
-                                onDrill={onDrill}
-                                drillableItems={drillableItems}
-                                config={config}
-                            />
-                        );
-                    }}
-                </IntlTranslationsProvider>
+                <XirrTransformation
+                    dataView={dataView}
+                    onAfterRender={afterRender}
+                    onDrill={onDrill}
+                    drillableItems={drillableItems}
+                    config={config}
+                />
             </IntlWrapper>
         );
     }

--- a/libs/sdk-ui-charts/src/highcharts/ChartTransformation.tsx
+++ b/libs/sdk-ui-charts/src/highcharts/ChartTransformation.tsx
@@ -5,7 +5,12 @@ import invariant from "ts-invariant";
 import React from "react";
 import { ContentRect } from "react-measure";
 
-import { convertDrillableItemsToPredicates, OnFiredDrillEvent, ExplicitDrill } from "@gooddata/sdk-ui";
+import {
+    convertDrillableItemsToPredicates,
+    OnFiredDrillEvent,
+    ExplicitDrill,
+    emptyHeaderTitleFromIntl,
+} from "@gooddata/sdk-ui";
 import { IChartConfig, OnLegendReady } from "../interfaces";
 import { getChartOptions } from "./chartTypes/_chartOptions/chartOptionsBuilder";
 import { getHighchartsOptions } from "./chartTypes/_chartCreators/highChartsCreators";
@@ -87,7 +92,7 @@ const ChartTransformationImpl = (props: IChartTransformationProps) => {
         dataView,
         config,
         drillablePredicates,
-        `(${intl.formatMessage({ id: "visualization.emptyValue" })})`,
+        emptyHeaderTitleFromIntl(intl),
         theme,
     );
     const legendOptions: ILegendOptions = buildLegendOptions(config.legend, chartOptions);

--- a/libs/sdk-ui-charts/src/highcharts/ChartTransformation.tsx
+++ b/libs/sdk-ui-charts/src/highcharts/ChartTransformation.tsx
@@ -83,7 +83,13 @@ const ChartTransformationImpl = (props: IChartTransformationProps) => {
     } = props;
     const visType = config.type;
     const drillablePredicates = convertDrillableItemsToPredicates(drillableItems);
-    const chartOptions: IChartOptions = getChartOptions(dataView, config, drillablePredicates, theme);
+    const chartOptions: IChartOptions = getChartOptions(
+        dataView,
+        config,
+        drillablePredicates,
+        `(${intl.formatMessage({ id: "visualization.emptyValue" })})`,
+        theme,
+    );
     const legendOptions: ILegendOptions = buildLegendOptions(config.legend, chartOptions);
     const validationResult = validateData(config.limits, chartOptions);
     const drillConfig = { dataView, onDrill };

--- a/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartOptions/chartSeries.ts
+++ b/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartOptions/chartSeries.ts
@@ -97,6 +97,7 @@ function getDefaultSeries(
     stackByAttribute: IUnwrappedAttributeHeadersWithItems,
     type: string,
     colorStrategy: IColorStrategy,
+    emptyHeaderName: string,
 ): ISeriesItemConfig[] {
     return dv
         .rawData()
@@ -122,7 +123,8 @@ function getDefaultSeries(
             if (stackByAttribute) {
                 // if stackBy attribute is available, seriesName is a stackBy attribute value of index seriesIndex
                 // this is a limitiation of highcharts and a reason why you can not have multi-measure stacked charts
-                seriesItemConfig.name = stackByAttribute.items[seriesIndex].attributeHeaderItem.name;
+                seriesItemConfig.name =
+                    stackByAttribute.items[seriesIndex].attributeHeaderItem.name || emptyHeaderName; // TODO RAIL-4360 distinguish between empty and null
             } else if (isOneOfTypes(type, multiMeasuresAlternatingTypes) && !viewByAttribute) {
                 // Pie charts with measures only have a single series which name would is ambiguous
                 seriesItemConfig.name = measureGroup.items
@@ -151,19 +153,35 @@ export function getSeries(
     stackByAttribute: IUnwrappedAttributeHeadersWithItems,
     type: string,
     colorStrategy: IColorStrategy,
+    emptyHeaderName: string,
     theme?: ITheme,
 ): any {
     if (isHeatmap(type)) {
         return getHeatmapSeries(dv, measureGroup, theme);
     } else if (isScatterPlot(type)) {
-        return getScatterPlotSeries(dv, stackByAttribute, colorStrategy);
+        return getScatterPlotSeries(dv, stackByAttribute, colorStrategy, emptyHeaderName);
     } else if (isBubbleChart(type)) {
-        return getBubbleChartSeries(dv, measureGroup, stackByAttribute, colorStrategy);
+        return getBubbleChartSeries(dv, measureGroup, stackByAttribute, colorStrategy, emptyHeaderName);
     } else if (isTreemap(type) && stackByAttribute) {
-        return getTreemapStackedSeries(dv, measureGroup, viewByAttribute, stackByAttribute, colorStrategy);
+        return getTreemapStackedSeries(
+            dv,
+            measureGroup,
+            viewByAttribute,
+            stackByAttribute,
+            colorStrategy,
+            emptyHeaderName,
+        );
     } else if (isBulletChart(type)) {
         return getBulletChartSeries(dv, measureGroup, colorStrategy);
     }
 
-    return getDefaultSeries(dv, measureGroup, viewByAttribute, stackByAttribute, type, colorStrategy);
+    return getDefaultSeries(
+        dv,
+        measureGroup,
+        viewByAttribute,
+        stackByAttribute,
+        type,
+        colorStrategy,
+        emptyHeaderName,
+    );
 }

--- a/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartOptions/chartSeries.ts
+++ b/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartOptions/chartSeries.ts
@@ -1,7 +1,7 @@
 // (C) 2007-2022 GoodData Corporation
 import { ITheme, IMeasureDescriptor, IMeasureGroupDescriptor } from "@gooddata/sdk-model";
 import { IUnwrappedAttributeHeadersWithItems } from "../../typings/mess";
-import { IColorStrategy } from "@gooddata/sdk-ui-vis-commons";
+import { IColorStrategy, valueWithEmptyHandling } from "@gooddata/sdk-ui-vis-commons";
 import { IPointData, ISeriesItemConfig } from "../../typings/unsafe";
 import {
     isBubbleChart,
@@ -97,7 +97,7 @@ function getDefaultSeries(
     stackByAttribute: IUnwrappedAttributeHeadersWithItems,
     type: string,
     colorStrategy: IColorStrategy,
-    emptyHeaderName: string,
+    emptyHeaderTitle: string,
 ): ISeriesItemConfig[] {
     return dv
         .rawData()
@@ -123,8 +123,10 @@ function getDefaultSeries(
             if (stackByAttribute) {
                 // if stackBy attribute is available, seriesName is a stackBy attribute value of index seriesIndex
                 // this is a limitiation of highcharts and a reason why you can not have multi-measure stacked charts
-                seriesItemConfig.name =
-                    stackByAttribute.items[seriesIndex].attributeHeaderItem.name || emptyHeaderName; // TODO RAIL-4360 distinguish between empty and null
+                seriesItemConfig.name = valueWithEmptyHandling(
+                    stackByAttribute.items[seriesIndex].attributeHeaderItem.name,
+                    emptyHeaderTitle,
+                );
             } else if (isOneOfTypes(type, multiMeasuresAlternatingTypes) && !viewByAttribute) {
                 // Pie charts with measures only have a single series which name would is ambiguous
                 seriesItemConfig.name = measureGroup.items
@@ -153,15 +155,15 @@ export function getSeries(
     stackByAttribute: IUnwrappedAttributeHeadersWithItems,
     type: string,
     colorStrategy: IColorStrategy,
-    emptyHeaderName: string,
+    emptyHeaderTitle: string,
     theme?: ITheme,
 ): any {
     if (isHeatmap(type)) {
         return getHeatmapSeries(dv, measureGroup, theme);
     } else if (isScatterPlot(type)) {
-        return getScatterPlotSeries(dv, stackByAttribute, colorStrategy, emptyHeaderName);
+        return getScatterPlotSeries(dv, stackByAttribute, colorStrategy, emptyHeaderTitle);
     } else if (isBubbleChart(type)) {
-        return getBubbleChartSeries(dv, measureGroup, stackByAttribute, colorStrategy, emptyHeaderName);
+        return getBubbleChartSeries(dv, measureGroup, stackByAttribute, colorStrategy, emptyHeaderTitle);
     } else if (isTreemap(type) && stackByAttribute) {
         return getTreemapStackedSeries(
             dv,
@@ -169,7 +171,7 @@ export function getSeries(
             viewByAttribute,
             stackByAttribute,
             colorStrategy,
-            emptyHeaderName,
+            emptyHeaderTitle,
         );
     } else if (isBulletChart(type)) {
         return getBulletChartSeries(dv, measureGroup, colorStrategy);
@@ -182,6 +184,6 @@ export function getSeries(
         stackByAttribute,
         type,
         colorStrategy,
-        emptyHeaderName,
+        emptyHeaderTitle,
     );
 }

--- a/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartOptions/chartTooltips.ts
+++ b/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartOptions/chartTooltips.ts
@@ -8,6 +8,7 @@ import { formatValueForTooltip, getFormattedValueForTooltip } from "./tooltip";
 import { multiMeasuresAlternatingTypes } from "./chartCapabilities";
 import cx from "classnames";
 import { IMeasureDescriptor } from "@gooddata/sdk-model";
+import { valueWithEmptyHandling } from "@gooddata/sdk-ui-vis-commons";
 
 const TOOLTIP_PADDING = 10;
 
@@ -204,7 +205,7 @@ export function generateTooltipXYFn(
 export function generateTooltipHeatmapFn(
     viewByAttribute: IUnwrappedAttributeHeadersWithItems,
     stackByAttribute: IUnwrappedAttributeHeadersWithItems,
-    emptyHeaderName: string,
+    emptyHeaderTitle: string,
     config: IChartConfig = {},
 ): ITooltipFactory {
     const { separators } = config;
@@ -223,13 +224,23 @@ export function generateTooltipHeatmapFn(
         if (viewByAttribute) {
             textData.unshift([
                 customEscape(viewByAttribute.formOf.name),
-                customEscape(viewByAttribute.items[point.x].attributeHeaderItem.name || emptyHeaderName), // TODO RAIL-4360 distinguish between empty and null
+                customEscape(
+                    valueWithEmptyHandling(
+                        viewByAttribute.items[point.x].attributeHeaderItem.name,
+                        emptyHeaderTitle,
+                    ),
+                ),
             ]);
         }
         if (stackByAttribute) {
             textData.unshift([
                 customEscape(stackByAttribute.formOf.name),
-                customEscape(stackByAttribute.items[point.y].attributeHeaderItem.name || emptyHeaderName), // TODO RAIL-4360 distinguish between empty and null
+                customEscape(
+                    valueWithEmptyHandling(
+                        stackByAttribute.items[point.y].attributeHeaderItem.name,
+                        emptyHeaderTitle,
+                    ),
+                ),
             ]);
         }
 
@@ -240,7 +251,7 @@ export function generateTooltipHeatmapFn(
 export function buildTooltipTreemapFactory(
     viewByAttribute: IUnwrappedAttributeHeadersWithItems,
     stackByAttribute: IUnwrappedAttributeHeadersWithItems,
-    emptyHeaderName: string,
+    emptyHeaderTitle: string,
     config: IChartConfig = {},
 ): ITooltipFactory {
     const { separators } = config;
@@ -257,14 +268,24 @@ export function buildTooltipTreemapFactory(
         if (stackByAttribute) {
             textData.push([
                 customEscape(stackByAttribute.formOf.name),
-                customEscape(stackByAttribute.items[point.y].attributeHeaderItem.name || emptyHeaderName), // TODO RAIL-4360 distinguish between empty and null
+                customEscape(
+                    valueWithEmptyHandling(
+                        stackByAttribute.items[point.y].attributeHeaderItem.name,
+                        emptyHeaderTitle,
+                    ),
+                ),
             ]);
         }
 
         if (viewByAttribute) {
             textData.unshift([
                 customEscape(viewByAttribute.formOf.name),
-                customEscape(viewByAttribute.items[point.x].attributeHeaderItem.name || emptyHeaderName), // TODO RAIL-4360 distinguish between empty and null
+                customEscape(
+                    valueWithEmptyHandling(
+                        viewByAttribute.items[point.x].attributeHeaderItem.name,
+                        emptyHeaderTitle,
+                    ),
+                ),
             ]);
             textData.push([customEscape(point.series.name), formattedValue]);
         } else {
@@ -281,13 +302,13 @@ export function getTooltipFactory(
     viewByParentAttribute: IUnwrappedAttributeHeadersWithItems,
     stackByAttribute: IUnwrappedAttributeHeadersWithItems,
     measure: IMeasureDescriptor,
-    emptyHeaderName: string,
+    emptyHeaderTitle: string,
     config: IChartConfig = {},
     isDualAxis: boolean = false,
 ): ITooltipFactory {
     const { type } = config;
     if (isTreemap(type)) {
-        return buildTooltipTreemapFactory(viewByAttribute, stackByAttribute, emptyHeaderName, config);
+        return buildTooltipTreemapFactory(viewByAttribute, stackByAttribute, emptyHeaderTitle, config);
     }
     if (isViewByTwoAttributes) {
         return buildTooltipForTwoAttributesFactory(

--- a/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartOptions/chartTooltips.ts
+++ b/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartOptions/chartTooltips.ts
@@ -204,6 +204,7 @@ export function generateTooltipXYFn(
 export function generateTooltipHeatmapFn(
     viewByAttribute: IUnwrappedAttributeHeadersWithItems,
     stackByAttribute: IUnwrappedAttributeHeadersWithItems,
+    emptyHeaderName: string,
     config: IChartConfig = {},
 ): ITooltipFactory {
     const { separators } = config;
@@ -222,13 +223,13 @@ export function generateTooltipHeatmapFn(
         if (viewByAttribute) {
             textData.unshift([
                 customEscape(viewByAttribute.formOf.name),
-                customEscape(viewByAttribute.items[point.x].attributeHeaderItem.name),
+                customEscape(viewByAttribute.items[point.x].attributeHeaderItem.name || emptyHeaderName), // TODO RAIL-4360 distinguish between empty and null
             ]);
         }
         if (stackByAttribute) {
             textData.unshift([
                 customEscape(stackByAttribute.formOf.name),
-                customEscape(stackByAttribute.items[point.y].attributeHeaderItem.name),
+                customEscape(stackByAttribute.items[point.y].attributeHeaderItem.name || emptyHeaderName), // TODO RAIL-4360 distinguish between empty and null
             ]);
         }
 
@@ -239,6 +240,7 @@ export function generateTooltipHeatmapFn(
 export function buildTooltipTreemapFactory(
     viewByAttribute: IUnwrappedAttributeHeadersWithItems,
     stackByAttribute: IUnwrappedAttributeHeadersWithItems,
+    emptyHeaderName: string,
     config: IChartConfig = {},
 ): ITooltipFactory {
     const { separators } = config;
@@ -255,14 +257,14 @@ export function buildTooltipTreemapFactory(
         if (stackByAttribute) {
             textData.push([
                 customEscape(stackByAttribute.formOf.name),
-                customEscape(stackByAttribute.items[point.y].attributeHeaderItem.name),
+                customEscape(stackByAttribute.items[point.y].attributeHeaderItem.name || emptyHeaderName), // TODO RAIL-4360 distinguish between empty and null
             ]);
         }
 
         if (viewByAttribute) {
             textData.unshift([
                 customEscape(viewByAttribute.formOf.name),
-                customEscape(viewByAttribute.items[point.x].attributeHeaderItem.name),
+                customEscape(viewByAttribute.items[point.x].attributeHeaderItem.name || emptyHeaderName), // TODO RAIL-4360 distinguish between empty and null
             ]);
             textData.push([customEscape(point.series.name), formattedValue]);
         } else {
@@ -279,12 +281,13 @@ export function getTooltipFactory(
     viewByParentAttribute: IUnwrappedAttributeHeadersWithItems,
     stackByAttribute: IUnwrappedAttributeHeadersWithItems,
     measure: IMeasureDescriptor,
+    emptyHeaderName: string,
     config: IChartConfig = {},
     isDualAxis: boolean = false,
 ): ITooltipFactory {
     const { type } = config;
     if (isTreemap(type)) {
-        return buildTooltipTreemapFactory(viewByAttribute, stackByAttribute, config);
+        return buildTooltipTreemapFactory(viewByAttribute, stackByAttribute, emptyHeaderName, config);
     }
     if (isViewByTwoAttributes) {
         return buildTooltipForTwoAttributesFactory(

--- a/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartOptions/extendedStackingChartOptions.ts
+++ b/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartOptions/extendedStackingChartOptions.ts
@@ -28,6 +28,7 @@ type NameAndCategories = {
 export function getCategoriesForTwoAttributes(
     viewByAttribute: IUnwrappedAttributeHeadersWithItems,
     viewByParentAttribute: IUnwrappedAttributeHeadersWithItems,
+    emptyHeaderName: string,
 ): NameAndCategories[] {
     const keys: string[] = [];
     const { items: children } = viewByAttribute;
@@ -36,8 +37,8 @@ export function getCategoriesForTwoAttributes(
     const combinedResult = parent.reduce(
         (result: Record<string, NameAndCategories>, parentAttr: IResultAttributeHeader, index: number) => {
             const uri = parentAttr?.attributeHeaderItem?.uri ?? "";
-            const name = parentAttr?.attributeHeaderItem?.name ?? "";
-            const value = children[index]?.attributeHeaderItem?.name ?? "";
+            const name = parentAttr?.attributeHeaderItem?.name || emptyHeaderName; // TODO RAIL-4360 distinguish between empty and null
+            const value = children[index]?.attributeHeaderItem?.name || emptyHeaderName; // TODO RAIL-4360 distinguish between empty and null
 
             const existingEntry = result[uri];
             const childCategories = existingEntry?.categories ?? [];

--- a/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartOptions/extendedStackingChartOptions.ts
+++ b/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartOptions/extendedStackingChartOptions.ts
@@ -1,6 +1,7 @@
 // (C) 2007-2022 GoodData Corporation
 import { IUnwrappedAttributeHeadersWithItems } from "../../typings/mess";
 import { IResultAttributeHeader } from "@gooddata/sdk-model";
+import { valueWithEmptyHandling } from "@gooddata/sdk-ui-vis-commons";
 
 type NameAndCategories = {
     name: string;
@@ -28,7 +29,7 @@ type NameAndCategories = {
 export function getCategoriesForTwoAttributes(
     viewByAttribute: IUnwrappedAttributeHeadersWithItems,
     viewByParentAttribute: IUnwrappedAttributeHeadersWithItems,
-    emptyHeaderName: string,
+    emptyHeaderTitle: string,
 ): NameAndCategories[] {
     const keys: string[] = [];
     const { items: children } = viewByAttribute;
@@ -37,8 +38,11 @@ export function getCategoriesForTwoAttributes(
     const combinedResult = parent.reduce(
         (result: Record<string, NameAndCategories>, parentAttr: IResultAttributeHeader, index: number) => {
             const uri = parentAttr?.attributeHeaderItem?.uri ?? "";
-            const name = parentAttr?.attributeHeaderItem?.name || emptyHeaderName; // TODO RAIL-4360 distinguish between empty and null
-            const value = children[index]?.attributeHeaderItem?.name || emptyHeaderName; // TODO RAIL-4360 distinguish between empty and null
+            const name = valueWithEmptyHandling(parentAttr?.attributeHeaderItem?.name, emptyHeaderTitle);
+            const value = valueWithEmptyHandling(
+                children[index]?.attributeHeaderItem?.name,
+                emptyHeaderTitle,
+            );
 
             const existingEntry = result[uri];
             const childCategories = existingEntry?.categories ?? [];

--- a/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartOptions/test/chartOptionsBuilder.test.ts
+++ b/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartOptions/test/chartOptionsBuilder.test.ts
@@ -628,6 +628,7 @@ describe("chartOptionsBuilder", () => {
                 stackByAttribute,
                 type,
                 attributeColorStrategy,
+                "empty value",
             );
 
             it("should return number of series equal to the count of measures", () => {
@@ -697,6 +698,7 @@ describe("chartOptionsBuilder", () => {
                 stackByAttribute,
                 type,
                 attributeColorStrategy,
+                "empty value",
             );
 
             it("should return number of series equal to the count of stack by attribute values", () => {
@@ -767,7 +769,15 @@ describe("chartOptionsBuilder", () => {
                     dv,
                 );
 
-                const seriesData = getSeries(dv, measureGroup, null, stackByAttribute, type, colorStrategy);
+                const seriesData = getSeries(
+                    dv,
+                    measureGroup,
+                    null,
+                    stackByAttribute,
+                    type,
+                    colorStrategy,
+                    "empty value",
+                );
 
                 expect(seriesData).toMatchSnapshot();
             });
@@ -784,7 +794,15 @@ describe("chartOptionsBuilder", () => {
                     dv,
                 );
 
-                const seriesData = getSeries(dv, measureGroup, null, stackByAttribute, type, colorStrategy);
+                const seriesData = getSeries(
+                    dv,
+                    measureGroup,
+                    null,
+                    stackByAttribute,
+                    type,
+                    colorStrategy,
+                    "empty value",
+                );
 
                 expect(seriesData).toMatchSnapshot();
             });
@@ -1182,6 +1200,7 @@ describe("chartOptionsBuilder", () => {
                     stackByAttribute,
                     type,
                     treeMapColorStrategy,
+                    "empty value",
                 );
 
                 it("should return only one serie", () => {
@@ -1230,6 +1249,7 @@ describe("chartOptionsBuilder", () => {
                     stackByAttribute,
                     type,
                     treeMapColorStrategy,
+                    "empty value",
                 );
 
                 it("should return only one serie", () => {
@@ -1284,6 +1304,7 @@ describe("chartOptionsBuilder", () => {
                     stackByAttribute,
                     type,
                     treeMapColorStrategy,
+                    "empty value",
                 );
 
                 it("should return only one serie", () => {
@@ -1348,6 +1369,7 @@ describe("chartOptionsBuilder", () => {
                     stackByAttribute,
                     type,
                     treeMapColorStrategy,
+                    "empty value",
                 );
 
                 it("should return only one serie", () => {
@@ -1442,6 +1464,7 @@ describe("chartOptionsBuilder", () => {
                     stackByAttribute,
                     type,
                     treeMapColorStrategy,
+                    "empty value",
                 );
 
                 it("should return only one serie", () => {
@@ -1577,6 +1600,7 @@ describe("chartOptionsBuilder", () => {
                 stackByAttribute,
                 type,
                 metricColorStrategy,
+                "empty value",
             );
 
             const drillableMeasures = [
@@ -1619,6 +1643,7 @@ describe("chartOptionsBuilder", () => {
                     stackByAttribute,
                     type,
                     metricColorStrategy,
+                    "empty value",
                 );
 
                 const drillableMeasures = [
@@ -1657,6 +1682,7 @@ describe("chartOptionsBuilder", () => {
                 stackByAttribute,
                 type,
                 attributeColorStrategy,
+                "empty value",
             );
             const drillableMeasures = [
                 HeaderPredicates.uriMatch("/gdc/md/hzyl5wlh8rnu0ixmbzlaqpzf09ttb7c8/obj/67097"),
@@ -1700,6 +1726,7 @@ describe("chartOptionsBuilder", () => {
                     stackByAttribute,
                     type,
                     attributeColorStrategy,
+                    "empty value",
                 );
 
                 const drillableMeasures = [
@@ -1736,6 +1763,7 @@ describe("chartOptionsBuilder", () => {
                 stackByAttribute,
                 type,
                 metricColorStrategy,
+                "empty value",
             );
 
             describe("with all drillable measures", () => {
@@ -1785,6 +1813,7 @@ describe("chartOptionsBuilder", () => {
                 stackByAttribute,
                 type,
                 metricColorStrategy,
+                "empty value",
             );
 
             describe("with all drillable measures", () => {
@@ -1835,6 +1864,7 @@ describe("chartOptionsBuilder", () => {
                 stackByAttribute,
                 type,
                 attColorStrategy,
+                "empty value",
             );
 
             describe("with no drillable items", () => {
@@ -1958,6 +1988,7 @@ describe("chartOptionsBuilder", () => {
                 stackByAttribute,
                 type,
                 attColorStrategy,
+                "empty value",
             );
 
             it("should return number of series equal to the count of stack by attribute values", () => {
@@ -2449,7 +2480,7 @@ describe("chartOptionsBuilder", () => {
             },
         };
         it("should generate valid tooltip for 1 measure", () => {
-            const tooltipFn = buildTooltipTreemapFactory(null, null);
+            const tooltipFn = buildTooltipTreemapFactory(null, null, "empty value");
             const tooltip = tooltipFn(point, DEFAULT_TOOLTIP_CONTENT_WIDTH);
             expect(getValues(tooltip)).toEqual(["category", "300"]);
         });
@@ -2458,7 +2489,7 @@ describe("chartOptionsBuilder", () => {
             const pointWithFormat = cloneDeep(point);
             pointWithFormat.format = "abcd";
 
-            const tooltipFn = buildTooltipTreemapFactory(null, null);
+            const tooltipFn = buildTooltipTreemapFactory(null, null, "empty value");
             const tooltip = tooltipFn(pointWithFormat, DEFAULT_TOOLTIP_CONTENT_WIDTH);
             expect(getValues(tooltip)).toEqual(["category", "abcd"]);
         });
@@ -2467,7 +2498,7 @@ describe("chartOptionsBuilder", () => {
             const dv = fixtures.treemapWithMetricAndViewByAttribute;
             const { viewByAttribute, stackByAttribute } = getMVSTreemap(dv);
 
-            const tooltipFn = buildTooltipTreemapFactory(viewByAttribute, stackByAttribute);
+            const tooltipFn = buildTooltipTreemapFactory(viewByAttribute, stackByAttribute, "empty value");
             const tooltip = tooltipFn(point, DEFAULT_TOOLTIP_CONTENT_WIDTH);
             expect(getValues(tooltip)).toEqual(["Department", "Direct Sales", "serie name", "300"]);
         });
@@ -2476,7 +2507,7 @@ describe("chartOptionsBuilder", () => {
             const dv = fixtures.treemapWithMetricAndStackByAttribute;
             const { viewByAttribute, stackByAttribute } = getMVSTreemap(dv);
 
-            const tooltipFn = buildTooltipTreemapFactory(viewByAttribute, stackByAttribute);
+            const tooltipFn = buildTooltipTreemapFactory(viewByAttribute, stackByAttribute, "empty value");
             const tooltip = tooltipFn(point, DEFAULT_TOOLTIP_CONTENT_WIDTH);
             expect(getValues(tooltip)).toEqual(["Department", "Direct Sales", "category", "300"]);
         });
@@ -2485,7 +2516,7 @@ describe("chartOptionsBuilder", () => {
             const dv = fixtures.treemapWithMetricViewByAndStackByAttribute;
             const { viewByAttribute, stackByAttribute } = getMVSTreemap(dv);
 
-            const tooltipFn = buildTooltipTreemapFactory(viewByAttribute, stackByAttribute);
+            const tooltipFn = buildTooltipTreemapFactory(viewByAttribute, stackByAttribute, "empty value");
             const tooltip = tooltipFn(point, DEFAULT_TOOLTIP_CONTENT_WIDTH);
             expect(getValues(tooltip)).toEqual([
                 "Department",
@@ -2504,7 +2535,12 @@ describe("chartOptionsBuilder", () => {
             const dv = fixtures.treemapWithMetricViewByAndStackByAttribute;
             const { viewByAttribute, stackByAttribute } = getMVSTreemap(dv);
 
-            const tooltipFn = buildTooltipTreemapFactory(viewByAttribute, stackByAttribute, chartConfig);
+            const tooltipFn = buildTooltipTreemapFactory(
+                viewByAttribute,
+                stackByAttribute,
+                "empty value",
+                chartConfig,
+            );
             const tooltip = tooltipFn(pointForSmallCharts, SMALL_TOOLTIP_CONTENT_WIDTH);
             expect(getStyleMaxWidth(tooltip)).toEqual([
                 "180",
@@ -2732,10 +2768,11 @@ describe("chartOptionsBuilder", () => {
                 );
                 expect(pieChartTooltip).toBe(expectedTooltip);
 
-                expectedTooltip = buildTooltipTreemapFactory(viewByAttribute, null)(
-                    pointData,
-                    DEFAULT_TOOLTIP_CONTENT_WIDTH,
-                );
+                expectedTooltip = buildTooltipTreemapFactory(
+                    viewByAttribute,
+                    null,
+                    "empty value",
+                )(pointData, DEFAULT_TOOLTIP_CONTENT_WIDTH);
 
                 const treemapTooltip = treemapOptions.actions.tooltip(
                     pointData,
@@ -2793,10 +2830,11 @@ describe("chartOptionsBuilder", () => {
                 );
                 expect(pieChartTooltip).toBe(expectedPieChartTooltip);
 
-                const expectedTreemapTooltip = buildTooltipTreemapFactory(null, null)(
-                    pointData,
-                    DEFAULT_TOOLTIP_CONTENT_WIDTH,
-                );
+                const expectedTreemapTooltip = buildTooltipTreemapFactory(
+                    null,
+                    null,
+                    "empty value",
+                )(pointData, DEFAULT_TOOLTIP_CONTENT_WIDTH);
                 const treemapTooltip = treemapOptions.actions.tooltip(
                     pointData,
                     DEFAULT_TOOLTIP_CONTENT_WIDTH,
@@ -3188,7 +3226,7 @@ describe("chartOptionsBuilder", () => {
                 };
 
                 it("should generate correct tooltip", () => {
-                    const tooltipFn = generateTooltipHeatmapFn(viewBy, stackBy);
+                    const tooltipFn = generateTooltipHeatmapFn(viewBy, stackBy, "empty value");
                     const tooltip = tooltipFn(point, DEFAULT_TOOLTIP_CONTENT_WIDTH);
 
                     expect(getValues(tooltip)).toEqual([
@@ -3205,7 +3243,7 @@ describe("chartOptionsBuilder", () => {
                     const chartConfig: IChartConfig = {
                         type: "heatmap",
                     };
-                    const tooltipFn = generateTooltipHeatmapFn(viewBy, stackBy, chartConfig);
+                    const tooltipFn = generateTooltipHeatmapFn(viewBy, stackBy, "empty value", chartConfig);
                     const tooltip = tooltipFn(pointForSmallCharts, SMALL_TOOLTIP_CONTENT_WIDTH);
 
                     expect(getStyleMaxWidth(tooltip)).toEqual([
@@ -3225,7 +3263,11 @@ describe("chartOptionsBuilder", () => {
                 });
 
                 it('should display "-" for null value', () => {
-                    const tooltipValue = generateTooltipHeatmapFn(viewBy, stackBy)(
+                    const tooltipValue = generateTooltipHeatmapFn(
+                        viewBy,
+                        stackBy,
+                        "empty value",
+                    )(
                         {
                             ...point,
                             value: null,

--- a/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartOptions/test/extendedStackingChartOptions.test.ts
+++ b/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartOptions/test/extendedStackingChartOptions.test.ts
@@ -97,7 +97,11 @@ describe("getCategoriesForTwoAttributes", () => {
             ],
         };
 
-        const categories = getCategoriesForTwoAttributes(viewByAttribute, viewByParentAttribute);
+        const categories = getCategoriesForTwoAttributes(
+            viewByAttribute,
+            viewByParentAttribute,
+            "empty value",
+        );
         expect(categories).toEqual([
             {
                 name: "Direct Sales",
@@ -162,7 +166,11 @@ describe("getCategoriesForTwoAttributes", () => {
             ],
         };
 
-        const categories = getCategoriesForTwoAttributes(viewByAttribute, viewByParentAttribute);
+        const categories = getCategoriesForTwoAttributes(
+            viewByAttribute,
+            viewByParentAttribute,
+            "empty value",
+        );
         expect(categories).toEqual([
             {
                 name: "3",
@@ -188,7 +196,11 @@ describe("getCategoriesForTwoAttributes", () => {
             ...attributeDescriptor,
             items: [],
         };
-        const categories = getCategoriesForTwoAttributes(viewByAttribute, viewByParentAttribute);
+        const categories = getCategoriesForTwoAttributes(
+            viewByAttribute,
+            viewByParentAttribute,
+            "empty value",
+        );
         expect(categories).toHaveLength(0);
     });
 });
@@ -212,6 +224,7 @@ describe("getDrillableSeriesWithParentAttribute", () => {
         stackByAttribute,
         type,
         metricColorStrategy,
+        "empty value",
     );
 
     const attributes = dv.def().attributes();

--- a/libs/sdk-ui-charts/src/highcharts/chartTypes/_util/test/helper.ts
+++ b/libs/sdk-ui-charts/src/highcharts/chartTypes/_util/test/helper.ts
@@ -28,7 +28,7 @@ export function generateChartOptions(
     },
     drillableItems: IHeaderPredicate[] = [],
 ): IChartOptions {
-    return getChartOptions(dv.dataView, config, drillableItems);
+    return getChartOptions(dv.dataView, config, drillableItems, "empty value");
 }
 
 export interface IMVS {

--- a/libs/sdk-ui-charts/src/highcharts/chartTypes/bubbleChart/bubbleChartSeries.ts
+++ b/libs/sdk-ui-charts/src/highcharts/chartTypes/bubbleChart/bubbleChartSeries.ts
@@ -7,7 +7,7 @@ import { parseValue, unwrap } from "../_util/common";
 import last from "lodash/last";
 
 function getCountOfEmptyBuckets(bucketEmptyFlags: boolean[] = []) {
-    return bucketEmptyFlags.filter((bucketEmpyFlag) => bucketEmpyFlag).length;
+    return bucketEmptyFlags.filter((bucketEmptyFlag) => bucketEmptyFlag).length;
 }
 
 export function getBubbleChartSeries(
@@ -16,6 +16,7 @@ export function getBubbleChartSeries(
     // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
     stackByAttribute: any,
     colorStrategy: IColorStrategy,
+    emptyHeaderName: string,
 ): ISeriesItemConfig[] {
     const primaryMeasuresBucketEmpty = dv.def().isBucketEmpty(BucketNames.MEASURES);
     const secondaryMeasuresBucketEmpty = dv.def().isBucketEmpty(BucketNames.SECONDARY_MEASURES);
@@ -44,7 +45,9 @@ export function getBubbleChartSeries(
                 },
             ];
             return {
-                name: stackByAttribute ? stackByAttribute.items[index].attributeHeaderItem.name : "",
+                name: stackByAttribute
+                    ? stackByAttribute.items[index].attributeHeaderItem.name || emptyHeaderName // TODO RAIL-4360 distinguish between empty and null
+                    : "",
                 color: colorStrategy.getColorByIndex(legendIndex),
                 legendIndex: legendIndex++,
                 data,

--- a/libs/sdk-ui-charts/src/highcharts/chartTypes/bubbleChart/bubbleChartSeries.ts
+++ b/libs/sdk-ui-charts/src/highcharts/chartTypes/bubbleChart/bubbleChartSeries.ts
@@ -2,7 +2,7 @@
 import { ISeriesItemConfig } from "../../typings/unsafe";
 import { BucketNames, DataViewFacade } from "@gooddata/sdk-ui";
 import { IMeasureGroupDescriptor } from "@gooddata/sdk-model";
-import { IColorStrategy } from "@gooddata/sdk-ui-vis-commons";
+import { IColorStrategy, valueWithEmptyHandling } from "@gooddata/sdk-ui-vis-commons";
 import { parseValue, unwrap } from "../_util/common";
 import last from "lodash/last";
 
@@ -16,7 +16,7 @@ export function getBubbleChartSeries(
     // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
     stackByAttribute: any,
     colorStrategy: IColorStrategy,
-    emptyHeaderName: string,
+    emptyHeaderTitle: string,
 ): ISeriesItemConfig[] {
     const primaryMeasuresBucketEmpty = dv.def().isBucketEmpty(BucketNames.MEASURES);
     const secondaryMeasuresBucketEmpty = dv.def().isBucketEmpty(BucketNames.SECONDARY_MEASURES);
@@ -46,7 +46,10 @@ export function getBubbleChartSeries(
             ];
             return {
                 name: stackByAttribute
-                    ? stackByAttribute.items[index].attributeHeaderItem.name || emptyHeaderName // TODO RAIL-4360 distinguish between empty and null
+                    ? valueWithEmptyHandling(
+                          stackByAttribute.items[index].attributeHeaderItem.name,
+                          emptyHeaderTitle,
+                      )
                     : "",
                 color: colorStrategy.getColorByIndex(legendIndex),
                 legendIndex: legendIndex++,

--- a/libs/sdk-ui-charts/src/highcharts/chartTypes/scatterPlot/scatterPlotSeries.ts
+++ b/libs/sdk-ui-charts/src/highcharts/chartTypes/scatterPlot/scatterPlotSeries.ts
@@ -1,6 +1,6 @@
 // (C) 2020-2022 GoodData Corporation
 import { BucketNames, DataViewFacade } from "@gooddata/sdk-ui";
-import { IColorStrategy } from "@gooddata/sdk-ui-vis-commons";
+import { IColorStrategy, valueWithEmptyHandling } from "@gooddata/sdk-ui-vis-commons";
 import { IPointData, ISeriesItemConfig } from "../../typings/unsafe";
 import { parseValue } from "../_util/common";
 
@@ -9,7 +9,7 @@ export function getScatterPlotSeries(
     // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
     stackByAttribute: any,
     colorStrategy: IColorStrategy,
-    emptyHeaderName: string,
+    emptyHeaderTitle: string,
 ): ISeriesItemConfig[] {
     const primaryMeasuresBucketEmpty = dv.def().isBucketEmpty(BucketNames.MEASURES);
     const secondaryMeasuresBucketEmpty = dv.def().isBucketEmpty(BucketNames.SECONDARY_MEASURES);
@@ -26,7 +26,10 @@ export function getScatterPlotSeries(
                 x: !primaryMeasuresBucketEmpty ? values[0] : 0,
                 y: !secondaryMeasuresBucketEmpty ? (primaryMeasuresBucketEmpty ? values[0] : values[1]) : 0,
                 name: stackByAttribute
-                    ? stackByAttribute.items[seriesIndex].attributeHeaderItem.name || emptyHeaderName // TODO RAIL-4360 distinguish between empty and null
+                    ? valueWithEmptyHandling(
+                          stackByAttribute.items[seriesIndex].attributeHeaderItem.name,
+                          emptyHeaderTitle,
+                      )
                     : "",
             };
         });

--- a/libs/sdk-ui-charts/src/highcharts/chartTypes/scatterPlot/scatterPlotSeries.ts
+++ b/libs/sdk-ui-charts/src/highcharts/chartTypes/scatterPlot/scatterPlotSeries.ts
@@ -1,4 +1,4 @@
-// (C) 2020-2021 GoodData Corporation
+// (C) 2020-2022 GoodData Corporation
 import { BucketNames, DataViewFacade } from "@gooddata/sdk-ui";
 import { IColorStrategy } from "@gooddata/sdk-ui-vis-commons";
 import { IPointData, ISeriesItemConfig } from "../../typings/unsafe";
@@ -9,6 +9,7 @@ export function getScatterPlotSeries(
     // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
     stackByAttribute: any,
     colorStrategy: IColorStrategy,
+    emptyHeaderName: string,
 ): ISeriesItemConfig[] {
     const primaryMeasuresBucketEmpty = dv.def().isBucketEmpty(BucketNames.MEASURES);
     const secondaryMeasuresBucketEmpty = dv.def().isBucketEmpty(BucketNames.SECONDARY_MEASURES);
@@ -24,7 +25,9 @@ export function getScatterPlotSeries(
             return {
                 x: !primaryMeasuresBucketEmpty ? values[0] : 0,
                 y: !secondaryMeasuresBucketEmpty ? (primaryMeasuresBucketEmpty ? values[0] : values[1]) : 0,
-                name: stackByAttribute ? stackByAttribute.items[seriesIndex].attributeHeaderItem.name : "",
+                name: stackByAttribute
+                    ? stackByAttribute.items[seriesIndex].attributeHeaderItem.name || emptyHeaderName // TODO RAIL-4360 distinguish between empty and null
+                    : "",
             };
         });
 

--- a/libs/sdk-ui-charts/src/highcharts/chartTypes/treemap/treemapChartSeries.ts
+++ b/libs/sdk-ui-charts/src/highcharts/chartTypes/treemap/treemapChartSeries.ts
@@ -38,9 +38,10 @@ function getLeafPoint(
     data: any,
     format: string,
     colorStrategy: IColorStrategy,
+    emptyHeaderName: string,
 ) {
     return {
-        name: stackByAttribute.items[seriesIndex].attributeHeaderItem.name,
+        name: stackByAttribute.items[seriesIndex].attributeHeaderItem.name || emptyHeaderName, // TODO RAIL-4360 distinguish between empty and null,
         parent: `${parentIndex}`,
         value: parseValue(data),
         x: seriesIndex,
@@ -61,6 +62,7 @@ export function getTreemapStackedSeriesDataWithViewBy(
     viewByAttribute: IUnwrappedAttributeHeadersWithItems,
     stackByAttribute: IUnwrappedAttributeHeadersWithItems,
     colorStrategy: IColorStrategy,
+    emptyHeaderName: string,
 ): any[] {
     const roots: any = [];
     const leafs: any = [];
@@ -87,7 +89,15 @@ export function getTreemapStackedSeriesDataWithViewBy(
         }
         // create leafs which will be colored at the end of group
         uncoloredLeafs.push(
-            getLeafPoint(stackByAttribute, rootId, seriesIndex, seriesItems[0], format, colorStrategy),
+            getLeafPoint(
+                stackByAttribute,
+                rootId,
+                seriesIndex,
+                seriesItems[0],
+                format,
+                colorStrategy,
+                emptyHeaderName,
+            ),
         );
 
         if (isLastSerie(seriesIndex, dataLength)) {
@@ -105,6 +115,7 @@ export function getTreemapStackedSeriesDataWithMeasures(
     // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
     stackByAttribute: any,
     colorStrategy: IColorStrategy,
+    emptyHeaderName: string,
 ): any[] {
     let data = measureGroup.items.map((measureGroupItem, index): IPointData => {
         return {
@@ -124,7 +135,7 @@ export function getTreemapStackedSeriesDataWithMeasures(
 
             const unsortedLeafs = seriesItems.map((seriesItem, seriesItemIndex): IPointData => {
                 return {
-                    name: stackByAttribute.items[seriesItemIndex].attributeHeaderItem.name,
+                    name: stackByAttribute.items[seriesItemIndex].attributeHeaderItem.name || emptyHeaderName, // TODO RAIL-4360 distinguish between empty and null,
                     parent: `${seriesIndex}`,
                     format: unwrap(measureGroup.items[seriesIndex]).format,
                     value: parseValue(seriesItem),
@@ -157,6 +168,7 @@ export function getTreemapStackedSeries(
     viewByAttribute: IUnwrappedAttributeHeadersWithItems,
     stackByAttribute: IUnwrappedAttributeHeadersWithItems,
     colorStrategy: IColorStrategy,
+    emptyHeaderName: string,
 ) {
     let data = [];
     if (viewByAttribute) {
@@ -166,9 +178,16 @@ export function getTreemapStackedSeries(
             viewByAttribute,
             stackByAttribute,
             colorStrategy,
+            emptyHeaderName,
         );
     } else {
-        data = getTreemapStackedSeriesDataWithMeasures(dv, measureGroup, stackByAttribute, colorStrategy);
+        data = getTreemapStackedSeriesDataWithMeasures(
+            dv,
+            measureGroup,
+            stackByAttribute,
+            colorStrategy,
+            emptyHeaderName,
+        );
     }
 
     const seriesName = measureGroup.items

--- a/libs/sdk-ui-charts/src/highcharts/chartTypes/treemap/treemapChartSeries.ts
+++ b/libs/sdk-ui-charts/src/highcharts/chartTypes/treemap/treemapChartSeries.ts
@@ -2,7 +2,7 @@
 import { DataViewFacade } from "@gooddata/sdk-ui";
 import { IMeasureDescriptor, IMeasureGroupDescriptor, IResultAttributeHeader } from "@gooddata/sdk-model";
 import { IUnwrappedAttributeHeadersWithItems } from "../../typings/mess";
-import { getLighterColor, IColorStrategy } from "@gooddata/sdk-ui-vis-commons";
+import { getLighterColor, IColorStrategy, valueWithEmptyHandling } from "@gooddata/sdk-ui-vis-commons";
 import { parseValue, unwrap } from "../_util/common";
 import isEqual from "lodash/isEqual";
 import { IPointData } from "../../typings/unsafe";
@@ -38,10 +38,13 @@ function getLeafPoint(
     data: any,
     format: string,
     colorStrategy: IColorStrategy,
-    emptyHeaderName: string,
+    emptyHeaderTitle: string,
 ) {
     return {
-        name: stackByAttribute.items[seriesIndex].attributeHeaderItem.name || emptyHeaderName, // TODO RAIL-4360 distinguish between empty and null,
+        name: valueWithEmptyHandling(
+            stackByAttribute.items[seriesIndex].attributeHeaderItem.name,
+            emptyHeaderTitle,
+        ),
         parent: `${parentIndex}`,
         value: parseValue(data),
         x: seriesIndex,
@@ -62,7 +65,7 @@ export function getTreemapStackedSeriesDataWithViewBy(
     viewByAttribute: IUnwrappedAttributeHeadersWithItems,
     stackByAttribute: IUnwrappedAttributeHeadersWithItems,
     colorStrategy: IColorStrategy,
-    emptyHeaderName: string,
+    emptyHeaderTitle: string,
 ): any[] {
     const roots: any = [];
     const leafs: any = [];
@@ -96,7 +99,7 @@ export function getTreemapStackedSeriesDataWithViewBy(
                 seriesItems[0],
                 format,
                 colorStrategy,
-                emptyHeaderName,
+                emptyHeaderTitle,
             ),
         );
 
@@ -115,7 +118,7 @@ export function getTreemapStackedSeriesDataWithMeasures(
     // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
     stackByAttribute: any,
     colorStrategy: IColorStrategy,
-    emptyHeaderName: string,
+    emptyHeaderTitle: string,
 ): any[] {
     let data = measureGroup.items.map((measureGroupItem, index): IPointData => {
         return {
@@ -135,7 +138,10 @@ export function getTreemapStackedSeriesDataWithMeasures(
 
             const unsortedLeafs = seriesItems.map((seriesItem, seriesItemIndex): IPointData => {
                 return {
-                    name: stackByAttribute.items[seriesItemIndex].attributeHeaderItem.name || emptyHeaderName, // TODO RAIL-4360 distinguish between empty and null,
+                    name: valueWithEmptyHandling(
+                        stackByAttribute.items[seriesItemIndex].attributeHeaderItem.name,
+                        emptyHeaderTitle,
+                    ),
                     parent: `${seriesIndex}`,
                     format: unwrap(measureGroup.items[seriesIndex]).format,
                     value: parseValue(seriesItem),
@@ -168,7 +174,7 @@ export function getTreemapStackedSeries(
     viewByAttribute: IUnwrappedAttributeHeadersWithItems,
     stackByAttribute: IUnwrappedAttributeHeadersWithItems,
     colorStrategy: IColorStrategy,
-    emptyHeaderName: string,
+    emptyHeaderTitle: string,
 ) {
     let data = [];
     if (viewByAttribute) {
@@ -178,7 +184,7 @@ export function getTreemapStackedSeries(
             viewByAttribute,
             stackByAttribute,
             colorStrategy,
-            emptyHeaderName,
+            emptyHeaderTitle,
         );
     } else {
         data = getTreemapStackedSeriesDataWithMeasures(
@@ -186,7 +192,7 @@ export function getTreemapStackedSeries(
             measureGroup,
             stackByAttribute,
             colorStrategy,
-            emptyHeaderName,
+            emptyHeaderTitle,
         );
     }
 

--- a/libs/sdk-ui-dashboard/src/presentation/drill/DrillConfigPanel/DrillToUrl/ParameterDetails/AttributeDisplayFormParameterDetail.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/drill/DrillConfigPanel/DrillToUrl/ParameterDetails/AttributeDisplayFormParameterDetail.tsx
@@ -5,7 +5,7 @@ import { LRUCache } from "@gooddata/util";
 import { IAttributeElement, ObjRef, objRefToString } from "@gooddata/sdk-model";
 import { ParameterDetail } from "./ParameterDetail";
 import { AttributeDisplayFormType } from "../../../types";
-import { useBackendStrict } from "@gooddata/sdk-ui";
+import { emptyHeaderTitleFromIntl, useBackendStrict } from "@gooddata/sdk-ui";
 import { IAnalyticalBackend, IElementsQueryResult } from "@gooddata/sdk-backend-spi";
 
 const MAX_CACHED_REQUESTS = 50;
@@ -41,9 +41,7 @@ interface IAttributeDisplayFormParameterDetailProps {
 }
 
 const handleEmptyValues = (values: string[], intl: IntlShape) =>
-    values.map((value: string) =>
-        value.length === 0 ? `(${intl.formatMessage({ id: "visualization.emptyValue" })})` : value,
-    );
+    values.map((value: string) => (value.length === 0 ? emptyHeaderTitleFromIntl(intl) : value));
 
 const prepareValues = (elements: IAttributeElement[], type?: string) => {
     if (type !== AttributeDisplayFormType.HYPERLINK) {

--- a/libs/sdk-ui-dashboard/src/presentation/localization/bundles/de-DE.json
+++ b/libs/sdk-ui-dashboard/src/presentation/localization/bundles/de-DE.json
@@ -316,7 +316,6 @@
     "configurationPanel.drillIntoUrl.editor.urlDisplayFormTypeLabel": "URL-Attributswert",
     "configurationPanel.drillConfig.selectInsight": "Betrachtung auswählen…",
     "dropdown.loading": "Lädt…",
-    "visualization.emptyValue": "leerer Wert",
     "gs.date.date-dataset.recommended": "Empfohlen",
     "gs.date.date-dataset.other": "Andere",
     "gs.date.date-dataset.related": "Zugehörig",

--- a/libs/sdk-ui-dashboard/src/presentation/localization/bundles/en-US.json
+++ b/libs/sdk-ui-dashboard/src/presentation/localization/bundles/en-US.json
@@ -1719,11 +1719,6 @@
         "comment": "Use '…' as one character, not 3 dots ('...').",
         "limit": 0
     },
-    "visualization.emptyValue": {
-        "value": "empty value",
-        "comment": "",
-        "limit": 0
-    },
     "gs.date.date-dataset.recommended": {
         "value": "Recommended",
         "comment": "",

--- a/libs/sdk-ui-dashboard/src/presentation/localization/bundles/es-ES.json
+++ b/libs/sdk-ui-dashboard/src/presentation/localization/bundles/es-ES.json
@@ -316,7 +316,6 @@
     "configurationPanel.drillIntoUrl.editor.urlDisplayFormTypeLabel": "Valor de la URL del atributo",
     "configurationPanel.drillConfig.selectInsight": "Elija una perspectiva…",
     "dropdown.loading": "Cargando…",
-    "visualization.emptyValue": "valor vacío",
     "gs.date.date-dataset.recommended": "Recomendado",
     "gs.date.date-dataset.other": "Otros",
     "gs.date.date-dataset.related": "Relacionado",

--- a/libs/sdk-ui-dashboard/src/presentation/localization/bundles/fr-FR.json
+++ b/libs/sdk-ui-dashboard/src/presentation/localization/bundles/fr-FR.json
@@ -316,7 +316,6 @@
     "configurationPanel.drillIntoUrl.editor.urlDisplayFormTypeLabel": "Valeur de l'URL de l'attribut",
     "configurationPanel.drillConfig.selectInsight": "Choisir une perception…",
     "dropdown.loading": "Chargement en cours…",
-    "visualization.emptyValue": "valeur vide",
     "gs.date.date-dataset.recommended": "Recommandé",
     "gs.date.date-dataset.other": "Autre",
     "gs.date.date-dataset.related": "Associé",

--- a/libs/sdk-ui-dashboard/src/presentation/localization/bundles/ja-JP.json
+++ b/libs/sdk-ui-dashboard/src/presentation/localization/bundles/ja-JP.json
@@ -316,7 +316,6 @@
     "configurationPanel.drillIntoUrl.editor.urlDisplayFormTypeLabel": "アトリビュート URL 値",
     "configurationPanel.drillConfig.selectInsight": "インサイトを選択…",
     "dropdown.loading": "読み込んでいます…",
-    "visualization.emptyValue": "空の値",
     "gs.date.date-dataset.recommended": "お勧め",
     "gs.date.date-dataset.other": "その他",
     "gs.date.date-dataset.related": "関係する",

--- a/libs/sdk-ui-dashboard/src/presentation/localization/bundles/nl-NL.json
+++ b/libs/sdk-ui-dashboard/src/presentation/localization/bundles/nl-NL.json
@@ -316,7 +316,6 @@
     "configurationPanel.drillIntoUrl.editor.urlDisplayFormTypeLabel": "Waarde attribuut-URL",
     "configurationPanel.drillConfig.selectInsight": "Inzicht kiezen…",
     "dropdown.loading": "Laden…",
-    "visualization.emptyValue": "lege waarde",
     "gs.date.date-dataset.recommended": "Aanbevolen",
     "gs.date.date-dataset.other": "Overige",
     "gs.date.date-dataset.related": "Verwant",

--- a/libs/sdk-ui-dashboard/src/presentation/localization/bundles/pt-BR.json
+++ b/libs/sdk-ui-dashboard/src/presentation/localization/bundles/pt-BR.json
@@ -316,7 +316,6 @@
     "configurationPanel.drillIntoUrl.editor.urlDisplayFormTypeLabel": "Valor da URL do atributo",
     "configurationPanel.drillConfig.selectInsight": "Escolher insight…",
     "dropdown.loading": "Carregando…",
-    "visualization.emptyValue": "valor vazio",
     "gs.date.date-dataset.recommended": "Recomendado",
     "gs.date.date-dataset.other": "Outros",
     "gs.date.date-dataset.related": "Relacionado",

--- a/libs/sdk-ui-dashboard/src/presentation/localization/bundles/pt-PT.json
+++ b/libs/sdk-ui-dashboard/src/presentation/localization/bundles/pt-PT.json
@@ -316,7 +316,6 @@
     "configurationPanel.drillIntoUrl.editor.urlDisplayFormTypeLabel": "Valor do URL do atributo",
     "configurationPanel.drillConfig.selectInsight": "Escolher insight…",
     "dropdown.loading": "A carregar…",
-    "visualization.emptyValue": "valor vazio",
     "gs.date.date-dataset.recommended": "Recomendado",
     "gs.date.date-dataset.other": "Outros",
     "gs.date.date-dataset.related": "Relacionado",

--- a/libs/sdk-ui-dashboard/src/presentation/localization/bundles/ru-RU.json
+++ b/libs/sdk-ui-dashboard/src/presentation/localization/bundles/ru-RU.json
@@ -316,7 +316,6 @@
     "configurationPanel.drillIntoUrl.editor.urlDisplayFormTypeLabel": "Значение URL атрибута",
     "configurationPanel.drillConfig.selectInsight": "Выбрать анализ…",
     "dropdown.loading": "Загрузка…",
-    "visualization.emptyValue": "значение отсутствует",
     "gs.date.date-dataset.recommended": "Рекомендуемые",
     "gs.date.date-dataset.other": "Прочие",
     "gs.date.date-dataset.related": "Связанные",

--- a/libs/sdk-ui-dashboard/src/presentation/localization/bundles/zh-Hans.json
+++ b/libs/sdk-ui-dashboard/src/presentation/localization/bundles/zh-Hans.json
@@ -316,7 +316,6 @@
     "configurationPanel.drillIntoUrl.editor.urlDisplayFormTypeLabel": "属性 URL 值",
     "configurationPanel.drillConfig.selectInsight": "选择洞察…",
     "dropdown.loading": "正在加载…",
-    "visualization.emptyValue": "空值",
     "gs.date.date-dataset.recommended": "已推荐",
     "gs.date.date-dataset.other": "其他",
     "gs.date.date-dataset.related": "相关",

--- a/libs/sdk-ui-geo/__mocks__/recordings.ts
+++ b/libs/sdk-ui-geo/__mocks__/recordings.ts
@@ -14,7 +14,7 @@ function createShortcut(rec: ScenarioRecording) {
 
     return {
         dv,
-        geoData: getGeoData(dv),
+        geoData: getGeoData(dv, "empty value", "null value"),
     };
 }
 
@@ -60,7 +60,7 @@ function trimmedScenario(rec: ScenarioRecording, to: number[]) {
 
     return {
         dv,
-        geoData: getGeoData(dv),
+        geoData: getGeoData(dv, "empty value", "null value"),
     };
 }
 

--- a/libs/sdk-ui-geo/src/core/geoChart/GeoChartOptionsWrapper.tsx
+++ b/libs/sdk-ui-geo/src/core/geoChart/GeoChartOptionsWrapper.tsx
@@ -19,7 +19,6 @@ import {
     getValidColorPalette,
     IColorStrategy,
     IPushpinCategoryLegendItem,
-    fixEmptyHeaderItems,
 } from "@gooddata/sdk-ui-vis-commons";
 import { getColorStrategy } from "./colorStrategy/geoChart";
 
@@ -64,13 +63,11 @@ export class GeoChartOptionsWrapper extends React.Component<IGeoChartInnerProps>
     }
 
     public renderVisualization(): React.ReactNode {
-        const sanitizedProps = this.sanitizeProperties();
-
-        const { dataView, onDataTooLarge } = sanitizedProps;
+        const { dataView, onDataTooLarge } = this.props;
 
         const dv = DataViewFacade.for(dataView!);
-        const geoData = getGeoData(dv);
-        const validationResult = this.validateData(geoData, sanitizedProps);
+        const geoData = getGeoData(dv, this.emptyHeaderString, this.nullHeaderString);
+        const validationResult = this.validateData(geoData, this.props);
 
         if (validationResult?.isDataTooLarge) {
             invariant(onDataTooLarge, "GeoChart's onDataTooLarge callback is missing.");
@@ -79,8 +76,8 @@ export class GeoChartOptionsWrapper extends React.Component<IGeoChartInnerProps>
             return null;
         }
 
-        const geoChartOptions = this.buildGeoChartOptions(geoData, sanitizedProps);
-        return <GeoChartInner {...sanitizedProps} geoChartOptions={geoChartOptions} />;
+        const geoChartOptions = this.buildGeoChartOptions(geoData, this.props);
+        return <GeoChartInner {...this.props} geoChartOptions={geoChartOptions} />;
     }
 
     private buildGeoChartOptions = (
@@ -120,17 +117,6 @@ export class GeoChartOptionsWrapper extends React.Component<IGeoChartInnerProps>
             isDataTooLarge: !isDataOfReasonableSize(dv, geoData, limit),
         };
     };
-
-    private sanitizeProperties(): IGeoChartInnerProps {
-        const { dataView } = this.props;
-
-        fixEmptyHeaderItems(dataView!, `(${this.emptyHeaderString})`);
-
-        return {
-            ...this.props,
-            dataView,
-        };
-    }
 }
 
 export function createCategoryLegendItems(

--- a/libs/sdk-ui-geo/src/core/geoChart/GeoChartOptionsWrapper.tsx
+++ b/libs/sdk-ui-geo/src/core/geoChart/GeoChartOptionsWrapper.tsx
@@ -30,7 +30,7 @@ export class GeoChartOptionsWrapper extends React.Component<IGeoChartInnerProps>
     constructor(props: IGeoChartInnerProps) {
         super(props);
         this.emptyHeaderString = props.intl.formatMessage({ id: "visualization.emptyValue" });
-        this.nullHeaderString = props.intl.formatMessage({ id: "visualization.emptyValue" }); // TODO RAIL-4360 replace by proper null header string id when available
+        this.nullHeaderString = props.intl.formatMessage({ id: "visualization.emptyValue" }); // TODO: RAIL-4360 replace by proper null header string id when available
         this.errorMap = newErrorMapping(props.intl);
     }
 

--- a/libs/sdk-ui-geo/src/core/geoChart/helpers/geoChart/data.ts
+++ b/libs/sdk-ui-geo/src/core/geoChart/helpers/geoChart/data.ts
@@ -55,7 +55,11 @@ export function getLocation(latlng: string | null): IGeoLngLat | null {
     };
 }
 
-export function getGeoData(dv: DataViewFacade): IGeoData {
+export function getGeoData(
+    dv: DataViewFacade,
+    emptyHeaderString: string,
+    nullHeaderString: string,
+): IGeoData {
     const geoData: IGeoData = getBucketItemNameAndDataIndex(dv);
     const attributeHeaderItems = getGeoAttributeHeaderItems(dv, geoData);
 
@@ -66,7 +70,12 @@ export function getGeoData(dv: DataViewFacade): IGeoData {
     const colorIndex = geoData?.color?.index;
 
     if (locationIndex !== undefined) {
-        const locationData = getAttributeData(attributeHeaderItems, locationIndex);
+        const locationData = getAttributeData(
+            attributeHeaderItems,
+            locationIndex,
+            emptyHeaderString,
+            nullHeaderString,
+        );
         geoData[BucketNames.LOCATION].data = locationData.map(getLocation);
     }
 
@@ -77,7 +86,12 @@ export function getGeoData(dv: DataViewFacade): IGeoData {
     }
 
     if (tooltipTextIndex !== undefined) {
-        geoData[BucketNames.TOOLTIP_TEXT].data = getAttributeData(attributeHeaderItems, tooltipTextIndex);
+        geoData[BucketNames.TOOLTIP_TEXT].data = getAttributeData(
+            attributeHeaderItems,
+            tooltipTextIndex,
+            emptyHeaderString,
+            nullHeaderString,
+        );
     }
 
     if (sizeIndex !== undefined) {
@@ -114,9 +128,20 @@ function getMeasureData(dv: DataViewFacade, dataIndex: number): number[] {
     return measureValues.map(dataValueAsFloat);
 }
 
-function getAttributeData(attributeHeaderItems: IResultHeader[][], dataIndex: number): string[] {
+function getAttributeData(
+    attributeHeaderItems: IResultHeader[][],
+    dataIndex: number,
+    emptyHeaderString: string,
+    nullHeaderString: string,
+): string[] {
     const headerItems = attributeHeaderItems[dataIndex];
-    return headerItems.map(resultHeaderName);
+    return headerItems.map((i) => {
+        const name = resultHeaderName(i);
+        if (name) {
+            return name;
+        }
+        return name === "" ? emptyHeaderString : nullHeaderString;
+    });
 }
 
 type BucketInfos = { [localId: string]: IBucketItemInfo | null };

--- a/libs/sdk-ui-geo/src/core/geoChart/helpers/geoChart/tests/data.test.ts
+++ b/libs/sdk-ui-geo/src/core/geoChart/helpers/geoChart/tests/data.test.ts
@@ -1,4 +1,4 @@
-// (C) 2020 GoodData Corporation
+// (C) 2020-2022 GoodData Corporation
 import { getGeoData, getLocation } from "../../geoChart/data";
 import { dummyDataView } from "@gooddata/sdk-backend-mockingbird";
 import { emptyDef } from "@gooddata/sdk-model";
@@ -24,7 +24,7 @@ describe("geoChartData", () => {
     it("should return geoData with empty bucket", () => {
         const emptyDv = DataViewFacade.for(dummyDataView(emptyDef("testWorkspace")));
 
-        const geoData = getGeoData(emptyDv);
+        const geoData = getGeoData(emptyDv, "empty value", "null value");
         expect(geoData).toEqual({});
     });
 

--- a/libs/sdk-ui-geo/src/core/geoChart/tests/geoChartDataSource.test.ts
+++ b/libs/sdk-ui-geo/src/core/geoChart/tests/geoChartDataSource.test.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2020 GoodData Corporation
+// (C) 2019-2022 GoodData Corporation
 import mapboxgl from "mapbox-gl";
 import { createPushpinDataSource, IGeoDataSourceProps } from "../geoChartDataSource";
 import { DataViewFacade, DefaultColorPalette } from "@gooddata/sdk-ui";
@@ -23,7 +23,7 @@ function createProps(complement: Partial<IGeoDataSourceProps>): IGeoDataSourcePr
 describe("createPushpinDataSource", () => {
     it("should return empty data source", () => {
         const emptyDv = DataViewFacade.for(dummyDataView(emptyDef("testWorkspace")));
-        const geoData = getGeoData(emptyDv);
+        const geoData = getGeoData(emptyDv, "empty value", "null value");
 
         const dataSourceProps = createProps({
             hasClustering: true,

--- a/libs/sdk-ui-pivot/src/impl/data/rowFactory.ts
+++ b/libs/sdk-ui-pivot/src/impl/data/rowFactory.ts
@@ -36,14 +36,12 @@ function getCell(
     rowHeader: SliceCol,
     rowHeaderIndex: number,
     intl: IntlShape,
-):
-    | {
-          field: string;
-          value: string | null;
-          rowHeaderDataItem: IResultHeader;
-          isSubtotal: boolean;
-      }
-    | undefined {
+): {
+    field: string;
+    value: string | null;
+    rowHeaderDataItem: IResultHeader;
+    isSubtotal: boolean;
+} {
     const rowHeaderDataItem = rowHeaderData[rowHeaderIndex][rowIndex];
     const cell = {
         field: rowHeader.id,
@@ -59,9 +57,7 @@ function getCell(
                 `(${intl.formatMessage({ id: "visualization.emptyValue" })})`,
             ),
         };
-    }
-
-    if (isResultTotalHeader(rowHeaderDataItem)) {
+    } else if (isResultTotalHeader(rowHeaderDataItem)) {
         const totalName = rowHeaderDataItem.totalHeaderItem.name;
         return {
             ...cell,
@@ -71,12 +67,9 @@ function getCell(
                     ? intl.formatMessage(messages[totalName])
                     : null,
         };
+    } else {
+        invariant(false, "row header is not of type IResultAttributeHeaderItem or IResultTotalHeaderItem");
     }
-
-    invariant(
-        rowHeaderDataItem,
-        "row header is not of type IResultAttributeHeaderItem or IResultTotalHeaderItem",
-    );
 }
 
 export function getRow(
@@ -98,7 +91,7 @@ export function getRow(
             rowHeader,
             rowHeaderIndex,
             intl,
-        )!;
+        );
         if (isSubtotal) {
             row.type = ROW_SUBTOTAL;
 

--- a/libs/sdk-ui-pivot/src/impl/data/rowFactory.ts
+++ b/libs/sdk-ui-pivot/src/impl/data/rowFactory.ts
@@ -2,6 +2,7 @@
 import { IntlShape } from "react-intl";
 
 import { DataViewFacade, IMappingHeader } from "@gooddata/sdk-ui";
+import { valueWithEmptyHandling } from "@gooddata/sdk-ui-vis-commons";
 import { ROW_SUBTOTAL, ROW_TOTAL } from "../base/constants";
 import { DataValue, IResultHeader, isResultAttributeHeader, isResultTotalHeader } from "@gooddata/sdk-model";
 import invariant from "ts-invariant";
@@ -53,9 +54,10 @@ function getCell(
     if (isResultAttributeHeader(rowHeaderDataItem)) {
         return {
             ...cell,
-            value:
-                rowHeaderDataItem.attributeHeaderItem.name ||
-                `(${intl.formatMessage({ id: "visualization.emptyValue" })})`, // TODO RAIL-4360 distinguish between empty and null
+            value: valueWithEmptyHandling(
+                rowHeaderDataItem.attributeHeaderItem.name,
+                `(${intl.formatMessage({ id: "visualization.emptyValue" })})`,
+            ),
         };
     }
 

--- a/libs/sdk-ui-pivot/src/impl/data/rowFactory.ts
+++ b/libs/sdk-ui-pivot/src/impl/data/rowFactory.ts
@@ -1,7 +1,7 @@
 // (C) 2007-2022 GoodData Corporation
 import { IntlShape } from "react-intl";
 
-import { DataViewFacade, IMappingHeader } from "@gooddata/sdk-ui";
+import { DataViewFacade, emptyHeaderTitleFromIntl, IMappingHeader } from "@gooddata/sdk-ui";
 import { valueWithEmptyHandling } from "@gooddata/sdk-ui-vis-commons";
 import { ROW_SUBTOTAL, ROW_TOTAL } from "../base/constants";
 import { DataValue, IResultHeader, isResultAttributeHeader, isResultTotalHeader } from "@gooddata/sdk-model";
@@ -54,7 +54,7 @@ function getCell(
             ...cell,
             value: valueWithEmptyHandling(
                 rowHeaderDataItem.attributeHeaderItem.name,
-                `(${intl.formatMessage({ id: "visualization.emptyValue" })})`,
+                emptyHeaderTitleFromIntl(intl),
             ),
         };
     } else if (isResultTotalHeader(rowHeaderDataItem)) {

--- a/libs/sdk-ui-pivot/src/impl/data/rowFactory.ts
+++ b/libs/sdk-ui-pivot/src/impl/data/rowFactory.ts
@@ -53,7 +53,9 @@ function getCell(
     if (isResultAttributeHeader(rowHeaderDataItem)) {
         return {
             ...cell,
-            value: rowHeaderDataItem.attributeHeaderItem.name,
+            value:
+                rowHeaderDataItem.attributeHeaderItem.name ||
+                `(${intl.formatMessage({ id: "visualization.emptyValue" })})`, // TODO RAIL-4360 distinguish between empty and null
         };
     }
 

--- a/libs/sdk-ui-pivot/src/impl/data/tests/rowFactory.test.ts
+++ b/libs/sdk-ui-pivot/src/impl/data/tests/rowFactory.test.ts
@@ -15,7 +15,7 @@ describe("getRowTotals", () => {
             ReferenceRecordings.Scenarios.PivotTable.SingleMeasureAndMultipleGrandTotals,
             DataViewFirstPage,
         );
-        const tableDescriptor = TableDescriptor.for(fixture);
+        const tableDescriptor = TableDescriptor.for(fixture, "empty value");
 
         expect(getRowTotals(tableDescriptor, fixture, intl)).toMatchSnapshot();
     });
@@ -24,7 +24,7 @@ describe("getRowTotals", () => {
             ReferenceRecordings.Scenarios.PivotTable.SingleMeasureWithRowAndColumnAttributes,
             DataViewFirstPage,
         );
-        const tableDescriptor = TableDescriptor.for(dv);
+        const tableDescriptor = TableDescriptor.for(dv, "empty value");
 
         expect(getRowTotals(tableDescriptor, dv, intl)).toBe(null);
     });
@@ -36,7 +36,7 @@ describe("getRow", () => {
             ReferenceRecordings.Scenarios.PivotTable.SingleMeasureWithRowAndColumnAttributes,
             DataViewFirstPage,
         );
-        const tableDescriptor = TableDescriptor.for(dv);
+        const tableDescriptor = TableDescriptor.for(dv, "empty value");
         const headerItems = dv.meta().allHeaders();
 
         expect(
@@ -48,7 +48,7 @@ describe("getRow", () => {
             ReferenceRecordings.Scenarios.PivotTable.TwoMeasuresAndMultipleSubtotals,
             DataViewFirstPage,
         );
-        const tableDescriptor = TableDescriptor.for(dv);
+        const tableDescriptor = TableDescriptor.for(dv, "empty value");
         const headerItems = dv.meta().allHeaders();
 
         expect(

--- a/libs/sdk-ui-pivot/src/impl/drilling/tests/drilling.fixture.ts
+++ b/libs/sdk-ui-pivot/src/impl/drilling/tests/drilling.fixture.ts
@@ -14,6 +14,7 @@ export const TwoMeasuresWithTwoRowAndTwoColumnAttributes = recordedDataFacade(
 );
 export const TwoMeasuresWithTwoRowAndTwoColumnAttributesDescriptor = TableDescriptor.for(
     TwoMeasuresWithTwoRowAndTwoColumnAttributes,
+    "empty value",
 );
 export const OneMeasureAndRepeatingRowAttributesOnDifferentPositions = recordedDataFacade(
     ReferenceRecordings.Scenarios.PivotTable.OneMeasureAndRepeatingRowAttributesOnDifferentPositions,

--- a/libs/sdk-ui-pivot/src/impl/resizing/tests/columnSizing.fixture.ts
+++ b/libs/sdk-ui-pivot/src/impl/resizing/tests/columnSizing.fixture.ts
@@ -12,21 +12,27 @@ const ColumnOnlyResult = recordedDataFacade(
     DataViewFirstPage,
 );
 
-export const ColumnOnlyResultDescriptor = TableDescriptor.for(ColumnOnlyResult);
+export const ColumnOnlyResultDescriptor = TableDescriptor.for(ColumnOnlyResult, "empty value");
 
 export const TwoMeasuresWithRowAttribute = recordedDataFacade(
     ReferenceRecordings.Scenarios.PivotTable.TwoMeasuresWithRowAttribute,
     DataViewFirstPage,
 );
 
-export const TwoMeasuresWithRowAttributeDescriptor = TableDescriptor.for(TwoMeasuresWithRowAttribute);
+export const TwoMeasuresWithRowAttributeDescriptor = TableDescriptor.for(
+    TwoMeasuresWithRowAttribute,
+    "empty value",
+);
 
 const SingleMeasureWithRowAttribute = recordedDataFacade(
     ReferenceRecordings.Scenarios.PivotTable.SingleMeasureWithRowAttribute,
     DataViewFirstPage,
 );
 
-export const SingleMeasureWithRowAttributeDescriptor = TableDescriptor.for(SingleMeasureWithRowAttribute);
+export const SingleMeasureWithRowAttributeDescriptor = TableDescriptor.for(
+    SingleMeasureWithRowAttribute,
+    "empty value",
+);
 
 export const TwoMeasuresWithTwoRowAndTwoColumnAttributes = recordedDataFacade(
     ReferenceRecordings.Scenarios.PivotTable.TwoMeasuresWithTwoRowAndTwoColumnAttributes,
@@ -34,6 +40,7 @@ export const TwoMeasuresWithTwoRowAndTwoColumnAttributes = recordedDataFacade(
 );
 export const TwoMeasuresWithTwoRowAndTwoColumnAttributesDescriptor = TableDescriptor.for(
     TwoMeasuresWithTwoRowAndTwoColumnAttributes,
+    "empty value",
 );
 
 export function testStore(

--- a/libs/sdk-ui-pivot/src/impl/resizing/tests/updateColDefs.test.ts
+++ b/libs/sdk-ui-pivot/src/impl/resizing/tests/updateColDefs.test.ts
@@ -21,7 +21,7 @@ import { ReferenceData, ReferenceMd } from "@gooddata/reference-workspace";
 //  as the ColDefs has will be updated during test runs.
 describe("updateColumnDefinitionsWithWidths", () => {
     it("should enrich colDefs based on column width items", () => {
-        const table = TableDescriptor.for(TwoMeasuresWithTwoRowAndTwoColumnAttributes);
+        const table = TableDescriptor.for(TwoMeasuresWithTwoRowAndTwoColumnAttributes, "empty value");
         const widths: ColumnWidthItem[] = [
             newWidthForSelectedColumns(
                 ReferenceMd.Amount,
@@ -47,7 +47,7 @@ describe("updateColumnDefinitionsWithWidths", () => {
     });
 
     it("should enrich colDefs when mix of manual and auto-resizing", () => {
-        const table = TableDescriptor.for(TwoMeasuresWithRowAttribute);
+        const table = TableDescriptor.for(TwoMeasuresWithRowAttribute, "empty value");
         const store = testStore(table, newWidthForAllMeasureColumns(200));
 
         // note: size of c_1 should be ignored because manual setting above (to 200) should have preference
@@ -65,7 +65,7 @@ describe("updateColumnDefinitionsWithWidths", () => {
     });
 
     it("should enrich colDefs when mix of manual and auto-resizing and grow-to-fit on", () => {
-        const table = TableDescriptor.for(TwoMeasuresWithRowAttribute);
+        const table = TableDescriptor.for(TwoMeasuresWithRowAttribute, "empty value");
         const store = testStore(table, newWidthForSelectedColumns(ReferenceMd.Won, [], 200));
 
         updateColumnDefinitionsWithWidths(table, store, { r_0: { width: 100 } }, 666, true, {
@@ -77,7 +77,7 @@ describe("updateColumnDefinitionsWithWidths", () => {
     });
 
     it("should set with to default if no other size specification provided", () => {
-        const table = TableDescriptor.for(TwoMeasuresWithRowAttribute);
+        const table = TableDescriptor.for(TwoMeasuresWithRowAttribute, "empty value");
         const store = testStore(table);
 
         updateColumnDefinitionsWithWidths(table, store, {}, 666, false, {});
@@ -87,7 +87,7 @@ describe("updateColumnDefinitionsWithWidths", () => {
     });
 
     it("should set maxWidth to undefined when growToFit width is bigger than MANUALLY_SIZED_MAX_WIDTH", () => {
-        const table = TableDescriptor.for(TwoMeasuresWithRowAttribute);
+        const table = TableDescriptor.for(TwoMeasuresWithRowAttribute, "empty value");
         const store = testStore(table);
 
         updateColumnDefinitionsWithWidths(table, store, {}, 100, true, {

--- a/libs/sdk-ui-pivot/src/impl/structure/colDefFactory.ts
+++ b/libs/sdk-ui-pivot/src/impl/structure/colDefFactory.ts
@@ -26,6 +26,7 @@ type TransformState = {
     rootColDefs: Array<ColDef | ColGroupDef>;
     leafColDefs: Array<ColDef>;
     allColDefs: Array<ColDef | ColGroupDef>;
+    emptyHeaderName: string;
 };
 
 function getSortProp(
@@ -74,7 +75,7 @@ function createColumnGroupColDef(col: ScopeCol, state: TransformState): ColDef |
         const colDef: ColDef = {
             type: COLUMN_ATTRIBUTE_COLUMN,
             colId: col.id,
-            headerName: col.header.attributeHeaderItem.name ?? "NULL", // TODO RAIL-4360 localize this when the null strings are available
+            headerName: col.header.attributeHeaderItem.name || state.emptyHeaderName, // TODO RAIL-4360 distinguish between empty and null
         };
 
         state.allColDefs.push(colDef);
@@ -84,7 +85,7 @@ function createColumnGroupColDef(col: ScopeCol, state: TransformState): ColDef |
     } else {
         const colGroup: ColGroupDef = {
             groupId: col.id,
-            headerName: col.header.attributeHeaderItem.name ?? "NULL", // TODO RAIL-4360 localize this when the null strings are available
+            headerName: col.header.attributeHeaderItem.name || state.emptyHeaderName, // TODO RAIL-4360 distinguish between empty and null
             children,
         };
 
@@ -167,8 +168,13 @@ function createAndAddDataColDefs(table: TableCols, state: TransformState) {
  *
  * @param table - table col descriptors
  * @param initialSorts - initial table sorting definition
+ * @param emptyHeaderName - what to show for empty headers
  */
-export function createColDefsFromTableDescriptor(table: TableCols, initialSorts: ISortItem[]): TableColDefs {
+export function createColDefsFromTableDescriptor(
+    table: TableCols,
+    initialSorts: ISortItem[],
+    emptyHeaderName: string,
+): TableColDefs {
     const state: TransformState = {
         initialSorts,
         cellRendererPlaced: undefined,
@@ -176,6 +182,7 @@ export function createColDefsFromTableDescriptor(table: TableCols, initialSorts:
         allColDefs: [],
         leafColDefs: [],
         rowColDefs: [],
+        emptyHeaderName,
     };
 
     createAndAddSliceColDefs(table.sliceCols, state);

--- a/libs/sdk-ui-pivot/src/impl/structure/colDefFactory.ts
+++ b/libs/sdk-ui-pivot/src/impl/structure/colDefFactory.ts
@@ -18,6 +18,7 @@ import {
 } from "./tableDescriptorTypes";
 import { ISortItem, sortDirection } from "@gooddata/sdk-model";
 import { attributeSortMatcher, measureSortMatcher } from "./colSortItemMatching";
+import { valueWithEmptyHandling } from "@gooddata/sdk-ui-vis-commons";
 
 type TransformState = {
     initialSorts: ISortItem[];
@@ -26,7 +27,7 @@ type TransformState = {
     rootColDefs: Array<ColDef | ColGroupDef>;
     leafColDefs: Array<ColDef>;
     allColDefs: Array<ColDef | ColGroupDef>;
-    emptyHeaderName: string;
+    emptyHeaderTitle: string;
 };
 
 function getSortProp(
@@ -75,7 +76,7 @@ function createColumnGroupColDef(col: ScopeCol, state: TransformState): ColDef |
         const colDef: ColDef = {
             type: COLUMN_ATTRIBUTE_COLUMN,
             colId: col.id,
-            headerName: col.header.attributeHeaderItem.name || state.emptyHeaderName, // TODO RAIL-4360 distinguish between empty and null
+            headerName: valueWithEmptyHandling(col.header.attributeHeaderItem.name, state.emptyHeaderTitle),
         };
 
         state.allColDefs.push(colDef);
@@ -85,7 +86,7 @@ function createColumnGroupColDef(col: ScopeCol, state: TransformState): ColDef |
     } else {
         const colGroup: ColGroupDef = {
             groupId: col.id,
-            headerName: col.header.attributeHeaderItem.name || state.emptyHeaderName, // TODO RAIL-4360 distinguish between empty and null
+            headerName: valueWithEmptyHandling(col.header.attributeHeaderItem.name, state.emptyHeaderTitle),
             children,
         };
 
@@ -168,12 +169,12 @@ function createAndAddDataColDefs(table: TableCols, state: TransformState) {
  *
  * @param table - table col descriptors
  * @param initialSorts - initial table sorting definition
- * @param emptyHeaderName - what to show for empty headers
+ * @param emptyHeaderTitle - what to show for title of headers with empty title
  */
 export function createColDefsFromTableDescriptor(
     table: TableCols,
     initialSorts: ISortItem[],
-    emptyHeaderName: string,
+    emptyHeaderTitle: string,
 ): TableColDefs {
     const state: TransformState = {
         initialSorts,
@@ -182,7 +183,7 @@ export function createColDefsFromTableDescriptor(
         allColDefs: [],
         leafColDefs: [],
         rowColDefs: [],
-        emptyHeaderName,
+        emptyHeaderTitle,
     };
 
     createAndAddSliceColDefs(table.sliceCols, state);

--- a/libs/sdk-ui-pivot/src/impl/structure/headers/tests/AggregationsMenu.test.tsx
+++ b/libs/sdk-ui-pivot/src/impl/structure/headers/tests/AggregationsMenu.test.tsx
@@ -29,7 +29,7 @@ describe("AggregationsMenu", () => {
         ReferenceRecordings.Scenarios.PivotTable.SingleMeasureWithTwoRowAndOneColumnAttributes,
         DataViewFirstPage,
     );
-    const tableDescriptor = TableDescriptor.for(fixture);
+    const tableDescriptor = TableDescriptor.for(fixture, "empty value");
     const getExecutionDefinition = () => emptyDef("testWorkspace");
     const getTotals = () => [] as ITotal[];
     const getTableDescriptor = () => tableDescriptor;
@@ -140,7 +140,7 @@ describe("AggregationsMenu", () => {
             ReferenceRecordings.Scenarios.PivotTable.TwoMeasuresWithColumnAttribute,
             DataViewFirstPage,
         );
-        const tableDescriptor = TableDescriptor.for(fixture);
+        const tableDescriptor = TableDescriptor.for(fixture, "empty value");
 
         const wrapper = render({
             showSubmenu: true,

--- a/libs/sdk-ui-pivot/src/impl/structure/headers/tests/ColumnHeader.test.tsx
+++ b/libs/sdk-ui-pivot/src/impl/structure/headers/tests/ColumnHeader.test.tsx
@@ -14,7 +14,7 @@ const fixture = recordedDataFacade(
     ReferenceRecordings.Scenarios.PivotTable.SingleMeasureWithTwoRowAndOneColumnAttributes,
     DataViewFirstPage,
 );
-const tableDescriptor = TableDescriptor.for(fixture);
+const tableDescriptor = TableDescriptor.for(fixture, "empty value");
 
 const getColumnHeader = (
     props = {},
@@ -67,7 +67,7 @@ describe("ColumnHeader renderer", () => {
             getColumnHeader(
                 { enableSorting: true },
                 { type: "COLUMN_ATTRIBUTE_COLUMN", colGroupId: "cg_0" },
-                TableDescriptor.for(SingleColumn),
+                TableDescriptor.for(SingleColumn, "empty value"),
             ),
         );
         expect(component.find(HeaderCell).props()).toHaveProperty("enableSorting", false);

--- a/libs/sdk-ui-pivot/src/impl/structure/headers/tests/HeaderCell.test.tsx
+++ b/libs/sdk-ui-pivot/src/impl/structure/headers/tests/HeaderCell.test.tsx
@@ -13,7 +13,7 @@ describe("HeaderCell renderer", () => {
         ReferenceRecordings.Scenarios.PivotTable.SingleMeasureWithTwoRowAndOneColumnAttributes,
         DataViewFirstPage,
     );
-    const tableDescriptor = TableDescriptor.for(fixture);
+    const tableDescriptor = TableDescriptor.for(fixture, "empty value");
     const getTableDescriptor = () => tableDescriptor;
 
     it("should render text for the cell", () => {

--- a/libs/sdk-ui-pivot/src/impl/structure/tableDescriptor.ts
+++ b/libs/sdk-ui-pivot/src/impl/structure/tableDescriptor.ts
@@ -75,9 +75,10 @@ export class TableDescriptor {
      * Creates a new table descriptor from the provided data view facade.
      *
      * @param dv - data view facade
+     * @param emptyHeaderName - what to show for empty headers
      */
-    public static for(dv: DataViewFacade): TableDescriptor {
-        const { headers, colDefs } = createHeadersAndColDefs(dv);
+    public static for(dv: DataViewFacade, emptyHeaderName: string): TableDescriptor {
+        const { headers, colDefs } = createHeadersAndColDefs(dv, emptyHeaderName);
 
         invariant(headers.leafDataCols.length === colDefs.leafDataColDefs.length);
 

--- a/libs/sdk-ui-pivot/src/impl/structure/tableDescriptor.ts
+++ b/libs/sdk-ui-pivot/src/impl/structure/tableDescriptor.ts
@@ -75,10 +75,10 @@ export class TableDescriptor {
      * Creates a new table descriptor from the provided data view facade.
      *
      * @param dv - data view facade
-     * @param emptyHeaderName - what to show for empty headers
+     * @param emptyHeaderTitle - what to show for title of headers with empty title
      */
-    public static for(dv: DataViewFacade, emptyHeaderName: string): TableDescriptor {
-        const { headers, colDefs } = createHeadersAndColDefs(dv, emptyHeaderName);
+    public static for(dv: DataViewFacade, emptyHeaderTitle: string): TableDescriptor {
+        const { headers, colDefs } = createHeadersAndColDefs(dv, emptyHeaderTitle);
 
         invariant(headers.leafDataCols.length === colDefs.leafDataColDefs.length);
 

--- a/libs/sdk-ui-pivot/src/impl/structure/tableDescriptorFactory.ts
+++ b/libs/sdk-ui-pivot/src/impl/structure/tableDescriptorFactory.ts
@@ -295,18 +295,18 @@ function createTableHeaders(dv: DataViewFacade): TableCols {
  * This function is not intended for stand-alone usage. It used during construction of TableDescriptor.
  *
  * @param dv - data view facade
- * @param emptyHeaderName - what to show for empty headers
+ * @param emptyHeaderTitle - what to show for title of headers with empty title
  * @internal
  */
 export function createHeadersAndColDefs(
     dv: DataViewFacade,
-    emptyHeaderName: string,
+    emptyHeaderTitle: string,
 ): { headers: TableCols; colDefs: TableColDefs } {
     const headers = createTableHeaders(dv);
     const colDefs = createColDefsFromTableDescriptor(
         headers,
         dv.meta().effectiveSortItems(),
-        emptyHeaderName,
+        emptyHeaderTitle,
     );
 
     return { headers, colDefs };

--- a/libs/sdk-ui-pivot/src/impl/structure/tableDescriptorFactory.ts
+++ b/libs/sdk-ui-pivot/src/impl/structure/tableDescriptorFactory.ts
@@ -295,11 +295,19 @@ function createTableHeaders(dv: DataViewFacade): TableCols {
  * This function is not intended for stand-alone usage. It used during construction of TableDescriptor.
  *
  * @param dv - data view facade
+ * @param emptyHeaderName - what to show for empty headers
  * @internal
  */
-export function createHeadersAndColDefs(dv: DataViewFacade): { headers: TableCols; colDefs: TableColDefs } {
+export function createHeadersAndColDefs(
+    dv: DataViewFacade,
+    emptyHeaderName: string,
+): { headers: TableCols; colDefs: TableColDefs } {
     const headers = createTableHeaders(dv);
-    const colDefs = createColDefsFromTableDescriptor(headers, dv.meta().effectiveSortItems());
+    const colDefs = createColDefsFromTableDescriptor(
+        headers,
+        dv.meta().effectiveSortItems(),
+        emptyHeaderName,
+    );
 
     return { headers, colDefs };
 }

--- a/libs/sdk-ui-pivot/src/impl/structure/tests/columnLocatorFactory.test.ts
+++ b/libs/sdk-ui-pivot/src/impl/structure/tests/columnLocatorFactory.test.ts
@@ -10,19 +10,19 @@ import { ScopeCol } from "../tableDescriptorTypes";
 
 describe("createColumnLocator", () => {
     it("creates valid leaf column locator in table without column attributes", () => {
-        const t = TableDescriptor.for(SingleMeasureWithRowAttribute);
+        const t = TableDescriptor.for(SingleMeasureWithRowAttribute, "empty value");
 
         expect(createColumnLocator(t.headers.leafDataCols[0])).toMatchSnapshot();
     });
 
     it("creates valid leaf column locator in table with column attributes", () => {
-        const t = TableDescriptor.for(SingleMeasureWithTwoRowAndTwoColumnAttributes);
+        const t = TableDescriptor.for(SingleMeasureWithTwoRowAndTwoColumnAttributes, "empty value");
 
         expect(createColumnLocator(t.headers.leafDataCols[0])).toMatchSnapshot();
     });
 
     it("creates valid group column locator for top-level group in table with column attributes", () => {
-        const t = TableDescriptor.for(SingleMeasureWithTwoRowAndTwoColumnAttributes);
+        const t = TableDescriptor.for(SingleMeasureWithTwoRowAndTwoColumnAttributes, "empty value");
 
         const topLevelGroup = t.headers.rootDataCols[0].children[0] as ScopeCol;
 
@@ -30,7 +30,7 @@ describe("createColumnLocator", () => {
     });
 
     it("creates valid group column locator for second-level group in table with column attributes", () => {
-        const t = TableDescriptor.for(SingleMeasureWithTwoRowAndTwoColumnAttributes);
+        const t = TableDescriptor.for(SingleMeasureWithTwoRowAndTwoColumnAttributes, "empty value");
 
         const secondLevelGroup = t.headers.rootDataCols[0].children[0].children[0] as ScopeCol;
 

--- a/libs/sdk-ui-pivot/src/impl/structure/tests/columnLocatorMatching.test.ts
+++ b/libs/sdk-ui-pivot/src/impl/structure/tests/columnLocatorMatching.test.ts
@@ -152,7 +152,7 @@ describe("searchForLocatorMatch", () => {
     ];
 
     it.each(Scenarios)("%s", (_desc, locators, dv, expected) => {
-        const tableDescriptor = createHeadersAndColDefs(dv);
+        const tableDescriptor = createHeadersAndColDefs(dv, "empty value");
         const result = searchForLocatorMatch(tableDescriptor.headers.rootDataCols, locators);
 
         expect(result?.id).toEqual(expected);

--- a/libs/sdk-ui-pivot/src/impl/structure/tests/columnSortItemFactory.test.ts
+++ b/libs/sdk-ui-pivot/src/impl/structure/tests/columnSortItemFactory.test.ts
@@ -10,25 +10,25 @@ import { createSortItemForCol } from "../colSortItemFactory";
 
 describe("createSortItem", () => {
     it("creates valid attribute sort", () => {
-        const t = TableDescriptor.for(SingleMeasureWithRowAttribute);
+        const t = TableDescriptor.for(SingleMeasureWithRowAttribute, "empty value");
 
         expect(createSortItemForCol(t.headers.sliceCols[0], "asc")).toMatchSnapshot();
     });
 
     it("creates valid measure sort item when no column attributes", () => {
-        const t = TableDescriptor.for(SingleMeasureWithRowAttribute);
+        const t = TableDescriptor.for(SingleMeasureWithRowAttribute, "empty value");
 
         expect(createSortItemForCol(t.headers.leafDataCols[0], "asc")).toMatchSnapshot();
     });
 
     it("creates valid measure sort item when single column attribute", () => {
-        const t = TableDescriptor.for(SingleMeasureWithColumnAttribute);
+        const t = TableDescriptor.for(SingleMeasureWithColumnAttribute, "empty value");
 
         expect(createSortItemForCol(t.headers.leafDataCols[0], "desc")).toMatchSnapshot();
     });
 
     it("creates valid measure sort item when two attributes", () => {
-        const t = TableDescriptor.for(SingleMeasureWithTwoRowAndTwoColumnAttributes);
+        const t = TableDescriptor.for(SingleMeasureWithTwoRowAndTwoColumnAttributes, "empty value");
 
         expect(createSortItemForCol(t.headers.leafDataCols[0], "desc")).toMatchSnapshot();
     });

--- a/libs/sdk-ui-pivot/src/impl/structure/tests/tableDescriptor.test.ts
+++ b/libs/sdk-ui-pivot/src/impl/structure/tests/tableDescriptor.test.ts
@@ -15,48 +15,60 @@ import { ReferenceMd } from "@gooddata/reference-workspace";
 describe("TableDescriptor", () => {
     describe("isFirstCol", () => {
         it("should identify first col in row attribute only table", () => {
-            expect(TableDescriptor.for(SingleAttribute).isFirstCol("r_0")).toBeTruthy();
+            expect(TableDescriptor.for(SingleAttribute, "empty value").isFirstCol("r_0")).toBeTruthy();
         });
 
         it("should identify first col in measure only table", () => {
-            expect(TableDescriptor.for(TwoMeasures).isFirstCol("c_0")).toBeTruthy();
+            expect(TableDescriptor.for(TwoMeasures, "empty value").isFirstCol("c_0")).toBeTruthy();
         });
 
         it("should identify first col in table with row and measure", () => {
-            expect(TableDescriptor.for(SingleMeasureWithRowAttribute).isFirstCol("r_0")).toBeTruthy();
+            expect(
+                TableDescriptor.for(SingleMeasureWithRowAttribute, "empty value").isFirstCol("r_0"),
+            ).toBeTruthy();
         });
 
         it("should identify first col in column attribute only table", () => {
-            expect(TableDescriptor.for(SingleColumn).isFirstCol("cg_0")).toBeTruthy();
+            expect(TableDescriptor.for(SingleColumn, "empty value").isFirstCol("cg_0")).toBeTruthy();
         });
 
         it("should identify first col in table without row attribute", () => {
-            expect(TableDescriptor.for(SingleMeasureWithColumnAttribute).isFirstCol("g_0")).toBeTruthy();
-            expect(TableDescriptor.for(SingleMeasureWithColumnAttribute).isFirstCol("c_0")).toBeTruthy();
+            expect(
+                TableDescriptor.for(SingleMeasureWithColumnAttribute, "empty value").isFirstCol("g_0"),
+            ).toBeTruthy();
+            expect(
+                TableDescriptor.for(SingleMeasureWithColumnAttribute, "empty value").isFirstCol("c_0"),
+            ).toBeTruthy();
         });
 
         it("should identify first col in table with row and col attributes", () => {
             expect(
-                TableDescriptor.for(SingleMeasureWithTwoRowAndTwoColumnAttributes).isFirstCol("r_0"),
+                TableDescriptor.for(SingleMeasureWithTwoRowAndTwoColumnAttributes, "empty value").isFirstCol(
+                    "r_0",
+                ),
             ).toBeTruthy();
         });
     });
 
     describe("hasGroupedDataCols", () => {
         it("should be true for table with column attributes", () => {
-            expect(TableDescriptor.for(SingleMeasureWithColumnAttribute).hasScopingCols()).toBeTruthy();
+            expect(
+                TableDescriptor.for(SingleMeasureWithColumnAttribute, "empty value").hasScopingCols(),
+            ).toBeTruthy();
         });
 
         it("should be false for table without column attributes", () => {
-            expect(TableDescriptor.for(SingleAttribute).hasScopingCols()).toBeFalsy();
-            expect(TableDescriptor.for(TwoMeasures).hasScopingCols()).toBeFalsy();
-            expect(TableDescriptor.for(SingleMeasureWithRowAttribute).hasScopingCols()).toBeFalsy();
+            expect(TableDescriptor.for(SingleAttribute, "empty value").hasScopingCols()).toBeFalsy();
+            expect(TableDescriptor.for(TwoMeasures, "empty value").hasScopingCols()).toBeFalsy();
+            expect(
+                TableDescriptor.for(SingleMeasureWithRowAttribute, "empty value").hasScopingCols(),
+            ).toBeFalsy();
         });
     });
 
     describe("getAbsoluteLeafColIndex", () => {
         it("should return correct indexes in table with just measures", () => {
-            const table = TableDescriptor.for(TwoMeasures);
+            const table = TableDescriptor.for(TwoMeasures, "empty value");
             const [firstCol, secondCol]: SeriesCol[] = table.headers.leafDataCols as any;
 
             expect(table.getAbsoluteLeafColIndex(firstCol)).toEqual(0);
@@ -64,7 +76,7 @@ describe("TableDescriptor", () => {
         });
 
         it("should return correct indexes in table with measure and row", () => {
-            const table = TableDescriptor.for(SingleMeasureWithRowAttribute);
+            const table = TableDescriptor.for(SingleMeasureWithRowAttribute, "empty value");
             const [firstCol]: SeriesCol[] = table.headers.leafDataCols as any;
 
             expect(table.getAbsoluteLeafColIndex(table.headers.sliceCols[0])).toEqual(0);
@@ -72,7 +84,7 @@ describe("TableDescriptor", () => {
         });
 
         it("should return correct indexes in table with just columns", () => {
-            const table = TableDescriptor.for(SingleColumn);
+            const table = TableDescriptor.for(SingleColumn, "empty value");
             const [firstCol, secondCol]: ScopeCol[] = table.headers.leafDataCols as any;
 
             expect(table.getAbsoluteLeafColIndex(firstCol)).toEqual(0);
@@ -83,32 +95,38 @@ describe("TableDescriptor", () => {
     describe("matchAttributeWidthItem", () => {
         it("should match row attribute in pivot table", () => {
             expect(
-                TableDescriptor.for(SingleMeasureWithTwoRowAndTwoColumnAttributes).matchAttributeWidthItem(
-                    newWidthForAttributeColumn(ReferenceMd.Product.Name, 100),
-                ),
+                TableDescriptor.for(
+                    SingleMeasureWithTwoRowAndTwoColumnAttributes,
+                    "empty value",
+                ).matchAttributeWidthItem(newWidthForAttributeColumn(ReferenceMd.Product.Name, 100)),
             ).toBeTruthy();
         });
 
         it("should not match column attribute in pivot table", () => {
             expect(
-                TableDescriptor.for(SingleMeasureWithTwoRowAndTwoColumnAttributes).matchAttributeWidthItem(
-                    newWidthForAttributeColumn(ReferenceMd.Region, 100),
-                ),
+                TableDescriptor.for(
+                    SingleMeasureWithTwoRowAndTwoColumnAttributes,
+                    "empty value",
+                ).matchAttributeWidthItem(newWidthForAttributeColumn(ReferenceMd.Region, 100)),
             ).toBeUndefined();
         });
     });
 
     describe("canTableHaveTotals", () => {
         it("should return false for table without row attribute", () => {
-            expect(TableDescriptor.for(SingleMeasureWithColumnAttribute).canTableHaveTotals()).toBeFalsy();
+            expect(
+                TableDescriptor.for(SingleMeasureWithColumnAttribute, "empty value").canTableHaveTotals(),
+            ).toBeFalsy();
         });
 
         it("should return false for table without measures", () => {
-            expect(TableDescriptor.for(SingleAttribute).canTableHaveTotals()).toBeFalsy();
+            expect(TableDescriptor.for(SingleAttribute, "empty value").canTableHaveTotals()).toBeFalsy();
         });
 
         it("should return true for table with row and measure", () => {
-            expect(TableDescriptor.for(SingleMeasureWithRowAttribute).canTableHaveTotals()).toBeTruthy();
+            expect(
+                TableDescriptor.for(SingleMeasureWithRowAttribute, "empty value").canTableHaveTotals(),
+            ).toBeTruthy();
         });
     });
 });

--- a/libs/sdk-ui-pivot/src/impl/structure/tests/tableDescriptorFactory.test.ts
+++ b/libs/sdk-ui-pivot/src/impl/structure/tests/tableDescriptorFactory.test.ts
@@ -32,14 +32,14 @@ describe("createTableDescriptor", () => {
     ];
 
     it.each(Scenarios)("correctly populates fullIndexPaths for %s", (_desc, dv) => {
-        const descriptor = createHeadersAndColDefs(dv);
+        const descriptor = createHeadersAndColDefs(dv, "empty value");
         const fullIndexPaths = descriptor.headers.leafDataCols.map((col) => col.fullIndexPathToHere);
 
         expect(fullIndexPaths).toMatchSnapshot();
     });
 
     it.each(Scenarios)("correctly creates colDefs for %s", (_desc, dv) => {
-        const descriptor = createHeadersAndColDefs(dv);
+        const descriptor = createHeadersAndColDefs(dv, "empty value");
         const allCols: Array<ColDef | ColGroupDef> = [];
 
         allCols.push(...descriptor.colDefs.sliceColDefs);

--- a/libs/sdk-ui-pivot/src/impl/tableFacade.ts
+++ b/libs/sdk-ui-pivot/src/impl/tableFacade.ts
@@ -4,6 +4,7 @@ import { IDataView, IExecutionResult, IPreparedExecution } from "@gooddata/sdk-b
 import {
     createExportFunction,
     DataViewFacade,
+    emptyHeaderTitleFromIntl,
     IAvailableDrillTargets,
     IExportFunction,
 } from "@gooddata/sdk-ui";
@@ -134,10 +135,7 @@ export class TableFacade {
         this.currentResult = result;
         this.visibleData = DataViewFacade.for(dataView);
         this.currentFingerprint = defFingerprint(this.currentResult.definition);
-        this.tableDescriptor = TableDescriptor.for(
-            this.visibleData,
-            `(${props.intl.formatMessage({ id: "visualization.emptyValue" })})`,
-        );
+        this.tableDescriptor = TableDescriptor.for(this.visibleData, emptyHeaderTitleFromIntl(props.intl));
 
         this.autoResizedColumns = {};
         this.growToFittedColumns = {};

--- a/libs/sdk-ui-vis-commons/api/sdk-ui-vis-commons.api.md
+++ b/libs/sdk-ui-vis-commons/api/sdk-ui-vis-commons.api.md
@@ -520,4 +520,7 @@ export class StaticLegend extends React_2.PureComponent<IStaticLegendProps> {
 // @internal (undocumented)
 export const SupportedLegendPositions: PositionType[];
 
+// @internal
+export function valueWithEmptyHandling(value: string | undefined | null, emptyValueText: string): string;
+
 ```

--- a/libs/sdk-ui-vis-commons/api/sdk-ui-vis-commons.api.md
+++ b/libs/sdk-ui-vis-commons/api/sdk-ui-vis-commons.api.md
@@ -71,7 +71,7 @@ export const DEFAULT_LEGEND_CONFIG: {
     position: PositionType;
 };
 
-// @public
+// @public @deprecated
 export function fixEmptyHeaderItems(dataView: IDataView, emptyHeaderString: string): void;
 
 // @internal (undocumented)

--- a/libs/sdk-ui-vis-commons/src/index.ts
+++ b/libs/sdk-ui-vis-commons/src/index.ts
@@ -73,6 +73,7 @@ export {
 } from "./legend/types";
 
 export { fixEmptyHeaderItems } from "./utils/fixEmptyHeaderItems";
+export { valueWithEmptyHandling } from "./utils/valueWithEmptyHandling";
 
 export { shouldRenderPagination, calculateHeadlineHeightFontSize } from "./utils/calculateCustomHeight";
 export { getHeadlineResponsiveClassName } from "./utils/headlineResponsiveClassName";

--- a/libs/sdk-ui-vis-commons/src/utils/fixEmptyHeaderItems.ts
+++ b/libs/sdk-ui-vis-commons/src/utils/fixEmptyHeaderItems.ts
@@ -1,4 +1,4 @@
-// (C) 2007-2020 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 import { IDataView } from "@gooddata/sdk-backend-spi";
 
 /**
@@ -7,6 +7,7 @@ import { IDataView } from "@gooddata/sdk-backend-spi";
  *
  * @param dataView - view to mutate
  * @param emptyHeaderString - value to use for empty strings
+ * @deprecated try to avoid using this function and handle empty headers when displaying them
  * @public
  */
 export function fixEmptyHeaderItems(dataView: IDataView, emptyHeaderString: string): void {

--- a/libs/sdk-ui-vis-commons/src/utils/valueWithEmptyHandling.ts
+++ b/libs/sdk-ui-vis-commons/src/utils/valueWithEmptyHandling.ts
@@ -1,0 +1,12 @@
+// (C) 2022 GoodData Corporation
+
+/**
+ * Returns the value if it is non-empty or a fallback text.
+ *
+ * @param value - value to handle
+ * @param emptyValueText - text to display if value is empty
+ * @internal
+ */
+export function valueWithEmptyHandling(value: string | undefined | null, emptyValueText: string): string {
+    return value || emptyValueText; // TODO: RAIL-4360 distinguish between empty and null
+}

--- a/libs/sdk-ui/api/sdk-ui.api.md
+++ b/libs/sdk-ui/api/sdk-ui.api.md
@@ -374,6 +374,9 @@ export class DynamicScriptLoadSdkError extends GoodDataSdkError {
     constructor(message?: string, cause?: Error);
 }
 
+// @internal
+export function emptyHeaderTitleFromIntl(intl: IntlShape): string;
+
 // @public
 export const ErrorCodes: {
     BAD_REQUEST: string;

--- a/libs/sdk-ui/src/base/index.tsx
+++ b/libs/sdk-ui/src/base/index.tsx
@@ -176,8 +176,7 @@ export {
     ITranslationsProviderOwnProps,
     ITranslationsProviderProps,
 } from "./localization/TranslationsProvider";
-// FIXME: temp build fix
-export { createIntlMock, withIntl, resolveLocale } from "./localization/intlUtils";
+export { createIntlMock, withIntl, resolveLocale, emptyHeaderTitleFromIntl } from "./localization/intlUtils";
 export {
     ITranslationsCustomizationContextProviderProps,
     TranslationsCustomizationContextProvider,

--- a/libs/sdk-ui/src/base/localization/TranslationsProvider.tsx
+++ b/libs/sdk-ui/src/base/localization/TranslationsProvider.tsx
@@ -2,6 +2,7 @@
 import React from "react";
 import { injectIntl, WrappedComponentProps, IntlShape } from "react-intl";
 import { messages } from "../../locales";
+import { emptyHeaderTitleFromIntl } from "./intlUtils";
 
 /**
  * @internal
@@ -37,15 +38,10 @@ export class TranslationsProvider extends React.PureComponent<ITranslationsProvi
     public render() {
         const props: ITranslationsComponentProps = {
             numericSymbols: getNumericSymbols(this.props.intl),
-            emptyHeaderString: this.getEmptyHeaderString(),
+            emptyHeaderString: emptyHeaderTitleFromIntl(this.props.intl),
             intl: this.props.intl,
         };
         return this.props.children(props);
-    }
-
-    private getEmptyHeaderString() {
-        const emptyValueTranslation = this.props.intl.formatMessage({ id: "visualization.emptyValue" });
-        return `(${emptyValueTranslation})`;
     }
 }
 

--- a/libs/sdk-ui/src/base/localization/intlUtils.tsx
+++ b/libs/sdk-ui/src/base/localization/intlUtils.tsx
@@ -51,3 +51,12 @@ export function withIntl<P>(
 export const resolveLocale = (locale: unknown): ILocale => {
     return isLocale(locale) ? locale : DefaultLocale;
 };
+
+/**
+ * Returns a string meant to represent a header with an empty value.
+ * @param intl - the source of i18n strings
+ * @internal
+ */
+export function emptyHeaderTitleFromIntl(intl: IntlShape): string {
+    return `(${intl.formatMessage({ id: "visualization.emptyValue" })})`;
+}

--- a/libs/sdk-ui/src/base/vis/drilling.ts
+++ b/libs/sdk-ui/src/base/vis/drilling.ts
@@ -145,7 +145,7 @@ function convertToEmpty(attributeItem: IResultAttributeHeader) {
         attributeHeaderItem: {
             ...attributeHeaderItem,
             // Send empty string for not, need to be updated for NULL in future
-            name: isEmpty ? "" : attributeHeaderItem.name,
+            name: isEmpty ? "" : attributeHeaderItem.name ?? "",
         },
     };
 }


### PR DESCRIPTION
Removes the fixEmptyHeaderItems usage. This means that drilling on empty item returns item with name correctly set to "" instead of localized "(empty value)". This in turn makes drill to insight work properly in the Dashboard component with empty values.

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
