### PR TITLE
RELATED: FET-1157 upgrade rush and pnpm to latest minors

### DIFF
--- a/common/scripts/install-run-rush.js
+++ b/common/scripts/install-run-rush.js
@@ -3,7 +3,11 @@
 // See the @microsoft/rush package's LICENSE file for license information.
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
-    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
 }) : (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
     o[k2] = m[k];
@@ -36,10 +40,11 @@ const fs = __importStar(require("fs"));
 const install_run_1 = require("./install-run");
 const PACKAGE_NAME = '@microsoft/rush';
 const RUSH_PREVIEW_VERSION = 'RUSH_PREVIEW_VERSION';
-function _getRushVersion() {
+const INSTALL_RUN_RUSH_LOCKFILE_PATH_VARIABLE = 'INSTALL_RUN_RUSH_LOCKFILE_PATH';
+function _getRushVersion(logger) {
     const rushPreviewVersion = process.env[RUSH_PREVIEW_VERSION];
     if (rushPreviewVersion !== undefined) {
-        console.log(`Using Rush version from environment variable ${RUSH_PREVIEW_VERSION}=${rushPreviewVersion}`);
+        logger.info(`Using Rush version from environment variable ${RUSH_PREVIEW_VERSION}=${rushPreviewVersion}`);
         return rushPreviewVersion;
     }
     const rushJsonFolder = (0, install_run_1.findRushJsonFolder)();
@@ -66,7 +71,28 @@ function _run() {
     if (!nodePath || !scriptPath) {
         throw new Error('Unexpected exception: could not detect node path or script path');
     }
-    if (process.argv.length < 3) {
+    let commandFound = false;
+    let logger = { info: console.log, error: console.error };
+    for (const arg of packageBinArgs) {
+        if (arg === '-q' || arg === '--quiet') {
+            // The -q/--quiet flag is supported by both `rush` and `rushx`, and will suppress
+            // any normal informational/diagnostic information printed during startup.
+            //
+            // To maintain the same user experience, the install-run* scripts pass along this
+            // flag but also use it to suppress any diagnostic information normally printed
+            // to stdout.
+            logger = {
+                info: () => { },
+                error: console.error
+            };
+        }
+        else if (!arg.startsWith('-') || arg === '-h' || arg === '--help') {
+            // We either found something that looks like a command (i.e. - doesn't start with a "-"),
+            // or we found the -h/--help flag, which can be run without a command
+            commandFound = true;
+        }
+    }
+    if (!commandFound) {
         console.log(`Usage: ${scriptName} <command> [args...]`);
         if (scriptName === 'install-run-rush.js') {
             console.log(`Example: ${scriptName} build --to myproject`);
@@ -76,10 +102,14 @@ function _run() {
         }
         process.exit(1);
     }
-    (0, install_run_1.runWithErrorAndStatusCode)(() => {
-        const version = _getRushVersion();
-        console.log(`The rush.json configuration requests Rush version ${version}`);
-        return (0, install_run_1.installAndRun)(PACKAGE_NAME, version, bin, packageBinArgs);
+    (0, install_run_1.runWithErrorAndStatusCode)(logger, () => {
+        const version = _getRushVersion(logger);
+        logger.info(`The rush.json configuration requests Rush version ${version}`);
+        const lockFilePath = process.env[INSTALL_RUN_RUSH_LOCKFILE_PATH_VARIABLE];
+        if (lockFilePath) {
+            logger.info(`Found ${INSTALL_RUN_RUSH_LOCKFILE_PATH_VARIABLE}="${lockFilePath}", installing with lockfile.`);
+        }
+        return (0, install_run_1.installAndRun)(logger, PACKAGE_NAME, version, bin, packageBinArgs, lockFilePath);
     });
 }
 _run();

--- a/rush.json
+++ b/rush.json
@@ -26,7 +26,7 @@
      * Specify one of: "pnpmVersion", "npmVersion", or "yarnVersion".  See the Rush documentation
      * for details about these alternatives.
      */
-    "pnpmVersion": "6.23.2",
+    "pnpmVersion": "6.35.0",
 
     // "npmVersion": "4.5.0",
     // "yarnVersion": "1.9.4",

--- a/rush.json
+++ b/rush.json
@@ -16,7 +16,7 @@
      * path segment in the "$schema" field for all your Rush config files.  This will ensure
      * correct error-underlining and tab-completion for editors such as VS Code.
      */
-    "rushVersion": "5.60.0",
+    "rushVersion": "5.82.1",
 
     /**
      * The next field selects which package manager should be installed and determines its version.


### PR DESCRIPTION
Skipped upgrading pnpm to version 7, it does not work without also using the PNPM workspaces (we will investigate it in a separate story).

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
