### PR TITLE
BUGFIX: TNT-1164 Dont use lodash/isEqual to compare whole props

### DIFF
--- a/common/config/rush/browser-approved-packages.json
+++ b/common/config/rush/browser-approved-packages.json
@@ -903,6 +903,10 @@
       "allowedCategories": [ "examples", "production", "tools" ]
     },
     {
+      "name": "react-fast-compare",
+      "allowedCategories": [ "production" ]
+    },
+    {
       "name": "react-ga",
       "allowedCategories": [ "examples" ]
     },

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -2019,7 +2019,7 @@ packages:
       fs-extra: 10.0.1
       json-stable-stringify: 1.0.1
       loud-rejection: 2.2.0
-      tslib: 2.3.1
+      tslib: 2.4.0
       typescript: 4.5.5
       vue: 3.2.34
     transitivePeerDependencies:
@@ -8464,7 +8464,7 @@ packages:
     dev: false
 
   /core-util-is/1.0.2:
-    resolution: {integrity: sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==}
+    resolution: {integrity: sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=}
     dev: false
 
   /core-util-is/1.0.3:
@@ -20928,7 +20928,7 @@ packages:
     dev: false
 
   file:projects/api-client-bear.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-0dIcIRMCwJzl4pHHVpv8nUO7uDUq72yAUOYJyKvZ9iNAxFLwME+wicsKQsMPWXGD+er7pVWXy1L72gnuqZ/rcw==, tarball: file:projects/api-client-bear.tgz}
+    resolution: {integrity: sha512-dst72WmEqYyvTn12horqCbASXCv71n2I59XOvhhRyHFb9ULJbq57ETU4PmSsNrztvoXjQqBWJS/Rt30/Q25EAA==, tarball: file:projects/api-client-bear.tgz}
     id: file:projects/api-client-bear.tgz
     name: '@rush-temp/api-client-bear'
     version: 0.0.0
@@ -20971,7 +20971,7 @@ packages:
       ts-invariant: 0.7.5
       ts-jest: 27.1.4_dddc46dbe41fd8ba74d3d274e144bf21
       ts-loader: 8.3.0_typescript@4.0.2+webpack@5.72.0
-      tslib: 2.3.1
+      tslib: 2.4.0
       typescript: 4.0.2
       webpack: 5.72.0_webpack-cli@4.9.2
       webpack-cli: 4.9.2_webpack@5.72.0
@@ -20996,7 +20996,7 @@ packages:
     dev: false
 
   file:projects/api-client-tiger.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-AmclSRPf3DGeqdh+fIcNguyXi7PR1lTP5ruvtMiGJRxTotHskrMyGyFlRSiJ/BBwXoh5E+VKBYz7XG3s7bikLg==, tarball: file:projects/api-client-tiger.tgz}
+    resolution: {integrity: sha512-LzY1GpILe5ndR/SU91ZF1NxnFQzCyJYvn4YxRXIh/iBiiRAlFit76TMjpDr98w9LZDBSoC6nwPx1uLjFBnkCbw==, tarball: file:projects/api-client-tiger.tgz}
     id: file:projects/api-client-tiger.tgz
     name: '@rush-temp/api-client-tiger'
     version: 0.0.0
@@ -21029,7 +21029,7 @@ packages:
       mkdirp: 1.0.4
       prettier: 2.5.1
       ts-jest: 27.1.4_dddc46dbe41fd8ba74d3d274e144bf21
-      tslib: 2.3.1
+      tslib: 2.4.0
       typescript: 4.0.2
     transitivePeerDependencies:
       - '@babel/core'
@@ -21081,7 +21081,7 @@ packages:
       lodash: 4.17.21
       prettier: 2.5.1
       ts-jest: 27.1.4_dddc46dbe41fd8ba74d3d274e144bf21
-      tslib: 2.3.1
+      tslib: 2.4.0
       typescript: 4.0.2
     transitivePeerDependencies:
       - '@babel/core'
@@ -21132,7 +21132,7 @@ packages:
       prettier: 2.5.1
       ts-jest: 27.1.4_dddc46dbe41fd8ba74d3d274e144bf21
       ts-node: 10.7.0_b04f371f35f79618750bcd4cb7cf2198
-      tslib: 2.3.1
+      tslib: 2.4.0
       typescript: 4.0.2
     transitivePeerDependencies:
       - '@babel/core'
@@ -21149,7 +21149,7 @@ packages:
     dev: false
 
   file:projects/catalog-export.tgz:
-    resolution: {integrity: sha512-RV6RIKwQrbDDuudo2+hiPK2s9+T0jZADqyzPXA700QcPYZvgcW9Z0CmeEfyGMZyMpeC1fOgyb+Boa42HsWKmLw==, tarball: file:projects/catalog-export.tgz}
+    resolution: {integrity: sha512-xw0naNoDO59zNCZWFsVm8O83jAvm3+NgEP5y135GuYSgWXk0vxpz92IPon/W76NmRCTDyuI3h7C5n0hYh0lfGg==, tarball: file:projects/catalog-export.tgz}
     name: '@rush-temp/catalog-export'
     version: 0.0.0
     dependencies:
@@ -21188,7 +21188,7 @@ packages:
       ts-jest: 27.1.4_04d0a0d69bd2aca5362e207508aff12f
       ts-morph: 13.0.3
       ts-node: 10.7.0_b04f371f35f79618750bcd4cb7cf2198
-      tslib: 2.3.1
+      tslib: 2.4.0
       typescript: 4.0.2
     transitivePeerDependencies:
       - '@swc/core'
@@ -21204,7 +21204,7 @@ packages:
     dev: false
 
   file:projects/dashboard-plugin-template.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-Gd81fRGayxEzoqKanUz4qzQEZhNmcTfUtHwfa20VPjqD/n5KLjbegi0OjANDlp0AFcyHUnSyd3JE5gyGvKH/Tw==, tarball: file:projects/dashboard-plugin-template.tgz}
