### PR TITLE
RELATED: RAIL-4410 Remove unnecessary part of the error statement

### DIFF
--- a/tools/plugin-toolkit/src/updatePluginParamsCmd/actionConfig.ts
+++ b/tools/plugin-toolkit/src/updatePluginParamsCmd/actionConfig.ts
@@ -135,9 +135,7 @@ export async function getUpdatePluginParamsCmdConfig(
     const parameters = await promptPluginParameters(originalParameters);
 
     if (isEmpty(parameters.trim())) {
-        logError(
-            "You did not specify any parameters. If you do not want to use plugin parameterization, remove the --with-parameters option.",
-        );
+        logError("You did not specify any parameters to be updated on the plugin.");
 
         process.exit(1);
     } else {


### PR DESCRIPTION
JIRA: RAIL-4410

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
