### PR TITLE
RELATED: RAIL-4539 Add missing empty header handling

### DIFF
--- a/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartOptions/test/chartOptionsBuilder.test.ts
+++ b/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartOptions/test/chartOptionsBuilder.test.ts
@@ -342,6 +342,7 @@ describe("chartOptionsBuilder", () => {
                 stackByAttribute,
                 "column",
                 attributeColorStrategy,
+                "empty value",
             );
 
             it("should fill correct pointData name", () => {
@@ -403,6 +404,7 @@ describe("chartOptionsBuilder", () => {
                 stackByAttribute,
                 "column",
                 attributeColorStrategy,
+                "empty value",
             );
 
             it("should fill correct pointData name", () => {
@@ -449,6 +451,7 @@ describe("chartOptionsBuilder", () => {
                 stackByAttribute,
                 "pie",
                 metricColorStrategy,
+                "empty value",
             );
 
             const treeMapColorStrategy = new TreemapColorStrategy(
@@ -467,6 +470,7 @@ describe("chartOptionsBuilder", () => {
                 stackByAttribute,
                 "treemap",
                 treeMapColorStrategy,
+                "empty value",
             );
 
             it("should fill correct pointData name", () => {
@@ -543,6 +547,7 @@ describe("chartOptionsBuilder", () => {
                 stackByAttribute,
                 "pie",
                 attributeColorStrategy,
+                "empty value",
             );
 
             const treeMapColorStrategy = new TreemapColorStrategy(
@@ -561,6 +566,7 @@ describe("chartOptionsBuilder", () => {
                 stackByAttribute,
                 "treemap",
                 treeMapColorStrategy,
+                "empty value",
             );
 
             it("should fill correct pointData name", () => {
@@ -672,6 +678,7 @@ describe("chartOptionsBuilder", () => {
                         stackByAttribute,
                         type,
                         attributeColorStrategy,
+                        "empty value",
                     );
                 });
                 expect(seriesData.map((seriesItem: any) => seriesItem.data)).toEqual(expectedData);
@@ -748,6 +755,7 @@ describe("chartOptionsBuilder", () => {
                         stackByAttribute,
                         type,
                         attributeColorStrategy,
+                        "empty value",
                     );
                 });
                 expect(seriesData.map((seriesItem: any) => seriesItem.data)).toEqual(expectedData);
@@ -2030,6 +2038,7 @@ describe("chartOptionsBuilder", () => {
                         stackByAttribute,
                         type,
                         attColorStrategy,
+                        "empty value",
                     );
                 });
                 expect(seriesData.map((seriesItem: any) => seriesItem.data)).toEqual(expectedData);

--- a/libs/sdk-ui-charts/src/highcharts/chartTypes/treemap/treemapChartSeries.ts
+++ b/libs/sdk-ui-charts/src/highcharts/chartTypes/treemap/treemapChartSeries.ts
@@ -1,6 +1,6 @@
 // (C) 2020-2022 GoodData Corporation
 import { DataViewFacade } from "@gooddata/sdk-ui";
-import { IMeasureDescriptor, IMeasureGroupDescriptor, IResultAttributeHeader } from "@gooddata/sdk-model";
+import { IMeasureGroupDescriptor, IResultAttributeHeader } from "@gooddata/sdk-model";
 import { IUnwrappedAttributeHeadersWithItems } from "../../typings/mess";
 import { getLighterColor, IColorStrategy, valueWithEmptyHandling } from "@gooddata/sdk-ui-vis-commons";
 import { parseValue, unwrap } from "../_util/common";
@@ -20,10 +20,16 @@ function gradientPreviousGroup(solidColorLeafs: any[]): any[] {
     }));
 }
 
-function getRootPoint(rootName: string, index: number, format: string, colorStrategy: IColorStrategy) {
+function getRootPoint(
+    rootName: string,
+    index: number,
+    format: string,
+    colorStrategy: IColorStrategy,
+    emptyHeaderTitle: string,
+) {
     return {
         id: `${index}`,
-        name: rootName,
+        name: valueWithEmptyHandling(rootName, emptyHeaderTitle),
         color: colorStrategy.getColorByIndex(index),
         showInLegend: true,
         legendIndex: index,
@@ -88,7 +94,7 @@ export function getTreemapStackedSeriesDataWithViewBy(
             uncoloredLeafs = [];
             // create parent for pasted leafs
             const lastRootName = lastRoot?.name;
-            roots.push(getRootPoint(lastRootName, rootId, format, colorStrategy));
+            roots.push(getRootPoint(lastRootName, rootId, format, colorStrategy, emptyHeaderTitle));
         }
         // create leafs which will be colored at the end of group
         uncoloredLeafs.push(
@@ -123,7 +129,7 @@ export function getTreemapStackedSeriesDataWithMeasures(
     let data = measureGroup.items.map((measureGroupItem, index): IPointData => {
         return {
             id: `${index}`,
-            name: measureGroupItem.measureHeaderItem.name,
+            name: valueWithEmptyHandling(measureGroupItem.measureHeaderItem.name, emptyHeaderTitle),
             format: measureGroupItem.measureHeaderItem.format,
             color: colorStrategy.getColorByIndex(index),
             showInLegend: true,
@@ -196,15 +202,11 @@ export function getTreemapStackedSeries(
         );
     }
 
-    const seriesName = measureGroup.items
-        .map((wrappedMeasure: IMeasureDescriptor) => {
-            return unwrap(wrappedMeasure).name;
-        })
-        .join(", ");
+    const seriesName = measureGroup.items.map((wrappedMeasure) => unwrap(wrappedMeasure).name).join(", ");
 
     return [
         {
-            name: seriesName,
+            name: valueWithEmptyHandling(seriesName, emptyHeaderTitle),
             legendType: "point",
             showInLegend: true,
             data,


### PR DESCRIPTION
There were some more places that needed the empty headers handled.

JIRA: RAIL-4539

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
