### PR TITLE
BUGFIX: RAIL-4519 Attribute metadata fetching for deprecated attributes

### DIFF
--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -1817,7 +1817,7 @@ export abstract class DashboardPluginV1 implements IDashboardPluginContract_V1 {
 }
 
 // @alpha (undocumented)
-export type DashboardQueries = QueryInsightDateDatasets | QueryMeasureDateDatasets | QueryInsightAttributesMeta | QueryWidgetFilters | QueryWidgetBrokenAlerts | QueryWidgetAlertCount | QueryConnectingAttributes;
+export type DashboardQueries = QueryInsightDateDatasets | QueryMeasureDateDatasets | QueryInsightAttributesMeta | QueryWidgetFilters | QueryWidgetBrokenAlerts | QueryWidgetAlertCount | QueryConnectingAttributes | QueryAttributeByDisplayForm;
 
 // @alpha
 export interface DashboardQueryCompleted<TQuery extends IDashboardQuery, TResult> extends IDashboardEvent {
@@ -1868,7 +1868,7 @@ export interface DashboardQueryStartedPayload {
 }
 
 // @alpha (undocumented)
-export type DashboardQueryType = "GDC.DASH/QUERY.INSIGHT.DATE.DATASETS" | "GDC.DASH/QUERY.INSIGHT.ATTRIBUTE.META" | "GDC.DASH/QUERY.MEASURE.DATE.DATASETS" | "GDC.DASH/QUERY.WIDGET.FILTERS" | "GDC.DASH/QUERY.WIDGET.BROKEN_ALERTS" | "GDC.DASH/QUERY.WIDGET.ALERT_COUNT" | "GDC.DASH/QUERY.CONNECTING.ATTRIBUTES";
+export type DashboardQueryType = "GDC.DASH/QUERY.INSIGHT.DATE.DATASETS" | "GDC.DASH/QUERY.INSIGHT.ATTRIBUTE.META" | "GDC.DASH/QUERY.MEASURE.DATE.DATASETS" | "GDC.DASH/QUERY.WIDGET.FILTERS" | "GDC.DASH/QUERY.WIDGET.BROKEN_ALERTS" | "GDC.DASH/QUERY.WIDGET.ALERT_COUNT" | "GDC.DASH/QUERY.CONNECTING.ATTRIBUTES" | "GDC.DASH/QUERY.DISPLAY.FORM.ATTRIBUTE";
 
 // @alpha
 export interface DashboardRenamed extends IDashboardEvent {
@@ -2863,6 +2863,8 @@ export interface IDashboardAttributeFilterDisplayForms {
 // @internal (undocumented)
 export interface IDashboardAttributeFilterParentItem {
     // (undocumented)
+    displayForm: ObjRef;
+    // (undocumented)
     isSelected: boolean;
     // (undocumented)
     localIdentifier: string;
@@ -2871,7 +2873,7 @@ export interface IDashboardAttributeFilterParentItem {
     // (undocumented)
     selectedConnectingAttribute: ObjRef | undefined;
     // (undocumented)
-    title: string;
+    title?: string;
 }
 
 // @internal (undocumented)
@@ -4535,6 +4537,19 @@ export type QueryActions<TQuery extends IDashboardQuery, TResult> = CaseReducerA
 
 // @alpha
 export function queryAndWaitFor<TQuery extends DashboardQueries, TQueryResult>(dispatch: DashboardDispatch, query: TQuery): Promise<TQueryResult>;
+
+// @internal (undocumented)
+export interface QueryAttributeByDisplayForm extends IDashboardQuery {
+    // (undocumented)
+    payload: {
+        readonly displayForms: ObjRef[];
+    };
+    // (undocumented)
+    type: "GDC.DASH/QUERY.DISPLAY.FORM.ATTRIBUTE";
+}
+
+// @internal
+export function queryAttributeByDisplayForm(displayForms: ObjRef[], correlationId?: string): QueryAttributeByDisplayForm;
 
 // @internal
 export type QueryCache<TQuery extends IDashboardQuery, TResult> = {

--- a/libs/sdk-ui-dashboard/src/model/queries/attributes.ts
+++ b/libs/sdk-ui-dashboard/src/model/queries/attributes.ts
@@ -14,13 +14,12 @@ export interface QueryAttributeByDisplayForm extends IDashboardQuery {
 }
 
 /**
- * Creates action through which you can query connecting attributes for the information about
- * possibility of parent-child attribute filter relationship.
+ * Creates action through which you can query attributes for given display forms
  *
- * @param refs - references of the attributes
+ * @param displayForms - attribute display forms
  * @param correlationId - specify correlation id to use for this command. this will be included in all
  *  events that will be emitted during the command processing
- * @returns connecting attributes for given array of references
+ * @returns attribute metadata for given display forms
  *
  * @internal
  */

--- a/libs/sdk-ui-dashboard/src/model/queries/attributes.ts
+++ b/libs/sdk-ui-dashboard/src/model/queries/attributes.ts
@@ -1,0 +1,38 @@
+// (C) 2022 GoodData Corporation
+
+import { ObjRef } from "@gooddata/sdk-model";
+import { IDashboardQuery } from "./base";
+
+/**
+ * @internal
+ */
+export interface QueryAttributeByDisplayForm extends IDashboardQuery {
+    type: "GDC.DASH/QUERY.DISPLAY.FORM.ATTRIBUTE";
+    payload: {
+        readonly displayForms: ObjRef[];
+    };
+}
+
+/**
+ * Creates action through which you can query connecting attributes for the information about
+ * possibility of parent-child attribute filter relationship.
+ *
+ * @param refs - references of the attributes
+ * @param correlationId - specify correlation id to use for this command. this will be included in all
+ *  events that will be emitted during the command processing
+ * @returns connecting attributes for given array of references
+ *
+ * @internal
+ */
+export function queryAttributeByDisplayForm(
+    displayForms: ObjRef[],
+    correlationId?: string,
+): QueryAttributeByDisplayForm {
+    return {
+        type: "GDC.DASH/QUERY.DISPLAY.FORM.ATTRIBUTE",
+        correlationId,
+        payload: {
+            displayForms,
+        },
+    };
+}

--- a/libs/sdk-ui-dashboard/src/model/queries/base.ts
+++ b/libs/sdk-ui-dashboard/src/model/queries/base.ts
@@ -10,7 +10,8 @@ export type DashboardQueryType =
     | "GDC.DASH/QUERY.WIDGET.FILTERS"
     | "GDC.DASH/QUERY.WIDGET.BROKEN_ALERTS"
     | "GDC.DASH/QUERY.WIDGET.ALERT_COUNT"
-    | "GDC.DASH/QUERY.CONNECTING.ATTRIBUTES";
+    | "GDC.DASH/QUERY.CONNECTING.ATTRIBUTES"
+    | "GDC.DASH/QUERY.DISPLAY.FORM.ATTRIBUTE";
 
 /**
  * Base type for all dashboard queries. A dashboard query encapsulates how complex, read-only dashboard-specific logic

--- a/libs/sdk-ui-dashboard/src/model/queries/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/queries/index.ts
@@ -4,6 +4,7 @@ import { QueryInsightAttributesMeta, QueryInsightDateDatasets } from "./insights
 import { QueryWidgetBrokenAlerts, QueryWidgetFilters, QueryWidgetAlertCount } from "./widgets";
 import { QueryMeasureDateDatasets } from "./kpis";
 import { QueryConnectingAttributes } from "./connectingAttributes";
+import { QueryAttributeByDisplayForm } from "./attributes";
 
 export { IDashboardQuery, DashboardQueryType } from "./base";
 export {
@@ -25,6 +26,8 @@ export {
     queryWidgetAlertCount,
 } from "./widgets";
 export { QueryConnectingAttributes, queryConnectingAttributes } from "./connectingAttributes";
+export { QueryAttributeByDisplayForm, queryAttributeByDisplayForm } from "./attributes";
+
 /**
  * @alpha
  */
@@ -35,4 +38,5 @@ export type DashboardQueries =
     | QueryWidgetFilters
     | QueryWidgetBrokenAlerts
     | QueryWidgetAlertCount
-    | QueryConnectingAttributes;
+    | QueryConnectingAttributes
+    | QueryAttributeByDisplayForm;

--- a/libs/sdk-ui-dashboard/src/model/queryServices/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/queryServices/index.ts
@@ -6,6 +6,7 @@ import { QueryDateDatasetsForMeasureService } from "./queryMeasureDateDatasets";
 import { QueryWidgetBrokenAlertService } from "./queryWidgetBrokenAlerts";
 import { QueryWidgetAlertCountService } from "./queryWidgetAlertCount";
 import { QueryConnectingAttributesService } from "./queryConnectingAttributes";
+import { QueryAttributeByDisplayFormService } from "./queryAttributeByDisplayForm";
 
 export const AllQueryServices = [
     QueryDateDatasetsForInsightService,
@@ -15,4 +16,5 @@ export const AllQueryServices = [
     QueryWidgetBrokenAlertService,
     QueryWidgetAlertCountService,
     QueryConnectingAttributesService,
+    QueryAttributeByDisplayFormService,
 ];

--- a/libs/sdk-ui-dashboard/src/model/queryServices/queryAttributeByDisplayForm.ts
+++ b/libs/sdk-ui-dashboard/src/model/queryServices/queryAttributeByDisplayForm.ts
@@ -46,7 +46,7 @@ async function loadAttributeByDisplayForm(
         return attribute.attribute;
     }
 
-    return await backend.workspace(workspace).attributes().getAttributeByDisplayForm(displayForm);
+    return backend.workspace(workspace).attributes().getAttributeByDisplayForm(displayForm);
 }
 
 async function loadAttributes(
@@ -54,9 +54,7 @@ async function loadAttributes(
     catalogAttributes: ICatalogAttribute[],
     displayForms: ObjRef[],
 ) {
-    return await Promise.all(
-        displayForms.map((df) => loadAttributeByDisplayForm(ctx, catalogAttributes, df)),
-    );
+    return Promise.all(displayForms.map((df) => loadAttributeByDisplayForm(ctx, catalogAttributes, df)));
 }
 
 function* queryService(

--- a/libs/sdk-ui-dashboard/src/model/queryServices/queryAttributeByDisplayForm.ts
+++ b/libs/sdk-ui-dashboard/src/model/queryServices/queryAttributeByDisplayForm.ts
@@ -27,6 +27,11 @@ export const QueryAttributeByDisplayFormService = createCachedQueryService(
     },
 );
 
+/**
+ * Loads the attribute metadata for given display form. Primarily the metadata are loaded
+ * from the catalog attributes. If the required attribute is not listed in the catalog
+ * (e.g. deprecated attributes), the attribute metadata are fetched from the backend.
+ */
 async function loadAttributeByDisplayForm(
     ctx: DashboardContext,
     catalogAttributes: ICatalogAttribute[],

--- a/libs/sdk-ui-dashboard/src/model/queryServices/queryAttributeByDisplayForm.ts
+++ b/libs/sdk-ui-dashboard/src/model/queryServices/queryAttributeByDisplayForm.ts
@@ -1,0 +1,81 @@
+// (C) 2022 GoodData Corporation
+
+import {
+    areObjRefsEqual,
+    IAttributeMetadataObject,
+    ICatalogAttribute,
+    ObjRef,
+    serializeObjRef,
+} from "@gooddata/sdk-model";
+import { QueryAttributeByDisplayForm } from "../queries/attributes";
+import { createCachedQueryService } from "../store/_infra/queryService";
+import { DashboardContext } from "../types/commonTypes";
+import { SagaIterator } from "redux-saga";
+import { call, SagaReturnType, select } from "redux-saga/effects";
+import { invalidQueryArguments } from "../events/general";
+import { selectCatalogAttributes } from "../store";
+
+export const QueryAttributeByDisplayFormService = createCachedQueryService(
+    "GDC.DASH/QUERY.DISPLAY.FORM.ATTRIBUTE",
+    queryService,
+    (query: QueryAttributeByDisplayForm) => {
+        const {
+            payload: { displayForms },
+        } = query;
+
+        return displayForms.map((df) => serializeObjRef(df)).join();
+    },
+);
+
+async function loadAttributeByDisplayForm(
+    ctx: DashboardContext,
+    catalogAttributes: ICatalogAttribute[],
+    displayForm: ObjRef,
+): Promise<IAttributeMetadataObject> {
+    const { backend, workspace } = ctx;
+    const attribute = catalogAttributes.find((catalogAttribute) =>
+        catalogAttribute.displayForms.some((df) => areObjRefsEqual(df, displayForm)),
+    );
+
+    if (attribute) {
+        return attribute.attribute;
+    }
+
+    return await backend.workspace(workspace).attributes().getAttributeByDisplayForm(displayForm);
+}
+
+async function loadAttributes(
+    ctx: DashboardContext,
+    catalogAttributes: ICatalogAttribute[],
+    displayForms: ObjRef[],
+) {
+    return await Promise.all(
+        displayForms.map((df) => loadAttributeByDisplayForm(ctx, catalogAttributes, df)),
+    );
+}
+
+function* queryService(
+    ctx: DashboardContext,
+    query: QueryAttributeByDisplayForm,
+): SagaIterator<IAttributeMetadataObject[]> {
+    const {
+        payload: { displayForms },
+        correlationId,
+    } = query;
+    const catalogAttributes: ReturnType<typeof selectCatalogAttributes> = yield select(
+        selectCatalogAttributes,
+    );
+
+    const attributes: SagaReturnType<typeof loadAttributes> = yield call(
+        loadAttributes,
+        ctx,
+        catalogAttributes,
+        displayForms,
+    );
+
+    if (!attributes) {
+        throw invalidQueryArguments(ctx, `Cannot find attribute for given displayForm`, correlationId);
+    }
+
+    return attributes;
+}

--- a/libs/sdk-ui-dashboard/src/model/types/attributeFilterTypes.ts
+++ b/libs/sdk-ui-dashboard/src/model/types/attributeFilterTypes.ts
@@ -7,7 +7,8 @@ import { IAttributeDisplayFormMetadataObject, ObjRef } from "@gooddata/sdk-model
  */
 export interface IDashboardAttributeFilterParentItem {
     localIdentifier: string;
-    title: string;
+    title?: string;
+    displayForm: ObjRef;
     isSelected: boolean;
     overAttributes?: ObjRef[];
     selectedConnectingAttribute: ObjRef | undefined;

--- a/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/AttributeFilterParentFilteringContext.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/AttributeFilterParentFilteringContext.tsx
@@ -57,11 +57,11 @@ export const AttributeFilterParentFilteringProvider: React.FC<
 
     const {
         parents,
+        configurationChanged,
         onParentSelect,
-        parentsConfigChanged,
         onConnectingAttributeChanged,
-        connectingAttributeChanged,
         onParentFiltersChange,
+        onConfigurationClose,
     } = useParentsConfiguration(neighborFilters, currentFilter);
 
     const { onDisplayFormSelect, filterDisplayForms, displayFormChanged, onDisplayFormChange } =
@@ -79,16 +79,16 @@ export const AttributeFilterParentFilteringProvider: React.FC<
             value={{
                 parents,
                 onParentSelect,
-                parentsConfigChanged,
                 onConnectingAttributeChanged,
-                connectingAttributeChanged,
                 onParentFiltersChange,
                 onDisplayFormSelect,
                 filterDisplayForms,
                 displayFormChanged,
                 onDisplayFormChange,
                 onConfigurationSave,
+                onConfigurationClose,
                 showDisplayFormPicker,
+                configurationChanged,
             }}
         >
             {children}

--- a/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/DefaultDashboardAttributeFilter.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/DefaultDashboardAttributeFilter.tsx
@@ -81,20 +81,14 @@ export const DefaultDashboardAttributeFilter = (props: IDashboardAttributeFilter
 
     const CustomDropdownActions = useMemo(() => {
         return function DropdownActions(props: IAttributeFilterDropdownActionsProps) {
-            const {
-                onConfigurationSave,
-                parentsConfigChanged,
-                connectingAttributeChanged,
-                displayFormChanged,
-            } = useAttributeFilterParentFiltering();
+            const { onConfigurationSave, configurationChanged, displayFormChanged, onConfigurationClose } =
+                useAttributeFilterParentFiltering();
 
             return (
                 <>
                     {isConfigurationOpen ? (
                         <CustomConfigureAttributeFilterDropdownActions
-                            isSaveDisabled={
-                                !(parentsConfigChanged || displayFormChanged || connectingAttributeChanged)
-                            }
+                            isSaveDisabled={!(configurationChanged || displayFormChanged)}
                             onSaveButtonClick={() => {
                                 onConfigurationSave();
                                 setIsConfigurationOpen(false);
@@ -112,6 +106,7 @@ export const DefaultDashboardAttributeFilter = (props: IDashboardAttributeFilter
                             cancelText={cancelText}
                             onConfigurationButtonClick={() => {
                                 setIsConfigurationOpen(true);
+                                onConfigurationClose();
                             }}
                             onDeleteButtonClick={() => {
                                 handleRemoveAttributeFilter();

--- a/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/dashboardDropdownBody/configuration/AttributeFilterConfiguration.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/dashboardDropdownBody/configuration/AttributeFilterConfiguration.tsx
@@ -17,6 +17,7 @@ import { useAttributeFilterParentFiltering } from "../../AttributeFilterParentFi
 import { useConnectingAttributes } from "./hooks/useConnectingAttributes";
 import { LoadingSpinner } from "@gooddata/sdk-ui-kit";
 import { useTheme } from "@gooddata/sdk-ui-theme-provider";
+import { useAttributes } from "./hooks/useAttributes";
 
 interface IAttributeFilterConfigurationProps {
     closeHandler: () => void;
@@ -67,7 +68,9 @@ export const AttributeFilterConfiguration: React.FC<IAttributeFilterConfiguratio
         neighborFilterDisplayForms,
     );
 
-    if (connectingAttributesLoading) {
+    const { attributes, attributesLoading } = useAttributes(neighborFilterDisplayForms);
+
+    if (connectingAttributesLoading || attributesLoading) {
         return (
             <div className="gd-loading-equalizer-attribute-filter-config-wrap">
                 <LoadingSpinner
@@ -78,7 +81,7 @@ export const AttributeFilterConfiguration: React.FC<IAttributeFilterConfiguratio
         );
     }
 
-    if (!filterRef || !connectingAttributes) {
+    if (!filterRef || !connectingAttributes || !attributes) {
         return null;
     }
 
@@ -92,6 +95,7 @@ export const AttributeFilterConfiguration: React.FC<IAttributeFilterConfiguratio
                 setParents={onParentSelect}
                 onConnectingAttributeChanged={onConnectingAttributeChanged}
                 connectingAttributes={connectingAttributes}
+                attributes={attributes}
             />
             {showDisplayFormPicker && (
                 <div className="s-display-form-configuration">

--- a/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/dashboardDropdownBody/configuration/hooks/useAttributes.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/dashboardDropdownBody/configuration/hooks/useAttributes.ts
@@ -1,0 +1,40 @@
+// (C) 2022 GoodData Corporation
+import { useEffect, useMemo } from "react";
+import { IAttributeMetadataObject, ObjRef } from "@gooddata/sdk-model";
+import {
+    queryAttributeByDisplayForm,
+    QueryAttributeByDisplayForm,
+    useDashboardQueryProcessing,
+} from "../../../../../../model";
+
+/**
+ * @internal
+ */
+export function useAttributes(displayForms: ObjRef[]) {
+    const {
+        run: getAttributes,
+        result: attributes,
+        status: attributesLoadingStatus,
+        error: attributesLoadingError,
+    } = useDashboardQueryProcessing<
+        QueryAttributeByDisplayForm,
+        IAttributeMetadataObject[],
+        Parameters<typeof queryAttributeByDisplayForm>
+    >({
+        queryCreator: queryAttributeByDisplayForm,
+    });
+
+    useEffect(() => {
+        getAttributes(displayForms);
+    }, [displayForms, getAttributes]);
+
+    const attributesLoading = useMemo(() => {
+        return attributesLoadingStatus === "pending" || attributesLoadingStatus === "running";
+    }, [attributesLoadingStatus]);
+
+    return {
+        attributes,
+        attributesLoading,
+        attributesLoadingError,
+    };
+}

--- a/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/dashboardDropdownBody/configuration/hooks/useDisplayFormConfiguration.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/dashboardDropdownBody/configuration/hooks/useDisplayFormConfiguration.ts
@@ -22,9 +22,10 @@ export function useDisplayFormConfiguration(currentFilter: IDashboardAttributeFi
         () => {
             const currentDisplayForm = currentFilter.attributeFilter.displayForm;
 
-            const availableDisplayForms = catalogAttributes.find((attribute) =>
-                attribute.displayForms.some((df) => areObjRefsEqual(df.ref, currentDisplayForm)),
-            )!.displayForms;
+            const availableDisplayForms =
+                catalogAttributes.find((attribute) =>
+                    attribute.displayForms.some((df) => areObjRefsEqual(df.ref, currentDisplayForm)),
+                )?.displayForms || [];
 
             return {
                 selectedDisplayForm: currentDisplayForm,

--- a/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/dashboardDropdownBody/configuration/hooks/useOriginalConfigurationState.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/dashboardDropdownBody/configuration/hooks/useOriginalConfigurationState.ts
@@ -1,0 +1,40 @@
+// (C) 2022 GoodData Corporation
+import { useMemo } from "react";
+import invariant from "ts-invariant";
+
+import { IDashboardAttributeFilter, IDashboardAttributeFilterParent } from "@gooddata/sdk-model";
+
+/**
+ * @internal
+ */
+export function useOriginalConfigurationState(
+    neighborFilters: IDashboardAttributeFilter[],
+    filterElementsBy: IDashboardAttributeFilterParent[] | undefined,
+) {
+    return useMemo(() => {
+        return neighborFilters.map((neighborFilter) => {
+            const neighborFilterLocalId = neighborFilter.attributeFilter.localIdentifier;
+            const neighborFilterDisplayForm = neighborFilter.attributeFilter.displayForm;
+
+            const isSelected =
+                filterElementsBy?.some((by) => by.filterLocalIdentifier === neighborFilterLocalId) || false;
+
+            const overAttributes = filterElementsBy?.find(
+                (by) => by.filterLocalIdentifier === neighborFilterLocalId,
+            )?.over.attributes;
+
+            invariant(
+                neighborFilterLocalId,
+                "Cannot initialize the attribute filter configuration panel, neighbor filter has missing 'localIdentifier' property.",
+            );
+
+            return {
+                localIdentifier: neighborFilterLocalId,
+                displayForm: neighborFilterDisplayForm,
+                isSelected,
+                overAttributes: overAttributes,
+                selectedConnectingAttribute: overAttributes?.[0],
+            };
+        });
+    }, [neighborFilters, filterElementsBy]);
+}

--- a/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/dashboardDropdownBody/configuration/parentFilters/ParentFiltersList.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/dashboardDropdownBody/configuration/parentFilters/ParentFiltersList.tsx
@@ -1,7 +1,7 @@
 // (C) 2022 GoodData Corporation
 import React from "react";
 
-import { ObjRef } from "@gooddata/sdk-model";
+import { IAttributeMetadataObject, ObjRef } from "@gooddata/sdk-model";
 import { ParentFiltersListItem } from "./ParentFiltersListItem";
 import { LoadingComponent } from "@gooddata/sdk-ui";
 import {
@@ -19,11 +19,18 @@ interface IConfigurationParentItemsProps {
     setParents: (localId: string, isSelected: boolean, overAttributes: ObjRef[]) => void;
     onConnectingAttributeChanged: (localId: string, selectedAttribute: ObjRef) => void;
     connectingAttributes: IConnectingAttribute[][];
+    attributes: IAttributeMetadataObject[];
 }
 
 export const ParentFiltersList: React.FC<IConfigurationParentItemsProps> = (props) => {
-    const { parents, currentFilterLocalId, setParents, onConnectingAttributeChanged, connectingAttributes } =
-        props;
+    const {
+        parents,
+        currentFilterLocalId,
+        setParents,
+        onConnectingAttributeChanged,
+        connectingAttributes,
+        attributes,
+    } = props;
 
     const isDependentFiltersEnabled = useDashboardSelector(selectSupportsElementsQueryParentFiltering);
 
@@ -51,6 +58,7 @@ export const ParentFiltersList: React.FC<IConfigurationParentItemsProps> = (prop
                         onClick={setParents}
                         onConnectingAttributeSelect={onConnectingAttributeChanged}
                         connectingAttributes={connectingAttributes[index]}
+                        title={attributes[index].title}
                     />
                 );
             })}

--- a/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/dashboardDropdownBody/configuration/parentFilters/ParentFiltersListItem.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/dashboardDropdownBody/configuration/parentFilters/ParentFiltersListItem.tsx
@@ -26,15 +26,17 @@ export interface IConfigurationParentItemProps {
     onClick: (localId: string, isSelected: boolean, overAttributes: ObjRef[]) => void;
     onConnectingAttributeSelect: (localIdentifier: string, targetRef: ObjRef) => void;
     connectingAttributes: IConnectingAttribute[];
+    title: string;
 }
 
 export const ParentFiltersListItem: React.FC<IConfigurationParentItemProps> = (props) => {
     const {
-        item: { isSelected, localIdentifier, title, selectedConnectingAttribute },
+        item: { isSelected, localIdentifier, selectedConnectingAttribute },
         onClick,
         currentFilterLocalId,
         connectingAttributes,
         onConnectingAttributeSelect,
+        title,
     } = props;
 
     const isCircularDependency = useDashboardSelector(


### PR DESCRIPTION
- refactoring of useParentsConfiguration hook
- add query to fetch attributes for given display forms
- refactor handling of changes in parent filters configuration

JIRA: RAIL-4519

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
