### PR TITLE
Scheduled emails are sent to the login address instead of email address

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/ScheduledMailDialogRenderer/ScheduledMailDialogRenderer.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/ScheduledMailDialogRenderer/ScheduledMailDialogRenderer.tsx
@@ -262,7 +262,8 @@ export class ScheduledMailDialogRendererUI extends React.PureComponent<
          *  silently by the method identifyWorkspaceRecipients.
          */
         const selectedRecipients = schedule.to.concat(schedule.bcc || []).map((email) => {
-            if (email === schedule.createdBy?.email) {
+            // user that created the schedule can have different login and email address
+            if (email === schedule.createdBy?.email || email === schedule.createdBy?.login) {
                 return userToRecipient(schedule.createdBy);
             }
             return {
@@ -818,7 +819,7 @@ export class ScheduledMailDialogRendererUI extends React.PureComponent<
         /// To: is currently only owner
         const toEmails = recipients
             .filter(isScheduleEmailExistingRecipient)
-            .map((recipient) => recipient.user.email!);
+            .map((recipient) => recipient.user.login);
 
         /// All other emails (without owner)
         const bccEmails = recipients

--- a/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/ScheduledMailDialogRenderer/test/ScheduledMailDialogRenderer.test.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/ScheduledMailDialogRenderer/test/ScheduledMailDialogRenderer.test.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { render, screen, within, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import noop from "lodash/noop";
-import { IUser, uriRef } from "@gooddata/sdk-model";
+import { uriRef } from "@gooddata/sdk-model";
 import { newInsightWidget } from "@gooddata/sdk-backend-base";
 
 import {
@@ -114,14 +114,7 @@ describe("ScheduledMailDialogRenderer", () => {
         });
         jest.useFakeTimers().setSystemTime(new Date("2022-01-02 12:13").getTime());
         const onSubmit = jest.fn();
-        const currentUser: IUser = {
-            login: "login.email@gooddata.com",
-            ref: uriRef("/gdc/user"),
-            email: "user@gooddata.com",
-            firstName: "John",
-            lastName: "Doe",
-        };
-        renderComponent({ onSubmit, currentUser });
+        renderComponent({ onSubmit });
 
         await user.click(screen.getByText("12:30 PM"));
         await user.click(screen.getByText("02:00 AM"));

--- a/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/utils/scheduledMailRecipients.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/utils/scheduledMailRecipients.ts
@@ -3,7 +3,7 @@ import { userFullName } from "@gooddata/sdk-model";
 import { IScheduleEmailRecipient, isScheduleEmailExistingRecipient } from "../interfaces";
 
 export const getScheduledEmailRecipientUniqueIdentifier = (recipient: IScheduleEmailRecipient): string =>
-    isScheduleEmailExistingRecipient(recipient) ? recipient.user.email! : recipient.email;
+    isScheduleEmailExistingRecipient(recipient) ? recipient.user.login : recipient.email;
 
 export const getScheduledEmailRecipientEmail = (recipient: IScheduleEmailRecipient): string =>
     isScheduleEmailExistingRecipient(recipient) ? recipient.user.email! : recipient.email;


### PR DESCRIPTION
- BE part for scheduled emails requires that the value sent is the login address since is unique identifier and from that it builds the proper payload to the user email address.

 - Handle case where login and email address are different, build proper user values to display on FE and send message to correct email address.
 

**JIRA: TNT-1036**

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
