### PR TITLE
RELATED: FET-1161 Get rid of Babel 6 packages

### DIFF
--- a/common/config/rush/browser-approved-packages.json
+++ b/common/config/rush/browser-approved-packages.json
@@ -511,14 +511,6 @@
       "allowedCategories": [ "production" ]
     },
     {
-      "name": "babel-polyfill",
-      "allowedCategories": [ "examples", "production" ]
-    },
-    {
-      "name": "babel-runtime",
-      "allowedCategories": [ "examples", "production" ]
-    },
-    {
       "name": "blessed",
       "allowedCategories": [ "tools" ]
     },

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -3201,6 +3201,7 @@ packages:
   /@npmcli/move-file/1.1.2:
     resolution: {integrity: sha512-1SUf/Cg2GzGDyaf15aR9St9TWlb+XvbZXWpDx8YKs7MLzMH/BCeopv+y9vzrzgkfykCGuWOlSu3mZhj2+FQcrg==}
     engines: {node: '>=10'}
+    deprecated: This functionality has been moved to @npmcli/fs
     dependencies:
       mkdirp: 1.0.4
       rimraf: 3.0.2
@@ -7130,14 +7131,6 @@ packages:
     resolution: {integrity: sha512-EMZD1563QUqLhzrqcThk759RhuNVX/ZJdrtGK6drwzgvnR+ARjWyXIHPbu+tUNaMGtPz/gQeAM2M6VUw2UiUeA==}
     dev: false
 
-  /babel-polyfill/6.26.0:
-    resolution: {integrity: sha512-F2rZGQnAdaHWQ8YAoeRbukc7HS9QgdgeyJ0rQDd485v9opwuPvjpPFcOOT/WmkKTdgy9ESgSPXDcTNpzrGr6iQ==}
-    dependencies:
-      babel-runtime: 6.26.0
-      core-js: 2.6.12
-      regenerator-runtime: 0.10.5
-    dev: false
-
   /babel-preset-current-node-syntax/1.0.1_@babel+core@7.17.9:
     resolution: {integrity: sha512-M7LQ0bxarkxQoN+vz5aJPsLBn77n8QgTFmo8WK0/44auK2xlCXrYcUxHFxgU7qW5Yzw/CjmLRK2uJzaCd7LvqQ==}
     peerDependencies:
@@ -7167,13 +7160,6 @@ packages:
       '@babel/core': 7.17.9
       babel-plugin-jest-hoist: 27.5.1
       babel-preset-current-node-syntax: 1.0.1_@babel+core@7.17.9
-    dev: false
-
-  /babel-runtime/6.26.0:
-    resolution: {integrity: sha512-ITKNuq2wKlW1fJg9sSW52eepoYgZBggvOAHC0u/CYu/qxQ9EVzThCgR69BnSXLHjy2f7SY5zaQ4yt7H9ZVxY2g==}
-    dependencies:
-      core-js: 2.6.12
-      regenerator-runtime: 0.11.1
     dev: false
 
   /bail/1.0.5:
@@ -17101,14 +17087,6 @@ packages:
     resolution: {integrity: sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==}
     dev: false
 
-  /regenerator-runtime/0.10.5:
-    resolution: {integrity: sha512-02YopEIhAgiBHWeoTiA8aitHDt8z6w+rQqNuIftlM+ZtvSl/brTouaU7DW6GO/cHtvxJvS4Hwv2ibKdxIRi24w==}
-    dev: false
-
-  /regenerator-runtime/0.11.1:
-    resolution: {integrity: sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==}
-    dev: false
-
   /regenerator-runtime/0.13.9:
     resolution: {integrity: sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==}
     dev: false
@@ -20918,7 +20896,7 @@ packages:
     dev: false
 
   file:projects/api-client-bear.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-Dk6btE+uAvMKvHFCFckxn3eVV2v2C+Z1xASDRX9C8Ivu56p16ZrFX7Z+tXZdbAxnLspcpwbRBYcFP/nGCs22XA==, tarball: file:projects/api-client-bear.tgz}
+    resolution: {integrity: sha512-0dIcIRMCwJzl4pHHVpv8nUO7uDUq72yAUOYJyKvZ9iNAxFLwME+wicsKQsMPWXGD+er7pVWXy1L72gnuqZ/rcw==, tarball: file:projects/api-client-bear.tgz}
     id: file:projects/api-client-bear.tgz
     name: '@rush-temp/api-client-bear'
     version: 0.0.0
@@ -20986,7 +20964,7 @@ packages:
     dev: false
 
   file:projects/api-client-tiger.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-i/AfeisboFVuRF44UfofrxXPgxh1EwOBvKg7y3kFTXp2E2gsP9nhphL7MJLxTQFTTn7FtWIGEHedL7DPnwE4cw==, tarball: file:projects/api-client-tiger.tgz}
