### PR TITLE
Remove dashboardEditModeDevRollout from unfinished

### DIFF
--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/initializeDashboardHandler/tests/__snapshots__/handler.test.ts.snap
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/initializeDashboardHandler/tests/__snapshots__/handler.test.ts.snap
@@ -193,9 +193,7 @@ Object {
     "decimal": ".",
     "thousand": ",",
   },
-  "settings": Object {
-    "dashboardEditModeDevRollout": Any<Boolean>,
-  },
+  "settings": Object {},
 }
 `;
 

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/initializeDashboardHandler/tests/handler.test.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/initializeDashboardHandler/tests/handler.test.ts
@@ -76,9 +76,7 @@ describe("initialize dashboard handler", () => {
                         to: expect.any(String),
                     },
                 },
-                settings: {
-                    dashboardEditModeDevRollout: expect.any(Boolean),
-                },
+                settings: {},
             });
         });
 

--- a/libs/sdk-ui-dashboard/src/model/disabledUnfinishedFeatureSettings.ts
+++ b/libs/sdk-ui-dashboard/src/model/disabledUnfinishedFeatureSettings.ts
@@ -13,8 +13,7 @@ import { ISettings } from "@gooddata/sdk-model";
 
 /**
  * Turns off development settings for unfinished features which cant be turned on in this version of UI SDK.
- * Add disabled FF for your feature, when it is not completed yet, but UI SDK needs to be released. It will prevent this feature from being accidentally turned on in WIP state by its platform setting when used in this version of UI SDK as part of old plugin.
+ * Add disabled FF for your feature, when it is not completed yet, but UI SDK needs to be released.
+ * It will prevent this feature from being accidentally turned on in WIP state by its platform setting when used in this version of UI SDK as part of old plugin.
  */
-export const disabledUnfinishedFeatureSettings: ISettings = {
-    dashboardEditModeDevRollout: false,
-};
+export const disabledUnfinishedFeatureSettings: ISettings = {};


### PR DESCRIPTION
The next SDK release will have this done, so we mark it as finished now to make it easier to test upstream.

JIRA: RAIL-4100

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
