### PR TITLE
RELATED: RAIL-4547 Change toolkit to work better with ignore rule

### DIFF
--- a/libs/sdk-ui/.i18nrc.js
+++ b/libs/sdk-ui/.i18nrc.js
@@ -9,10 +9,13 @@ module.exports = {
     source: "../{sdk-ui,sdk-ui-charts,sdk-ui-pivot,sdk-ui-kit,sdk-ui-filters,sdk-ui-vis-commons,sdk-ui-geo}/src/**/*.{ts,js,tsx,jsx}",
     rules: [
         {
-            // some messages need to be included for the sake of older dashboard plugins
-            pattern:
-                /^(?!gs.filter.loading|attrf.all|attrf.all_except|attributeFilterDropdown.emptyValue).*$/,
-            filterTranslationFile: true,
+            pattern: [/.+/],
+        },
+        // some messages need to be included for the sake of older dashboard plugins
+        {
+            dir: /src\/base\/localization\/bundles/,
+            pattern: /^(gs.filter.loading|attrf.all|attrf.all_except|attributeFilterDropdown.emptyValue)$/,
+            ignore: true,
         },
     ],
 };

--- a/tools/i18n-toolkit/src/data.ts
+++ b/tools/i18n-toolkit/src/data.ts
@@ -43,11 +43,13 @@ export type UsageResult = {
     stats: {
         extracted: number;
         loaded: number;
+        ignored: number;
         missing: number;
         unused: number;
     };
     data: {
         missingMessages: string[];
         unusedMessages: string[];
+        ignoredMessages: string[];
     };
 };

