### PR TITLE
Fix elements loading on tiger for primary label

### DIFF
--- a/libs/sdk-ui-filters/src/AttributeFilterHandler/internal/redux/common/selectors.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilterHandler/internal/redux/common/selectors.ts
@@ -12,3 +12,8 @@ export const selectState = (state: AttributeFilterState) => state;
  */
 export const getElementCacheKey = (state: AttributeFilterState, element: IAttributeElement) =>
     state.elementsForm === "uris" ? element.uri : element.title;
+
+/**
+ * @internal
+ */
+export const selectElementsForm = (state: AttributeFilterState) => state.elementsForm;

--- a/libs/sdk-ui-filters/src/AttributeFilterHandler/internal/redux/init/initTotalCount.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilterHandler/internal/redux/init/initTotalCount.ts
@@ -1,17 +1,21 @@
 // (C) 2022 GoodData Corporation
 import { SagaIterator } from "redux-saga";
-import { put, fork, race, take } from "redux-saga/effects";
+import { put, fork, race, take, call, select, SagaReturnType } from "redux-saga/effects";
 import { AnyAction } from "@reduxjs/toolkit";
 
 import { Correlation } from "../../../types";
 import { loadCustomElementsSaga } from "../loadCustomElements/loadCustomElementsSaga";
 import { actions } from "../store/slice";
+import { getAttributeFilterContext } from "../common/sagas";
+import { selectElementsForm } from "../common/selectors";
 
 /**
  * @internal
  */
 export function* initTotalCountSaga(correlation: Correlation): SagaIterator<void> {
     const initTotalCountCorrelation = `initTotalCount_${correlation}`;
+    const context: SagaReturnType<typeof getAttributeFilterContext> = yield call(getAttributeFilterContext);
+    const elementsForm: ReturnType<typeof selectElementsForm> = yield select(selectElementsForm);
 
     yield fork(
         loadCustomElementsSaga,
@@ -19,7 +23,8 @@ export function* initTotalCountSaga(correlation: Correlation): SagaIterator<void
             options: {
                 limit: 1,
                 includeTotalCountWithoutFilters: true,
-                excludePrimaryLabel: true,
+                excludePrimaryLabel:
+                    !context.backend.capabilities.supportsElementUris && elementsForm === "values",
             },
             correlation: initTotalCountCorrelation,
         }),

--- a/libs/sdk-ui-filters/src/AttributeFilterHandler/internal/redux/loadInitialElementsPage/loadInitialElementsPageSaga.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilterHandler/internal/redux/loadInitialElementsPage/loadInitialElementsPageSaga.ts
@@ -2,6 +2,7 @@
 import { SagaIterator } from "redux-saga";
 import { put, call, takeLatest, select, cancelled, SagaReturnType } from "redux-saga/effects";
 import { getAttributeFilterContext } from "../common/sagas";
+import { selectElementsForm } from "../common/selectors";
 
 import { elementsSaga } from "../elements/elementsSaga";
 import { selectLoadElementsOptions } from "../elements/elementsSelectors";
@@ -44,9 +45,12 @@ export function* loadInitialElementsPageSaga(
             selectLoadElementsOptions,
         );
 
+        const elementsForm: ReturnType<typeof selectElementsForm> = yield select(selectElementsForm);
+
         const loadOptionsWithExcludePrimaryLabel = {
             ...loadOptions,
-            excludePrimaryLabel: true,
+            excludePrimaryLabel:
+                !context.backend.capabilities.supportsElementUris && elementsForm === "values",
         };
 
         const result: SagaReturnType<typeof elementsSaga> = yield call(

--- a/libs/sdk-ui-filters/src/AttributeFilterHandler/test/__snapshots__/loadInitialElementsPage.test.ts.snap
+++ b/libs/sdk-ui-filters/src/AttributeFilterHandler/test/__snapshots__/loadInitialElementsPage.test.ts.snap
@@ -182,7 +182,7 @@ Array [
       },
     ],
     "options": Object {
-      "excludePrimaryLabel": true,
+      "excludePrimaryLabel": false,
       "limit": 500,
       "limitingAttributeFilters": Array [],
       "limitingDateFilters": Array [],

--- a/libs/sdk-ui-filters/src/AttributeFilterHandler/test/__snapshots__/loadNextElementsPage.test.ts.snap
+++ b/libs/sdk-ui-filters/src/AttributeFilterHandler/test/__snapshots__/loadNextElementsPage.test.ts.snap
@@ -78,7 +78,7 @@ Array [
       },
     ],
     "options": Object {
-      "excludePrimaryLabel": true,
+      "excludePrimaryLabel": false,
       "limit": 2,
       "limitingAttributeFilters": Array [],
       "limitingDateFilters": Array [],


### PR DESCRIPTION
- When user specifies elements by primaryLabel (uris), but uses different label for the filter, do not use excludePrimaryLabel option

JIRA: RAIL-4529

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