+    resolution: {integrity: sha512-AmclSRPf3DGeqdh+fIcNguyXi7PR1lTP5ruvtMiGJRxTotHskrMyGyFlRSiJ/BBwXoh5E+VKBYz7XG3s7bikLg==, tarball: file:projects/api-client-tiger.tgz}
     id: file:projects/api-client-tiger.tgz
     name: '@rush-temp/api-client-tiger'
     version: 0.0.0
@@ -21139,7 +21117,7 @@ packages:
     dev: false
 
   file:projects/catalog-export.tgz:
-    resolution: {integrity: sha512-wGq5fZVEEKX3Y4zfOXJ2cyZdn8bFeXhwHg3i4ufrGVDrOTr5hhLcI4jqjXjvkJi048vxtPqWw5QzeyeKPfbLlQ==, tarball: file:projects/catalog-export.tgz}
+    resolution: {integrity: sha512-RV6RIKwQrbDDuudo2+hiPK2s9+T0jZADqyzPXA700QcPYZvgcW9Z0CmeEfyGMZyMpeC1fOgyb+Boa42HsWKmLw==, tarball: file:projects/catalog-export.tgz}
     name: '@rush-temp/catalog-export'
     version: 0.0.0
     dependencies:
@@ -21194,7 +21172,7 @@ packages:
     dev: false
 
   file:projects/dashboard-plugin-template.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-PnAaZrISK+QwA0YglpVVoRH8t20VKw4eIUcn8SJqkhjodfYH4KYvGsVBlS7DfIH0dn1pheGjLcJXDbdlcoiZ/g==, tarball: file:projects/dashboard-plugin-template.tgz}
+    resolution: {integrity: sha512-Gd81fRGayxEzoqKanUz4qzQEZhNmcTfUtHwfa20VPjqD/n5KLjbegi0OjANDlp0AFcyHUnSyd3JE5gyGvKH/Tw==, tarball: file:projects/dashboard-plugin-template.tgz}
     id: file:projects/dashboard-plugin-template.tgz
     name: '@rush-temp/dashboard-plugin-template'
     version: 0.0.0
@@ -21273,7 +21251,7 @@ packages:
     dev: false
 
   file:projects/dashboard-plugin-tests.tgz:
-    resolution: {integrity: sha512-Y2mcxiB5e7iUCb9Tsq/nV34NU0JMzuUOPQIqd12DcDtBUa0I34r+xiOyPwiD3T21t1P/JcvqdFKfr6dV8U61qw==, tarball: file:projects/dashboard-plugin-tests.tgz}
+    resolution: {integrity: sha512-MyzG0Q1WznNJbqvI51b2XYbCZZtAI4Ui4F1dOZY8drrGgwkmbLS9OqIt6RqDhEEYX2qJDoBdvm71/i4TthVE/A==, tarball: file:projects/dashboard-plugin-tests.tgz}
     name: '@rush-temp/dashboard-plugin-tests'
     version: 0.0.0
     dependencies:
@@ -21364,7 +21342,7 @@ packages:
     dev: false
 
   file:projects/experimental-workspace.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-lcw2aqTgErO3o2OjZvV91lxdPpLdo1/fpuv6PNO6nJpyqzjcmjuYdUexroOKpYGnZY9GvEz2oHXqi59+DNqDSA==, tarball: file:projects/experimental-workspace.tgz}
+    resolution: {integrity: sha512-HAo8+fF4oLzDMIBiUTy+q70cu9AZD19lvO4pM81UE1EQOOBS0O/MjcN0pHN2uv3pgd/QRq8JKBDJAcl5KpFpew==, tarball: file:projects/experimental-workspace.tgz}
     id: file:projects/experimental-workspace.tgz
     name: '@rush-temp/experimental-workspace'
     version: 0.0.0
@@ -21462,7 +21440,7 @@ packages:
     dev: false
 
   file:projects/live-examples-workspace.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-aZ1Ruv88GFYTJcCq7mLxjhUBCqIRB4HKUU+PRARCslHnrcD12CPup4naAdUZuBi7K6OeYoUAkr1iHQeM6gwmcQ==, tarball: file:projects/live-examples-workspace.tgz}
+    resolution: {integrity: sha512-pIDm78+F01PPnR9gUrlNBubuNzL3qbfsRWcgE68SW1munCpsE6wU7b2bEPpGFE5dOqB2pXaLXvG/UuoW2Kfvhg==, tarball: file:projects/live-examples-workspace.tgz}
     id: file:projects/live-examples-workspace.tgz
     name: '@rush-temp/live-examples-workspace'
     version: 0.0.0
@@ -21504,7 +21482,7 @@ packages:
     dev: false
 
   file:projects/mock-handling.tgz:
-    resolution: {integrity: sha512-Y4Z0T3I/PmZpOsKRRnFyN0V69yr13yTXYrnLD2RV3OVVTx4ckFl7f8KL7hn3mlw2x8/JGHguld+1uslaUHzUqw==, tarball: file:projects/mock-handling.tgz}
+    resolution: {integrity: sha512-Y86oDzFuBITILF77ozlTpekX/+Zpcie7X+nwd2rNll0wFr6CozcK17dcAXJUOLDrmYluORTtPJsRms4mDeRk1w==, tarball: file:projects/mock-handling.tgz}
     name: '@rush-temp/mock-handling'
     version: 0.0.0
     dependencies:
@@ -21559,7 +21537,7 @@ packages:
     dev: false
 
   file:projects/playground.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-JtFijeuifUsynGD7GguEfPC3fVPUcFfQ+URjqtJy307APUg74+HmHNqe0jlC8th2whT6DDIgNBHhIqn3zqlxOQ==, tarball: file:projects/playground.tgz}
+    resolution: {integrity: sha512-xJ1GUTAcV1muwGgjv3UgAj5FpjwcVl1NclC/Wlx1Cz/6/sDlKRWE0LlYQICUUZtjKSd3ZAPYvkIH7JA8PiROOA==, tarball: file:projects/playground.tgz}
     id: file:projects/playground.tgz
     name: '@rush-temp/playground'
     version: 0.0.0
@@ -21585,8 +21563,6 @@ packages:
       '@welldone-software/why-did-you-render': 7.0.1_react@17.0.2
       babel-loader: 8.2.4_acba72ea4bf9d339cdfcd8f55cdb7006
       babel-plugin-lodash: 3.3.4
-      babel-polyfill: 6.26.0
-      babel-runtime: 6.26.0
       clean-webpack-plugin: 4.0.0_webpack@5.72.0
       css-loader: 6.7.1_webpack@5.72.0
       dotenv-webpack: 7.1.0_webpack@5.72.0
@@ -21643,7 +21619,7 @@ packages:
     dev: false
 
   file:projects/plugin-toolkit.tgz:
-    resolution: {integrity: sha512-Ew3P3oGEDnP5b+g/erFdsHRDT534NiMiI/JW4J9HAcHFU7ZkOC09JqyK74kroZfgyTXe2NS2kJPFGFQXvxVQow==, tarball: file:projects/plugin-toolkit.tgz}
+    resolution: {integrity: sha512-+gkiQ6ys3DiNCz2NUkhaPuPzrDxyplIWGWpjSAcoOW8uMP3SoY+EidyderphkUS9W6+7yHUYPWfzBjXv+iWgYA==, tarball: file:projects/plugin-toolkit.tgz}
     name: '@rush-temp/plugin-toolkit'
     version: 0.0.0
     dependencies:
@@ -21708,7 +21684,7 @@ packages:
     dev: false
 
   file:projects/reference-workspace-mgmt.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-WKOWSd2QulxEmwysgEw0xqlc2alYypOOhN7Cpv0j0Q9pjdretlIK+twtfU9YlHOPur0FlcX71ECd6bi3uvuKWA==, tarball: file:projects/reference-workspace-mgmt.tgz}
+    resolution: {integrity: sha512-QlfoEOr9ouvYgpQ+tOG8QNd0GhNIZqsMjXstiQXaBCNy3mLQcP+fgUEFFdk8oi8EGGqXtsRyEUPPbgEtB5sSvA==, tarball: file:projects/reference-workspace-mgmt.tgz}
     id: file:projects/reference-workspace-mgmt.tgz
     name: '@rush-temp/reference-workspace-mgmt'
     version: 0.0.0
@@ -21749,7 +21725,7 @@ packages:
     dev: false
 
   file:projects/reference-workspace.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-xdZ+4pGPgJYYSGkYJ/OVev0rWd/QluW/n9uFDiQzAE0Nq8rJMGRQ7eJNog0YG9izixpNV5MVqCmjTx319JttSA==, tarball: file:projects/reference-workspace.tgz}
+    resolution: {integrity: sha512-AaeTzNFrLVwdji/MlgUt+zSEykZsIRAfnOiFPbUMOBKigk4FMuFtGFYj1PBpJWlZaMd/ljQOEZpx4rnB4OwLKA==, tarball: file:projects/reference-workspace.tgz}
     id: file:projects/reference-workspace.tgz
     name: '@rush-temp/reference-workspace'
     version: 0.0.0
@@ -21791,7 +21767,7 @@ packages:
     dev: false
 
   file:projects/sdk-backend-base.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-51k8XfVPv4UFywgL5fACRcYQU9NNU5AimRJCs7ixCX5KjY32djwYzJLJGNPMeJhG1sRJmhORJya/llr0FzDorQ==, tarball: file:projects/sdk-backend-base.tgz}
+    resolution: {integrity: sha512-8fZRu93dmsDiNLrMAkDRkKux6Muv8BIzD/XDkOGe8xRj0ZsBvrZejKQZik62JvNv8ZYT++gRYtG7pFCyTSlKGA==, tarball: file:projects/sdk-backend-base.tgz}
     id: file:projects/sdk-backend-base.tgz
     name: '@rush-temp/sdk-backend-base'
     version: 0.0.0