+    resolution: {integrity: sha512-Xn8yMNlOTF+9rx1bIDq0yhnKu/9Hz92LCspZ7QudbJC/8wTVtcUV7KMvJcOzx9E2O+7SC1SBNWf55BbDVV2Yhw==, tarball: file:projects/dashboard-plugin-template.tgz}
     id: file:projects/dashboard-plugin-template.tgz
     name: '@rush-temp/dashboard-plugin-template'
     version: 0.0.0
@@ -21258,7 +21258,7 @@ packages:
       style-loader: 3.3.1_webpack@5.72.0
       ts-jest: 27.1.4_04d0a0d69bd2aca5362e207508aff12f
       ts-loader: 8.3.0_typescript@4.0.2+webpack@5.72.0
-      tslib: 2.3.1
+      tslib: 2.4.0
       typescript: 4.0.2
       util: 0.12.4
       webpack: 5.72.0_webpack-cli@4.9.2
@@ -21283,7 +21283,7 @@ packages:
     dev: false
 
   file:projects/dashboard-plugin-tests.tgz:
-    resolution: {integrity: sha512-MyzG0Q1WznNJbqvI51b2XYbCZZtAI4Ui4F1dOZY8drrGgwkmbLS9OqIt6RqDhEEYX2qJDoBdvm71/i4TthVE/A==, tarball: file:projects/dashboard-plugin-tests.tgz}
+    resolution: {integrity: sha512-+fEBxLglPExqICLEDggwCVKhfbw2EjB0kngj2MQe+5ew3A26CnADe1VOpr9+J/o2gABHWjBWm8giCbJlldTE/Q==, tarball: file:projects/dashboard-plugin-tests.tgz}
     name: '@rush-temp/dashboard-plugin-tests'
     version: 0.0.0
     dependencies:
@@ -21351,7 +21351,7 @@ packages:
       style-loader: 3.3.1_webpack@5.72.0
       ts-jest: 27.1.4_04d0a0d69bd2aca5362e207508aff12f
       ts-node: 10.7.0_b04f371f35f79618750bcd4cb7cf2198
-      tslib: 2.3.1
+      tslib: 2.4.0
       typescript: 4.0.2
       wait-on: 6.0.1
       webpack: 5.72.0
@@ -21374,7 +21374,7 @@ packages:
     dev: false
 
   file:projects/experimental-workspace.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-HAo8+fF4oLzDMIBiUTy+q70cu9AZD19lvO4pM81UE1EQOOBS0O/MjcN0pHN2uv3pgd/QRq8JKBDJAcl5KpFpew==, tarball: file:projects/experimental-workspace.tgz}
+    resolution: {integrity: sha512-5CrlUl2KIrf1/Q3IZXOVbRkDIPMl2tPkKUI/u8JxOVV+eh2ZhKrwd5oa2ycm2H1PNUxqPf1R9JBDx0cgt7L27w==, tarball: file:projects/experimental-workspace.tgz}
     id: file:projects/experimental-workspace.tgz
     name: '@rush-temp/experimental-workspace'
     version: 0.0.0
@@ -21401,7 +21401,7 @@ packages:
       lodash: 4.17.21
       prettier: 2.5.1
       ts-jest: 27.1.4_dddc46dbe41fd8ba74d3d274e144bf21
-      tslib: 2.3.1
+      tslib: 2.4.0
       typescript: 4.0.2
     transitivePeerDependencies:
       - '@babel/core'
@@ -21454,7 +21454,7 @@ packages:
       mkdirp: 1.0.4
       prettier: 2.5.1
       ts-jest: 27.1.4_dddc46dbe41fd8ba74d3d274e144bf21
-      tslib: 2.3.1
+      tslib: 2.4.0
       typescript: 4.0.2
       util: 0.12.4
     transitivePeerDependencies:
@@ -21473,7 +21473,7 @@ packages:
     dev: false
 
   file:projects/live-examples-workspace.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-pIDm78+F01PPnR9gUrlNBubuNzL3qbfsRWcgE68SW1munCpsE6wU7b2bEPpGFE5dOqB2pXaLXvG/UuoW2Kfvhg==, tarball: file:projects/live-examples-workspace.tgz}
+    resolution: {integrity: sha512-uwEpW5MXlwJMruxfTsuRrRl7jHOlYvpbQ/wy/WGXB/YJx/aH0owQN0VN+TSQrcTGKCSoMc+QyXM/g/Acg+hDhw==, tarball: file:projects/live-examples-workspace.tgz}
     id: file:projects/live-examples-workspace.tgz
     name: '@rush-temp/live-examples-workspace'
     version: 0.0.0
@@ -21499,7 +21499,7 @@ packages:
       lodash: 4.17.21
       prettier: 2.5.1
       ts-jest: 27.1.4_dddc46dbe41fd8ba74d3d274e144bf21
-      tslib: 2.3.1
+      tslib: 2.4.0
       typescript: 4.0.2
     transitivePeerDependencies:
       - '@babel/core'
@@ -21515,7 +21515,7 @@ packages:
     dev: false
 
   file:projects/mock-handling.tgz:
-    resolution: {integrity: sha512-Y86oDzFuBITILF77ozlTpekX/+Zpcie7X+nwd2rNll0wFr6CozcK17dcAXJUOLDrmYluORTtPJsRms4mDeRk1w==, tarball: file:projects/mock-handling.tgz}
+    resolution: {integrity: sha512-EEW9PGs/x9CPYykAB+loa7tCzKSMsvUzkFfTZ4WS3bGKBSpO3tT0aKNpKJp4YdU+gOPQPWqIGT5Flr2hdHM5eg==, tarball: file:projects/mock-handling.tgz}
     name: '@rush-temp/mock-handling'
     version: 0.0.0
     dependencies:
@@ -21553,7 +21553,7 @@ packages:
       ts-jest: 27.1.4_dddc46dbe41fd8ba74d3d274e144bf21
       ts-morph: 13.0.3
       ts-node: 10.7.0_b04f371f35f79618750bcd4cb7cf2198
