### PR TITLE
RELATED: RAIL-4611 Load web-components styles only when needed

### DIFF
--- a/libs/sdk-ui-tests/.storybook/preview-head.html
+++ b/libs/sdk-ui-tests/.storybook/preview-head.html
@@ -1,5 +1,8 @@
 <script type="module">
-    import { setContext } from "/static/web-components/index.js";
-
-    window.__setWebComponentsContext = setContext;
+    // only load the web-components stuff for the web-components stories
+    if (window.location.href.includes("13-web-components")) {
+        import("/static/web-components/index.js").then((m) => {
+            window.__setWebComponentsContext = m.setContext;
+        });
+    }
 </script>

--- a/libs/sdk-ui-tests/stories/_infra/webComponents.ts
+++ b/libs/sdk-ui-tests/stories/_infra/webComponents.ts
@@ -11,7 +11,7 @@ const configureWebComponentsBackend = (backend: IAnalyticalBackend, workspaceId:
     // preview-head.html loads after this file.
     // I.e. by the time this runs the global variables is not set yet
     const configureBackend = () => {
-        if (window.__setWebComponentsContext) {
+        if (typeof window.__setWebComponentsContext !== "undefined") {
             try {
                 window.__setWebComponentsContext({
                     backend: backend,


### PR DESCRIPTION
Otherwise the styles from sdk-ui-dashboard will pollute the global styles with its normalize.css which breaks all the PlugVis stories as it changes styles for legend and fieldset enough to break screenshots.

JIRA: RAIL-4611

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
