### PR TITLE
RELATED: RAIL-4661 Remove normalize.css from dashboard

### DIFF
--- a/common/config/rush/browser-approved-packages.json
+++ b/common/config/rush/browser-approved-packages.json
@@ -839,10 +839,6 @@
       "allowedCategories": [ "production" ]
     },
     {
-      "name": "normalize.css",
-      "allowedCategories": [ "production" ]
-    },
-    {
       "name": "npm-run-all",
       "allowedCategories": [ "examples", "production" ]
     },

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -14950,10 +14950,6 @@ packages:
     engines: {node: '>=8'}
     dev: false
 
-  /normalize.css/8.0.1:
-    resolution: {integrity: sha512-qizSNPO93t1YUuUhP22btGOo3chcvDFqFaj2TRybP0DMxkHOCTYwp3n34fel4a31ORXy4m1Xq0Gyqpb5m33qIg==}
-    dev: false
-
   /npm-run-all/4.1.5:
     resolution: {integrity: sha512-Oo82gJDAVcaMdi3nuoKFavkIHBRVqQ1qvMb+9LHk/cF4P6B2m8aP04hGf7oL6wZ9BuGwX1onlLhpuoofSyoQDQ==}
     engines: {node: '>= 4'}
@@ -22529,7 +22525,6 @@ packages:
       jest-junit: 3.7.0
       json-stable-stringify: 1.0.1
       lodash: 4.17.21
-      normalize.css: 8.0.1
       prettier: 2.5.1
       raf: 3.4.1
       react: 17.0.2

--- a/libs/sdk-ui-dashboard/package.json
+++ b/libs/sdk-ui-dashboard/package.json
@@ -82,7 +82,6 @@
         "immer": "^9.0.3",
         "json-stable-stringify": "^1.0.1",
         "lodash": "^4.17.19",
-        "normalize.css": "^8.0.1",
         "react-dnd": "^14.0.5",
         "react-dnd-html5-backend": "^14.1.0",
         "react-grid-system": "^8.1.4",

--- a/libs/sdk-ui-dashboard/scripts/build.sh
+++ b/libs/sdk-ui-dashboard/scripts/build.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 _build_styles() {
-    sass --load-path=node_modules --load-path=node_modules/normalize.css styles/scss:styles/css
+    sass --load-path=node_modules styles/scss:styles/css
 }
 
 _clean() {

--- a/libs/sdk-ui-dashboard/styles/scss/main.scss
+++ b/libs/sdk-ui-dashboard/styles/scss/main.scss
@@ -1,5 +1,4 @@
 // (C) 2021-2022 GoodData Corporation
-@use "normalize";
 @use "@gooddata/sdk-ui-kit/styles/css/list";
 @use "@gooddata/sdk-ui-kit/styles/css/messages";
 @use "@gooddata/sdk-ui-filters/styles/css/attributeFilter";

--- a/libs/sdk-ui-tests/.storybook/preview-head.html
+++ b/libs/sdk-ui-tests/.storybook/preview-head.html
@@ -1,5 +1,8 @@
 <script type="module">
-    import { setContext } from "/static/web-components/index.js";
-
-    window.__setWebComponentsContext = setContext;
+    // only load the web-components stuff for the web-components stories
+    if (window.location.href.includes("13-web-components")) {
+        import("/static/web-components/index.js").then((m) => {
+            window.__setWebComponentsContext = m.setContext;
+        });
+    }
 </script>

--- a/libs/sdk-ui-tests/backstop/scenarios.config.js
+++ b/libs/sdk-ui-tests/backstop/scenarios.config.js
@@ -126,6 +126,7 @@ const ScenarioConfig = [
         idRegex: /(13).*/g,
         config: {
             misMatchThreshold: 0.01,
+            delay: 1000, // wait for a bit for the async import to resolve
         },
     },
 ];

--- a/libs/sdk-ui-tests/stories/_infra/webComponents.ts
+++ b/libs/sdk-ui-tests/stories/_infra/webComponents.ts
@@ -11,7 +11,7 @@ const configureWebComponentsBackend = (backend: IAnalyticalBackend, workspaceId:
     // preview-head.html loads after this file.
     // I.e. by the time this runs the global variables is not set yet
     const configureBackend = () => {
-        if (window.__setWebComponentsContext) {
+        if (typeof window.__setWebComponentsContext !== "undefined") {
             try {
                 window.__setWebComponentsContext({
                     backend: backend,


### PR DESCRIPTION
It pollutes global styles which can break users' applications. Also load web-components stuff in storybook only when needed, otherwise it loads bunch of unrelated styles and makes the tests unstable (there is a delay there).

JIRA: RAIL-4661

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
