### PR TITLE
RELATED: RAIL-4574, RAIL-4577 Add support for saving untitled dashboards, add date filter message

### DIFF
--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -5131,11 +5131,13 @@ export const SaveButton: (props: ISaveButtonProps) => JSX.Element;
 // @alpha (undocumented)
 export interface SaveDashboard extends IDashboardCommand {
     // (undocumented)
+    readonly payload: SaveDashboardPayload;
+    // (undocumented)
     readonly type: "GDC.DASH/CMD.SAVE";
 }
 
 // @alpha
-export function saveDashboard(correlationId?: string): SaveDashboard;
+export function saveDashboard(title?: string, correlationId?: string): SaveDashboard;
 
 // @public (undocumented)
 export interface SaveDashboardAs extends IDashboardCommand {
@@ -5153,6 +5155,11 @@ export interface SaveDashboardAsPayload {
     readonly switchToCopy?: boolean;
     readonly title?: string;
     readonly useOriginalFilterContext?: boolean;
+}
+
+// @alpha
+export interface SaveDashboardPayload {
+    readonly title?: string;
 }
 
 // @alpha

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/saveDashboardHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/saveDashboardHandler.ts
@@ -151,6 +151,7 @@ function* createDashboardSaveContext(
     const dashboardFromState: IDashboardDefinition = {
         type: "IDashboard",
         ...dashboardDescriptor,
+        title: cmd.payload.title ?? dashboardDescriptor.title,
         ...dashboardIdentity,
         filterContext: {
             ...filterContextIdentity,

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/tests/saveDashboardHandler.test.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/tests/saveDashboardHandler.test.ts
@@ -99,7 +99,7 @@ describe("save dashboard handler", () => {
         });
 
         it("should emit correct events", async () => {
-            await Tester.dispatchAndWaitFor(saveDashboard(TestCorrelation), "GDC.DASH/EVT.SAVED");
+            await Tester.dispatchAndWaitFor(saveDashboard(undefined, TestCorrelation), "GDC.DASH/EVT.SAVED");
 
             expect(Tester.emittedEventsDigest()).toMatchSnapshot();
         });

--- a/libs/sdk-ui-dashboard/src/model/commands/dashboard.ts
+++ b/libs/sdk-ui-dashboard/src/model/commands/dashboard.ts
@@ -132,10 +132,23 @@ export function initializeDashboardWithPersistedDashboard(
 //
 
 /**
+ * Payload of the {@link SaveDashboard} command.
+ * @alpha
+ */
+export interface SaveDashboardPayload {
+    /**
+     * Specify new title for the dashboard that will be created during the Save operation. If not specified,
+     * the current dashboard title will be used.
+     */
+    readonly title?: string;
+}
+
+/**
  * @alpha
  */
 export interface SaveDashboard extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.SAVE";
+    readonly payload: SaveDashboardPayload;
 }
 
 /**
@@ -144,15 +157,19 @@ export interface SaveDashboard extends IDashboardCommand {
  *
  * The command will not have any effect if dashboard is not initialized or is empty.
  *
+ * @param title - new title for the dashboard; if not specified, the current title of the dashboard will be used
  * @param correlationId - specify correlation id to use for this command. this will be included in all
  *  events that will be emitted during the command processing
  *
  * @alpha
  */
-export function saveDashboard(correlationId?: string): SaveDashboard {
+export function saveDashboard(title?: string, correlationId?: string): SaveDashboard {
     return {
         type: "GDC.DASH/CMD.SAVE",
         correlationId,
+        payload: {
+            title,
+        },
     };
 }
 

--- a/libs/sdk-ui-dashboard/src/model/commands/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/commands/index.ts
@@ -83,6 +83,7 @@ export {
     SaveDashboardAsPayload,
     saveDashboardAs,
     SaveDashboard,
+    SaveDashboardPayload,
     saveDashboard,
     RenameDashboard,
     RenameDashboardPayload,

--- a/libs/sdk-ui-dashboard/src/presentation/filterBar/dateFilter/DefaultDashboardDateFilter.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/filterBar/dateFilter/DefaultDashboardDateFilter.tsx
@@ -8,6 +8,7 @@ import { matchDateFilterToDateFilterOptionWithPreference } from "../../../_stagi
 import { IDashboardDateFilterProps } from "./types";
 import {
     selectBackendCapabilities,
+    selectIsInEditMode,
     selectLocale,
     selectSettings,
     useDashboardSelector,
@@ -24,6 +25,7 @@ export const DefaultDashboardDateFilter = (props: IDashboardDateFilterProps): JS
     const settings = useDashboardSelector(selectSettings);
     const capabilities = useDashboardSelector(selectBackendCapabilities);
     const locale = useDashboardSelector(selectLocale);
+    const isInEditMode = useDashboardSelector(selectIsInEditMode);
     const { filter, onFilterChanged, config, readonly } = props;
     const [lastSelectedOptionId, setLastSelectedOptionId] = useState("");
     const { dateFilterOption, excludeCurrentPeriod } = useMemo(
@@ -55,6 +57,7 @@ export const DefaultDashboardDateFilter = (props: IDashboardDateFilterProps): JS
             dateFormat={settings.responsiveUiDateFormat}
             locale={locale}
             isTimeForAbsoluteRangeEnabled={!!capabilities.supportsTimeGranularities}
+            isEditMode={isInEditMode}
         />
     );
 };

--- a/libs/sdk-ui-dashboard/src/presentation/topBar/buttonBar/button/saveButton/DefaultSaveButton.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/topBar/buttonBar/button/saveButton/DefaultSaveButton.tsx
@@ -16,6 +16,7 @@ import {
     selectIsInEditMode,
     useDashboardDispatch,
     useDashboardSelector,
+    selectDashboardTitle,
 } from "../../../../../model";
 import { messages } from "../../../../../locales";
 import { selectCanSaveDashboard, selectIsPrivateDashboard } from "../selectors";
@@ -26,12 +27,21 @@ import { ISaveButtonProps } from "./types";
  */
 export function useSaveButtonProps(): ISaveButtonProps {
     const dispatch = useDashboardDispatch();
+
+    const title = useDashboardSelector(selectDashboardTitle);
+    const intl = useIntl();
+    const emptyTitle = intl.formatMessage({ id: "untitled" });
+
     const onSaveClick = useCallback(
         () =>
-            dispatchAndWaitFor(dispatch, saveDashboard()).then(() => {
+            dispatchAndWaitFor(
+                dispatch,
+                // the || is intentional, we want to replace empty string as well
+                saveDashboard(title || emptyTitle),
+            ).then(() => {
                 dispatch(cancelEditRenderMode());
             }),
-        [dispatch],
+        [dispatch, emptyTitle, title],
     );
 
     const isEditing = useDashboardSelector(selectIsInEditMode);


### PR DESCRIPTION
* RAIL-4574 - We must provide the default title from outside as it needs to be localized and we can only access that information from react-land.
* RAIL-4577 - Indicate edit mode for date filter properly.

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
