### PR TITLE
Added a warning message about missing Authentication setup in web components

### DIFF
--- a/libs/sdk-ui-web-components/src/parseUrl.ts
+++ b/libs/sdk-ui-web-components/src/parseUrl.ts
@@ -1,7 +1,5 @@
 // (C) 2022 GoodData Corporation
 
-import invariant from "ts-invariant";
-
 /**
  * "none" means programmatic backend setup
  * "sso" means automatic Tiger SSO with redirection
@@ -38,16 +36,29 @@ const mapAuthType = (auth: string | null): AuthType => {
  *
  * @internal
  */
-export const parseUrl = (scriptUrl: URL) => {
-    const protocol = scriptUrl.protocol.toLowerCase() === "http:" ? "http:" : "https:";
-    const host = scriptUrl.host;
-    const workspaceId = scriptUrl.searchParams.has("workspace")
-        ? scriptUrl.searchParams.get("workspace")
-        : scriptUrl.pathname.match(/^\/components\/(.+)\.js$/i)?.[1];
+export const parseUrl = (
+    scriptUrl: string,
+): {
+    hostname?: string;
+    workspaceId?: string;
+    authType: AuthType;
+} => {
+    let url: URL;
 
-    invariant(workspaceId, "Unable to parse workspace id based on the script URL");
+    try {
+        url = new URL(scriptUrl);
+    } catch (e) {
+        // Invalid URL provided...
+        return { hostname: undefined, workspaceId: undefined, authType: "none" };
+    }
 
-    const authType: AuthType = mapAuthType(scriptUrl.searchParams.get("auth"));
+    const protocol = url.protocol.toLowerCase() === "http:" ? "http:" : "https:";
+    const host = url.host;
+    const workspaceId = url.searchParams.has("workspace")
+        ? url.searchParams.get("workspace")!
+        : url.pathname.match(/^\/components\/(.+)\.js$/i)?.[1];
+
+    const authType: AuthType = mapAuthType(url.searchParams.get("auth"));
 
     return { hostname: `${protocol}//${host}`, workspaceId, authType };
 };

--- a/libs/sdk-ui-web-components/src/tests/parseUrl.test.ts
+++ b/libs/sdk-ui-web-components/src/tests/parseUrl.test.ts
@@ -4,67 +4,64 @@ import { parseUrl } from "../parseUrl";
 
 describe("parseUrl", () => {
     it("should parse workspaceId from the URL", () => {
-        const { workspaceId } = parseUrl(new URL("https://somehost.com/components/workspace-id.js"));
+        const { workspaceId } = parseUrl("https://somehost.com/components/workspace-id.js");
 
         expect(workspaceId).toEqual("workspace-id");
     });
 
     it("should parse workspaceId from the URL query", () => {
         const { workspaceId } = parseUrl(
-            new URL("https://somehost.com/components/workspace-id.js?workspace=override"),
+            "https://somehost.com/components/workspace-id.js?workspace=override",
         );
 
         expect(workspaceId).toEqual("override");
     });
 
     it("should parse workspaceId in case it includes dot", () => {
-        const { workspaceId } = parseUrl(new URL("https://somehost.com/components/work.space.id.js"));
+        const { workspaceId } = parseUrl("https://somehost.com/components/work.space.id.js");
 
         expect(workspaceId).toEqual("work.space.id");
     });
 
+    it("should return undefined for the workspaceId in case it can't be parsed", () => {
+        const { workspaceId } = parseUrl("https://somehost.com/some/other/url.js");
+
+        expect(workspaceId).toBeUndefined();
+    });
+
     it.each(["sso", "bearSso", "bear"])("should parse '%s' authType from the URL", (auth) => {
-        const { authType } = parseUrl(
-            new URL(`https://somehost.com/components/workspace-id.js?auth=${auth}`),
-        );
+        const { authType } = parseUrl(`https://somehost.com/components/workspace-id.js?auth=${auth}`);
 
         expect(authType).toEqual(auth);
     });
 
     it("should set authType to 'none' if query parameter is omitted", () => {
-        const { authType } = parseUrl(new URL("https://somehost.com/components/workspace-id.js"));
+        const { authType } = parseUrl("https://somehost.com/components/workspace-id.js");
 
         expect(authType).toEqual("none");
     });
 
     it("should set authType to 'none' if query parameter is set to unknown value", () => {
-        const { authType } = parseUrl(
-            new URL("https://somehost.com/components/workspace-id.js?auth=unknown"),
-        );
+        const { authType } = parseUrl("https://somehost.com/components/workspace-id.js?auth=unknown");
 
         expect(authType).toEqual("none");
     });
 
-    it("should throw if provided with a weird or incomplete URL", () => {
-        // No "components" part
-        expect(() => {
-            parseUrl(new URL("https://somehost.com/workspace-id.js"));
-        }).toThrow();
+    it("should return an undefined hostname and workspaceId in case an invalid URL is provided", () => {
+        const { workspaceId, hostname } = parseUrl("I am not a URL");
 
-        // Unexpectedly long pathname
-        expect(() => {
-            parseUrl(new URL("https://somehost.com/components/workspace-id/some-unexpected-part"));
-        }).toThrow();
+        expect(workspaceId).toBeUndefined();
+        expect(hostname).toBeUndefined();
     });
 
     it("should detect HTTP hostname", () => {
-        const { hostname } = parseUrl(new URL("http://localhost/components/workspace-id.js"));
+        const { hostname } = parseUrl("http://localhost/components/workspace-id.js");
 
         expect(hostname).toBe("http://localhost");
     });
 
     it("should detect HTTPS protocol", () => {
-        const { hostname } = parseUrl(new URL("https://localhost/components/workspace-id.js"));
+        const { hostname } = parseUrl("https://localhost/components/workspace-id.js");
 
         expect(hostname).toBe("https://localhost");
     });


### PR DESCRIPTION
JIRA: RAIL-4599

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