-      tslib: 2.3.1
+      tslib: 2.4.0
       typescript: 4.0.2
     transitivePeerDependencies:
       - '@babel/core'
@@ -21570,7 +21570,7 @@ packages:
     dev: false
 
   file:projects/playground.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-xJ1GUTAcV1muwGgjv3UgAj5FpjwcVl1NclC/Wlx1Cz/6/sDlKRWE0LlYQICUUZtjKSd3ZAPYvkIH7JA8PiROOA==, tarball: file:projects/playground.tgz}
+    resolution: {integrity: sha512-xRZ1Q8W7B3mFmt37nuL04AMIoL0+aKpfHw0tJdAec3xMv+lA/NZGZuYPbr0SczNA0v2XuiH/GsWtFVA47eNbUg==, tarball: file:projects/playground.tgz}
     id: file:projects/playground.tgz
     name: '@rush-temp/playground'
     version: 0.0.0
@@ -21626,7 +21626,7 @@ packages:
       speed-measure-webpack-plugin: 1.5.0_webpack@5.72.0
       style-loader: 3.3.1_webpack@5.72.0
       ts-invariant: 0.7.5
-      tslib: 2.3.1
+      tslib: 2.4.0
       typescript: 4.0.2
       webpack: 5.72.0_webpack-cli@4.9.2
       webpack-cli: 4.9.2_832a5854b19f7f260bd9c93005d13eee
@@ -21652,7 +21652,7 @@ packages:
     dev: false
 
   file:projects/plugin-toolkit.tgz:
-    resolution: {integrity: sha512-+gkiQ6ys3DiNCz2NUkhaPuPzrDxyplIWGWpjSAcoOW8uMP3SoY+EidyderphkUS9W6+7yHUYPWfzBjXv+iWgYA==, tarball: file:projects/plugin-toolkit.tgz}
+    resolution: {integrity: sha512-HvoUECNINcCT5D6ylAeJ2dxR0llKKaS/hzCeKwkZg6m9Iew9WmZhjJV6CpKPgwnp/KqkBY8RIvoZTbocQRGOWg==, tarball: file:projects/plugin-toolkit.tgz}
     name: '@rush-temp/plugin-toolkit'
     version: 0.0.0
     dependencies:
@@ -21700,7 +21700,7 @@ packages:
       tar: 6.1.11
       ts-jest: 27.1.4_04d0a0d69bd2aca5362e207508aff12f
       ts-node: 10.7.0_b04f371f35f79618750bcd4cb7cf2198
-      tslib: 2.3.1
+      tslib: 2.4.0
       typescript: 4.0.2
     transitivePeerDependencies:
       - '@swc/core'
@@ -21717,7 +21717,7 @@ packages:
     dev: false
 
   file:projects/reference-workspace-mgmt.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-QlfoEOr9ouvYgpQ+tOG8QNd0GhNIZqsMjXstiQXaBCNy3mLQcP+fgUEFFdk8oi8EGGqXtsRyEUPPbgEtB5sSvA==, tarball: file:projects/reference-workspace-mgmt.tgz}
+    resolution: {integrity: sha512-tEap4GQbbgqB6EGfFFCo9/OOxlPR8E4yYXvL0JijQs21cwxwrqwMZgAiqCFNTKvcXeYBmL8GGB9Nv2cJheLJjQ==, tarball: file:projects/reference-workspace-mgmt.tgz}
     id: file:projects/reference-workspace-mgmt.tgz
     name: '@rush-temp/reference-workspace-mgmt'
     version: 0.0.0
@@ -21742,7 +21742,7 @@ packages:
       jest-junit: 3.7.0
       prettier: 2.5.1
       ts-jest: 27.1.4_dddc46dbe41fd8ba74d3d274e144bf21
-      tslib: 2.3.1
+      tslib: 2.4.0
       typescript: 4.0.2
     transitivePeerDependencies:
       - '@babel/core'
@@ -21758,7 +21758,7 @@ packages:
     dev: false
 
   file:projects/reference-workspace.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-AaeTzNFrLVwdji/MlgUt+zSEykZsIRAfnOiFPbUMOBKigk4FMuFtGFYj1PBpJWlZaMd/ljQOEZpx4rnB4OwLKA==, tarball: file:projects/reference-workspace.tgz}
+    resolution: {integrity: sha512-/IcAYO3fCG4YyRoa41HuSBUL0lUHHSnDNlN7SvJ14+bMbWxrptZdjvhqb13NzfqXkDAutmhTmQ1fkdk581NfLA==, tarball: file:projects/reference-workspace.tgz}
     id: file:projects/reference-workspace.tgz
     name: '@rush-temp/reference-workspace'
     version: 0.0.0
@@ -21784,7 +21784,7 @@ packages:
       lodash: 4.17.21
       prettier: 2.5.1
       ts-jest: 27.1.4_dddc46dbe41fd8ba74d3d274e144bf21
-      tslib: 2.3.1
+      tslib: 2.4.0
       typescript: 4.0.2
     transitivePeerDependencies:
       - '@babel/core'
@@ -21800,7 +21800,7 @@ packages:
     dev: false
 
   file:projects/sdk-backend-base.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-8fZRu93dmsDiNLrMAkDRkKux6Muv8BIzD/XDkOGe8xRj0ZsBvrZejKQZik62JvNv8ZYT++gRYtG7pFCyTSlKGA==, tarball: file:projects/sdk-backend-base.tgz}
+    resolution: {integrity: sha512-iDtwaTtS3W8/7fxCnqM6bjAJFyLnjOm3Q4B9MwsB5N9F8VZM1Jr+KhHqTbL9fHZ61T36vOWaMu5PeVAHFq8nfQ==, tarball: file:projects/sdk-backend-base.tgz}
     id: file:projects/sdk-backend-base.tgz
     name: '@rush-temp/sdk-backend-base'
     version: 0.0.0
