### PR TITLE
RELATED: RAIL-4528 plugin template DX improvements

### DIFF
--- a/tools/dashboard-plugin-template/.eslintrc.js
+++ b/tools/dashboard-plugin-template/.eslintrc.js
@@ -16,4 +16,5 @@ module.exports = {
         "import/no-unassigned-import": "off",
     },
     parserOptions: { tsconfigRootDir: __dirname },
+    ignorePatterns: ["webpack.config.js", "jest.setup.ts", "scripts/refresh-md.js"],
 };

--- a/tools/dashboard-plugin-template/.gitignore
+++ b/tools/dashboard-plugin-template/.gitignore
@@ -1,2 +1,3 @@
 .env.secrets
 dist
+node_modules

--- a/tools/dashboard-plugin-template/configTemplates/js/.eslintrc.js
+++ b/tools/dashboard-plugin-template/configTemplates/js/.eslintrc.js
@@ -4,4 +4,5 @@ module.exports = {
     plugins: ["react-hooks", "prettier"],
     extends: ["plugin:react/recommended", "plugin:import/errors"],
     parserOptions: { tsconfigRootDir: __dirname },
+    ignorePatterns: ["webpack.config.js", "jest.setup.js", "scripts/refresh-md.js"],
 };

--- a/tools/dashboard-plugin-template/configTemplates/js/jest.setup.js
+++ b/tools/dashboard-plugin-template/configTemplates/js/jest.setup.js
@@ -1,5 +1,4 @@
 // (C) 2019 GoodData Corporation
-/* eslint-disable @typescript-eslint/no-var-requires */
 import "jest-enzyme";
 import * as raf from "raf";
 

--- a/tools/dashboard-plugin-template/configTemplates/ts/.eslintrc.js
+++ b/tools/dashboard-plugin-template/configTemplates/ts/.eslintrc.js
@@ -4,4 +4,5 @@ module.exports = {
     plugins: ["react-hooks", "prettier"],
     extends: ["plugin:react/recommended", "plugin:import/errors", "plugin:import/typescript"],
     parserOptions: { tsconfigRootDir: __dirname },
+    ignorePatterns: ["webpack.config.js", "jest.setup.ts", "scripts/refresh-md.js"],
 };

--- a/tools/dashboard-plugin-template/configTemplates/ts/jest.setup.ts
+++ b/tools/dashboard-plugin-template/configTemplates/ts/jest.setup.ts
@@ -1,5 +1,4 @@
 // (C) 2019 GoodData Corporation
-/* eslint-disable @typescript-eslint/no-var-requires */
 import "jest-enzyme";
 import * as raf from "raf";
 

--- a/tools/dashboard-plugin-template/jest.setup.ts
+++ b/tools/dashboard-plugin-template/jest.setup.ts
@@ -1,5 +1,4 @@
 // (C) 2019 GoodData Corporation
-/* eslint-disable @typescript-eslint/no-var-requires */
 import "jest-enzyme";
 import * as raf from "raf";
 

--- a/tools/dashboard-plugin-template/scripts/refresh-md.js
+++ b/tools/dashboard-plugin-template/scripts/refresh-md.js
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 // (C) 2022 GoodData Corporation
-/* eslint-disable @typescript-eslint/no-var-requires */
 
 const dotenv = require("dotenv");
 const path = require("path");

--- a/tools/dashboard-plugin-template/webpack.config.js
+++ b/tools/dashboard-plugin-template/webpack.config.js
@@ -1,5 +1,4 @@
 // (C) 2007-2021 GoodData Corporation
-/* eslint-disable @typescript-eslint/no-var-requires */
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 const CaseSensitivePathsPlugin = require("case-sensitive-paths-webpack-plugin");
 const { ModuleFederationPlugin } = require("webpack").container;


### PR DESCRIPTION
* add node_modules to gitignore
* remove eslint rule ignores from config files and exclude them from ESLint validation. This is because the rules we use to validate SDK are different than the rules used to validate the bootstrapped plugin. The ignores then made some IDEs issue warnings of unknown ESLint rules being included.
---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
