### PR TITLE
Try latest backstop

### DIFF
--- a/libs/sdk-ui-tests/backstop/run-backstop.sh
+++ b/libs/sdk-ui-tests/backstop/run-backstop.sh
@@ -51,7 +51,7 @@ docker network create "${BACKSTOP_NET}" || { echo "Network creation failed" && e
         --net "${BACKSTOP_NET}" --net-alias storybook \
         --volume ${STORYBOOK_ASSETS}:/usr/share/nginx/html:ro,Z \
         --volume ${STORYBOOK_CONF}:/etc/nginx/conf.d/storybook.conf:ro,Z \
-        nginxinc/nginx-unprivileged:1.21.6-alpine)
+        nginxinc/nginx-unprivileged:1.23.1-alpine)
 
     echo "waiting for nginx in container: ${NGINX_CONTAINER} to start serving storybook"
 
@@ -75,7 +75,7 @@ docker network create "${BACKSTOP_NET}" || { echo "Network creation failed" && e
             --user $UID:$GID \
             --net ${BACKSTOP_NET} --net-alias backstop \
             --volume ${BACKSTOP_DIR}:/src:Z,consistent \
-            backstopjs/backstopjs:5.1.0 --config=/src/backstop.config.js "$@"
+            backstopjs/backstopjs:6.1.3 --config=/src/backstop.config.js "$@"
 
         echo "BackstopJS finished. Killing nginx container ${NGINX_CONTAINER}"
     }

--- a/libs/sdk-ui-tests/stories/serve-storybook.sh
+++ b/libs/sdk-ui-tests/stories/serve-storybook.sh
@@ -13,4 +13,4 @@ docker run --rm \
         --volume ${STORYBOOK_ASSETS}:/usr/share/nginx/html:ro,Z \
         --volume ${STORYBOOK_CONF}:/etc/nginx/conf.d/storybook.conf:ro,Z \
         -p ${PORT}:8080 \
-        nginxinc/nginx-unprivileged:1.21.6-alpine
+        nginxinc/nginx-unprivileged:1.23.1-alpine


### PR DESCRIPTION
<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