@@ -21843,7 +21819,7 @@ packages:
     dev: false
 
   file:projects/sdk-backend-bear.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-/RJxxDDlgkUS0D0SLivMUNr375tVOkdzUHBl28qoqmWtw60K0jw3wnkyzA7jIDJs30fu80ayKYfU4721cSCN2w==, tarball: file:projects/sdk-backend-bear.tgz}
+    resolution: {integrity: sha512-dZJ0ansb1u7vpIQPLMN517yUtq5Oxqe/58TL8cKtA5ANaIdYy+6wA9RoV4n06zMPQc3j0oPOol1ybNYeOtmOIQ==, tarball: file:projects/sdk-backend-bear.tgz}
     id: file:projects/sdk-backend-bear.tgz
     name: '@rush-temp/sdk-backend-bear'
     version: 0.0.0
@@ -21897,7 +21873,7 @@ packages:
     dev: false
 
   file:projects/sdk-backend-mockingbird.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-uRLufeVOCghBxr6jzHdrVJ/pC6TIZWtjYRKBPrsGmr/VP34jOFx6Xc2Tug0/S7KVR5hWK00UPZV3GeHMDnKydg==, tarball: file:projects/sdk-backend-mockingbird.tgz}
+    resolution: {integrity: sha512-TiZja7NLaQxnD0bzS48g4Arjd7AJSDbNq9UpEgBR7DcPWGhemjYeDJaPXrjq/KEJltd1EUkMd3rIyPA+BwaXTg==, tarball: file:projects/sdk-backend-mockingbird.tgz}
     id: file:projects/sdk-backend-mockingbird.tgz
     name: '@rush-temp/sdk-backend-mockingbird'
     version: 0.0.0
@@ -21944,7 +21920,7 @@ packages:
     dev: false
 
   file:projects/sdk-backend-spi.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-oye13p6Ofa87UKY47CNoWxe1B6O3Up8rKHKy+SOxziOSjO24KMM47NNdcHd3ZhjiqQyhkeGqrmqHUTaqr12ALQ==, tarball: file:projects/sdk-backend-spi.tgz}
+    resolution: {integrity: sha512-pmPQJpommUo93QB5xyfmpVdSRtxXsjQj1d0t2MYDmnQhOwlmylJEr/pa7cQmK3kFon+Kdfa15uw5cD5DcSsauQ==, tarball: file:projects/sdk-backend-spi.tgz}
     id: file:projects/sdk-backend-spi.tgz
     name: '@rush-temp/sdk-backend-spi'
     version: 0.0.0
@@ -21989,7 +21965,7 @@ packages:
     dev: false
 
   file:projects/sdk-backend-tiger.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-eDTLsR8HV7UuIwOOSu+VzoLkP/Sxrm3JQdxYznVeRoQt0rYqAJXoyVcervI11Q88GM4za/Eog0Li721j9NSWoA==, tarball: file:projects/sdk-backend-tiger.tgz}
+    resolution: {integrity: sha512-wEdTctclLJ467vy2qcDd+sWAVZbrP8gadq6YjrJk40OeQ5H5nyS4vAB14r4sJBym4+lVvJVBJRQFUs6S0qrbtA==, tarball: file:projects/sdk-backend-tiger.tgz}
     id: file:projects/sdk-backend-tiger.tgz
     name: '@rush-temp/sdk-backend-tiger'
     version: 0.0.0
@@ -22042,7 +22018,7 @@ packages:
     dev: false
 
   file:projects/sdk-embedding.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-EDc6cWJDhu16Ihj6H8iOGX5y0JSxV4aaZ+C1ftPVxggd+oEn79fSkAql2tTXEnNDsz6au7nZqmO6TUixRmBgnQ==, tarball: file:projects/sdk-embedding.tgz}
+    resolution: {integrity: sha512-6uiIhdkvJYF56G0eoyjVaeUKXl3A9WnKWGGE5C1qTsiSpO3RihRxz4jNxgclGldJg+h9zFl2evrn3XefbErQDg==, tarball: file:projects/sdk-embedding.tgz}
     id: file:projects/sdk-embedding.tgz
     name: '@rush-temp/sdk-embedding'
     version: 0.0.0
@@ -22087,7 +22063,7 @@ packages:
     dev: false
 
   file:projects/sdk-examples.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-40pV1YJJUHLHQrAET7lsCIsz8VOMZNzjcW9DeSjYdNXF0MTLNbMmTu7031sOePFukCwGEf+m2QnNwWmi8dLdaw==, tarball: file:projects/sdk-examples.tgz}