@@ -21835,7 +21835,7 @@ packages:
       spark-md5: 3.0.2
       ts-invariant: 0.7.5
       ts-jest: 27.1.4_dddc46dbe41fd8ba74d3d274e144bf21
-      tslib: 2.3.1
+      tslib: 2.4.0
       typescript: 4.0.2
       uuid: 8.3.2
     transitivePeerDependencies:
@@ -21852,7 +21852,7 @@ packages:
     dev: false
 
   file:projects/sdk-backend-bear.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-dZJ0ansb1u7vpIQPLMN517yUtq5Oxqe/58TL8cKtA5ANaIdYy+6wA9RoV4n06zMPQc3j0oPOol1ybNYeOtmOIQ==, tarball: file:projects/sdk-backend-bear.tgz}
+    resolution: {integrity: sha512-PCL/v/k8XMOQEgdyTtpce/tUOqlAz0WotTLHldB4lVBn5enDkBjAbP4/oSpxNXpuWBu0BXC8q41K9nOWf6ynpg==, tarball: file:projects/sdk-backend-bear.tgz}
     id: file:projects/sdk-backend-bear.tgz
     name: '@rush-temp/sdk-backend-bear'
     version: 0.0.0
@@ -21889,7 +21889,7 @@ packages:
       spark-md5: 3.0.2
       ts-invariant: 0.7.5
       ts-jest: 27.1.4_dddc46dbe41fd8ba74d3d274e144bf21
-      tslib: 2.3.1
+      tslib: 2.4.0
       typescript: 4.0.2
       uuid: 8.3.2
     transitivePeerDependencies:
@@ -21906,7 +21906,7 @@ packages:
     dev: false
 
   file:projects/sdk-backend-mockingbird.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-TiZja7NLaQxnD0bzS48g4Arjd7AJSDbNq9UpEgBR7DcPWGhemjYeDJaPXrjq/KEJltd1EUkMd3rIyPA+BwaXTg==, tarball: file:projects/sdk-backend-mockingbird.tgz}
+    resolution: {integrity: sha512-OHInZKptX7w7jJH1J96pQZ8rs5rertZyLxzUaWXOoglHK5PcqIauzsock+3AbibJxt33EudHpHkcz3rQpIuUUA==, tarball: file:projects/sdk-backend-mockingbird.tgz}
     id: file:projects/sdk-backend-mockingbird.tgz
     name: '@rush-temp/sdk-backend-mockingbird'
     version: 0.0.0
@@ -21936,7 +21936,7 @@ packages:
       prettier: 2.5.1
       ts-invariant: 0.7.5
       ts-jest: 27.1.4_dddc46dbe41fd8ba74d3d274e144bf21
-      tslib: 2.3.1
+      tslib: 2.4.0
       typescript: 4.0.2
       uuid: 8.3.2
     transitivePeerDependencies:
@@ -21953,7 +21953,7 @@ packages:
     dev: false
 
   file:projects/sdk-backend-spi.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-pmPQJpommUo93QB5xyfmpVdSRtxXsjQj1d0t2MYDmnQhOwlmylJEr/pa7cQmK3kFon+Kdfa15uw5cD5DcSsauQ==, tarball: file:projects/sdk-backend-spi.tgz}
+    resolution: {integrity: sha512-yaexwd/T3z6UEP52jVgUohAhKnWWMNmFcDTqDi7RH2m51+8+BBsqRhPqG+WQ6bMkd7rVsMm2NIlTP1+YQiKlUQ==, tarball: file:projects/sdk-backend-spi.tgz}
     id: file:projects/sdk-backend-spi.tgz
     name: '@rush-temp/sdk-backend-spi'
     version: 0.0.0
@@ -21982,7 +21982,7 @@ packages:
       prettier: 2.5.1
       ts-invariant: 0.7.5
       ts-jest: 27.1.4_dddc46dbe41fd8ba74d3d274e144bf21
-      tslib: 2.3.1
+      tslib: 2.4.0
       typescript: 4.0.2
     transitivePeerDependencies:
       - '@babel/core'
@@ -21998,7 +21998,7 @@ packages:
     dev: false
 
   file:projects/sdk-backend-tiger.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-wEdTctclLJ467vy2qcDd+sWAVZbrP8gadq6YjrJk40OeQ5H5nyS4vAB14r4sJBym4+lVvJVBJRQFUs6S0qrbtA==, tarball: file:projects/sdk-backend-tiger.tgz}
+    resolution: {integrity: sha512-ii9cEU0Q1Gjreb0y9XbQTxSAP1ukqvRKeBsEsgdSA5wmqeo5yO5nI7VwjU/UNeQDHFwvylb2PccwrgyQcLI5qw==, tarball: file:projects/sdk-backend-tiger.tgz}
     id: file:projects/sdk-backend-tiger.tgz
     name: '@rush-temp/sdk-backend-tiger'
     version: 0.0.0
@@ -22033,7 +22033,7 @@ packages:
       spark-md5: 3.0.2
       ts-invariant: 0.7.5
       ts-jest: 27.1.4_dddc46dbe41fd8ba74d3d274e144bf21
-      tslib: 2.3.1
+      tslib: 2.4.0
       typescript: 4.0.2
       uuid: 8.3.2
     transitivePeerDependencies:
@@ -22051,7 +22051,7 @@ packages:
     dev: false
 
   file:projects/sdk-embedding.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-6uiIhdkvJYF56G0eoyjVaeUKXl3A9WnKWGGE5C1qTsiSpO3RihRxz4jNxgclGldJg+h9zFl2evrn3XefbErQDg==, tarball: file:projects/sdk-embedding.tgz}
+    resolution: {integrity: sha512-lMIXtMparzB2zfpilrI0y2Bl2roKZ0F6DIoDXaibiwKf6a13I25eegC1D/WG03pBxEaY4WC8kQVcmWaj66DxWg==, tarball: file:projects/sdk-embedding.tgz}
     id: file:projects/sdk-embedding.tgz
     name: '@rush-temp/sdk-embedding'
     version: 0.0.0
