### PR TITLE
RELATED: RAIL-4596 Pass real userId in anonymous provider

### DIFF
--- a/examples/sdk-examples/src/context/auth/GoodDataAuthProvider.ts
+++ b/examples/sdk-examples/src/context/auth/GoodDataAuthProvider.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2020 GoodData Corporation
+// (C) 2019-2022 GoodData Corporation
 import sdk from "@gooddata/api-client-bear";
 import { IAuthenticationProvider, IAuthenticatedPrincipal } from "@gooddata/sdk-backend-spi";
 import { ANONYMOUS_ACCESS } from "../../constants/env";
@@ -45,14 +45,19 @@ export class GoodDataAuthProvider implements IAuthenticationProvider {
         userId: string;
         userMeta: any;
     }> {
+        const user = await sdk.user.getCurrentProfile();
+
         if (ANONYMOUS_ACCESS) {
             return {
                 userId: "anonymous",
-                userMeta: {},
+                userMeta: {
+                    links: {
+                        // we need the actual self link of the user from the proxy, this is needed by some of the API calls
+                        self: user.links?.self,
+                    },
+                },
             };
         }
-
-        const user = await sdk.user.getCurrentProfile();
 
         return {
             userId: user.login!,


### PR DESCRIPTION
Otherwise, some calls like permissions fail.

JIRA: RAIL-4596

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