+    resolution: {integrity: sha512-CMK7FRZS+Gud63fXEr3tqlUQ287yHOJ47i/bMW49FFILnxmx4nrh19OVzk7q0PaFjOAi646koodsewk8NXFb1Q==, tarball: file:projects/sdk-examples.tgz}
     id: file:projects/sdk-examples.tgz
     name: '@rush-temp/sdk-examples'
     version: 0.0.0
@@ -22122,8 +22098,6 @@ packages:
       '@typescript-eslint/parser': 5.18.0_eslint@8.25.0+typescript@4.0.2
       babel-loader: 8.2.4_acba72ea4bf9d339cdfcd8f55cdb7006
       babel-plugin-lodash: 3.3.4
-      babel-polyfill: 6.26.0
-      babel-runtime: 6.26.0
       circular-dependency-plugin: 5.2.2_webpack@5.72.0
       classnames: 2.3.1
       clean-webpack-plugin: 4.0.0_webpack@5.72.0
@@ -22354,7 +22328,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-all.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-4NvnKTDCsX+Ld7fUwVI/Dp9q7Vj6B2ncYgoesJUb37i6xw6/GCmbzWOfzG+rYsJuUXWwdbAK5++xEMTBCTnE6w==, tarball: file:projects/sdk-ui-all.tgz}
+    resolution: {integrity: sha512-l8rBF5eUTFaOyLY/PH7mBs33iNp/77+jGvgFlDgk6aS1Y+7gJR72+CTWec3kt0MurDKecNjMwsuaY9K+pG2WXA==, tarball: file:projects/sdk-ui-all.tgz}
     id: file:projects/sdk-ui-all.tgz
     name: '@rush-temp/sdk-ui-all'
     version: 0.0.0
@@ -22396,7 +22370,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-charts.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-lPXTa1ggV8N6NI1P5TDStUgNhOxBTL9rKFnY9Ko1VvV76FnDAedykUDz52em+OgrSTnFn0FghPj0FExf9FjQ7g==, tarball: file:projects/sdk-ui-charts.tgz}
+    resolution: {integrity: sha512-hhr41k3GxdpxVQnHwWnNyoRLqdrrgwpc0IwzQt504A5H4VFF/0o1Yzs5LMI3LfJmZa9TY0fxAn8+tRH58Iw6xw==, tarball: file:projects/sdk-ui-charts.tgz}
     id: file:projects/sdk-ui-charts.tgz
     name: '@rush-temp/sdk-ui-charts'
     version: 0.0.0
@@ -22473,7 +22447,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-dashboard.tgz_a7e570fd5a4985262571d64f4bc94b86:
-    resolution: {integrity: sha512-YLB29M3u0/fCNXg4ZW/SrF2DGyjNcvUoU7Xn60WIdFinQtr/83psGlRu5wOWgRcWuG/TABWGbt7s9XCn9Hhx1Q==, tarball: file:projects/sdk-ui-dashboard.tgz}
+    resolution: {integrity: sha512-I7n6C8bOwgTt09JAi4aJNQrQTsirgOQNzaYEH+wRMMe8GC5qrq4dIV/OBMf0FqKGlYTSAOY2zEzin7rIRrqHoA==, tarball: file:projects/sdk-ui-dashboard.tgz}
     id: file:projects/sdk-ui-dashboard.tgz
     name: '@rush-temp/sdk-ui-dashboard'
     version: 0.0.0
@@ -22569,7 +22543,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-ext.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-ekSZ8mUMcKa3TkZcEW2F4aXbCZYPVSVifySg3M1PRj9tFe2FWTH7KJCqzIrRQR5F3MYOGTtPE3rKfD9LF5K04A==, tarball: file:projects/sdk-ui-ext.tgz}
+    resolution: {integrity: sha512-7+SupK1jLHLIiWLSlfhf3d6tvx6w35MIxyuTzVCD2rCVbZZHprn97Whbdot6aQkTpTSuXg88FbyDXG0Y3LQj/A==, tarball: file:projects/sdk-ui-ext.tgz}
     id: file:projects/sdk-ui-ext.tgz
     name: '@rush-temp/sdk-ui-ext'
     version: 0.0.0
@@ -22656,7 +22630,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-filters.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-T5gqCy7Y8nH+FVoekNDbgxsd86NxqcYuWVUkN+2B+EdYhQG05AF/DGzrCBEAF4x5+B/V9trCZCW6I8hqXZY9AA==, tarball: file:projects/sdk-ui-filters.tgz}
+    resolution: {integrity: sha512-8mMPrrnPfN+TySH1fIoK1HomtZoBowDEevX1Y3nZQMpCmeJukmYBKmdKIabnWtEEPgQyOWU/+hPAumlKWZ3r+g==, tarball: file:projects/sdk-ui-filters.tgz}
     id: file:projects/sdk-ui-filters.tgz
     name: '@rush-temp/sdk-ui-filters'
     version: 0.0.0
