### PR TITLE
Do not use ShadowDOM for WebComponents

### DIFF
--- a/libs/sdk-ui-web-components/src/index.ts
+++ b/libs/sdk-ui-web-components/src/index.ts
@@ -15,6 +15,11 @@ import { parseUrl } from "./parseUrl";
 import { Insight } from "./visualizations/Insight";
 import { Dashboard } from "./visualizations/Dashboard";
 
+// Include styles async to use native link injection from MiniCssExtractPlugin
+import("./visualizations/components.css").catch((error) => {
+    console.error("Failed to load GoodData styles", error);
+});
+
 const authMethodsMap = {
     sso: async function configureTigerSso(hostname: string) {
         const {

--- a/libs/sdk-ui-web-components/src/typings.d.ts
+++ b/libs/sdk-ui-web-components/src/typings.d.ts
@@ -2,4 +2,3 @@
 declare module "*.css";
 declare const NPM_PACKAGE_NAME: string;
 declare const NPM_PACKAGE_VERSION: string;
-declare const SHADOW_STYLES: string;

--- a/libs/sdk-ui-web-components/src/visualizations/components.css
+++ b/libs/sdk-ui-web-components/src/visualizations/components.css
@@ -1,3 +1,10 @@
+@import "~@gooddata/sdk-ui-filters/styles/css/main.css";
+@import "~@gooddata/sdk-ui-charts/styles/css/main.css";
+@import "~@gooddata/sdk-ui-pivot/styles/css/main.css";
+@import "~@gooddata/sdk-ui-kit/styles/css/main.css";
+@import "~@gooddata/sdk-ui-ext/styles/css/main.css";
+@import "~@gooddata/sdk-ui-dashboard/styles/css/main.css";
+
 gd-insight,
 gd-dashboard {
     display: flex;

--- a/libs/sdk-ui-web-components/src/visualizations/components.shadow.css
+++ b/libs/sdk-ui-web-components/src/visualizations/components.shadow.css
@@ -1,7 +1,0 @@
-@import "~@gooddata/sdk-ui-filters/styles/css/main.css";
-@import "~@gooddata/sdk-ui-charts/styles/css/main.css";
-@import "~@gooddata/sdk-ui-geo/styles/css/main.css";
-@import "~@gooddata/sdk-ui-pivot/styles/css/main.css";
-@import "~@gooddata/sdk-ui-kit/styles/css/main.css";
-@import "~@gooddata/sdk-ui-ext/styles/css/main.css";
-@import "~@gooddata/sdk-ui-dashboard/styles/css/main.css";

--- a/libs/sdk-ui-web-components/webpack.config.js
+++ b/libs/sdk-ui-web-components/webpack.config.js
@@ -5,7 +5,6 @@ const BundleAnalyzerPlugin = require("webpack-bundle-analyzer").BundleAnalyzerPl
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 const path = require("path");
 const npmPackage = require("./package.json");
-const SHADOW_STYLES = "assets/styles.shadow.css";
 
 module.exports = (env, argv) => ({
     mode: argv.mode,
@@ -80,14 +79,9 @@ module.exports = (env, argv) => ({
             },
             {
                 test: /\.css$/,
-                oneOf: [
-                    {
-                        test: /\.shadow\.css$/,
-                        use: [MiniCssExtractPlugin.loader, "css-loader"],
-                    },
-                    {
-                        use: ["style-loader", "css-loader"],
-                    },
+                use: [
+                    argv.mode === "production" ? MiniCssExtractPlugin.loader : "style-loader",
+                    "css-loader",
                 ],
             },
             {
@@ -121,15 +115,11 @@ module.exports = (env, argv) => ({
         new DefinePlugin({
             NPM_PACKAGE_NAME: JSON.stringify(npmPackage.name),
             NPM_PACKAGE_VERSION: JSON.stringify(npmPackage.version),
-            SHADOW_STYLES: JSON.stringify(SHADOW_STYLES),
         }),
         new ProvidePlugin({
             process: "process/browser",
         }),
-        new MiniCssExtractPlugin({
-            filename: SHADOW_STYLES,
-            runtime: false,
-        }),
+        argv.mode === "production" && new MiniCssExtractPlugin(),
         env.analyze &&
             new BundleAnalyzerPlugin({
                 analyzerMode: "static",


### PR DESCRIPTION
Some popups are mounted to the body directly, which breaks their styling and positioning (ShadowDOM isolates styles).

JIRA: RAIL-4588

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
