### PR TITLE
RELATED: RAIL-4607 Show attribute name in filter drag preview

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableAttributeFilter/DefaultAttributeFilterDraggingComponent.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableAttributeFilter/DefaultAttributeFilterDraggingComponent.tsx
@@ -11,7 +11,7 @@ import {
     uriRef,
 } from "@gooddata/sdk-model";
 import { createSelector } from "@reduxjs/toolkit";
-import { selectCatalogAttributeDisplayForms, useDashboardSelector } from "../../../model";
+import { selectCatalogAttributes, useDashboardSelector } from "../../../model";
 import { AttributeFilterDraggingComponent } from "../../componentDefinition";
 
 function isDisplayFormEqual(displayForm: IAttributeDisplayFormMetadataObject, identifierOrUriRef: ObjRef) {
@@ -21,17 +21,19 @@ function isDisplayFormEqual(displayForm: IAttributeDisplayFormMetadataObject, id
     );
 }
 
-const selectFilterDisplayForm = (filter: IDashboardAttributeFilter) =>
-    createSelector(selectCatalogAttributeDisplayForms, (displayForms) =>
-        displayForms.find((displayForm) =>
-            isDisplayFormEqual(displayForm, filter.attributeFilter.displayForm),
+const selectFilterAttribute = (filter: IDashboardAttributeFilter) =>
+    createSelector(selectCatalogAttributes, (attributes) =>
+        attributes.find((attribute) =>
+            attribute.displayForms.some((displayForm) =>
+                isDisplayFormEqual(displayForm, filter.attributeFilter.displayForm),
+            ),
         ),
     );
 
 export const DefaultAttributeFilterDraggingComponent: AttributeFilterDraggingComponent = ({ item }) => {
     const theme = useTheme();
-    const filterDisplayForm = useDashboardSelector(selectFilterDisplayForm(item.filter));
-    if (!filterDisplayForm) {
+    const filterAttribute = useDashboardSelector(selectFilterAttribute(item.filter));
+    if (!filterAttribute) {
         return null;
     }
 
@@ -45,7 +47,7 @@ export const DefaultAttributeFilterDraggingComponent: AttributeFilterDraggingCom
             />
             <div className="button-content">
                 <div className="button-title">
-                    <ShortenedText>{filterDisplayForm.title}</ShortenedText>
+                    <ShortenedText>{filterAttribute.attribute.title}</ShortenedText>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
We must show the attribute name, not the display form name: we show attribute in the filter title as well -> make it consistent.

JIRA: RAIL-4607

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
