### PR TITLE
Measure dropdown has blank space if the bucket contains incomplete AM

### DIFF
--- a/libs/sdk-ui-kit/src/ChartSorting/MeasureDropdown/MeasureDropdown.tsx
+++ b/libs/sdk-ui-kit/src/ChartSorting/MeasureDropdown/MeasureDropdown.tsx
@@ -60,13 +60,15 @@ const getItems = (
     if (measures) {
         measures.forEach((measure) => {
             const measureLocator = measure.locators.find(isMeasureLocator);
-            const bucket = measureNames[measureLocator.measureLocatorItem.measureIdentifier];
-            measureValues.push({
-                id: measureLocator.measureLocatorItem.measureIdentifier,
-                title: bucket?.name,
-                sequenceNumber: bucket?.sequenceNumber,
-                localIdentifier: measureLocator.measureLocatorItem.measureIdentifier,
-            });
+            const bucketItem = measureNames[measureLocator.measureLocatorItem.measureIdentifier];
+            if (bucketItem) {
+                measureValues.push({
+                    id: measureLocator.measureLocatorItem.measureIdentifier,
+                    title: bucketItem?.name,
+                    sequenceNumber: bucketItem?.sequenceNumber,
+                    localIdentifier: measureLocator.measureLocatorItem.measureIdentifier,
+                });
+            }
         });
     }
 


### PR DESCRIPTION
Make sure that arithmetic measures are not incomplete when displaying them on measure dropdown.

JIRA: TNT-558


---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
