### PR TITLE
Fixed FOUC on WebComponents loading

### DIFF
--- a/libs/sdk-ui-web-components/src/visualizations/CustomElementAdapter.ts
+++ b/libs/sdk-ui-web-components/src/visualizations/CustomElementAdapter.ts
@@ -55,17 +55,23 @@ export abstract class CustomElementAdapter<C> extends HTMLElement {
         const link = document.createElement("link");
         link.type = "text/css";
         link.rel = "stylesheet";
+        const stylesLoadPromise = new Promise((res, rej) => {
+            link.addEventListener("load", () => res());
+            link.addEventListener("error", rej);
+        });
         const webpackWorkaround = SHADOW_STYLES;
         link.href = new URL(webpackWorkaround, import.meta.url).href;
         shadowRoot.appendChild(link);
 
         // Attach a mounting point for React
         this[MOUNT_POINT] = document.createElement("div");
-        this[MOUNT_POINT].classList.add("mount-point");
+        this[MOUNT_POINT].style.display = "flex";
+        this[MOUNT_POINT].style.flex = "1";
+        this[MOUNT_POINT].style.flexDirection = "column";
         shadowRoot.appendChild(this[MOUNT_POINT]);
 
         // Load the rest of the dependencies needed for React element rendering
-        Promise.all([this[LOAD_COMPONENT](), getContext()])
+        Promise.all([this[LOAD_COMPONENT](), getContext(), stylesLoadPromise])
             .then(([Component, context]) => {
                 this[COMPONENT] = Component;
                 this[CONTEXT] = context;

--- a/libs/sdk-ui-web-components/src/visualizations/components.shadow.css
+++ b/libs/sdk-ui-web-components/src/visualizations/components.shadow.css
@@ -5,9 +5,3 @@
 @import "~@gooddata/sdk-ui-kit/styles/css/main.css";
 @import "~@gooddata/sdk-ui-ext/styles/css/main.css";
 @import "~@gooddata/sdk-ui-dashboard/styles/css/main.css";
-
-.mount-point {
-    display: flex;
-    flex-direction: column;
-    flex: 1;
-}


### PR DESCRIPTION
JIRA: RAIL-4569

* Added style loading to the list of dependencies that we need to wait for before removing the Loader
* Inlined the mount point styles to prevent Loader from jumping once the styles are applied

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
