### PR TITLE
Reduce widget re-renders

### DIFF
--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -2193,7 +2193,7 @@ export const DefaultDashboardLayout: (props: IDashboardLayoutProps) => JSX.Eleme
 export const defaultDashboardThemeModifier: (theme: ITheme) => ITheme;
 
 // @internal (undocumented)
-export const DefaultDashboardWidget: (props: IDashboardWidgetProps) => JSX.Element;
+export const DefaultDashboardWidget: React_2.NamedExoticComponent<IDashboardWidgetProps>;
 
 // @internal (undocumented)
 export function DefaultEditButton({ isVisible, isEnabled, onEditClick }: IEditButtonProps): JSX.Element | null;

--- a/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayoutRenderer/DashboardLayoutSection.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayoutRenderer/DashboardLayoutSection.tsx
@@ -49,11 +49,10 @@ export function DashboardLayoutSection<TWidget>(props: IDashboardLayoutSectionPr
     } = props;
     const renderProps = { section, screen, renderMode };
 
-    const items = flatMap(section.items().asGridRows(screen), (itemsInRow) => {
-        const rowKey = itemsInRow.map((item) => itemKeyGetter({ item, screen })).join(";");
+    const items = flatMap(section.items().asGridRows(screen), (itemsInRow, index) => {
         return (
             <DashboardLayoutGridRow
-                key={rowKey}
+                key={index.toString()}
                 screen={screen}
                 section={section}
                 items={itemsInRow}

--- a/libs/sdk-ui-dashboard/src/presentation/widget/widget/DefaultDashboardWidget.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/widget/DefaultDashboardWidget.tsx
@@ -19,7 +19,9 @@ import { RenderModeAwareDashboardInsightWidget } from "./InsightWidget";
 /**
  * @internal
  */
-export const DefaultDashboardWidget = (props: IDashboardWidgetProps): JSX.Element => {
+export const DefaultDashboardWidget = React.memo(function DefaultDashboardWidget(
+    props: IDashboardWidgetProps,
+): JSX.Element {
     const {
         onError,
         onFiltersChange,
@@ -98,4 +100,4 @@ export const DefaultDashboardWidget = (props: IDashboardWidgetProps): JSX.Elemen
     }
 
     return <div>Unknown widget</div>;
-};
+});


### PR DESCRIPTION
- On layout change, do not re-render all the widgets, but only widgets in changed section
- Also avoid DashboardLayoutGridRow (and nested child widgets) remounting, by switching to index keys

JIRA: RAIL-4568

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
