### PR TITLE
RELATED: RAIL-4579 Fix KPI drill in edit mode

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/widget/kpi/ViewModeDashboardKpi/DefaultDashboardKpiWithDrills.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/kpi/ViewModeDashboardKpi/DefaultDashboardKpiWithDrills.tsx
@@ -1,42 +1,15 @@
 // (C) 2020-2022 GoodData Corporation
-import React, { useCallback } from "react";
-import { IDrillToLegacyDashboard } from "@gooddata/sdk-model";
+import React from "react";
 import { IDashboardKpiProps } from "../types";
 import { DashboardKpiCore } from "./DashboardKpiCore";
-import { OnFiredDashboardDrillEvent } from "../../../../types";
-import { useDrill, useDrillToLegacyDashboard } from "../../../drill";
-import { useDashboardSelector, selectDisableDefaultDrills } from "../../../../model";
+import { useKpiDrill } from "../common/useKpiDrill";
 
 /**
  * @internal
  */
 export const DefaultDashboardKpiWithDrills = (props: IDashboardKpiProps): JSX.Element => {
     const { kpiWidget } = props;
-    const disableDefaultDrills = useDashboardSelector(selectDisableDefaultDrills);
-
-    const { run: handleDrillToLegacyDashboard } = useDrillToLegacyDashboard();
-    const { run: handleDrill } = useDrill({
-        onSuccess: (event) => {
-            if (disableDefaultDrills || !event.payload.drillEvent.drillDefinitions[0]) {
-                return;
-            }
-
-            handleDrillToLegacyDashboard(
-                event.payload.drillEvent.drillDefinitions[0] as IDrillToLegacyDashboard,
-                event.payload.drillEvent,
-                event.correlationId,
-            );
-        },
-    });
-
-    const onDrill = useCallback<OnFiredDashboardDrillEvent>(
-        (event) => {
-            handleDrill(event, {
-                widget: kpiWidget,
-            });
-        },
-        [handleDrill, kpiWidget],
-    );
+    const onDrill = useKpiDrill(kpiWidget);
 
     return <DashboardKpiCore {...props} onDrill={onDrill} />;
 };

--- a/libs/sdk-ui-dashboard/src/presentation/widget/kpi/common/KpiRenderer.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/kpi/common/KpiRenderer.tsx
@@ -16,6 +16,7 @@ interface IKpiRendererProps {
     disableDrillUnderline?: boolean;
     isDrillable?: boolean;
     onDrill?: (drillContext: IDrillEventContext) => ReturnType<OnFiredDashboardDrillEvent>;
+    isKpiValueClickDisabled?: boolean;
     enableCompactSize?: boolean;
     error?: GoodDataSdkError;
     errorHelp?: string;
@@ -29,6 +30,7 @@ export const KpiRenderer: React.FC<IKpiRendererProps> = ({
     disableDrillUnderline,
     onDrill,
     isDrillable,
+    isKpiValueClickDisabled,
     kpi,
     kpiResult,
     filters,
@@ -64,6 +66,7 @@ export const KpiRenderer: React.FC<IKpiRendererProps> = ({
             kpiResult={kpiResult}
             isKpiUnderlineHiddenWhenClickable={disableDrillUnderline}
             onKpiValueClick={isDrillable && onDrill ? onPrimaryValueClick : undefined}
+            isKpiValueClickDisabled={isKpiValueClickDisabled}
             filters={filters}
             separators={separators}
             enableCompactSize={enableCompactSize}

--- a/libs/sdk-ui-dashboard/src/presentation/widget/kpi/common/useKpiDrill.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/kpi/common/useKpiDrill.ts
@@ -1,0 +1,38 @@
+// (C) 2022 GoodData Corporation
+import { useCallback } from "react";
+import { IDrillToLegacyDashboard, IKpiWidget } from "@gooddata/sdk-model";
+import { OnFiredDashboardDrillEvent } from "../../../../types";
+import { useDrill, useDrillToLegacyDashboard } from "../../../drill";
+import { useDashboardSelector, selectDisableDefaultDrills } from "../../../../model";
+
+/**
+ * Returns a drill handler for a given KPI.
+ *
+ * @param kpiWidget - widget the drills of which to handle
+ * @internal
+ */
+export function useKpiDrill(kpiWidget: IKpiWidget) {
+    const disableDefaultDrills = useDashboardSelector(selectDisableDefaultDrills);
+
+    const { run: handleDrillToLegacyDashboard } = useDrillToLegacyDashboard();
+    const { run: handleDrill } = useDrill({
+        onSuccess: (event) => {
+            if (disableDefaultDrills || !event.payload.drillEvent.drillDefinitions[0]) {
+                return;
+            }
+
+            handleDrillToLegacyDashboard(
+                event.payload.drillEvent.drillDefinitions[0] as IDrillToLegacyDashboard,
+                event.payload.drillEvent,
+                event.correlationId,
+            );
+        },
+    });
+
+    return useCallback<OnFiredDashboardDrillEvent>(
+        (event) => {
+            handleDrill(event, { widget: kpiWidget });
+        },
+        [handleDrill, kpiWidget],
+    );
+}


### PR DESCRIPTION
Turns out the KPI should drill even in edit mode when selected and not embedded and default drill not disabled.

JIRA: RAIL-4579

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
