### PR TITLE
RELATED: RAIL-4618 Fix getAttributeDisplayForm on tiger with prefixes

### DIFF
--- a/libs/sdk-backend-tiger/src/backend/workspace/attributes/index.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/attributes/index.ts
@@ -13,6 +13,7 @@ import {
     IAttributeDisplayFormMetadataObject,
     IAttributeMetadataObject,
     IDataSetMetadataObject,
+    IdentifierRef,
 } from "@gooddata/sdk-model";
 import { TigerAuthenticatedCallGuard } from "../../../types";
 import { TigerWorkspaceElements } from "./elements";
@@ -100,11 +101,14 @@ async function loadAttributeDisplayForm(
     // to be able to get the defaultView value, we need to load the attribute itself and then find the appropriate label inside of it
     // otherwise, we would have to load the label first and then load its attribute to see the defaultView relation thus needing
     // an extra network request
+    // tiger RSQL does not support prefixed ids, so we strip the prefix to load matches with or without prefix
+    // and then find the prefixed value in the results
+    const idWithoutPrefix = last(ref.identifier.split(":"));
     const attributeRes = await client.entities.getAllEntitiesAttributes(
         {
             workspaceId,
             include: ["labels", "defaultView"],
-            filter: `labels.id==${ref.identifier}`, // use RSQL to load the appropriate attribute
+            filter: `labels.id==${idWithoutPrefix}`, // use RSQL to load the appropriate attribute
         },
         {
             headers: jsonApiHeaders,
@@ -119,13 +123,24 @@ async function loadAttributeDisplayForm(
         );
     }
 
-    const [attribute] = convertAttributesWithSideloadedLabels(attributeRes.data);
-
-    const matchingLabel = attribute.displayForms.find((df) => areObjRefsEqual(df.ref, ref));
-
+    const attributes = convertAttributesWithSideloadedLabels(attributeRes.data);
+    const matchingLabel = findLabelInAttributes(attributes, ref);
     invariant(matchingLabel, "inconsistent server response, RSQL matched but ref matching did not");
-
     return matchingLabel;
+}
+
+function findLabelInAttributes(
+    attributes: IAttributeMetadataObject[],
+    ref: IdentifierRef,
+): IAttributeDisplayFormMetadataObject | undefined {
+    for (const attr of attributes) {
+        for (const df of attr.displayForms) {
+            if (areObjRefsEqual(df.ref, ref)) {
+                return df;
+            }
+        }
+    }
+    return undefined;
 }
 
 function loadAttribute(


### PR DESCRIPTION
RSQL cannot handle prefixes, so we strip them for the RSQL filter and filter the result on client instead.

See 8d0ed453243a1ee2f74c65c9c985877a8b25fcd0 for a similar fix.

JIRA: RAIL-4618

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
