### PR TITLE
RELATED: RAIL-4531 Remove the redundant word in plugin comments

### DIFF
--- a/examples/sdk-examples/src/examples/dashboardComponent/DashboardComponentWithLocalPluginSrc.tsx
+++ b/examples/sdk-examples/src/examples/dashboardComponent/DashboardComponentWithLocalPluginSrc.tsx
@@ -144,7 +144,7 @@ class LocalPlugin extends DashboardPluginV1 {
                         }),
                         {
                             xl: {
-                                // all 12 columns of the grid will be 'allocated' for this this new item
+                                // all 12 columns of the grid will be 'allocated' for this new item
                                 gridWidth: 12,
                                 // medium height to fit the chart
                                 gridHeight: 12,

--- a/examples/sdk-examples/src/examples/dashboardComponent/DashboardComponentWithUseDispatchDashboardCommandSrc.tsx
+++ b/examples/sdk-examples/src/examples/dashboardComponent/DashboardComponentWithUseDispatchDashboardCommandSrc.tsx
@@ -127,7 +127,7 @@ class LocalPlugin extends DashboardPluginV1 {
                     "Buttons to dispatch filter commands",
                     newDashboardItem(newCustomWidget("myWidget1", "myCustomWidget"), {
                         xl: {
-                            // all 12 columns of the grid will be 'allocated' for this this new item
+                            // all 12 columns of the grid will be 'allocated' for this new item
                             gridWidth: 12,
                             // medium height to fit the chart
                             gridHeight: 3,

--- a/libs/sdk-ui-dashboard/src/model/store/user/userSelectors.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/user/userSelectors.ts
@@ -35,7 +35,7 @@ const selectSelf = createSelector(
  *                  "Greetings by Plugin",
  *                  newDashboardItem(newCustomWidget("greetings", "greetingsWidget"), {
  *                      xl: {
- *                          // all 12 columns of the grid will be 'allocated' for this this new item
+ *                          // all 12 columns of the grid will be 'allocated' for this new item
  *                          gridWidth: 12,
  *                          // minimum height since the custom widget now has just some one-liner text
  *                          gridHeight: 1,

--- a/tools/dashboard-plugin-template/src/plugin/Plugin.tsx
+++ b/tools/dashboard-plugin-template/src/plugin/Plugin.tsx
@@ -1,4 +1,4 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 import {
     DashboardContext,
     DashboardPluginV1,
@@ -56,7 +56,7 @@ export class Plugin extends DashboardPluginV1 {
                     "Section Added By Plugin",
                     newDashboardItem(newCustomWidget("myWidget1", "myCustomWidget"), {
                         xl: {
-                            // all 12 columns of the grid will be 'allocated' for this this new item
+                            // all 12 columns of the grid will be 'allocated' for this new item
                             gridWidth: 12,
                             // minimum height since the custom widget now has just some one-liner text
                             gridHeight: 1,


### PR DESCRIPTION
JIRA: RAIL-4531

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
