### PR TITLE
RELATED: RAIL-4625 Show attr filter config only when useful

### DIFF
--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -5610,6 +5610,9 @@ itemIndex: number;
 } | undefined>;
 
 // @internal
+export const selectIsAlternativeDisplayFormSelectionEnabled: OutputSelector<DashboardState, boolean, (res: ResolvedDashboardConfig) => boolean>;
+
+// @internal
 export const selectIsAnalyticalDesignerEnabled: OutputSelector<DashboardState, boolean, (res: ResolvedDashboardConfig) => boolean>;
 
 // @internal (undocumented)
@@ -5668,6 +5671,9 @@ export const selectIsKpiAlertHighlightedByWidgetRef: (ref: ObjRef | undefined) =
 
 // @alpha (undocumented)
 export const selectIsKpiAlertOpenedByWidgetRef: (ref: ObjRef | undefined) => (state: DashboardState) => boolean;
+
+// @internal
+export const selectIsKPIDashboardDependentFiltersEnabled: OutputSelector<DashboardState, boolean, (res: ResolvedDashboardConfig) => boolean>;
 
 // @internal (undocumented)
 export const selectIsKpiDeleteDialogOpen: OutputSelector<DashboardState, boolean, (res: UiState) => boolean>;

--- a/libs/sdk-ui-dashboard/src/model/store/config/configSelectors.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/config/configSelectors.ts
@@ -389,3 +389,23 @@ export const selectIsDeleteFilterButtonEnabled = createSelector(
     selectConfig,
     (state) => !!(state.settings?.enableKPIDashboardDeleteFilterButton || false),
 );
+
+/**
+ * Returns whether dependent filters are enabled.
+ *
+ * @internal
+ */
+export const selectIsKPIDashboardDependentFiltersEnabled = createSelector(
+    selectConfig,
+    (state) => !!(state.settings?.enableKPIDashboardDependentFilters || false),
+);
+
+/**
+ * Returns whether choice of alternate display forms is enabled.
+ *
+ * @internal
+ */
+export const selectIsAlternativeDisplayFormSelectionEnabled = createSelector(
+    selectConfig,
+    (state) => !!(state.settings?.enableAlternativeDisplayFormSelection || false),
+);

--- a/libs/sdk-ui-dashboard/src/model/store/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/index.ts
@@ -55,6 +55,8 @@ export {
     selectDashboardEditModeDevRollout,
     selectIsAnalyticalDesignerEnabled,
     selectIsDeleteFilterButtonEnabled,
+    selectIsKPIDashboardDependentFiltersEnabled,
+    selectIsAlternativeDisplayFormSelectionEnabled,
 } from "./config/configSelectors";
 export { PermissionsState } from "./permissions/permissionsState";
 export {

--- a/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/DefaultDashboardAttributeFilter.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/DefaultDashboardAttributeFilter.tsx
@@ -105,6 +105,7 @@ export const DefaultDashboardAttributeFilter = (props: IDashboardAttributeFilter
                     ) : (
                         <CustomAttributeFilterDropdownActions
                             {...props}
+                            filterDisplayFormRef={filter.attributeFilter.displayForm}
                             applyText={applyText}
                             cancelText={cancelText}
                             onConfigurationButtonClick={() => {
@@ -119,7 +120,14 @@ export const DefaultDashboardAttributeFilter = (props: IDashboardAttributeFilter
                 </>
             );
         };
-    }, [isConfigurationOpen, cancelText, saveText, applyText, handleRemoveAttributeFilter]);
+    }, [
+        isConfigurationOpen,
+        cancelText,
+        saveText,
+        filter.attributeFilter.displayForm,
+        applyText,
+        handleRemoveAttributeFilter,
+    ]);
 
     const CustomElementsSelect = useMemo(() => {
         return function ElementsSelect(props: IAttributeFilterElementsSelectProps) {


### PR DESCRIPTION
Hide the config button if there is nothing to actually configure:
* there is only one filter -> no parent filtering possible
* filter attribute has single df -> no df config possible

JIRA: RAIL-4625

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