@@ -22080,7 +22080,7 @@ packages:
       prettier: 2.5.1
       ts-invariant: 0.7.5
       ts-jest: 27.1.4_dddc46dbe41fd8ba74d3d274e144bf21
-      tslib: 2.3.1
+      tslib: 2.4.0
       typescript: 4.0.2
     transitivePeerDependencies:
       - '@babel/core'
@@ -22096,7 +22096,7 @@ packages:
     dev: false
 
   file:projects/sdk-examples.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-CMK7FRZS+Gud63fXEr3tqlUQ287yHOJ47i/bMW49FFILnxmx4nrh19OVzk7q0PaFjOAi646koodsewk8NXFb1Q==, tarball: file:projects/sdk-examples.tgz}
+    resolution: {integrity: sha512-R9mlEqmwed9iwkd1LUaGbrYTCgMDEkPq2vIHvRUI29VN+gDTek2H3O1tUeS1xCLCVBngusytuwrwogQZ1sZikQ==, tarball: file:projects/sdk-examples.tgz}
     id: file:projects/sdk-examples.tgz
     name: '@rush-temp/sdk-examples'
     version: 0.0.0
@@ -22180,7 +22180,7 @@ packages:
       style-loader: 3.3.1_webpack@5.72.0
       styled-jsx: 4.0.1_@babel+core@7.17.9+react@17.0.2
       ts-invariant: 0.7.5
-      tslib: 2.3.1
+      tslib: 2.4.0
       typescript: 4.0.2
       webpack: 5.72.0_webpack-cli@4.9.2
       webpack-cli: 4.9.2_832a5854b19f7f260bd9c93005d13eee
@@ -22244,7 +22244,7 @@ packages:
       stringify-object: 3.3.0
       ts-invariant: 0.7.5
       ts-jest: 27.1.4_dddc46dbe41fd8ba74d3d274e144bf21
-      tslib: 2.3.1
+      tslib: 2.4.0
       typescript: 4.0.2
     transitivePeerDependencies:
       - '@babel/core'
@@ -22288,7 +22288,7 @@ packages:
       lodash: 4.17.21
       prettier: 2.5.1
       ts-jest: 27.1.4_dddc46dbe41fd8ba74d3d274e144bf21
-      tslib: 2.3.1
+      tslib: 2.4.0
       typescript: 4.0.2
     transitivePeerDependencies:
       - '@babel/core'
@@ -22345,7 +22345,7 @@ packages:
       react-dom: 17.0.2_react@17.0.2
       react-intl: 5.24.8_react@17.0.2+typescript@4.0.2
       ts-jest: 27.1.4_dddc46dbe41fd8ba74d3d274e144bf21
-      tslib: 2.3.1
+      tslib: 2.4.0
       typescript: 4.0.2
     transitivePeerDependencies:
       - '@babel/core'
@@ -22361,7 +22361,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-all.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-l8rBF5eUTFaOyLY/PH7mBs33iNp/77+jGvgFlDgk6aS1Y+7gJR72+CTWec3kt0MurDKecNjMwsuaY9K+pG2WXA==, tarball: file:projects/sdk-ui-all.tgz}
+    resolution: {integrity: sha512-wHH2fCUcQh7uAwb35eB4B4cKg+RKPaIZqswDAAm8tr7HCjKFI4ydGHlE4YDyOtZ1t8y7eXfBfEQn1W+boaI8+A==, tarball: file:projects/sdk-ui-all.tgz}
     id: file:projects/sdk-ui-all.tgz
     name: '@rush-temp/sdk-ui-all'
     version: 0.0.0
@@ -22387,7 +22387,7 @@ packages:
       jest-junit: 3.7.0
       prettier: 2.5.1
       ts-jest: 27.1.4_dddc46dbe41fd8ba74d3d274e144bf21
-      tslib: 2.3.1
+      tslib: 2.4.0
       typescript: 4.0.2
     transitivePeerDependencies:
       - '@babel/core'
@@ -22403,7 +22403,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-charts.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-hhr41k3GxdpxVQnHwWnNyoRLqdrrgwpc0IwzQt504A5H4VFF/0o1Yzs5LMI3LfJmZa9TY0fxAn8+tRH58Iw6xw==, tarball: file:projects/sdk-ui-charts.tgz}
+    resolution: {integrity: sha512-/m19ymBUpg40pqtpl9PaW+uxMGuAXY8SOqyiF9z3FzQG54nBa1XZ13HJqSLlV1HdYOnXBIOVz9yNxmtgHzySzw==, tarball: file:projects/sdk-ui-charts.tgz}
     id: file:projects/sdk-ui-charts.tgz
     name: '@rush-temp/sdk-ui-charts'
     version: 0.0.0
@@ -22463,7 +22463,7 @@ packages:
       svg-classlist-polyfill: 1.0.6
       ts-invariant: 0.7.5
       ts-jest: 27.1.4_dddc46dbe41fd8ba74d3d274e144bf21
-      tslib: 2.3.1
+      tslib: 2.4.0
       typescript: 4.0.2
       uuid: 8.3.2
     transitivePeerDependencies:
@@ -22480,7 +22480,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-dashboard.tgz_a7e570fd5a4985262571d64f4bc94b86:
-    resolution: {integrity: sha512-I7n6C8bOwgTt09JAi4aJNQrQTsirgOQNzaYEH+wRMMe8GC5qrq4dIV/OBMf0FqKGlYTSAOY2zEzin7rIRrqHoA==, tarball: file:projects/sdk-ui-dashboard.tgz}
+    resolution: {integrity: sha512-nZxpz8DwqVEvKYaBzyvAK3aNgDHoRD0FvMCj8Cc0AG8XlQfIBhMdOfK8M41RJIoqlWJxIJ7lwnJpPucJokwJcA==, tarball: file:projects/sdk-ui-dashboard.tgz}
     id: file:projects/sdk-ui-dashboard.tgz
     name: '@rush-temp/sdk-ui-dashboard'
     version: 0.0.0
