### PR TITLE
BUGFIX:  RAIL-4628 can not save widget layout in new edit mode

### DIFF
--- a/libs/sdk-backend-tiger/src/convertors/toBackend/AnalyticalDashboardConverter.ts
+++ b/libs/sdk-backend-tiger/src/convertors/toBackend/AnalyticalDashboardConverter.ts
@@ -15,7 +15,6 @@ import {
     IDashboardPluginLink,
 } from "@gooddata/sdk-model";
 import omit from "lodash/omit";
-import updateWith from "lodash/updateWith";
 import { cloneWithSanitizedIds } from "./IdSanitization";
 import isEmpty from "lodash/isEmpty";
 import update from "lodash/fp/update";
@@ -35,8 +34,8 @@ function removeWidgetIdentifiersInLayout(layout: IDashboardLayout<IDashboardWidg
         widgetCallback: (_, widgetPath) => widgetsPaths.push(widgetPath),
     });
 
-    return widgetsPaths.reduce((layout, widgetPath) => {
-        return updateWith(layout, widgetPath, removeIdentifiers);
+    return widgetsPaths.reduce((newLayout, widgetPath) => {
+        return update(widgetPath, removeIdentifiers, newLayout);
     }, layout);
 }
 


### PR DESCRIPTION
JIRA: RAIL-4628

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