--- a/tools/i18n-toolkit/src/utils/console.ts
+++ b/tools/i18n-toolkit/src/utils/console.ts
@@ -56,8 +56,8 @@ export function resultsInfo(cwd: string, results: UsageResult[], uncontrolled: A
 
 export function resultsToRows(cwd: string, results: UsageResult[], uncontrolled: Array<string>): string[][] {
     return [
-        [" ┣ ", "Identifier", "Extracted", "Loaded", "Missing", "Unused", "Translation files"].map((s) =>
-            chalk.bold(s),
+        [" ┣ ", "Identifier", "Extracted", "Loaded", "Missing", "Unused", "Ignored", "Translation files"].map(
+            (s) => chalk.bold(s),
         ),
         ...results.map<string[]>(resultToRow.bind(null, cwd)),
         [
@@ -75,22 +75,24 @@ function resultToRow(cwd: string, { identifier, ignore, stats, files }: UsageRes
     if (ignore) {
         return [
             " ┣ ",
-            ignore ? chalk.white(`IGNORED: ${identifier}`) : chalk.blueBright(identifier),
+            chalk.white(`IGNORED: ${crop(identifier)}`),
             chalk.white(stats.extracted),
-            chalk.white(stats.loaded),
             "-",
             "-",
+            "-",
+            chalk.white(stats.ignored),
             filesText,
         ];
     }
 
     return [
         " ┣ ",
-        ignore ? chalk.white(`IGNORED: ${identifier}`) : chalk.blueBright(identifier),
+        chalk.blueBright(crop(identifier)),
         chalk.white(stats.extracted),
         chalk.white(stats.loaded),
         stats.missing > 0 ? chalk.redBright(stats.missing) : chalk.white(stats.missing),
         stats.unused > 0 ? chalk.redBright(stats.unused) : chalk.white(stats.unused),
+        stats.ignored > 0 ? chalk.gray(stats.ignored) : "-",
         filesText,
     ];
 }
@@ -157,4 +159,12 @@ function table(data: string[][]) {
 function realLength(str: string) {
     // eslint-disable-next-line no-control-regex
     return ("" + str).replace(/\u001b\[\d+m/g, "").length;
+}
+
+function crop(text: string) {
+    const max = 70;
+    if (text.length > max) {
+        return text.slice(0, max - 3) + "...";
+    }
+    return text;
 }

--- a/tools/i18n-toolkit/src/validations/test/checkTranslations.test.ts
+++ b/tools/i18n-toolkit/src/validations/test/checkTranslations.test.ts
@@ -1,0 +1,332 @@
+// (C) 2020-2022 GoodData Corporation
+
+import { checkTranslations } from "../usage/checkTranslations";
+import { UsageResult } from "../../data";
+import { LocalesStructure } from "../../schema/localization";
+
+describe("check translations", () => {
+    it("valid, extracted and loaded are same", () => {
+        const { uncontrolled, results } = checkTranslations(
+            [TestJsonBasic],
+            [PatternAll],
+            createExtracted(["ok.key", "fail.key"]),
+            {},
+        );
+
+        expect(uncontrolled).toEqual([]);
+        expect(results.length).toEqual(1);
+        checkResults(results[0], {
+            files: ["defaults/en-US/test.json"],
+            identifier: "/.+/",
+            extracted: 2,
+            loaded: 2,
+        });
+    });
+
+    it("invalid, only 1 extracted message, but loaded 2", () => {
+        const { uncontrolled, results } = checkTranslations(
+            [TestJsonBasic],
+            [PatternAll],
+            createExtracted(["ok.key"]),
+            {},
+        );
+
+        expect(uncontrolled).toEqual([]);
+        expect(results.length).toEqual(1);
+        checkResults(results[0], {
+            files: ["defaults/en-US/test.json"],
+            identifier: "/.+/",
+            extracted: 1,
+            loaded: 2,
+            unused: 1,
+            unusedMessages: ["fail.key"],
+        });
+    });
+
+    it("invalid, extracted 3 message, but loaded 2", () => {
+        const { uncontrolled, results } = checkTranslations(
+            [TestJsonBasic],
+            [PatternAll],
+            createExtracted(["ok.key", "fail.key", "fail.key1"]),
+            {},
+        );
+
+        expect(uncontrolled).toEqual([]);
+        expect(results.length).toEqual(1);
+        checkResults(results[0], {
+            files: ["defaults/en-US/test.json"],
+            identifier: "/.+/",
+            extracted: 3,
+            loaded: 2,
+            missing: 1,
+            missingMessages: ["fail.key1"],
+        });
+    });
+
+    it("valid with filtered, extracted and loaded are same", () => {
+        const { uncontrolled, results } = checkTranslations(
+            [TestJsonBasicWithIgnore],
+            [PatternOkAndFail_Filtered],
+            createExtracted(["ok.key", "fail.key"]),
+            {},
+        );
+
+        expect(uncontrolled).toEqual([]);
+        expect(results.length).toEqual(1);
+        checkResults(results[0], {
+            files: ["defaults/en-US/test.json"],
+            identifier: "/^ok\\./,/^fail\\./",
+            extracted: 2,
+            loaded: 2,
+        });
+    });
+
+    it("valid with filtered, extracted and loaded are same and there is uncontrolled message", () => {
+        const { uncontrolled, results } = checkTranslations(
+            [TestJsonBasicWithIgnore],
+            [PatternOkAndFail_Filtered],
+            createExtracted(["ok.key", "fail.key", "ignore.key1"]),
+            {},
+        );
+
+        expect(uncontrolled).toEqual(["ignore.key1"]);
+        expect(results.length).toEqual(1);
+        checkResults(results[0], {
+            files: ["defaults/en-US/test.json"],
+            identifier: "/^ok\\./,/^fail\\./",
+            extracted: 2,
+            loaded: 2,
+        });
+    });
+
+    it("valid with filtered, extracted and loaded are same and there are ignored messages", () => {
+        const { uncontrolled, results } = checkTranslations(
+            [TestJsonBasicWithIgnore],
+            [PatternOkAndFail_Filtered, PatternIgnore],
+            createExtracted(["ok.key", "fail.key", "ignored.key1"]),
+            {},
+        );
+
+        expect(uncontrolled).toEqual([]);
+        expect(results.length).toEqual(2);
+        checkResults(results[0], {
+            files: ["defaults/en-US/test.json"],
+            identifier: "/^ok\\./,/^fail\\./",
+            extracted: 2,
+            loaded: 2,
+        });
+        checkResults(results[1], {
+            files: ["defaults/en-US/test.json"],
+            identifier: "/^ignored\\./",
+            ignore: true,
+            extracted: 1,
+            loaded: 3,
+            ignored: 3,
+            ignoredMessages: ["ignored.key1", "ignored.key2", "ignored.key3"],
+        });
+    });
+
+    it("valid, extracted and loaded are same and there are ignored messages", () => {
+        const { uncontrolled, results } = checkTranslations(
+            [TestJsonBasicWithIgnore],
+            [PatternAll, PatternIgnore],
+            createExtracted(["ok.key", "fail.key"]),
+            {},
+        );
+
+        expect(uncontrolled).toEqual([]);
+        expect(results.length).toEqual(2);
+        checkResults(results[0], {
+            files: ["defaults/en-US/test.json"],
+            identifier: "/.+/",
+            extracted: 2,
+            loaded: 2,
+        });
+        checkResults(results[1], {
+            files: ["defaults/en-US/test.json"],
+            identifier: "/^ignored\\./",
+            ignore: true,
+            loaded: 3,
+            ignored: 3,
+            ignoredMessages: ["ignored.key1", "ignored.key2", "ignored.key3"],
+        });
+    });
+
+    it("invalid, extracted more messages than loaded", () => {
+        const { uncontrolled, results } = checkTranslations(
+            [TestJsonBasic],
+            [PatternAll, PatternIgnore],
+            createExtracted(["ok.key", "fail.key", "ignored.key1", "ignored.key2", "ignored.key3"]),
+            {},
+        );
+
+        expect(uncontrolled).toEqual([]);
+        expect(results.length).toEqual(2);
+        checkResults(results[0], {
+            files: ["defaults/en-US/test.json"],
+            identifier: "/.+/",
+            extracted: 5,
+            loaded: 2,
+            missing: 3,
+            missingMessages: ["ignored.key1", "ignored.key2", "ignored.key3"],
+        });
+        checkResults(results[1], {
+            files: ["defaults/en-US/test.json"],
+            identifier: "/^ignored\\./",
+            ignore: true,
+        });
+    });
+
+    it("valid, extracted and loaded are same because of ignored messages for all", () => {
+        const { uncontrolled, results } = checkTranslations(
+            [TestJsonBasicWithIgnore, TestJsonBasicWithIgnore2],
+            [PatternAll, PatternIgnore],
+            createExtracted(["ok.key", "fail.key"]),
+            {},
+        );
+
+        expect(uncontrolled).toEqual([]);
+        expect(results.length).toEqual(2);
+        checkResults(results[0], {
+            files: ["defaults/en-US/test.json", "extended/en-US/test.json"],
+            identifier: "/.+/",
+            extracted: 2,
+            loaded: 2,
+        });
+        checkResults(results[1], {
+            files: ["defaults/en-US/test.json", "extended/en-US/test.json"],
+            identifier: "/^ignored\\./",
+            ignore: true,
+            loaded: 3,
+            ignored: 3,
+            ignoredMessages: ["ignored.key1", "ignored.key2", "ignored.key3"],
+        });
+    });
+
+    it("invalid, extracted and loaded are not same because of ignored messages for only extended/ directory", () => {
+        const { uncontrolled, results } = checkTranslations(
+            [TestJsonBasicWithIgnore, TestJsonBasicWithIgnore2],
+            [PatternAll, PatternIgnoreOnlyExtended],
+            createExtracted(["ok.key", "fail.key"]),
+            {},
+        );
+
+        expect(uncontrolled).toEqual([]);
+        expect(results.length).toEqual(2);
+        checkResults(results[0], {
+            files: ["defaults/en-US/test.json", "extended/en-US/test.json"],
+            identifier: "/.+/",
+            extracted: 2,
+            loaded: 5,
+            unused: 3,
+            unusedMessages: ["ignored.key1", "ignored.key2", "ignored.key3"],
+        });
+        checkResults(results[1], {
+            files: ["extended/en-US/test.json"],
+            identifier: "/^ignored\\./",
+            ignore: true,
+            loaded: 3,
+            ignored: 3,
+            ignoredMessages: ["ignored.key1", "ignored.key2", "ignored.key3"],
+        });
+    });
+});
+
+function checkResults(
+    result: UsageResult,
+    {
+        files,
+        identifier,
+        missingMessages = [],
+        unusedMessages = [],
+        ignoredMessages = [],
+        ignore = undefined,
+        loaded = 0,
+        missing = 0,
+        extracted = 0,
+        unused = 0,
+        ignored = 0,
+    }: {
+        missingMessages?: string[];
+        unusedMessages?: string[];
+        ignoredMessages?: string[];
+        files: string[];
+        identifier: string;
+        ignore?: boolean;
+        extracted?: number;
+        loaded?: number;
+        missing?: number;
+        unused?: number;
+        ignored?: number;
+    },
+) {
+    expect(result.data.missingMessages).toEqual(missingMessages);
+    expect(result.data.unusedMessages).toEqual(unusedMessages);
+    expect(result.data.ignoredMessages).toEqual(ignoredMessages);
+
+    expect(result.files).toEqual(files);
+    expect(result.identifier).toEqual(identifier);
+    expect(result.ignore).toEqual(ignore);
+
+    expect(result.stats.extracted).toBe(extracted);
+    expect(result.stats.loaded).toBe(loaded);
+    expect(result.stats.missing).toBe(missing);
+    expect(result.stats.unused).toBe(unused);
+    expect(result.stats.ignored).toBe(ignored);
+}
+
+function createExtracted(arr: string[]) {
+    return arr.reduce((prev, item) => ({ ...prev, [item]: true }), {} as Record<string, any>);
+}
+
+//FILES
+
+const TestJsonBasic: [string, LocalesStructure] = [
+    "defaults/en-US/test.json",
+    {
+        "ok.key": { value: "OK", comment: "", limit: 0 },
+        "fail.key": { value: "FAIL", comment: "", limit: 0 },
+    },
+];
+
+const TestJsonBasicWithIgnore: [string, LocalesStructure] = [
+    "defaults/en-US/test.json",
+    {
+        ...TestJsonBasic[1],
+        "ignored.key1": { value: "Ignore1", comment: "", limit: 0 },
+        "ignored.key2": { value: "Ignore2", comment: "", limit: 0 },
+        "ignored.key3": { value: "Ignore3", comment: "", limit: 0 },
+    },
+];
+
+const TestJsonBasicWithIgnore2: [string, LocalesStructure] = [
+    "extended/en-US/test.json",
+    {
+        ...TestJsonBasic[1],
+        "ignored.key1": { value: "Ignore1", comment: "", limit: 0 },
+        "ignored.key2": { value: "Ignore2", comment: "", limit: 0 },
+        "ignored.key3": { value: "Ignore3", comment: "", limit: 0 },
+    },
+];
+
+//PATTERNS
+
+const PatternAll = {
+    pattern: [/.+/],
+};
+
+const PatternOkAndFail_Filtered = {
+    pattern: [/^ok\./, /^fail\./],
+    filterTranslationFile: true,
+};
+
+const PatternIgnore = {
+    pattern: [/^ignored\./],
+    ignore: true,
+};
+
+const PatternIgnoreOnlyExtended = {
+    dir: /^extended/,
+    pattern: [/^ignored\./],
+    ignore: true,
+};


### PR DESCRIPTION
 - added test to check translations method

JIRA: RAIL-4547
---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
