### PR TITLE
BUGFIX: RAIL-4629 wrong arrow color

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/widget/insightMenu/DefaultDashboardInsightMenu/DashboardInsightMenu/DashboardInsightEditMenuBubble.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insightMenu/DefaultDashboardInsightMenu/DashboardInsightMenu/DashboardInsightEditMenuBubble.tsx
@@ -1,0 +1,29 @@
+// (C) 2021-2022 GoodData Corporation
+
+import React from "react";
+import cx from "classnames";
+
+import { ConfigurationBubble } from "../../../common";
+
+interface IDashboardInsightMenuBubbleProps {
+    onClose: () => void;
+    isSubmenu?: boolean;
+}
+
+export const DashboardInsightEditMenuBubble: React.FC<IDashboardInsightMenuBubbleProps> = (props) => {
+    const { children, onClose, isSubmenu } = props;
+
+    return (
+        <ConfigurationBubble
+            classNames={cx(
+                "edit-insight-config",
+                "s-edit-insight-config",
+                "edit-insight-config-title-1-line",
+                isSubmenu ? "edit-insight-config-arrow-submenu-color" : "edit-insight-config-arrow-color",
+            )}
+            onClose={onClose}
+        >
+            {children}
+        </ConfigurationBubble>
+    );
+};

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insightMenu/DefaultDashboardInsightMenu/DashboardInsightMenu/DashboardInsightMenuBubble.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insightMenu/DefaultDashboardInsightMenu/DashboardInsightMenu/DashboardInsightMenuBubble.tsx
@@ -27,10 +27,11 @@ const arrowOffsets: ArrowOffsets = {
 interface IDashboardInsightMenuBubbleProps {
     widget: IWidget;
     onClose: () => void;
+    isSubmenu?: boolean;
 }
 
 export const DashboardInsightMenuBubble: React.FC<IDashboardInsightMenuBubbleProps> = (props) => {
-    const { onClose, widget, children } = props;
+    const { onClose, isSubmenu, widget, children } = props;
     const widgetRefAsString = objRefToString(widgetRef(widget));
 
     return (
@@ -44,8 +45,8 @@ export const DashboardInsightMenuBubble: React.FC<IDashboardInsightMenuBubblePro
                 "gd-configuration-bubble",
                 "edit-insight-config",
                 "s-edit-insight-config",
-                "edit-insight-config-arrow-color",
                 "edit-insight-config-title-1-line",
+                isSubmenu ? "edit-insight-config-arrow-submenu-color" : "edit-insight-config-arrow-color",
             )}
             closeOnOutsideClick
             onClose={onClose}

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insightMenu/DefaultDashboardInsightMenu/DashboardInsightMenu/index.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insightMenu/DefaultDashboardInsightMenu/DashboardInsightMenu/index.tsx
@@ -1,6 +1,5 @@
 // (C) 2021-2022 GoodData Corporation
 import React, { useState } from "react";
-import cx from "classnames";
 import { Separator } from "@gooddata/sdk-ui-kit";
 
 import { IDashboardInsightMenuProps, IInsightMenuSubmenu, IInsightMenuItem } from "../../types";
@@ -8,12 +7,16 @@ import { DashboardInsightMenuContainer } from "./DashboardInsightMenuContainer";
 import { DashboardInsightMenuItemButton } from "./DashboardInsightMenuItemButton";
 import { DashboardInsightSubmenuContainer } from "./DashboardInsightSubmenuContainer";
 import { selectIsInEditMode, useDashboardSelector } from "../../../../../model";
-import { ConfigurationBubble } from "../../../common";
 import { DashboardInsightMenuBubble } from "./DashboardInsightMenuBubble";
+import { DashboardInsightEditMenuBubble } from "./DashboardInsightEditMenuBubble";
 
-const DashboardInsightMenuBody: React.FC<IDashboardInsightMenuProps> = (props) => {
-    const { items, widget, onClose } = props;
-    const [submenu, setSubmenu] = useState<IInsightMenuSubmenu | null>(null);
+const DashboardInsightMenuBody: React.FC<
+    IDashboardInsightMenuProps & {
+        submenu: IInsightMenuSubmenu | null;
+        setSubmenu: React.Dispatch<React.SetStateAction<IInsightMenuSubmenu | null>>;
+    }
+> = (props) => {
+    const { items, widget, submenu, setSubmenu, onClose } = props;
 
     return submenu ? (
         <DashboardInsightSubmenuContainer
@@ -33,22 +36,15 @@ const DashboardInsightMenuBody: React.FC<IDashboardInsightMenuProps> = (props) =
 export const DashboardInsightMenu: React.FC<IDashboardInsightMenuProps> = (props) => {
     const { widget, onClose } = props;
     const isInEditMode = useDashboardSelector(selectIsInEditMode);
+    const [submenu, setSubmenu] = useState<IInsightMenuSubmenu | null>(null);
 
     return isInEditMode ? (
-        <ConfigurationBubble
-            classNames={cx(
-                "edit-insight-config",
-                "s-edit-insight-config",
-                "edit-insight-config-arrow-color",
-                "edit-insight-config-title-1-line",
-            )}
-            onClose={onClose}
-        >
-            <DashboardInsightMenuBody {...props} />
-        </ConfigurationBubble>
+        <DashboardInsightEditMenuBubble onClose={onClose} isSubmenu={!!submenu}>
+            <DashboardInsightMenuBody {...props} submenu={submenu} setSubmenu={setSubmenu} />
+        </DashboardInsightEditMenuBubble>
     ) : (
-        <DashboardInsightMenuBubble onClose={onClose} widget={widget}>
-            <DashboardInsightMenuBody {...props} />
+        <DashboardInsightMenuBubble onClose={onClose} widget={widget} isSubmenu={!!submenu}>
+            <DashboardInsightMenuBody {...props} submenu={submenu} setSubmenu={setSubmenu} />
         </DashboardInsightMenuBubble>
     );
 };


### PR DESCRIPTION
In KD edit mode open Config panel for some Widget and go to some submenu, eg. Configuration. Arrow color needs to be different based on submenu.

JIRA: RAIL-4629

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