@@ -22739,7 +22713,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-geo.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-B7fITWa8PyoXbHl7vZOQt9LH5t0g2JOXJEyfl3VZz50uLzCcqm3+2/lhGucv2IU7dcDepj/rSt8nYZoWGGO4Ag==, tarball: file:projects/sdk-ui-geo.tgz}
+    resolution: {integrity: sha512-I0ABtQJub2SSJPh0EURUzp+UmBW15dOxkkONB8JDo430VEHEBJfEGpsIOf8F6kSfvhaImEjcEH0fgT4I3B6oBw==, tarball: file:projects/sdk-ui-geo.tgz}
     id: file:projects/sdk-ui-geo.tgz
     name: '@rush-temp/sdk-ui-geo'
     version: 0.0.0
@@ -22810,7 +22784,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-kit.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-sziBDrajcemoUo6O8TdaZ2b/JrE6seVsRrO4b1G2sP5W2BV0Llh/p6yPrYwV2EKaHyqFfsqWUR8eUH+g66TLxg==, tarball: file:projects/sdk-ui-kit.tgz}
+    resolution: {integrity: sha512-lVjladw7olun1COjmSWT+G/7neIQzcLEryA9hz8DgY/eEXAxnuX0kTZ2ps1MJV8YQiC33TUpIub5hTytDoouXQ==, tarball: file:projects/sdk-ui-kit.tgz}
     id: file:projects/sdk-ui-kit.tgz
     name: '@rush-temp/sdk-ui-kit'
     version: 0.0.0
@@ -22922,7 +22896,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-loaders.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-dwYF5vp3pAFrDJtO4XqZsaC4qQa2Y5LFTjXtV4EqYoNiaybrI0P43mrEL+GWQn/YrGadzpC51P/g7UMyjw980w==, tarball: file:projects/sdk-ui-loaders.tgz}
+    resolution: {integrity: sha512-ti5M5ubGCPB0mFb4GkeYymJdmh+S702LiWApCeEV0ocCfyBh1IdXO9OPwZtR2EKq816s3O5lcDLG6dxHNQwDCw==, tarball: file:projects/sdk-ui-loaders.tgz}
     id: file:projects/sdk-ui-loaders.tgz
     name: '@rush-temp/sdk-ui-loaders'
     version: 0.0.0
@@ -22984,7 +22958,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-pivot.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-RTq8R75vIiso1GHX9+9trWiyTnXY8ew47TlcjZ7tk3+qtHD+tg/sYBR7VRMEP7CR1XXxEWQc/IOLTHHn0TUOrw==, tarball: file:projects/sdk-ui-pivot.tgz}
+    resolution: {integrity: sha512-sswSdYlA5hnu90MueP9B4olvyeQRs8C8yTYWDtkBVENxB9J3iMcWyj+dLxRDbgso+rKFAXHV/OrnS6UmegjReQ==, tarball: file:projects/sdk-ui-pivot.tgz}
     id: file:projects/sdk-ui-pivot.tgz
     name: '@rush-temp/sdk-ui-pivot'
     version: 0.0.0
@@ -23058,7 +23032,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-tests-e2e.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-wdrFS7BEmt87qsW4qYu7phQOLuk5SX+luMZRR/03TL4bqIw6bNMRFeqzAdZtPf2amygoZVCGBoAdrVWUbFIhRA==, tarball: file:projects/sdk-ui-tests-e2e.tgz}
+    resolution: {integrity: sha512-B3g9Jdc4Rhi6RlSJovHmFm53ALBnmzpkV3QU8f995QOSYiIA8dNOx2Cjp2+QxhRcHiVc9esQC7H5Ue5ya3qGWg==, tarball: file:projects/sdk-ui-tests-e2e.tgz}
     id: file:projects/sdk-ui-tests-e2e.tgz
     name: '@rush-temp/sdk-ui-tests-e2e'
     version: 0.0.0
@@ -23090,8 +23064,6 @@ packages:
       axios: 0.21.4
       babel-loader: 8.2.4_acba72ea4bf9d339cdfcd8f55cdb7006
       babel-plugin-lodash: 3.3.4
-      babel-polyfill: 6.26.0
-      babel-runtime: 6.26.0
       circular-dependency-plugin: 5.2.2_webpack@5.72.0
       clean-webpack-plugin: 4.0.0_webpack@5.72.0
       compression-webpack-plugin: 7.1.2_webpack@5.72.0
@@ -23161,7 +23133,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-tests.tgz:
-    resolution: {integrity: sha512-YJ/2ljnBp8gTpLu18/ybhRvbviXbEZfS5TEHUEYeXobga3MS43ihYBI5rIvSiQ5t+makOCX4sB6Ib3RTY2vy+A==, tarball: file:projects/sdk-ui-tests.tgz}
+    resolution: {integrity: sha512-6iWvkry7JcxBjYhxgkdWIHsaxP1Hdh1F3FbMT61kXWxf5+KJOlIqh90o9i63dJi9YtJbLHocW+8mftmitN5lNw==, tarball: file:projects/sdk-ui-tests.tgz}
     name: '@rush-temp/sdk-ui-tests'
     version: 0.0.0
     dependencies:
