### PR TITLE
Fix attribute filters using non-primary labels

### DIFF
--- a/libs/sdk-ui-dashboard/src/_staging/dashboard/legacyFilterConvertors.ts
+++ b/libs/sdk-ui-dashboard/src/_staging/dashboard/legacyFilterConvertors.ts
@@ -1,0 +1,47 @@
+// (C) 2022 GoodData Corporation
+import {
+    IDashboardAttributeFilter,
+    isAttributeElementsByRef,
+    isAttributeElementsByValue,
+} from "@gooddata/sdk-model";
+
+// In KD, filter is always "uri" based. This is also way, how it's currently saved on panther/tiger (even though uris are actually values).
+// In the past, we were relying on the fact, that tiger/panther does not support multiple labels and uri was always equal to the title.
+// This is not correct anymore, so we need to send them as values also to AttributeFilter.
+// When we are converting it back to "backend" shape, we need to preserve the previous expectations/behavior.
+export function convertDashboardAttributeFilterElementsValuesToUris(
+    filter: IDashboardAttributeFilter,
+): IDashboardAttributeFilter {
+    if (isAttributeElementsByRef(filter.attributeFilter.attributeElements)) {
+        return filter;
+    }
+
+    return {
+        attributeFilter: {
+            ...filter.attributeFilter,
+            attributeElements: {
+                uris: filter.attributeFilter.attributeElements.values,
+            },
+        },
+    };
+}
+
+// In KD, filter is always "uri" based. This is also way, how it's currently saved on panther/tiger (even though uris are actually values).
+// In the past, we were relying on the fact, that tiger/panther does not support multiple labels and uri was always equal to the title.
+// This is not correct anymore, so we need to send them as values also to AttributeFilter.
+export function convertDashboardAttributeFilterElementsUrisToValues(
+    filter: IDashboardAttributeFilter,
+): IDashboardAttributeFilter {
+    if (isAttributeElementsByValue(filter.attributeFilter.attributeElements)) {
+        return filter;
+    }
+
+    return {
+        attributeFilter: {
+            ...filter.attributeFilter,
+            attributeElements: {
+                values: filter.attributeFilter.attributeElements.uris,
+            },
+        },
+    };
+}

--- a/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableAttributeFilter/DraggableAttributeFilter.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableAttributeFilter/DraggableAttributeFilter.tsx
@@ -1,11 +1,12 @@
 // (C) 2022 GoodData Corporation
-import React from "react";
+import React, { useMemo } from "react";
 import { IDashboardAttributeFilter } from "@gooddata/sdk-model";
 import classNames from "classnames";
-import { useDashboardSelector, selectIsInEditMode } from "../../../model";
+import { useDashboardSelector, selectIsInEditMode, selectSupportsElementUris } from "../../../model";
 import { AttributeFilterDropZoneHint } from "./AttributeFilterDropZoneHint";
 import { CustomDashboardAttributeFilterComponent } from "../../filterBar/types";
 import { useDashboardDrag } from "../useDashboardDrag";
+import { convertDashboardAttributeFilterElementsUrisToValues } from "../../../_staging/dashboard/legacyFilterConvertors";
 
 type DraggableAttributeFilterProps = {
     filter: IDashboardAttributeFilter;
@@ -35,6 +36,13 @@ export function DraggableAttributeFilter({
         [filter, filterIndex, isInEditMode],
     );
     const showDropZones = isInEditMode && !isDragging;
+    const supportElementUris = useDashboardSelector(selectSupportsElementUris);
+    const filterToUse = useMemo(() => {
+        if (supportElementUris) {
+            return filter;
+        }
+        return convertDashboardAttributeFilterElementsUrisToValues(filter);
+    }, [filter, supportElementUris]);
 
     return (
         <div className="draggable-attribute-filter">
@@ -53,7 +61,7 @@ export function DraggableAttributeFilter({
                 ref={dragRef}
             >
                 <FilterComponent
-                    filter={filter}
+                    filter={filterToUse}
                     onFilterChanged={onAttributeFilterChanged}
                     isDraggable={isInEditMode}
                 />


### PR DESCRIPTION
- In the past, we were relying on the fact that uris and titles are equal on panther/tiger (this is also the way, how it's stored on the backend)
- This is not true anymore, so convert filter before passing it to plugins / components
- Also convert it back to uris in onFilterChanged callback

JIRA: RAIL-4517

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