@@ -22554,7 +22554,7 @@ packages:
       svgo: 2.8.0
       ts-invariant: 0.7.5
       ts-jest: 27.1.4_dddc46dbe41fd8ba74d3d274e144bf21
-      tslib: 2.3.1
+      tslib: 2.4.0
       typescript: 4.0.2
       uuid: 8.3.2
     transitivePeerDependencies:
@@ -22576,7 +22576,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-ext.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-7+SupK1jLHLIiWLSlfhf3d6tvx6w35MIxyuTzVCD2rCVbZZHprn97Whbdot6aQkTpTSuXg88FbyDXG0Y3LQj/A==, tarball: file:projects/sdk-ui-ext.tgz}
+    resolution: {integrity: sha512-fPRSv0aEFiDuUzFXD6o9QqJ9WUwFPxZ+/esWX3Vtkxj0p2x1FXK1xFxbQSw/o/xxN5InUboWF3Fcqe9Q4JqjVA==, tarball: file:projects/sdk-ui-ext.tgz}
     id: file:projects/sdk-ui-ext.tgz
     name: '@rush-temp/sdk-ui-ext'
     version: 0.0.0
@@ -22645,7 +22645,7 @@ packages:
       svgo: 2.8.0
       ts-invariant: 0.7.5
       ts-jest: 27.1.4_dddc46dbe41fd8ba74d3d274e144bf21
-      tslib: 2.3.1
+      tslib: 2.4.0
       typescript: 4.0.2
       uuid: 8.3.2
     transitivePeerDependencies:
@@ -22663,7 +22663,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-filters.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-8mMPrrnPfN+TySH1fIoK1HomtZoBowDEevX1Y3nZQMpCmeJukmYBKmdKIabnWtEEPgQyOWU/+hPAumlKWZ3r+g==, tarball: file:projects/sdk-ui-filters.tgz}
+    resolution: {integrity: sha512-ti3iCt6xGAwfhVHpGQikHKIc3Fona+I/HJJjG47yR6iQeayYNtqFUBw2WUtLjSRZsIXU24t0mOEgsKHSUScWOw==, tarball: file:projects/sdk-ui-filters.tgz}
     id: file:projects/sdk-ui-filters.tgz
     name: '@rush-temp/sdk-ui-filters'
     version: 0.0.0
@@ -22728,7 +22728,7 @@ packages:
       stylelint-config-prettier: 8.0.2_stylelint@13.13.1
       ts-invariant: 0.7.5
       ts-jest: 27.1.4_dddc46dbe41fd8ba74d3d274e144bf21
-      tslib: 2.3.1
+      tslib: 2.4.0
       typescript: 4.0.2
       uuid: 8.3.2
     transitivePeerDependencies:
@@ -22746,7 +22746,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-geo.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-I0ABtQJub2SSJPh0EURUzp+UmBW15dOxkkONB8JDo430VEHEBJfEGpsIOf8F6kSfvhaImEjcEH0fgT4I3B6oBw==, tarball: file:projects/sdk-ui-geo.tgz}
+    resolution: {integrity: sha512-t1KetDzLW4Z5ZL6aJ1PDMRjwQ8NgGMUyDqgMN98Txwdxt7T5bQrp4qaiki9zt09S5euR1Q21qc1q7bg9cZz1/g==, tarball: file:projects/sdk-ui-geo.tgz}
     id: file:projects/sdk-ui-geo.tgz
     name: '@rush-temp/sdk-ui-geo'
     version: 0.0.0
@@ -22800,7 +22800,7 @@ packages:
       stylelint-config-prettier: 8.0.2_stylelint@13.13.1
       ts-invariant: 0.7.5
       ts-jest: 27.1.4_dddc46dbe41fd8ba74d3d274e144bf21
-      tslib: 2.3.1
+      tslib: 2.4.0
       typescript: 4.0.2
       uuid: 8.3.2
     transitivePeerDependencies:
@@ -22817,7 +22817,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-kit.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-0S60WZmeQ1aDQZH0qMtdo0jccqp6AgRX8i3NRD53Fq+4YP3G/ekyXIIzQp4ji8QK0QZWJQQAs59lshgaBgggpA==, tarball: file:projects/sdk-ui-kit.tgz}
+    resolution: {integrity: sha512-CbeKmhR3AGWW4Jcm2Cn2GcjD2GwqJyWSNsPOy0e7OcVpK7jvt2OnScYQaADI+pUT3Jmbjx4rsTE6Mj0kot0E/w==, tarball: file:projects/sdk-ui-kit.tgz}
     id: file:projects/sdk-ui-kit.tgz
     name: '@rush-temp/sdk-ui-kit'
     version: 0.0.0
@@ -22894,6 +22894,7 @@ packages:
       react-content-loader: 6.2.0_react@17.0.2
       react-day-picker: 8.0.7_4781667a0ce088dd5680677bceac5559
       react-dom: 17.0.2_react@17.0.2
+      react-fast-compare: 3.2.0
       react-helmet: 6.1.0_react@17.0.2
       react-intl: 5.24.8_react@17.0.2+typescript@4.0.2
       react-measure: 2.5.2_react-dom@17.0.2+react@17.0.2
@@ -22911,7 +22912,7 @@ packages:
       tinycolor2: 1.4.2
       ts-invariant: 0.7.5
       ts-jest: 27.1.4_dddc46dbe41fd8ba74d3d274e144bf21
-      tslib: 2.3.1
+      tslib: 2.4.0
       typescript: 4.0.2
       uuid: 8.3.2
     transitivePeerDependencies:
@@ -22930,7 +22931,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-loaders.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-ti5M5ubGCPB0mFb4GkeYymJdmh+S702LiWApCeEV0ocCfyBh1IdXO9OPwZtR2EKq816s3O5lcDLG6dxHNQwDCw==, tarball: file:projects/sdk-ui-loaders.tgz}
+    resolution: {integrity: sha512-tkGjGZIVxSg7cQZhTrBksqHtpQ4xbZAUmCfF/TRCWnS+aTbyutums81J5hBOnsK9qKTHRa94NhduoO88mKKhNg==, tarball: file:projects/sdk-ui-loaders.tgz}
     id: file:projects/sdk-ui-loaders.tgz
     name: '@rush-temp/sdk-ui-loaders'
     version: 0.0.0
@@ -22976,7 +22977,7 @@ packages:
       semver: 7.3.6
       ts-invariant: 0.7.5
       ts-jest: 27.1.4_dddc46dbe41fd8ba74d3d274e144bf21
-      tslib: 2.3.1
+      tslib: 2.4.0
       typescript: 4.0.2
     transitivePeerDependencies:
       - '@babel/core'
@@ -22992,7 +22993,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-pivot.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-sswSdYlA5hnu90MueP9B4olvyeQRs8C8yTYWDtkBVENxB9J3iMcWyj+dLxRDbgso+rKFAXHV/OrnS6UmegjReQ==, tarball: file:projects/sdk-ui-pivot.tgz}
+    resolution: {integrity: sha512-FAhCtc7vXvSxvCVpSlYIdgU4yxkd0wQ/985nJd2/4pX2dQ4+JtAIJIqO79isXFhOJpHJPMaSS0tUg6MzCtBMKg==, tarball: file:projects/sdk-ui-pivot.tgz}
     id: file:projects/sdk-ui-pivot.tgz
     name: '@rush-temp/sdk-ui-pivot'
     version: 0.0.0
@@ -23048,7 +23049,7 @@ packages:
       stylelint-config-prettier: 8.0.2_stylelint@13.13.1
       ts-invariant: 0.7.5
       ts-jest: 27.1.4_dddc46dbe41fd8ba74d3d274e144bf21
-      tslib: 2.3.1
+      tslib: 2.4.0
       typescript: 4.0.2
       uuid: 8.3.2
     transitivePeerDependencies:
@@ -23066,7 +23067,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-tests-e2e.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-B3g9Jdc4Rhi6RlSJovHmFm53ALBnmzpkV3QU8f995QOSYiIA8dNOx2Cjp2+QxhRcHiVc9esQC7H5Ue5ya3qGWg==, tarball: file:projects/sdk-ui-tests-e2e.tgz}
+    resolution: {integrity: sha512-id7QDNltJWap19Hd7vpA2WgspVi7/oefg05o4DwLcoFHHWy5gPIwDH4lWzgoftsf1At3wluhQ9kbkS7pnCJgng==, tarball: file:projects/sdk-ui-tests-e2e.tgz}
     id: file:projects/sdk-ui-tests-e2e.tgz
     name: '@rush-temp/sdk-ui-tests-e2e'
     version: 0.0.0
@@ -23139,7 +23140,7 @@ packages:
       speed-measure-webpack-plugin: 1.5.0_webpack@5.72.0
       style-loader: 3.3.1_webpack@5.72.0
       styled-jsx: 4.0.1_@babel+core@7.17.9+react@17.0.2
-      tslib: 2.3.1
+      tslib: 2.4.0
       typescript: 4.0.2
       wait-on: 6.0.1
       webpack: 5.72.0_webpack-cli@4.9.2
@@ -23167,7 +23168,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-tests.tgz:
-    resolution: {integrity: sha512-6iWvkry7JcxBjYhxgkdWIHsaxP1Hdh1F3FbMT61kXWxf5+KJOlIqh90o9i63dJi9YtJbLHocW+8mftmitN5lNw==, tarball: file:projects/sdk-ui-tests.tgz}
+    resolution: {integrity: sha512-LLVwSFjOfa4M+njzxeswXRMv0chyyDCHz0t8jRaym2v6IPcITjju5PHoOiU9VJhMqK8UldegpE1HtGlO+SfbxA==, tarball: file:projects/sdk-ui-tests.tgz}
     name: '@rush-temp/sdk-ui-tests'
     version: 0.0.0
     dependencies:
@@ -23242,7 +23243,7 @@ packages:
       ts-jest: 27.1.4_04d0a0d69bd2aca5362e207508aff12f
       ts-loader: 8.3.0_typescript@4.0.2
       ts-node: 10.7.0_b04f371f35f79618750bcd4cb7cf2198
-      tslib: 2.3.1
+      tslib: 2.4.0
       typescript: 4.0.2
       uuid: 8.3.2
     transitivePeerDependencies:
@@ -23278,7 +23279,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-theme-provider.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-fb8gk7deTxpyvXJqgTbiMu28ZvYFtlYES04ABNStiD8fpKIllchd+A22T+Kutmg5UqeFODdbwVT68uRbjtAxMg==, tarball: file:projects/sdk-ui-theme-provider.tgz}
+    resolution: {integrity: sha512-Ywp/y/AWmYIkMZd8lxctND8Vf2Srq9PR6vS1D8/0YF6VvHSrOA/CIEYFoN4RHsAy9cb1+W3HPdx825l22xe9Zw==, tarball: file:projects/sdk-ui-theme-provider.tgz}
     id: file:projects/sdk-ui-theme-provider.tgz
     name: '@rush-temp/sdk-ui-theme-provider'
     version: 0.0.0
@@ -23320,7 +23321,7 @@ packages:
       react-dom: 17.0.2_react@17.0.2
       ts-invariant: 0.7.5
       ts-jest: 27.1.4_dddc46dbe41fd8ba74d3d274e144bf21
-      tslib: 2.3.1
+      tslib: 2.4.0
       typescript: 4.0.2
     transitivePeerDependencies:
       - '@babel/core'
