### PR TITLE
Scheduled emails are sent to the login address instead of email address

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/ScheduledMailDialogRenderer/ScheduledMailDialogRenderer.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/ScheduledMailDialogRenderer/ScheduledMailDialogRenderer.tsx
@@ -818,7 +818,7 @@ export class ScheduledMailDialogRendererUI extends React.PureComponent<
         /// To: is currently only owner
         const toEmails = recipients
             .filter(isScheduleEmailExistingRecipient)
-            .map((recipient) => recipient.user.login);
+            .map((recipient) => recipient.user.email!);
 
         /// All other emails (without owner)
         const bccEmails = recipients

--- a/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/ScheduledMailDialogRenderer/test/ScheduledMailDialogRenderer.test.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/ScheduledMailDialogRenderer/test/ScheduledMailDialogRenderer.test.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { render, screen, within, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import noop from "lodash/noop";
-import { uriRef } from "@gooddata/sdk-model";
+import { IUser, uriRef } from "@gooddata/sdk-model";
 import { newInsightWidget } from "@gooddata/sdk-backend-base";
 
 import {
@@ -114,7 +114,14 @@ describe("ScheduledMailDialogRenderer", () => {
         });
         jest.useFakeTimers().setSystemTime(new Date("2022-01-02 12:13").getTime());
         const onSubmit = jest.fn();
-        renderComponent({ onSubmit });
+        const currentUser: IUser = {
+            login: "login.email@gooddata.com",
+            ref: uriRef("/gdc/user"),
+            email: "user@gooddata.com",
+            firstName: "John",
+            lastName: "Doe",
+        };
+        renderComponent({ onSubmit, currentUser });
 
         await user.click(screen.getByText("12:30 PM"));
         await user.click(screen.getByText("02:00 AM"));

--- a/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/utils/scheduledMailRecipients.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/utils/scheduledMailRecipients.ts
@@ -3,7 +3,7 @@ import { userFullName } from "@gooddata/sdk-model";
 import { IScheduleEmailRecipient, isScheduleEmailExistingRecipient } from "../interfaces";
 
 export const getScheduledEmailRecipientUniqueIdentifier = (recipient: IScheduleEmailRecipient): string =>
-    isScheduleEmailExistingRecipient(recipient) ? recipient.user.login : recipient.email;
+    isScheduleEmailExistingRecipient(recipient) ? recipient.user.email! : recipient.email;
 
 export const getScheduledEmailRecipientEmail = (recipient: IScheduleEmailRecipient): string =>
     isScheduleEmailExistingRecipient(recipient) ? recipient.user.email! : recipient.email;


### PR DESCRIPTION
User can have different login and email address. Scheduled emails were sent based on user login address, which was also causing some issues on the way we display user information on UI.

Update schedule email so it takes correct user email address and displays correct value on UI.

**JIRA: TNT-1036**

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
