### PR TITLE
RELATED: RAIL-4596 Handle anonymous user on bear better

### DIFF
--- a/libs/sdk-backend-bear/src/backend/workspace/permissions/permissions.ts
+++ b/libs/sdk-backend-bear/src/backend/workspace/permissions/permissions.ts
@@ -12,9 +12,15 @@ export class BearWorkspacePermissionsFactory implements IWorkspacePermissionsSer
 
     public async getPermissionsForCurrentUser(): Promise<IWorkspacePermissions> {
         const permissions = await this.authCall(async (sdk, { getPrincipal }) => {
-            const userLoginMd5 = await userLoginMd5FromAuthenticatedPrincipal(getPrincipal);
-            return sdk.project.getPermissions(this.workspace, userLoginMd5);
+            let userLoginMd5;
+            try {
+                userLoginMd5 = await userLoginMd5FromAuthenticatedPrincipal(getPrincipal);
+                return sdk.project.getPermissions(this.workspace, userLoginMd5);
+            } catch {
+                // if getting the userLoginMd5 fails, fall back to null -> empty permissions
+                return null;
+            }
         });
-        return convertPermissions(permissions.associatedPermissions || emptyPermissions);
+        return convertPermissions(permissions?.associatedPermissions || emptyPermissions);
     }
 }


### PR DESCRIPTION
Anonymous user does not have the login MD5 so obtaining it would always fail. Instead, we now fallback to empty permissions so that it does not blow up anymore. This fixes live examples at the cost of the user no longer being able to export the dashboard to PDF.

JIRA: RAIL-4596

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