@@ -23197,7 +23169,6 @@ packages:
       '@wojtekmaj/enzyme-adapter-react-17': 0.6.7_fae758709a8810ba97b4c03852dde4d0
       babel-loader: 8.2.4_@babel+core@7.17.9
       babel-plugin-require-context-hook: 1.0.0
-      babel-runtime: 6.26.0
       copy-webpack-plugin: 11.0.0
       core-js: 2.6.12
       css-loader: 6.7.1
@@ -23273,7 +23244,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-theme-provider.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-vkfEsyEI7auYtdMjrJAby+xx3dIw2zMXVkG7h41Ot+UZlP4T31V0daNUlFNIFl81P+/9laT1IojpcSnQyTn9Qg==, tarball: file:projects/sdk-ui-theme-provider.tgz}
+    resolution: {integrity: sha512-fb8gk7deTxpyvXJqgTbiMu28ZvYFtlYES04ABNStiD8fpKIllchd+A22T+Kutmg5UqeFODdbwVT68uRbjtAxMg==, tarball: file:projects/sdk-ui-theme-provider.tgz}
     id: file:projects/sdk-ui-theme-provider.tgz
     name: '@rush-temp/sdk-ui-theme-provider'
     version: 0.0.0
@@ -23331,7 +23302,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-vis-commons.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-/a5DwvLqcnUKie8sNtjs0HPWnCEe1RyrMIp536p9UtCE84swJQGj4Ls7OQJ7Zc2TAw4x96mUtmwBWFwfOhNGiA==, tarball: file:projects/sdk-ui-vis-commons.tgz}
+    resolution: {integrity: sha512-3XwbFuQq3+NDHtu2GY2y81cnLoHBg3MAJ8N31p+mqhy/CBGai6pNcclMVgKAgn/z1XKoMVw/VAzoEfk1vRigdQ==, tarball: file:projects/sdk-ui-vis-commons.tgz}
     id: file:projects/sdk-ui-vis-commons.tgz
     name: '@rush-temp/sdk-ui-vis-commons'
     version: 0.0.0
@@ -23396,7 +23367,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-web-components.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-xgkl4QqvMdAlKHtALx5IP8vdyWj3R8yo8hG/FPcgml//5rCvDSWwkypsJo7+3O68PvUPHfUiSc8+mM7W4OIGGg==, tarball: file:projects/sdk-ui-web-components.tgz}
+    resolution: {integrity: sha512-f3rYWP6SL1VJwE3/PCvWMyDkwTPWFYnm7B3Embwj4BbDSS5kjTaYJ44tNH24wjRhkMkzLnMxD70tKoDkoyT3Vg==, tarball: file:projects/sdk-ui-web-components.tgz}
     id: file:projects/sdk-ui-web-components.tgz
     name: '@rush-temp/sdk-ui-web-components'
     version: 0.0.0
@@ -23470,7 +23441,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-IQ4Dbwf4vcZIGy8jal5jZL07Th2fukQcLlmBq1zcRKUfOFUTrzsuUoX33wpWzyAyp3zNRPSYjbSnlBL+Gsp0NA==, tarball: file:projects/sdk-ui.tgz}
+    resolution: {integrity: sha512-UgjSn/ypVz8WtkK1tSMl7MtMcNdEY4FZG1vOOuQ9rupqAuwm4YTlSKXGozbrf/xCkNSRKeqAENjt9Sx2Ya1PBg==, tarball: file:projects/sdk-ui.tgz}
     id: file:projects/sdk-ui.tgz
     name: '@rush-temp/sdk-ui'
     version: 0.0.0

--- a/examples/playground/package.json
+++ b/examples/playground/package.json
@@ -23,7 +23,6 @@
         "@babel/plugin-proposal-object-rest-spread": "^7.7.2",
         "@babel/plugin-transform-async-to-generator": "^7.7.2",
         "@babel/plugin-transform-typescript": "^7.7.2",
-        "@babel/polyfill": "^7.7.2",
         "@babel/preset-env": "^7.7.2",
         "@babel/preset-react": "^7.7.2",
         "@babel/preset-typescript": "^7.7.2",