@@ -23336,7 +23337,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-vis-commons.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-3XwbFuQq3+NDHtu2GY2y81cnLoHBg3MAJ8N31p+mqhy/CBGai6pNcclMVgKAgn/z1XKoMVw/VAzoEfk1vRigdQ==, tarball: file:projects/sdk-ui-vis-commons.tgz}
+    resolution: {integrity: sha512-WusM9EUVY89WD/XmtENDH4kqGC3on2/fxLX/y1I3chspqVd620qTnM/nXCCkU8spMgU0d7xo3WR59i/Q4KTjBw==, tarball: file:projects/sdk-ui-vis-commons.tgz}
     id: file:projects/sdk-ui-vis-commons.tgz
     name: '@rush-temp/sdk-ui-vis-commons'
     version: 0.0.0
@@ -23385,7 +23386,7 @@ packages:
       stylelint-checkstyle-formatter: 0.1.2
       stylelint-config-prettier: 8.0.2_stylelint@13.13.1
       ts-jest: 27.1.4_dddc46dbe41fd8ba74d3d274e144bf21
-      tslib: 2.3.1
+      tslib: 2.4.0
       typescript: 4.0.2
     transitivePeerDependencies:
       - '@babel/core'
@@ -23401,7 +23402,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-web-components.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-f3rYWP6SL1VJwE3/PCvWMyDkwTPWFYnm7B3Embwj4BbDSS5kjTaYJ44tNH24wjRhkMkzLnMxD70tKoDkoyT3Vg==, tarball: file:projects/sdk-ui-web-components.tgz}
+    resolution: {integrity: sha512-xhLdmHfI6RcaGdrABAglNM/1GKh/I8qMuRqhJsfXCToWJ5zImMWUz0BNVXl/vg3R81K5IM760MW+wdUy6FakCw==, tarball: file:projects/sdk-ui-web-components.tgz}
     id: file:projects/sdk-ui-web-components.tgz
     name: '@rush-temp/sdk-ui-web-components'
     version: 0.0.0
@@ -23451,7 +23452,7 @@ packages:
       ts-invariant: 0.7.5
       ts-jest: 27.1.4_dddc46dbe41fd8ba74d3d274e144bf21
       ts-loader: 8.3.0_typescript@4.0.2+webpack@5.72.0
-      tslib: 2.3.1
+      tslib: 2.4.0
       typescript: 4.0.2
       webpack: 5.72.0_webpack-cli@4.9.2
       webpack-bundle-analyzer: 4.5.0
@@ -23475,7 +23476,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-UgjSn/ypVz8WtkK1tSMl7MtMcNdEY4FZG1vOOuQ9rupqAuwm4YTlSKXGozbrf/xCkNSRKeqAENjt9Sx2Ya1PBg==, tarball: file:projects/sdk-ui.tgz}
+    resolution: {integrity: sha512-ilusISZCV9KphNghSviyHJ2Pn8VkMBAQRehE2Ro8hJwlO07L/vujqBvUgQdJPi0TZAnQVIgzut6BAVFbNcpwmg==, tarball: file:projects/sdk-ui.tgz}
     id: file:projects/sdk-ui.tgz
     name: '@rush-temp/sdk-ui'
     version: 0.0.0
@@ -23537,7 +23538,7 @@ packages:
       ts-invariant: 0.7.5
       ts-jest: 27.1.4_dddc46dbe41fd8ba74d3d274e144bf21
       tsd: 0.21.0
-      tslib: 2.3.1
+      tslib: 2.4.0
       typescript: 4.0.2
       uuid: 8.3.2
     transitivePeerDependencies:
@@ -23584,7 +23585,7 @@ packages:
       prettier: 2.5.1
       ts-invariant: 0.7.5
       ts-jest: 27.1.4_dddc46dbe41fd8ba74d3d274e144bf21
-      tslib: 2.3.1
+      tslib: 2.4.0
       typescript: 4.0.2
     transitivePeerDependencies:
       - '@babel/core'

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -139,6 +139,8 @@ consistent across subprojects.
 > Note: **never** add new packages by running package manager directly (e.g. `yarn add ...`).
 > This will break the node_modules.
 
+After adding new dependency run `rush update` to approve new package.
+
 ### How do I remove dependencies from a project?
 
 Remove the dependencies from package.json and then run `rush update`.

--- a/libs/sdk-ui-kit/package.json
+++ b/libs/sdk-ui-kit/package.json
@@ -96,7 +96,8 @@
         "tinycolor2": "^1.4.2",
         "ts-invariant": "^0.7.3",
         "tslib": "^2.0.0",
-        "uuid": "^8.3.2"
+        "uuid": "^8.3.2",
+        "react-fast-compare": "^3.2.0"
     },
     "peerDependencies": {
         "react": "^16.10.0 || ^17.0.0",

--- a/libs/sdk-ui-kit/src/Overlay/Overlay.tsx
+++ b/libs/sdk-ui-kit/src/Overlay/Overlay.tsx
@@ -6,6 +6,7 @@ import { Portal } from "react-portal";
 import bindAll from "lodash/bindAll";
 import pick from "lodash/pick";
 import isEqual from "lodash/isEqual";
+import isReactEqual from "react-fast-compare";
 import findIndex from "lodash/findIndex";
 import debounce from "lodash/debounce";
 import noop from "lodash/noop";
@@ -148,7 +149,7 @@ export class Overlay<T = HTMLElement> extends React.Component<IOverlayProps<T>, 
     }
 
     public shouldComponentUpdate(nextProps: IOverlayProps<T>, nextState: IOverlayState): boolean {
-        const propsChanged = !isEqual(this.props, nextProps);
+        const propsChanged = !isReactEqual(this.props, nextProps);
         const positionChanged = !isEqual(this.state.alignment, nextState.alignment);
 
         return propsChanged || positionChanged;


### PR DESCRIPTION
Comparing whole props including children by lodash/isEqual may end up in infinite loop https://github.com/facebook/react/issues/19811

It happened when UI tested by Cypress tests

JIRA: TNT-1164

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