@@ -71,6 +70,7 @@
         "webpack-dev-server": "^4.9.1"
     },
     "dependencies": {
+        "@babel/polyfill": "^7.7.2",
         "@gooddata/sdk-backend-base": "^8.12.0-alpha.31",
         "@gooddata/sdk-backend-bear": "^8.12.0-alpha.31",
         "@gooddata/sdk-backend-spi": "^8.12.0-alpha.31",
@@ -86,8 +86,6 @@
         "@gooddata/sdk-ui-loaders": "^8.12.0-alpha.31",
         "@gooddata/sdk-ui-pivot": "^8.12.0-alpha.31",
         "@gooddata/sdk-ui-theme-provider": "^8.12.0-alpha.31",
-        "babel-runtime": "^6.26.0",
-        "babel-polyfill": "^6.26.0",
         "lodash": "^4.17.19",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",

--- a/examples/playground/src/index.tsx
+++ b/examples/playground/src/index.tsx
@@ -1,4 +1,4 @@
-// (C) 2019 GoodData Corporation
+// (C) 2019-2022 GoodData Corporation
 // this line is to avoid the TS2580 error. We do have the required dependencies but the error still happens.
 declare const require: any;
 if (process.env.WDYR === "true") {
@@ -9,7 +9,7 @@ if (process.env.WDYR === "true") {
         include: [/WithLoading/],
     });
 }
-import "babel-polyfill";
+import "@babel/polyfill";
 import React from "react";
 import ReactDOM from "react-dom";
 

--- a/examples/sdk-examples/package.json
+++ b/examples/sdk-examples/package.json
@@ -23,7 +23,6 @@
         "@babel/plugin-proposal-object-rest-spread": "^7.7.2",
         "@babel/plugin-transform-async-to-generator": "^7.7.2",
         "@babel/plugin-transform-typescript": "^7.7.2",
-        "@babel/polyfill": "^7.7.2",
         "@babel/preset-env": "^7.7.2",
         "@babel/preset-react": "^7.7.2",
         "@babel/preset-typescript": "^7.7.2",
@@ -84,6 +83,7 @@
         "webpack-dev-server": "^4.9.1"
     },
     "dependencies": {
+        "@babel/polyfill": "^7.7.2",
         "@gooddata/api-client-bear": "^8.12.0-alpha.31",
         "@gooddata/api-model-bear": "^8.12.0-alpha.31",
         "@gooddata/sdk-backend-base": "^8.12.0-alpha.31",
@@ -100,8 +100,6 @@
         "@gooddata/sdk-ui-loaders": "^8.12.0-alpha.31",
         "@gooddata/sdk-ui-pivot": "^8.12.0-alpha.31",
         "@gooddata/sdk-ui-theme-provider": "^8.12.0-alpha.31",
-        "babel-runtime": "^6.26.0",
-        "babel-polyfill": "^6.26.0",
         "formik": "^0.11.11",
         "history": "^4.7.2",
         "isomorphic-fetch": "^3.0.0",

--- a/examples/sdk-examples/src/index.tsx
+++ b/examples/sdk-examples/src/index.tsx
@@ -1,5 +1,5 @@
 // (C) 2019-2022 GoodData Corporation
-import "babel-polyfill";
+import "@babel/polyfill";
 import React from "react";
 import ReactDOM from "react-dom";
 

--- a/libs/sdk-ui-tests-e2e/package.json
+++ b/libs/sdk-ui-tests-e2e/package.json
@@ -60,6 +60,7 @@
         "refresh-md": "./scripts/refresh-md.sh"
     },
     "dependencies": {
+        "@babel/polyfill": "^7.7.2",
         "@gooddata/catalog-export": "^8.12.0-alpha.31",
         "@gooddata/eslint-config": "^2.1.0",
         "@gooddata/sdk-backend-bear": "^8.12.0-alpha.31",
@@ -75,8 +76,6 @@
         "@gooddata/sdk-ui-pivot": "^8.12.0-alpha.31",
         "@gooddata/util": "^8.12.0-alpha.31",
         "axios": "^0.21.4",
-        "babel-polyfill": "^6.26.0",
-        "babel-runtime": "^6.26.0",
         "dotenv": "^10.0.0",
         "lodash": "^4.17.19",
         "react": "^17.0.2",
@@ -95,7 +94,6 @@
         "@babel/plugin-proposal-object-rest-spread": "^7.7.2",
         "@babel/plugin-transform-async-to-generator": "^7.7.2",
         "@babel/plugin-transform-typescript": "^7.7.2",
-        "@babel/polyfill": "^7.7.2",
         "@babel/preset-env": "^7.7.2",
         "@babel/preset-react": "^7.7.2",
         "@babel/preset-typescript": "^7.7.2",

--- a/libs/sdk-ui-tests/package.json
+++ b/libs/sdk-ui-tests/package.json
@@ -76,7 +76,6 @@
         "@wojtekmaj/enzyme-adapter-react-17": "^0.6.5",
         "babel-loader": "^8.0.5",
         "babel-plugin-require-context-hook": "^1.0.0",
-        "babel-runtime": "^6.26.0",
         "core-js": "^2.6.10",
         "enzyme": "^3.10.0",
         "jest": "^27.5.1",


### PR DESCRIPTION
- babel-runtime removed, it was not used anyway
- babel-polyfill replaced by @babel/polyfill
- @babel/polyfill moved to dependencies

JIRA: FET-1161

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
