### PR TITLE
RELATED: RAIL-4626 fix attribute convertors

### DIFF
--- a/libs/sdk-backend-tiger/tests/integrated/__snapshots__/catalog.test.ts.snap
+++ b/libs/sdk-backend-tiger/tests/integrated/__snapshots__/catalog.test.ts.snap
@@ -723,6 +723,40 @@ TigerWorkspaceCatalogWithAvailableItems {
     Object {
       "attribute": Object {
         "description": "Account",
+        "displayForms": Array [
+          Object {
+            "attribute": Object {
+              "identifier": "attr.f_account.account",
+              "type": "attribute",
+            },
+            "description": "",
+            "displayFormType": undefined,
+            "id": "label.f_account.account",
+            "ref": Object {
+              "identifier": "label.f_account.account",
+              "type": "displayForm",
+            },
+            "title": "Name",
+            "type": "displayForm",
+            "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/labels/label.f_account.account",
+          },
+          Object {
+            "attribute": Object {
+              "identifier": "attr.f_account.account",
+              "type": "attribute",
+            },
+            "description": "",
+            "displayFormType": undefined,
+            "id": "label.f_account.account.accountid",
+            "ref": Object {
+              "identifier": "label.f_account.account.accountid",
+              "type": "displayForm",
+            },
+            "title": "Account",
+            "type": "displayForm",
+            "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/labels/label.f_account.account.accountid",
+          },
+        ],
         "id": "attr.f_account.account",
         "ref": Object {
           "identifier": "attr.f_account.account",
@@ -733,7 +767,12 @@ TigerWorkspaceCatalogWithAvailableItems {
         "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/attr.f_account.account",
       },
       "defaultDisplayForm": Object {
+        "attribute": Object {
+          "identifier": "attr.f_account.account",
+          "type": "attribute",
+        },
         "description": "",
+        "displayFormType": undefined,
         "id": "label.f_account.account",
         "ref": Object {
           "identifier": "label.f_account.account",
@@ -745,6 +784,10 @@ TigerWorkspaceCatalogWithAvailableItems {
       },
       "displayForms": Array [
         Object {
+          "attribute": Object {
+            "identifier": "attr.f_account.account",
+            "type": "attribute",
+          },
           "description": "",
           "displayFormType": undefined,
           "id": "label.f_account.account",
@@ -757,6 +800,10 @@ TigerWorkspaceCatalogWithAvailableItems {
           "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/labels/label.f_account.account",
         },
         Object {
+          "attribute": Object {
+            "identifier": "attr.f_account.account",
+            "type": "attribute",
+          },
           "description": "",
           "displayFormType": undefined,
           "id": "label.f_account.account.accountid",
@@ -781,6 +828,24 @@ TigerWorkspaceCatalogWithAvailableItems {
     Object {
       "attribute": Object {
         "description": "Account",
+        "displayForms": Array [
+          Object {
+            "attribute": Object {
+              "identifier": "f_account.id",
+              "type": "attribute",
+            },
+            "description": "Id",
+            "displayFormType": undefined,
+            "id": "f_account.id",
+            "ref": Object {
+              "identifier": "f_account.id",
+              "type": "displayForm",
+            },
+            "title": "Account Id",
+            "type": "displayForm",
+            "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/labels/f_account.id",
+          },
+        ],
         "id": "f_account.id",
         "ref": Object {
           "identifier": "f_account.id",
@@ -791,7 +856,12 @@ TigerWorkspaceCatalogWithAvailableItems {
         "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/f_account.id",
       },
       "defaultDisplayForm": Object {
+        "attribute": Object {
+          "identifier": "f_account.id",
+          "type": "attribute",
+        },
         "description": "Id",
+        "displayFormType": undefined,
         "id": "f_account.id",
         "ref": Object {
           "identifier": "f_account.id",
@@ -803,6 +873,10 @@ TigerWorkspaceCatalogWithAvailableItems {
       },
       "displayForms": Array [
         Object {
+          "attribute": Object {
+            "identifier": "f_account.id",
+            "type": "attribute",
+          },
           "description": "Id",
           "displayFormType": undefined,
           "id": "f_account.id",
@@ -827,6 +901,40 @@ TigerWorkspaceCatalogWithAvailableItems {
     Object {
       "attribute": Object {
         "description": "Activity",
+        "displayForms": Array [
+          Object {
+            "attribute": Object {
+              "identifier": "attr.f_activity.activity",
+              "type": "attribute",
+            },
+            "description": "",
+            "displayFormType": undefined,
+            "id": "label.f_activity.activity",
+            "ref": Object {
+              "identifier": "label.f_activity.activity",
+              "type": "displayForm",
+            },
+            "title": "Activity",
+            "type": "displayForm",
+            "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/labels/label.f_activity.activity",
+          },
+          Object {
+            "attribute": Object {
+              "identifier": "attr.f_activity.activity",
+              "type": "attribute",
+            },
+            "description": "",
+            "displayFormType": undefined,
+            "id": "label.f_activity.activity.name",
+            "ref": Object {
+              "identifier": "label.f_activity.activity.name",
+              "type": "displayForm",
+            },
+            "title": "Subject",
+            "type": "displayForm",
+            "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/labels/label.f_activity.activity.name",
+          },
+        ],
         "id": "attr.f_activity.activity",
         "ref": Object {
           "identifier": "attr.f_activity.activity",
@@ -837,7 +945,12 @@ TigerWorkspaceCatalogWithAvailableItems {
         "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/attr.f_activity.activity",
       },
       "defaultDisplayForm": Object {
+        "attribute": Object {
+          "identifier": "attr.f_activity.activity",
+          "type": "attribute",
+        },
         "description": "",
+        "displayFormType": undefined,
         "id": "label.f_activity.activity.name",
         "ref": Object {
           "identifier": "label.f_activity.activity.name",
@@ -849,6 +962,10 @@ TigerWorkspaceCatalogWithAvailableItems {
       },
       "displayForms": Array [
         Object {
+          "attribute": Object {
+            "identifier": "attr.f_activity.activity",
+            "type": "attribute",
+          },
           "description": "",
           "displayFormType": undefined,
           "id": "label.f_activity.activity",
@@ -861,6 +978,10 @@ TigerWorkspaceCatalogWithAvailableItems {
           "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/labels/label.f_activity.activity",
         },
         Object {
+          "attribute": Object {
+            "identifier": "attr.f_activity.activity",
+            "type": "attribute",
+          },
           "description": "",
           "displayFormType": undefined,
           "id": "label.f_activity.activity.name",
@@ -905,6 +1026,24 @@ TigerWorkspaceCatalogWithAvailableItems {
     Object {
       "attribute": Object {
         "description": "Activity Id",
+        "displayForms": Array [
+          Object {
+            "attribute": Object {
+              "identifier": "f_activity.id",
+              "type": "attribute",
+            },
+            "description": "Id",
+            "displayFormType": undefined,
+            "id": "f_activity.id",
+            "ref": Object {
+              "identifier": "f_activity.id",
+              "type": "displayForm",
+            },
+            "title": "Activity Id",
+            "type": "displayForm",
+            "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/labels/f_activity.id",
+          },
+        ],
         "id": "f_activity.id",
         "ref": Object {
           "identifier": "f_activity.id",
@@ -915,7 +1054,12 @@ TigerWorkspaceCatalogWithAvailableItems {
         "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/f_activity.id",
       },
       "defaultDisplayForm": Object {
+        "attribute": Object {
+          "identifier": "f_activity.id",
+          "type": "attribute",
+        },
         "description": "Id",
+        "displayFormType": undefined,
         "id": "f_activity.id",
         "ref": Object {
           "identifier": "f_activity.id",
@@ -927,6 +1071,10 @@ TigerWorkspaceCatalogWithAvailableItems {
       },
       "displayForms": Array [
         Object {
+          "attribute": Object {
+            "identifier": "f_activity.id",
+            "type": "attribute",
+          },
           "description": "Id",
           "displayFormType": undefined,
           "id": "f_activity.id",
@@ -951,6 +1099,24 @@ TigerWorkspaceCatalogWithAvailableItems {
     Object {
       "attribute": Object {
         "description": "Activity Type",
+        "displayForms": Array [
+          Object {
+            "attribute": Object {
+              "identifier": "f_activity.activitytype_id",
+              "type": "attribute",
+            },
+            "description": "Activitytype id",
+            "displayFormType": undefined,
+            "id": "f_activity.activitytype_id",
+            "ref": Object {
+              "identifier": "f_activity.activitytype_id",
+              "type": "displayForm",
+            },
+            "title": "Activity Type",
+            "type": "displayForm",
+            "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/labels/f_activity.activitytype_id",
+          },
+        ],
         "id": "f_activity.activitytype_id",
         "ref": Object {
           "identifier": "f_activity.activitytype_id",
@@ -961,7 +1127,12 @@ TigerWorkspaceCatalogWithAvailableItems {
         "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/f_activity.activitytype_id",
       },
       "defaultDisplayForm": Object {
+        "attribute": Object {
+          "identifier": "f_activity.activitytype_id",
+          "type": "attribute",
+        },
         "description": "Activitytype id",
+        "displayFormType": undefined,
         "id": "f_activity.activitytype_id",
         "ref": Object {
           "identifier": "f_activity.activitytype_id",
@@ -973,6 +1144,10 @@ TigerWorkspaceCatalogWithAvailableItems {
       },
       "displayForms": Array [
         Object {
+          "attribute": Object {
+            "identifier": "f_activity.activitytype_id",
+            "type": "attribute",
+          },
           "description": "Activitytype id",
           "displayFormType": undefined,
           "id": "f_activity.activitytype_id",
@@ -1109,6 +1284,24 @@ TigerWorkspaceCatalogWithAvailableItems {
     Object {
       "attribute": Object {
         "description": "Department",
+        "displayForms": Array [
+          Object {
+            "attribute": Object {
+              "identifier": "f_owner.department_id",
+              "type": "attribute",
+            },
+            "description": "Department id",
+            "displayFormType": undefined,
+            "id": "f_owner.department_id",
+            "ref": Object {
+              "identifier": "f_owner.department_id",
+              "type": "displayForm",
+            },
+            "title": "Department",
+            "type": "displayForm",
+            "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/labels/f_owner.department_id",
+          },
+        ],
         "id": "f_owner.department_id",
         "ref": Object {
           "identifier": "f_owner.department_id",
@@ -1119,7 +1312,12 @@ TigerWorkspaceCatalogWithAvailableItems {
         "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/f_owner.department_id",
       },
       "defaultDisplayForm": Object {
+        "attribute": Object {
+          "identifier": "f_owner.department_id",
+          "type": "attribute",
+        },
         "description": "Department id",
+        "displayFormType": undefined,
         "id": "f_owner.department_id",
         "ref": Object {
           "identifier": "f_owner.department_id",
@@ -1131,6 +1329,10 @@ TigerWorkspaceCatalogWithAvailableItems {
       },
       "displayForms": Array [
         Object {
+          "attribute": Object {
+            "identifier": "f_owner.department_id",
+            "type": "attribute",
+          },
           "description": "Department id",
           "displayFormType": undefined,
           "id": "f_owner.department_id",
@@ -1175,6 +1377,24 @@ TigerWorkspaceCatalogWithAvailableItems {
     Object {
       "attribute": Object {
         "description": "Forecast Category",
+        "displayForms": Array [
+          Object {
+            "attribute": Object {
+              "identifier": "f_opportunitysnapshot.forecastcategory_id",
+              "type": "attribute",
+            },
+            "description": "Forecastcategory id",
+            "displayFormType": undefined,
+            "id": "f_opportunitysnapshot.forecastcategory_id",
+            "ref": Object {
+              "identifier": "f_opportunitysnapshot.forecastcategory_id",
+              "type": "displayForm",
+            },
+            "title": "Forecast Category",
+            "type": "displayForm",
+            "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/labels/f_opportunitysnapshot.forecastcategory_id",
+          },
+        ],
         "id": "f_opportunitysnapshot.forecastcategory_id",
         "ref": Object {
           "identifier": "f_opportunitysnapshot.forecastcategory_id",
@@ -1185,7 +1405,12 @@ TigerWorkspaceCatalogWithAvailableItems {
         "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/f_opportunitysnapshot.forecastcategory_id",
       },
       "defaultDisplayForm": Object {
+        "attribute": Object {
+          "identifier": "f_opportunitysnapshot.forecastcategory_id",
+          "type": "attribute",
+        },
         "description": "Forecastcategory id",
+        "displayFormType": undefined,
         "id": "f_opportunitysnapshot.forecastcategory_id",
         "ref": Object {
           "identifier": "f_opportunitysnapshot.forecastcategory_id",
@@ -1197,6 +1422,10 @@ TigerWorkspaceCatalogWithAvailableItems {
       },
       "displayForms": Array [
         Object {
+          "attribute": Object {
+            "identifier": "f_opportunitysnapshot.forecastcategory_id",
+            "type": "attribute",
+          },
           "description": "Forecastcategory id",
           "displayFormType": undefined,
           "id": "f_opportunitysnapshot.forecastcategory_id",
@@ -1221,6 +1450,24 @@ TigerWorkspaceCatalogWithAvailableItems {
     Object {
       "attribute": Object {
         "description": "Is Active?",
+        "displayForms": Array [
+          Object {
+            "attribute": Object {
+              "identifier": "f_stage.isactive_id",
+              "type": "attribute",
+            },
+            "description": "Isactive id",
+            "displayFormType": undefined,
+            "id": "f_stage.isactive_id",
+            "ref": Object {
+              "identifier": "f_stage.isactive_id",
+              "type": "displayForm",
+            },
+            "title": "Is Active?",
+            "type": "displayForm",
+            "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/labels/f_stage.isactive_id",
+          },
+        ],
         "id": "f_stage.isactive_id",
         "ref": Object {
           "identifier": "f_stage.isactive_id",
@@ -1231,7 +1478,12 @@ TigerWorkspaceCatalogWithAvailableItems {
         "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/f_stage.isactive_id",
       },
       "defaultDisplayForm": Object {
+        "attribute": Object {
+          "identifier": "f_stage.isactive_id",
+          "type": "attribute",
+        },
         "description": "Isactive id",
+        "displayFormType": undefined,
         "id": "f_stage.isactive_id",
         "ref": Object {
           "identifier": "f_stage.isactive_id",
@@ -1243,6 +1495,10 @@ TigerWorkspaceCatalogWithAvailableItems {
       },
       "displayForms": Array [
         Object {
+          "attribute": Object {
+            "identifier": "f_stage.isactive_id",
+            "type": "attribute",
+          },
           "description": "Isactive id",
           "displayFormType": undefined,
           "id": "f_stage.isactive_id",
@@ -1267,6 +1523,24 @@ TigerWorkspaceCatalogWithAvailableItems {
     Object {
       "attribute": Object {
         "description": "Is Closed?",
+        "displayForms": Array [
+          Object {
+            "attribute": Object {
+              "identifier": "f_activity.isclosed_id",
+              "type": "attribute",
+            },
+            "description": "Isclosed id",
+            "displayFormType": undefined,
+            "id": "f_activity.isclosed_id",
+            "ref": Object {
+              "identifier": "f_activity.isclosed_id",
+              "type": "displayForm",
+            },
+            "title": "Is Closed?",
+            "type": "displayForm",
+            "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/labels/f_activity.isclosed_id",
+          },
+        ],
         "id": "f_activity.isclosed_id",
         "ref": Object {
           "identifier": "f_activity.isclosed_id",
@@ -1277,7 +1551,12 @@ TigerWorkspaceCatalogWithAvailableItems {
         "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/f_activity.isclosed_id",
       },
       "defaultDisplayForm": Object {
+        "attribute": Object {
+          "identifier": "f_activity.isclosed_id",
+          "type": "attribute",
+        },
         "description": "Isclosed id",
+        "displayFormType": undefined,
         "id": "f_activity.isclosed_id",
         "ref": Object {
           "identifier": "f_activity.isclosed_id",
@@ -1289,6 +1568,10 @@ TigerWorkspaceCatalogWithAvailableItems {
       },
       "displayForms": Array [
         Object {
+          "attribute": Object {
+            "identifier": "f_activity.isclosed_id",
+            "type": "attribute",
+          },
           "description": "Isclosed id",
           "displayFormType": undefined,
           "id": "f_activity.isclosed_id",
@@ -1313,6 +1596,24 @@ TigerWorkspaceCatalogWithAvailableItems {
     Object {
       "attribute": Object {
         "description": "Is Closed?",
+        "displayForms": Array [
+          Object {
+            "attribute": Object {
+              "identifier": "f_stage.isclosed_id",
+              "type": "attribute",
+            },
+            "description": "Isclosed id",
+            "displayFormType": undefined,
+            "id": "f_stage.isclosed_id",
+            "ref": Object {
+              "identifier": "f_stage.isclosed_id",
+              "type": "displayForm",
+            },
+            "title": "Is Closed?",
+            "type": "displayForm",
+            "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/labels/f_stage.isclosed_id",
+          },
+        ],
         "id": "f_stage.isclosed_id",
         "ref": Object {
           "identifier": "f_stage.isclosed_id",
@@ -1323,7 +1624,12 @@ TigerWorkspaceCatalogWithAvailableItems {
         "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/f_stage.isclosed_id",
       },
       "defaultDisplayForm": Object {
+        "attribute": Object {
+          "identifier": "f_stage.isclosed_id",
+          "type": "attribute",
+        },
         "description": "Isclosed id",
+        "displayFormType": undefined,
         "id": "f_stage.isclosed_id",
         "ref": Object {
           "identifier": "f_stage.isclosed_id",
@@ -1335,6 +1641,10 @@ TigerWorkspaceCatalogWithAvailableItems {
       },
       "displayForms": Array [
         Object {
+          "attribute": Object {
+            "identifier": "f_stage.isclosed_id",
+            "type": "attribute",
+          },
           "description": "Isclosed id",
           "displayFormType": undefined,
           "id": "f_stage.isclosed_id",
@@ -1359,6 +1669,24 @@ TigerWorkspaceCatalogWithAvailableItems {
     Object {
       "attribute": Object {
         "description": "Is Task?",
+        "displayForms": Array [
+          Object {
+            "attribute": Object {
+              "identifier": "f_activity.istask_id",
+              "type": "attribute",
+            },
+            "description": "Istask id",
+            "displayFormType": undefined,
+            "id": "f_activity.istask_id",
+            "ref": Object {
+              "identifier": "f_activity.istask_id",
+              "type": "displayForm",
+            },
+            "title": "Is Task?",
+            "type": "displayForm",
+            "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/labels/f_activity.istask_id",
+          },
+        ],
         "id": "f_activity.istask_id",
         "ref": Object {
           "identifier": "f_activity.istask_id",
@@ -1369,7 +1697,12 @@ TigerWorkspaceCatalogWithAvailableItems {
         "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/f_activity.istask_id",
       },
       "defaultDisplayForm": Object {
+        "attribute": Object {
+          "identifier": "f_activity.istask_id",
+          "type": "attribute",
+        },
         "description": "Istask id",
+        "displayFormType": undefined,
         "id": "f_activity.istask_id",
         "ref": Object {
           "identifier": "f_activity.istask_id",
@@ -1381,6 +1714,10 @@ TigerWorkspaceCatalogWithAvailableItems {
       },
       "displayForms": Array [
         Object {
+          "attribute": Object {
+            "identifier": "f_activity.istask_id",
+            "type": "attribute",
+          },
           "description": "Istask id",
           "displayFormType": undefined,
           "id": "f_activity.istask_id",
@@ -1405,6 +1742,24 @@ TigerWorkspaceCatalogWithAvailableItems {
     Object {
       "attribute": Object {
         "description": "Is Won?",
+        "displayForms": Array [
+          Object {
+            "attribute": Object {
+              "identifier": "f_stage.iswon_id",
+              "type": "attribute",
+            },
+            "description": "Iswon id",
+            "displayFormType": undefined,
+            "id": "f_stage.iswon_id",
+            "ref": Object {
+              "identifier": "f_stage.iswon_id",
+              "type": "displayForm",
+            },
+            "title": "Is Won?",
+            "type": "displayForm",
+            "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/labels/f_stage.iswon_id",
+          },
+        ],
         "id": "f_stage.iswon_id",
         "ref": Object {
           "identifier": "f_stage.iswon_id",
@@ -1415,7 +1770,12 @@ TigerWorkspaceCatalogWithAvailableItems {
         "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/f_stage.iswon_id",
       },
       "defaultDisplayForm": Object {
+        "attribute": Object {
+          "identifier": "f_stage.iswon_id",
+          "type": "attribute",
+        },
         "description": "Iswon id",
+        "displayFormType": undefined,
         "id": "f_stage.iswon_id",
         "ref": Object {
           "identifier": "f_stage.iswon_id",
@@ -1427,6 +1787,10 @@ TigerWorkspaceCatalogWithAvailableItems {
       },
       "displayForms": Array [
         Object {
+          "attribute": Object {
+            "identifier": "f_stage.iswon_id",
+            "type": "attribute",
+          },
           "description": "Iswon id",
           "displayFormType": undefined,
           "id": "f_stage.iswon_id",
@@ -1527,6 +1891,24 @@ TigerWorkspaceCatalogWithAvailableItems {
     Object {
       "attribute": Object {
         "description": "Opp. Snapshot",
+        "displayForms": Array [
+          Object {
+            "attribute": Object {
+              "identifier": "attr.f_opportunitysnapshot.oppsnapshot",
+              "type": "attribute",
+            },
+            "description": "",
+            "displayFormType": undefined,
+            "id": "label.f_opportunitysnapshot.oppsnapshot",
+            "ref": Object {
+              "identifier": "label.f_opportunitysnapshot.oppsnapshot",
+              "type": "displayForm",
+            },
+            "title": "Opp. Snapshot",
+            "type": "displayForm",
+            "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/labels/label.f_opportunitysnapshot.oppsnapshot",
+          },
+        ],
         "id": "attr.f_opportunitysnapshot.oppsnapshot",
         "ref": Object {
           "identifier": "attr.f_opportunitysnapshot.oppsnapshot",
@@ -1537,7 +1919,12 @@ TigerWorkspaceCatalogWithAvailableItems {
         "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/attr.f_opportunitysnapshot.oppsnapshot",
       },
       "defaultDisplayForm": Object {
+        "attribute": Object {
+          "identifier": "attr.f_opportunitysnapshot.oppsnapshot",
+          "type": "attribute",
+        },
         "description": "",
+        "displayFormType": undefined,
         "id": "label.f_opportunitysnapshot.oppsnapshot",
         "ref": Object {
           "identifier": "label.f_opportunitysnapshot.oppsnapshot",
@@ -1549,6 +1936,10 @@ TigerWorkspaceCatalogWithAvailableItems {
       },
       "displayForms": Array [
         Object {
+          "attribute": Object {
+            "identifier": "attr.f_opportunitysnapshot.oppsnapshot",
+            "type": "attribute",
+          },
           "description": "",
           "displayFormType": undefined,
           "id": "label.f_opportunitysnapshot.oppsnapshot",
@@ -1593,6 +1984,24 @@ TigerWorkspaceCatalogWithAvailableItems {
     Object {
       "attribute": Object {
         "description": "Opp. Snapshot Id",
+        "displayForms": Array [
+          Object {
+            "attribute": Object {
+              "identifier": "f_opportunitysnapshot.id",
+              "type": "attribute",
+            },
+            "description": "Id",
+            "displayFormType": undefined,
+            "id": "f_opportunitysnapshot.id",
+            "ref": Object {
+              "identifier": "f_opportunitysnapshot.id",
+              "type": "displayForm",
+            },
+            "title": "Opp. Snapshot Id",
+            "type": "displayForm",
+            "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/labels/f_opportunitysnapshot.id",
+          },
+        ],
         "id": "f_opportunitysnapshot.id",
         "ref": Object {
           "identifier": "f_opportunitysnapshot.id",
@@ -1603,7 +2012,12 @@ TigerWorkspaceCatalogWithAvailableItems {
         "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/f_opportunitysnapshot.id",
       },
       "defaultDisplayForm": Object {
+        "attribute": Object {
+          "identifier": "f_opportunitysnapshot.id",
+          "type": "attribute",
+        },
         "description": "Id",
+        "displayFormType": undefined,
         "id": "f_opportunitysnapshot.id",
         "ref": Object {
           "identifier": "f_opportunitysnapshot.id",
@@ -1615,6 +2029,10 @@ TigerWorkspaceCatalogWithAvailableItems {
       },
       "displayForms": Array [
         Object {
+          "attribute": Object {
+            "identifier": "f_opportunitysnapshot.id",
+            "type": "attribute",
+          },
           "description": "Id",
           "displayFormType": undefined,
           "id": "f_opportunitysnapshot.id",
@@ -1639,6 +2057,56 @@ TigerWorkspaceCatalogWithAvailableItems {
     Object {
       "attribute": Object {
         "description": "Opportunity",
+        "displayForms": Array [
+          Object {
+            "attribute": Object {
+              "identifier": "attr.f_opportunity.opportunity",
+              "type": "attribute",
+            },
+            "description": "",
+            "displayFormType": undefined,
+            "id": "label.f_opportunity.opportunity.opportunity",
+            "ref": Object {
+              "identifier": "label.f_opportunity.opportunity.opportunity",
+              "type": "displayForm",
+            },
+            "title": "Opportunity",
+            "type": "displayForm",
+            "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/labels/label.f_opportunity.opportunity.opportunity",
+          },
+          Object {
+            "attribute": Object {
+              "identifier": "attr.f_opportunity.opportunity",
+              "type": "attribute",
+            },
+            "description": "",
+            "displayFormType": undefined,
+            "id": "label.f_opportunity.opportunity.sfdcurl",
+            "ref": Object {
+              "identifier": "label.f_opportunity.opportunity.sfdcurl",
+              "type": "displayForm",
+            },
+            "title": "SFDC URL",
+            "type": "displayForm",
+            "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/labels/label.f_opportunity.opportunity.sfdcurl",
+          },
+          Object {
+            "attribute": Object {
+              "identifier": "attr.f_opportunity.opportunity",
+              "type": "attribute",
+            },
+            "description": "",
+            "displayFormType": undefined,
+            "id": "label.f_opportunity.opportunity",
+            "ref": Object {
+              "identifier": "label.f_opportunity.opportunity",
+              "type": "displayForm",
+            },
+            "title": "Opportunity Name",
+            "type": "displayForm",
+            "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/labels/label.f_opportunity.opportunity",
+          },
+        ],
         "id": "attr.f_opportunity.opportunity",
         "ref": Object {
           "identifier": "attr.f_opportunity.opportunity",
@@ -1649,7 +2117,12 @@ TigerWorkspaceCatalogWithAvailableItems {
         "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/attr.f_opportunity.opportunity",
       },
       "defaultDisplayForm": Object {
+        "attribute": Object {
+          "identifier": "attr.f_opportunity.opportunity",
+          "type": "attribute",
+        },
         "description": "",
+        "displayFormType": undefined,
         "id": "label.f_opportunity.opportunity",
         "ref": Object {
           "identifier": "label.f_opportunity.opportunity",
@@ -1661,6 +2134,10 @@ TigerWorkspaceCatalogWithAvailableItems {
       },
       "displayForms": Array [
         Object {
+          "attribute": Object {
+            "identifier": "attr.f_opportunity.opportunity",
+            "type": "attribute",
+          },
           "description": "",
           "displayFormType": undefined,
           "id": "label.f_opportunity.opportunity.opportunity",
@@ -1673,6 +2150,10 @@ TigerWorkspaceCatalogWithAvailableItems {
           "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/labels/label.f_opportunity.opportunity.opportunity",
         },
         Object {
+          "attribute": Object {
+            "identifier": "attr.f_opportunity.opportunity",
+            "type": "attribute",
+          },
           "description": "",
           "displayFormType": undefined,
           "id": "label.f_opportunity.opportunity.sfdcurl",
@@ -1685,6 +2166,10 @@ TigerWorkspaceCatalogWithAvailableItems {
           "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/labels/label.f_opportunity.opportunity.sfdcurl",
         },
         Object {
+          "attribute": Object {
+            "identifier": "attr.f_opportunity.opportunity",
+            "type": "attribute",
+          },
           "description": "",
           "displayFormType": undefined,
           "id": "label.f_opportunity.opportunity",
@@ -1709,6 +2194,24 @@ TigerWorkspaceCatalogWithAvailableItems {
     Object {
       "attribute": Object {
         "description": "Opportunity Id",
+        "displayForms": Array [
+          Object {
+            "attribute": Object {
+              "identifier": "f_opportunity.id",
+              "type": "attribute",
+            },
+            "description": "Id",
+            "displayFormType": undefined,
+            "id": "f_opportunity.id",
+            "ref": Object {
+              "identifier": "f_opportunity.id",
+              "type": "displayForm",
+            },
+            "title": "Opportunity Id",
+            "type": "displayForm",
+            "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/labels/f_opportunity.id",
+          },
+        ],
         "id": "f_opportunity.id",
         "ref": Object {
           "identifier": "f_opportunity.id",
@@ -1719,7 +2222,12 @@ TigerWorkspaceCatalogWithAvailableItems {
         "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/f_opportunity.id",
       },
       "defaultDisplayForm": Object {
+        "attribute": Object {
+          "identifier": "f_opportunity.id",
+          "type": "attribute",
+        },
         "description": "Id",
+        "displayFormType": undefined,
         "id": "f_opportunity.id",
         "ref": Object {
           "identifier": "f_opportunity.id",
@@ -1731,6 +2239,10 @@ TigerWorkspaceCatalogWithAvailableItems {
       },
       "displayForms": Array [
         Object {
+          "attribute": Object {
+            "identifier": "f_opportunity.id",
+            "type": "attribute",
+          },
           "description": "Id",
           "displayFormType": undefined,
           "id": "f_opportunity.id",
@@ -1755,6 +2267,24 @@ TigerWorkspaceCatalogWithAvailableItems {
     Object {
       "attribute": Object {
         "description": "Id",
+        "displayForms": Array [
+          Object {
+            "attribute": Object {
+              "identifier": "f_owner.id",
+              "type": "attribute",
+            },
+            "description": "Id",
+            "displayFormType": undefined,
+            "id": "f_owner.id",
+            "ref": Object {
+              "identifier": "f_owner.id",
+              "type": "displayForm",
+            },
+            "title": "Owner Id",
+            "type": "displayForm",
+            "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/labels/f_owner.id",
+          },
+        ],
         "id": "f_owner.id",
         "ref": Object {
           "identifier": "f_owner.id",
@@ -1765,7 +2295,12 @@ TigerWorkspaceCatalogWithAvailableItems {
         "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/f_owner.id",
       },
       "defaultDisplayForm": Object {
+        "attribute": Object {
+          "identifier": "f_owner.id",
+          "type": "attribute",
+        },
         "description": "Id",
+        "displayFormType": undefined,
         "id": "f_owner.id",
         "ref": Object {
           "identifier": "f_owner.id",
@@ -1777,6 +2312,10 @@ TigerWorkspaceCatalogWithAvailableItems {
       },
       "displayForms": Array [
         Object {
+          "attribute": Object {
+            "identifier": "f_owner.id",
+            "type": "attribute",
+          },
           "description": "Id",
           "displayFormType": undefined,
           "id": "f_owner.id",
@@ -1801,6 +2340,24 @@ TigerWorkspaceCatalogWithAvailableItems {
     Object {
       "attribute": Object {
         "description": "Priority",
+        "displayForms": Array [
+          Object {
+            "attribute": Object {
+              "identifier": "f_activity.priority_id",
+              "type": "attribute",
+            },
+            "description": "Priority id",
+            "displayFormType": undefined,
+            "id": "f_activity.priority_id",
+            "ref": Object {
+              "identifier": "f_activity.priority_id",
+              "type": "displayForm",
+            },
+            "title": "Priority",
+            "type": "displayForm",
+            "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/labels/f_activity.priority_id",
+          },
+        ],
         "id": "f_activity.priority_id",
         "ref": Object {
           "identifier": "f_activity.priority_id",
@@ -1811,7 +2368,12 @@ TigerWorkspaceCatalogWithAvailableItems {
         "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/f_activity.priority_id",
       },
       "defaultDisplayForm": Object {
+        "attribute": Object {
+          "identifier": "f_activity.priority_id",
+          "type": "attribute",
+        },
         "description": "Priority id",
+        "displayFormType": undefined,
         "id": "f_activity.priority_id",
         "ref": Object {
           "identifier": "f_activity.priority_id",
@@ -1823,6 +2385,10 @@ TigerWorkspaceCatalogWithAvailableItems {
       },
       "displayForms": Array [
         Object {
+          "attribute": Object {
+            "identifier": "f_activity.priority_id",
+            "type": "attribute",
+          },
           "description": "Priority id",
           "displayFormType": undefined,
           "id": "f_activity.priority_id",
@@ -1885,6 +2451,40 @@ TigerWorkspaceCatalogWithAvailableItems {
     Object {
       "attribute": Object {
         "description": "Product",
+        "displayForms": Array [
+          Object {
+            "attribute": Object {
+              "identifier": "attr.f_product.product",
+              "type": "attribute",
+            },
+            "description": "",
+            "displayFormType": undefined,
+            "id": "label.f_product.product.productid",
+            "ref": Object {
+              "identifier": "label.f_product.product.productid",
+              "type": "displayForm",
+            },
+            "title": "Product",
+            "type": "displayForm",
+            "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/labels/label.f_product.product.productid",
+          },
+          Object {
+            "attribute": Object {
+              "identifier": "attr.f_product.product",
+              "type": "attribute",
+            },
+            "description": "",
+            "displayFormType": undefined,
+            "id": "label.f_product.product",
+            "ref": Object {
+              "identifier": "label.f_product.product",
+              "type": "displayForm",
+            },
+            "title": "Product Name",
+            "type": "displayForm",
+            "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/labels/label.f_product.product",
+          },
+        ],
         "id": "attr.f_product.product",
         "ref": Object {
           "identifier": "attr.f_product.product",
@@ -1895,7 +2495,12 @@ TigerWorkspaceCatalogWithAvailableItems {
         "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/attr.f_product.product",
       },
       "defaultDisplayForm": Object {
+        "attribute": Object {
+          "identifier": "attr.f_product.product",
+          "type": "attribute",
+        },
         "description": "",
+        "displayFormType": undefined,
         "id": "label.f_product.product",
         "ref": Object {
           "identifier": "label.f_product.product",
@@ -1907,6 +2512,10 @@ TigerWorkspaceCatalogWithAvailableItems {
       },
       "displayForms": Array [
         Object {
+          "attribute": Object {
+            "identifier": "attr.f_product.product",
+            "type": "attribute",
+          },
           "description": "",
           "displayFormType": undefined,
           "id": "label.f_product.product.productid",
@@ -1919,6 +2528,10 @@ TigerWorkspaceCatalogWithAvailableItems {
           "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/labels/label.f_product.product.productid",
         },
         Object {
+          "attribute": Object {
+            "identifier": "attr.f_product.product",
+            "type": "attribute",
+          },
           "description": "",
           "displayFormType": undefined,
           "id": "label.f_product.product",
@@ -1943,6 +2556,24 @@ TigerWorkspaceCatalogWithAvailableItems {
     Object {
       "attribute": Object {
         "description": "Product",
+        "displayForms": Array [
+          Object {
+            "attribute": Object {
+              "identifier": "f_product.id",
+              "type": "attribute",
+            },
+            "description": "Id",
+            "displayFormType": undefined,
+            "id": "f_product.id",
+            "ref": Object {
+              "identifier": "f_product.id",
+              "type": "displayForm",
+            },
+            "title": "Product Id",
+            "type": "displayForm",
+            "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/labels/f_product.id",
+          },
+        ],
         "id": "f_product.id",
         "ref": Object {
           "identifier": "f_product.id",
@@ -1953,7 +2584,12 @@ TigerWorkspaceCatalogWithAvailableItems {
         "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/f_product.id",
       },
       "defaultDisplayForm": Object {
+        "attribute": Object {
+          "identifier": "f_product.id",
+          "type": "attribute",
+        },
         "description": "Id",
+        "displayFormType": undefined,
         "id": "f_product.id",
         "ref": Object {
           "identifier": "f_product.id",
@@ -1965,6 +2601,10 @@ TigerWorkspaceCatalogWithAvailableItems {
       },
       "displayForms": Array [
         Object {
+          "attribute": Object {
+            "identifier": "f_product.id",
+            "type": "attribute",
+          },
           "description": "Id",
           "displayFormType": undefined,
           "id": "f_product.id",
@@ -1989,6 +2629,24 @@ TigerWorkspaceCatalogWithAvailableItems {
     Object {
       "attribute": Object {
         "description": "Region",
+        "displayForms": Array [
+          Object {
+            "attribute": Object {
+              "identifier": "f_owner.region_id",
+              "type": "attribute",
+            },
+            "description": "Region id",
+            "displayFormType": undefined,
+            "id": "f_owner.region_id",
+            "ref": Object {
+              "identifier": "f_owner.region_id",
+              "type": "displayForm",
+            },
+            "title": "Region",
+            "type": "displayForm",
+            "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/labels/f_owner.region_id",
+          },
+        ],
         "id": "f_owner.region_id",
         "ref": Object {
           "identifier": "f_owner.region_id",
@@ -1999,7 +2657,12 @@ TigerWorkspaceCatalogWithAvailableItems {
         "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/f_owner.region_id",
       },
       "defaultDisplayForm": Object {
+        "attribute": Object {
+          "identifier": "f_owner.region_id",
+          "type": "attribute",
+        },
         "description": "Region id",
+        "displayFormType": undefined,
         "id": "f_owner.region_id",
         "ref": Object {
           "identifier": "f_owner.region_id",
@@ -2011,6 +2674,10 @@ TigerWorkspaceCatalogWithAvailableItems {
       },
       "displayForms": Array [
         Object {
+          "attribute": Object {
+            "identifier": "f_owner.region_id",
+            "type": "attribute",
+          },
           "description": "Region id",
           "displayFormType": undefined,
           "id": "f_owner.region_id",
@@ -2035,6 +2702,40 @@ TigerWorkspaceCatalogWithAvailableItems {
     Object {
       "attribute": Object {
         "description": "",
+        "displayForms": Array [
+          Object {
+            "attribute": Object {
+              "identifier": "attr.f_owner.salesrep",
+              "type": "attribute",
+            },
+            "description": "",
+            "displayFormType": undefined,
+            "id": "label.f_owner.salesrep",
+            "ref": Object {
+              "identifier": "label.f_owner.salesrep",
+              "type": "displayForm",
+            },
+            "title": "Owner Name",
+            "type": "displayForm",
+            "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/labels/label.f_owner.salesrep",
+          },
+          Object {
+            "attribute": Object {
+              "identifier": "attr.f_owner.salesrep",
+              "type": "attribute",
+            },
+            "description": "",
+            "displayFormType": undefined,
+            "id": "label.f_owner.salesrep.owner",
+            "ref": Object {
+              "identifier": "label.f_owner.salesrep.owner",
+              "type": "displayForm",
+            },
+            "title": "Owner",
+            "type": "displayForm",
+            "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/labels/label.f_owner.salesrep.owner",
+          },
+        ],
         "id": "attr.f_owner.salesrep",
         "ref": Object {
           "identifier": "attr.f_owner.salesrep",
@@ -2045,7 +2746,12 @@ TigerWorkspaceCatalogWithAvailableItems {
         "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/attr.f_owner.salesrep",
       },
       "defaultDisplayForm": Object {
+        "attribute": Object {
+          "identifier": "attr.f_owner.salesrep",
+          "type": "attribute",
+        },
         "description": "",
+        "displayFormType": undefined,
         "id": "label.f_owner.salesrep",
         "ref": Object {
           "identifier": "label.f_owner.salesrep",
@@ -2057,6 +2763,10 @@ TigerWorkspaceCatalogWithAvailableItems {
       },
       "displayForms": Array [
         Object {
+          "attribute": Object {
+            "identifier": "attr.f_owner.salesrep",
+            "type": "attribute",
+          },
           "description": "",
           "displayFormType": undefined,
           "id": "label.f_owner.salesrep",
@@ -2069,6 +2779,10 @@ TigerWorkspaceCatalogWithAvailableItems {
           "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/labels/label.f_owner.salesrep",
         },
         Object {
+          "attribute": Object {
+            "identifier": "attr.f_owner.salesrep",
+            "type": "attribute",
+          },
           "description": "",
           "displayFormType": undefined,
           "id": "label.f_owner.salesrep.owner",
@@ -2111,6 +2825,24 @@ TigerWorkspaceCatalogWithAvailableItems {
     Object {
       "attribute": Object {
         "description": "Stage History",
+        "displayForms": Array [
+          Object {
+            "attribute": Object {
+              "identifier": "attr.f_stagehistory.stagehistory",
+              "type": "attribute",
+            },
+            "description": "",
+            "displayFormType": undefined,
+            "id": "label.f_stagehistory.stagehistory",
+            "ref": Object {
+              "identifier": "label.f_stagehistory.stagehistory",
+              "type": "displayForm",
+            },
+            "title": "Stage History",
+            "type": "displayForm",
+            "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/labels/label.f_stagehistory.stagehistory",
+          },
+        ],
         "id": "attr.f_stagehistory.stagehistory",
         "ref": Object {
           "identifier": "attr.f_stagehistory.stagehistory",
@@ -2121,7 +2853,12 @@ TigerWorkspaceCatalogWithAvailableItems {
         "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/attr.f_stagehistory.stagehistory",
       },
       "defaultDisplayForm": Object {
+        "attribute": Object {
+          "identifier": "attr.f_stagehistory.stagehistory",
+          "type": "attribute",
+        },
         "description": "",
+        "displayFormType": undefined,
         "id": "label.f_stagehistory.stagehistory",
         "ref": Object {
           "identifier": "label.f_stagehistory.stagehistory",
@@ -2133,6 +2870,10 @@ TigerWorkspaceCatalogWithAvailableItems {
       },
       "displayForms": Array [
         Object {
+          "attribute": Object {
+            "identifier": "attr.f_stagehistory.stagehistory",
+            "type": "attribute",
+          },
           "description": "",
           "displayFormType": undefined,
           "id": "label.f_stagehistory.stagehistory",
@@ -2157,6 +2898,24 @@ TigerWorkspaceCatalogWithAvailableItems {
     Object {
       "attribute": Object {
         "description": "Stage History Id",
+        "displayForms": Array [
+          Object {
+            "attribute": Object {
+              "identifier": "f_stagehistory.id",
+              "type": "attribute",
+            },
+            "description": "Id",
+            "displayFormType": undefined,
+            "id": "f_stagehistory.id",
+            "ref": Object {
+              "identifier": "f_stagehistory.id",
+              "type": "displayForm",
+            },
+            "title": "Stage History Id",
+            "type": "displayForm",
+            "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/labels/f_stagehistory.id",
+          },
+        ],
         "id": "f_stagehistory.id",
         "ref": Object {
           "identifier": "f_stagehistory.id",
@@ -2167,7 +2926,12 @@ TigerWorkspaceCatalogWithAvailableItems {
         "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/f_stagehistory.id",
       },
       "defaultDisplayForm": Object {
+        "attribute": Object {
+          "identifier": "f_stagehistory.id",
+          "type": "attribute",
+        },
         "description": "Id",
+        "displayFormType": undefined,
         "id": "f_stagehistory.id",
         "ref": Object {
           "identifier": "f_stagehistory.id",
@@ -2179,6 +2943,10 @@ TigerWorkspaceCatalogWithAvailableItems {
       },
       "displayForms": Array [
         Object {
+          "attribute": Object {
+            "identifier": "f_stagehistory.id",
+            "type": "attribute",
+          },
           "description": "Id",
           "displayFormType": undefined,
           "id": "f_stagehistory.id",
@@ -2203,6 +2971,24 @@ TigerWorkspaceCatalogWithAvailableItems {
     Object {
       "attribute": Object {
         "description": "Stage Id",
+        "displayForms": Array [
+          Object {
+            "attribute": Object {
+              "identifier": "f_stage.id",
+              "type": "attribute",
+            },
+            "description": "Id",
+            "displayFormType": undefined,
+            "id": "f_stage.id",
+            "ref": Object {
+              "identifier": "f_stage.id",
+              "type": "displayForm",
+            },
+            "title": "Stage Id",
+            "type": "displayForm",
+            "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/labels/f_stage.id",
+          },
+        ],
         "id": "f_stage.id",
         "ref": Object {
           "identifier": "f_stage.id",
@@ -2213,7 +2999,12 @@ TigerWorkspaceCatalogWithAvailableItems {
         "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/f_stage.id",
       },
       "defaultDisplayForm": Object {
+        "attribute": Object {
+          "identifier": "f_stage.id",
+          "type": "attribute",
+        },
         "description": "Id",
+        "displayFormType": undefined,
         "id": "f_stage.id",
         "ref": Object {
           "identifier": "f_stage.id",
@@ -2225,6 +3016,10 @@ TigerWorkspaceCatalogWithAvailableItems {
       },
       "displayForms": Array [
         Object {
+          "attribute": Object {
+            "identifier": "f_stage.id",
+            "type": "attribute",
+          },
           "description": "Id",
           "displayFormType": undefined,
           "id": "f_stage.id",
@@ -2249,6 +3044,56 @@ TigerWorkspaceCatalogWithAvailableItems {
     Object {
       "attribute": Object {
         "description": "Stage Name",
+        "displayForms": Array [
+          Object {
+            "attribute": Object {
+              "identifier": "attr.f_stage.stagename",
+              "type": "attribute",
+            },
+            "description": "",
+            "displayFormType": undefined,
+            "id": "label.f_stage.stagename.order",
+            "ref": Object {
+              "identifier": "label.f_stage.stagename.order",
+              "type": "displayForm",
+            },
+            "title": "Order",
+            "type": "displayForm",
+            "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/labels/label.f_stage.stagename.order",
+          },
+          Object {
+            "attribute": Object {
+              "identifier": "attr.f_stage.stagename",
+              "type": "attribute",
+            },
+            "description": "",
+            "displayFormType": undefined,
+            "id": "label.f_stage.stagename.stagename",
+            "ref": Object {
+              "identifier": "label.f_stage.stagename.stagename",
+              "type": "displayForm",
+            },
+            "title": "Stage Name",
+            "type": "displayForm",
+            "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/labels/label.f_stage.stagename.stagename",
+          },
+          Object {
+            "attribute": Object {
+              "identifier": "attr.f_stage.stagename",
+              "type": "attribute",
+            },
+            "description": "",
+            "displayFormType": undefined,
+            "id": "label.f_stage.stagename",
+            "ref": Object {
+              "identifier": "label.f_stage.stagename",
+              "type": "displayForm",
+            },
+            "title": "Stage Name",
+            "type": "displayForm",
+            "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/labels/label.f_stage.stagename",
+          },
+        ],
         "id": "attr.f_stage.stagename",
         "ref": Object {
           "identifier": "attr.f_stage.stagename",
@@ -2259,7 +3104,12 @@ TigerWorkspaceCatalogWithAvailableItems {
         "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/attr.f_stage.stagename",
       },
       "defaultDisplayForm": Object {
+        "attribute": Object {
+          "identifier": "attr.f_stage.stagename",
+          "type": "attribute",
+        },
         "description": "",
+        "displayFormType": undefined,
         "id": "label.f_stage.stagename",
         "ref": Object {
           "identifier": "label.f_stage.stagename",
@@ -2271,6 +3121,10 @@ TigerWorkspaceCatalogWithAvailableItems {
       },
       "displayForms": Array [
         Object {
+          "attribute": Object {
+            "identifier": "attr.f_stage.stagename",
+            "type": "attribute",
+          },
           "description": "",
           "displayFormType": undefined,
           "id": "label.f_stage.stagename.order",
@@ -2283,6 +3137,10 @@ TigerWorkspaceCatalogWithAvailableItems {
           "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/labels/label.f_stage.stagename.order",
         },
         Object {
+          "attribute": Object {
+            "identifier": "attr.f_stage.stagename",
+            "type": "attribute",
+          },
           "description": "",
           "displayFormType": undefined,
           "id": "label.f_stage.stagename.stagename",
@@ -2295,6 +3153,10 @@ TigerWorkspaceCatalogWithAvailableItems {
           "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/labels/label.f_stage.stagename.stagename",
         },
         Object {
+          "attribute": Object {
+            "identifier": "attr.f_stage.stagename",
+            "type": "attribute",
+          },
           "description": "",
           "displayFormType": undefined,
           "id": "label.f_stage.stagename",
@@ -2319,6 +3181,24 @@ TigerWorkspaceCatalogWithAvailableItems {
     Object {
       "attribute": Object {
         "description": "Status",
+        "displayForms": Array [
+          Object {
+            "attribute": Object {
+              "identifier": "f_activity.status_id",
+              "type": "attribute",
+            },
+            "description": "Status id",
+            "displayFormType": undefined,
+            "id": "f_activity.status_id",
+            "ref": Object {
+              "identifier": "f_activity.status_id",
+              "type": "displayForm",
+            },
+            "title": "Status",
+            "type": "displayForm",
+            "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/labels/f_activity.status_id",
+          },
+        ],
         "id": "f_activity.status_id",
         "ref": Object {
           "identifier": "f_activity.status_id",
@@ -2329,7 +3209,12 @@ TigerWorkspaceCatalogWithAvailableItems {
         "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/f_activity.status_id",
       },
       "defaultDisplayForm": Object {
+        "attribute": Object {
+          "identifier": "f_activity.status_id",
+          "type": "attribute",
+        },
         "description": "Status id",
+        "displayFormType": undefined,
         "id": "f_activity.status_id",
         "ref": Object {
           "identifier": "f_activity.status_id",
@@ -2341,6 +3226,10 @@ TigerWorkspaceCatalogWithAvailableItems {
       },
       "displayForms": Array [
         Object {
+          "attribute": Object {
+            "identifier": "f_activity.status_id",
+            "type": "attribute",
+          },
           "description": "Status id",
           "displayFormType": undefined,
           "id": "f_activity.status_id",
@@ -2365,6 +3254,24 @@ TigerWorkspaceCatalogWithAvailableItems {
     Object {
       "attribute": Object {
         "description": "Status",
+        "displayForms": Array [
+          Object {
+            "attribute": Object {
+              "identifier": "f_stage.status_id",
+              "type": "attribute",
+            },
+            "description": "Status id",
+            "displayFormType": undefined,
+            "id": "f_stage.status_id",
+            "ref": Object {
+              "identifier": "f_stage.status_id",
+              "type": "displayForm",
+            },
+            "title": "Status",
+            "type": "displayForm",
+            "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/labels/f_stage.status_id",
+          },
+        ],
         "id": "f_stage.status_id",
         "ref": Object {
           "identifier": "f_stage.status_id",
@@ -2375,7 +3282,12 @@ TigerWorkspaceCatalogWithAvailableItems {
         "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/f_stage.status_id",
       },
       "defaultDisplayForm": Object {
+        "attribute": Object {
+          "identifier": "f_stage.status_id",
+          "type": "attribute",
+        },
         "description": "Status id",
+        "displayFormType": undefined,
         "id": "f_stage.status_id",
         "ref": Object {
           "identifier": "f_stage.status_id",
@@ -2387,6 +3299,10 @@ TigerWorkspaceCatalogWithAvailableItems {
       },
       "displayForms": Array [
         Object {
+          "attribute": Object {
+            "identifier": "f_stage.status_id",
+            "type": "attribute",
+          },
           "description": "Status id",
           "displayFormType": undefined,
           "id": "f_stage.status_id",
@@ -2411,6 +3327,24 @@ TigerWorkspaceCatalogWithAvailableItems {
     Object {
       "attribute": Object {
         "description": "Timeline",
+        "displayForms": Array [
+          Object {
+            "attribute": Object {
+              "identifier": "f_timeline.id",
+              "type": "attribute",
+            },
+            "description": "Id",
+            "displayFormType": undefined,
+            "id": "f_timeline.id",
+            "ref": Object {
+              "identifier": "f_timeline.id",
+              "type": "displayForm",
+            },
+            "title": "Timeline",
+            "type": "displayForm",
+            "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/labels/f_timeline.id",
+          },
+        ],
         "id": "f_timeline.id",
         "ref": Object {
           "identifier": "f_timeline.id",
@@ -2421,7 +3355,12 @@ TigerWorkspaceCatalogWithAvailableItems {
         "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/f_timeline.id",
       },
       "defaultDisplayForm": Object {
+        "attribute": Object {
+          "identifier": "f_timeline.id",
+          "type": "attribute",
+        },
         "description": "Id",
+        "displayFormType": undefined,
         "id": "f_timeline.id",
         "ref": Object {
           "identifier": "f_timeline.id",
@@ -2433,6 +3372,10 @@ TigerWorkspaceCatalogWithAvailableItems {
       },
       "displayForms": Array [
         Object {
+          "attribute": Object {
+            "identifier": "f_timeline.id",
+            "type": "attribute",
+          },
           "description": "Id",
           "displayFormType": undefined,
           "id": "f_timeline.id",
@@ -2658,6 +3601,10 @@ TigerWorkspaceCatalogWithAvailableItems {
             "description": "Minute",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_activity_timestamp.minute",
+                  "type": "attribute",
+                },
                 "description": "Minute",
                 "displayFormType": undefined,
                 "id": "dt_activity_timestamp.minute",
@@ -2680,7 +3627,12 @@ TigerWorkspaceCatalogWithAvailableItems {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_activity_timestamp.minute",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_activity_timestamp.minute",
+              "type": "attribute",
+            },
             "description": "Minute",
+            "displayFormType": undefined,
             "id": "dt_activity_timestamp.minute",
             "ref": Object {
               "identifier": "dt_activity_timestamp.minute",
@@ -2697,6 +3649,10 @@ TigerWorkspaceCatalogWithAvailableItems {
             "description": "Hour",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_activity_timestamp.hour",
+                  "type": "attribute",
+                },
                 "description": "Hour",
                 "displayFormType": undefined,
                 "id": "dt_activity_timestamp.hour",
@@ -2719,7 +3675,12 @@ TigerWorkspaceCatalogWithAvailableItems {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_activity_timestamp.hour",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_activity_timestamp.hour",
+              "type": "attribute",
+            },
             "description": "Hour",
+            "displayFormType": undefined,
             "id": "dt_activity_timestamp.hour",
             "ref": Object {
               "identifier": "dt_activity_timestamp.hour",
@@ -2736,6 +3697,10 @@ TigerWorkspaceCatalogWithAvailableItems {
             "description": "Date",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_activity_timestamp.day",
+                  "type": "attribute",
+                },
                 "description": "Date",
                 "displayFormType": undefined,
                 "id": "dt_activity_timestamp.day",
@@ -2758,7 +3723,12 @@ TigerWorkspaceCatalogWithAvailableItems {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_activity_timestamp.day",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_activity_timestamp.day",
+              "type": "attribute",
+            },
             "description": "Date",
+            "displayFormType": undefined,
             "id": "dt_activity_timestamp.day",
             "ref": Object {
               "identifier": "dt_activity_timestamp.day",
@@ -2775,6 +3745,10 @@ TigerWorkspaceCatalogWithAvailableItems {
             "description": "Week and Year (W52/2020)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_activity_timestamp.week",
+                  "type": "attribute",
+                },
                 "description": "Week and Year (W52/2020)",
                 "displayFormType": undefined,
                 "id": "dt_activity_timestamp.week",
@@ -2797,7 +3771,12 @@ TigerWorkspaceCatalogWithAvailableItems {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_activity_timestamp.week",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_activity_timestamp.week",
+              "type": "attribute",
+            },
             "description": "Week and Year (W52/2020)",
+            "displayFormType": undefined,
             "id": "dt_activity_timestamp.week",
             "ref": Object {
               "identifier": "dt_activity_timestamp.week",
@@ -2814,6 +3793,10 @@ TigerWorkspaceCatalogWithAvailableItems {
             "description": "Month and Year (12/2020)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_activity_timestamp.month",
+                  "type": "attribute",
+                },
                 "description": "Month and Year (12/2020)",
                 "displayFormType": undefined,
                 "id": "dt_activity_timestamp.month",
@@ -2836,7 +3819,12 @@ TigerWorkspaceCatalogWithAvailableItems {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_activity_timestamp.month",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_activity_timestamp.month",
+              "type": "attribute",
+            },
             "description": "Month and Year (12/2020)",
+            "displayFormType": undefined,
             "id": "dt_activity_timestamp.month",
             "ref": Object {
               "identifier": "dt_activity_timestamp.month",
@@ -2853,6 +3841,10 @@ TigerWorkspaceCatalogWithAvailableItems {
             "description": "Quarter and Year (Q1/2020)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_activity_timestamp.quarter",
+                  "type": "attribute",
+                },
                 "description": "Quarter and Year (Q1/2020)",
                 "displayFormType": undefined,
                 "id": "dt_activity_timestamp.quarter",
@@ -2875,7 +3867,12 @@ TigerWorkspaceCatalogWithAvailableItems {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_activity_timestamp.quarter",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_activity_timestamp.quarter",
+              "type": "attribute",
+            },
             "description": "Quarter and Year (Q1/2020)",
+            "displayFormType": undefined,
             "id": "dt_activity_timestamp.quarter",
             "ref": Object {
               "identifier": "dt_activity_timestamp.quarter",
@@ -2892,6 +3889,10 @@ TigerWorkspaceCatalogWithAvailableItems {
             "description": "Year",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_activity_timestamp.year",
+                  "type": "attribute",
+                },
                 "description": "Year",
                 "displayFormType": undefined,
                 "id": "dt_activity_timestamp.year",
@@ -2914,7 +3915,12 @@ TigerWorkspaceCatalogWithAvailableItems {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_activity_timestamp.year",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_activity_timestamp.year",
+              "type": "attribute",
+            },
             "description": "Year",
+            "displayFormType": undefined,
             "id": "dt_activity_timestamp.year",
             "ref": Object {
               "identifier": "dt_activity_timestamp.year",
@@ -2931,6 +3937,10 @@ TigerWorkspaceCatalogWithAvailableItems {
             "description": "Generic Minute of the Hour(MI1-MI60)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_activity_timestamp.minuteOfHour",
+                  "type": "attribute",
+                },
                 "description": "Generic Minute of the Hour(MI1-MI60)",
                 "displayFormType": undefined,
                 "id": "dt_activity_timestamp.minuteOfHour",
@@ -2953,7 +3963,12 @@ TigerWorkspaceCatalogWithAvailableItems {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_activity_timestamp.minuteOfHour",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_activity_timestamp.minuteOfHour",
+              "type": "attribute",
+            },
             "description": "Generic Minute of the Hour(MI1-MI60)",
+            "displayFormType": undefined,
             "id": "dt_activity_timestamp.minuteOfHour",
             "ref": Object {
               "identifier": "dt_activity_timestamp.minuteOfHour",
@@ -2970,6 +3985,10 @@ TigerWorkspaceCatalogWithAvailableItems {
             "description": "Generic Hour of the Day(H1-H24)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_activity_timestamp.hourOfDay",
+                  "type": "attribute",
+                },
                 "description": "Generic Hour of the Day(H1-H24)",
                 "displayFormType": undefined,
                 "id": "dt_activity_timestamp.hourOfDay",
@@ -2992,7 +4011,12 @@ TigerWorkspaceCatalogWithAvailableItems {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_activity_timestamp.hourOfDay",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_activity_timestamp.hourOfDay",
+              "type": "attribute",
+            },
             "description": "Generic Hour of the Day(H1-H24)",
+            "displayFormType": undefined,
             "id": "dt_activity_timestamp.hourOfDay",
             "ref": Object {
               "identifier": "dt_activity_timestamp.hourOfDay",
@@ -3009,6 +4033,10 @@ TigerWorkspaceCatalogWithAvailableItems {
             "description": "Generic Day of the Week (D1-D7)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_activity_timestamp.dayOfWeek",
+                  "type": "attribute",
+                },
                 "description": "Generic Day of the Week (D1-D7)",
                 "displayFormType": undefined,
                 "id": "dt_activity_timestamp.dayOfWeek",
@@ -3031,7 +4059,12 @@ TigerWorkspaceCatalogWithAvailableItems {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_activity_timestamp.dayOfWeek",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_activity_timestamp.dayOfWeek",
+              "type": "attribute",
+            },
             "description": "Generic Day of the Week (D1-D7)",
+            "displayFormType": undefined,
             "id": "dt_activity_timestamp.dayOfWeek",
             "ref": Object {
               "identifier": "dt_activity_timestamp.dayOfWeek",
@@ -3048,6 +4081,10 @@ TigerWorkspaceCatalogWithAvailableItems {
             "description": "Generic Day of the Month (D1-D31)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_activity_timestamp.dayOfMonth",
+                  "type": "attribute",
+                },
                 "description": "Generic Day of the Month (D1-D31)",
                 "displayFormType": undefined,
                 "id": "dt_activity_timestamp.dayOfMonth",
@@ -3070,7 +4107,12 @@ TigerWorkspaceCatalogWithAvailableItems {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_activity_timestamp.dayOfMonth",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_activity_timestamp.dayOfMonth",
+              "type": "attribute",
+            },
             "description": "Generic Day of the Month (D1-D31)",
+            "displayFormType": undefined,
             "id": "dt_activity_timestamp.dayOfMonth",
             "ref": Object {
               "identifier": "dt_activity_timestamp.dayOfMonth",
@@ -3087,6 +4129,10 @@ TigerWorkspaceCatalogWithAvailableItems {
             "description": "Generic Day of the Year (D1-D366)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_activity_timestamp.dayOfYear",
+                  "type": "attribute",
+                },
                 "description": "Generic Day of the Year (D1-D366)",
                 "displayFormType": undefined,
                 "id": "dt_activity_timestamp.dayOfYear",
@@ -3109,7 +4155,12 @@ TigerWorkspaceCatalogWithAvailableItems {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_activity_timestamp.dayOfYear",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_activity_timestamp.dayOfYear",
+              "type": "attribute",
+            },
             "description": "Generic Day of the Year (D1-D366)",
+            "displayFormType": undefined,
             "id": "dt_activity_timestamp.dayOfYear",
             "ref": Object {
               "identifier": "dt_activity_timestamp.dayOfYear",
@@ -3126,6 +4177,10 @@ TigerWorkspaceCatalogWithAvailableItems {
             "description": "Generic Week (W1-W53)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_activity_timestamp.weekOfYear",
+                  "type": "attribute",
+                },
                 "description": "Generic Week (W1-W53)",
                 "displayFormType": undefined,
                 "id": "dt_activity_timestamp.weekOfYear",
@@ -3148,7 +4203,12 @@ TigerWorkspaceCatalogWithAvailableItems {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_activity_timestamp.weekOfYear",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_activity_timestamp.weekOfYear",
+              "type": "attribute",
+            },
             "description": "Generic Week (W1-W53)",
+            "displayFormType": undefined,
             "id": "dt_activity_timestamp.weekOfYear",
             "ref": Object {
               "identifier": "dt_activity_timestamp.weekOfYear",
@@ -3165,6 +4225,10 @@ TigerWorkspaceCatalogWithAvailableItems {
             "description": "Generic Month (M1-M12)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_activity_timestamp.monthOfYear",
+                  "type": "attribute",
+                },
                 "description": "Generic Month (M1-M12)",
                 "displayFormType": undefined,
                 "id": "dt_activity_timestamp.monthOfYear",
@@ -3187,7 +4251,12 @@ TigerWorkspaceCatalogWithAvailableItems {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_activity_timestamp.monthOfYear",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_activity_timestamp.monthOfYear",
+              "type": "attribute",
+            },
             "description": "Generic Month (M1-M12)",
+            "displayFormType": undefined,
             "id": "dt_activity_timestamp.monthOfYear",
             "ref": Object {
               "identifier": "dt_activity_timestamp.monthOfYear",
@@ -3204,6 +4273,10 @@ TigerWorkspaceCatalogWithAvailableItems {
             "description": "Generic Quarter (Q1-Q4)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_activity_timestamp.quarterOfYear",
+                  "type": "attribute",
+                },
                 "description": "Generic Quarter (Q1-Q4)",
                 "displayFormType": undefined,
                 "id": "dt_activity_timestamp.quarterOfYear",
@@ -3226,7 +4299,12 @@ TigerWorkspaceCatalogWithAvailableItems {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_activity_timestamp.quarterOfYear",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_activity_timestamp.quarterOfYear",
+              "type": "attribute",
+            },
             "description": "Generic Quarter (Q1-Q4)",
+            "displayFormType": undefined,
             "id": "dt_activity_timestamp.quarterOfYear",
             "ref": Object {
               "identifier": "dt_activity_timestamp.quarterOfYear",
@@ -3262,6 +4340,10 @@ TigerWorkspaceCatalogWithAvailableItems {
             "description": "Minute",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_closedate_timestamp.minute",
+                  "type": "attribute",
+                },
                 "description": "Minute",
                 "displayFormType": undefined,
                 "id": "dt_closedate_timestamp.minute",
@@ -3284,7 +4366,12 @@ TigerWorkspaceCatalogWithAvailableItems {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_closedate_timestamp.minute",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_closedate_timestamp.minute",
+              "type": "attribute",
+            },
             "description": "Minute",
+            "displayFormType": undefined,
             "id": "dt_closedate_timestamp.minute",
             "ref": Object {
               "identifier": "dt_closedate_timestamp.minute",
@@ -3301,6 +4388,10 @@ TigerWorkspaceCatalogWithAvailableItems {
             "description": "Hour",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_closedate_timestamp.hour",
+                  "type": "attribute",
+                },
                 "description": "Hour",
                 "displayFormType": undefined,
                 "id": "dt_closedate_timestamp.hour",
@@ -3323,7 +4414,12 @@ TigerWorkspaceCatalogWithAvailableItems {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_closedate_timestamp.hour",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_closedate_timestamp.hour",
+              "type": "attribute",
+            },
             "description": "Hour",
+            "displayFormType": undefined,
             "id": "dt_closedate_timestamp.hour",
             "ref": Object {
               "identifier": "dt_closedate_timestamp.hour",
@@ -3340,6 +4436,10 @@ TigerWorkspaceCatalogWithAvailableItems {
             "description": "Date",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_closedate_timestamp.day",
+                  "type": "attribute",
+                },
                 "description": "Date",
                 "displayFormType": undefined,
                 "id": "dt_closedate_timestamp.day",
@@ -3362,7 +4462,12 @@ TigerWorkspaceCatalogWithAvailableItems {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_closedate_timestamp.day",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_closedate_timestamp.day",
+              "type": "attribute",
+            },
             "description": "Date",
+            "displayFormType": undefined,
             "id": "dt_closedate_timestamp.day",
             "ref": Object {
               "identifier": "dt_closedate_timestamp.day",
@@ -3379,6 +4484,10 @@ TigerWorkspaceCatalogWithAvailableItems {
             "description": "Week and Year (W52/2020)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_closedate_timestamp.week",
+                  "type": "attribute",
+                },
                 "description": "Week and Year (W52/2020)",
                 "displayFormType": undefined,
                 "id": "dt_closedate_timestamp.week",
@@ -3401,7 +4510,12 @@ TigerWorkspaceCatalogWithAvailableItems {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_closedate_timestamp.week",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_closedate_timestamp.week",
+              "type": "attribute",
+            },
             "description": "Week and Year (W52/2020)",
+            "displayFormType": undefined,
             "id": "dt_closedate_timestamp.week",
             "ref": Object {
               "identifier": "dt_closedate_timestamp.week",
@@ -3418,6 +4532,10 @@ TigerWorkspaceCatalogWithAvailableItems {
             "description": "Month and Year (12/2020)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_closedate_timestamp.month",
+                  "type": "attribute",
+                },
                 "description": "Month and Year (12/2020)",
                 "displayFormType": undefined,
                 "id": "dt_closedate_timestamp.month",
@@ -3440,7 +4558,12 @@ TigerWorkspaceCatalogWithAvailableItems {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_closedate_timestamp.month",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_closedate_timestamp.month",
+              "type": "attribute",
+            },
             "description": "Month and Year (12/2020)",
+            "displayFormType": undefined,
             "id": "dt_closedate_timestamp.month",
             "ref": Object {
               "identifier": "dt_closedate_timestamp.month",
@@ -3457,6 +4580,10 @@ TigerWorkspaceCatalogWithAvailableItems {
             "description": "Quarter and Year (Q1/2020)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_closedate_timestamp.quarter",
+                  "type": "attribute",
+                },
                 "description": "Quarter and Year (Q1/2020)",
                 "displayFormType": undefined,
                 "id": "dt_closedate_timestamp.quarter",
@@ -3479,7 +4606,12 @@ TigerWorkspaceCatalogWithAvailableItems {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_closedate_timestamp.quarter",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_closedate_timestamp.quarter",
+              "type": "attribute",
+            },
             "description": "Quarter and Year (Q1/2020)",
+            "displayFormType": undefined,
             "id": "dt_closedate_timestamp.quarter",
             "ref": Object {
               "identifier": "dt_closedate_timestamp.quarter",
@@ -3496,6 +4628,10 @@ TigerWorkspaceCatalogWithAvailableItems {
             "description": "Year",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_closedate_timestamp.year",
+                  "type": "attribute",
+                },
                 "description": "Year",
                 "displayFormType": undefined,
                 "id": "dt_closedate_timestamp.year",
@@ -3518,7 +4654,12 @@ TigerWorkspaceCatalogWithAvailableItems {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_closedate_timestamp.year",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_closedate_timestamp.year",
+              "type": "attribute",
+            },
             "description": "Year",
+            "displayFormType": undefined,
             "id": "dt_closedate_timestamp.year",
             "ref": Object {
               "identifier": "dt_closedate_timestamp.year",
@@ -3535,6 +4676,10 @@ TigerWorkspaceCatalogWithAvailableItems {
             "description": "Generic Minute of the Hour(MI1-MI60)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_closedate_timestamp.minuteOfHour",
+                  "type": "attribute",
+                },
                 "description": "Generic Minute of the Hour(MI1-MI60)",
                 "displayFormType": undefined,
                 "id": "dt_closedate_timestamp.minuteOfHour",
@@ -3557,7 +4702,12 @@ TigerWorkspaceCatalogWithAvailableItems {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_closedate_timestamp.minuteOfHour",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_closedate_timestamp.minuteOfHour",
+              "type": "attribute",
+            },
             "description": "Generic Minute of the Hour(MI1-MI60)",
+            "displayFormType": undefined,
             "id": "dt_closedate_timestamp.minuteOfHour",
             "ref": Object {
               "identifier": "dt_closedate_timestamp.minuteOfHour",
@@ -3574,6 +4724,10 @@ TigerWorkspaceCatalogWithAvailableItems {
             "description": "Generic Hour of the Day(H1-H24)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_closedate_timestamp.hourOfDay",
+                  "type": "attribute",
+                },
                 "description": "Generic Hour of the Day(H1-H24)",
                 "displayFormType": undefined,
                 "id": "dt_closedate_timestamp.hourOfDay",
@@ -3596,7 +4750,12 @@ TigerWorkspaceCatalogWithAvailableItems {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_closedate_timestamp.hourOfDay",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_closedate_timestamp.hourOfDay",
+              "type": "attribute",
+            },
             "description": "Generic Hour of the Day(H1-H24)",
+            "displayFormType": undefined,
             "id": "dt_closedate_timestamp.hourOfDay",
             "ref": Object {
               "identifier": "dt_closedate_timestamp.hourOfDay",
@@ -3613,6 +4772,10 @@ TigerWorkspaceCatalogWithAvailableItems {
             "description": "Generic Day of the Week (D1-D7)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_closedate_timestamp.dayOfWeek",
+                  "type": "attribute",
+                },
                 "description": "Generic Day of the Week (D1-D7)",
                 "displayFormType": undefined,
                 "id": "dt_closedate_timestamp.dayOfWeek",
@@ -3635,7 +4798,12 @@ TigerWorkspaceCatalogWithAvailableItems {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_closedate_timestamp.dayOfWeek",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_closedate_timestamp.dayOfWeek",
+              "type": "attribute",
+            },
             "description": "Generic Day of the Week (D1-D7)",
+            "displayFormType": undefined,
             "id": "dt_closedate_timestamp.dayOfWeek",
             "ref": Object {
               "identifier": "dt_closedate_timestamp.dayOfWeek",
@@ -3652,6 +4820,10 @@ TigerWorkspaceCatalogWithAvailableItems {
             "description": "Generic Day of the Month (D1-D31)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_closedate_timestamp.dayOfMonth",
+                  "type": "attribute",
+                },
                 "description": "Generic Day of the Month (D1-D31)",
                 "displayFormType": undefined,
                 "id": "dt_closedate_timestamp.dayOfMonth",
@@ -3674,7 +4846,12 @@ TigerWorkspaceCatalogWithAvailableItems {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_closedate_timestamp.dayOfMonth",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_closedate_timestamp.dayOfMonth",
+              "type": "attribute",
+            },
             "description": "Generic Day of the Month (D1-D31)",
+            "displayFormType": undefined,
             "id": "dt_closedate_timestamp.dayOfMonth",
             "ref": Object {
               "identifier": "dt_closedate_timestamp.dayOfMonth",
@@ -3691,6 +4868,10 @@ TigerWorkspaceCatalogWithAvailableItems {
             "description": "Generic Day of the Year (D1-D366)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_closedate_timestamp.dayOfYear",
+                  "type": "attribute",
+                },
                 "description": "Generic Day of the Year (D1-D366)",
                 "displayFormType": undefined,
                 "id": "dt_closedate_timestamp.dayOfYear",
@@ -3713,7 +4894,12 @@ TigerWorkspaceCatalogWithAvailableItems {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_closedate_timestamp.dayOfYear",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_closedate_timestamp.dayOfYear",
+              "type": "attribute",
+            },
             "description": "Generic Day of the Year (D1-D366)",
+            "displayFormType": undefined,
             "id": "dt_closedate_timestamp.dayOfYear",
             "ref": Object {
               "identifier": "dt_closedate_timestamp.dayOfYear",
@@ -3730,6 +4916,10 @@ TigerWorkspaceCatalogWithAvailableItems {
             "description": "Generic Week (W1-W53)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_closedate_timestamp.weekOfYear",
+                  "type": "attribute",
+                },
                 "description": "Generic Week (W1-W53)",
                 "displayFormType": undefined,
                 "id": "dt_closedate_timestamp.weekOfYear",
@@ -3752,7 +4942,12 @@ TigerWorkspaceCatalogWithAvailableItems {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_closedate_timestamp.weekOfYear",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_closedate_timestamp.weekOfYear",
+              "type": "attribute",
+            },
             "description": "Generic Week (W1-W53)",
+            "displayFormType": undefined,
             "id": "dt_closedate_timestamp.weekOfYear",
             "ref": Object {
               "identifier": "dt_closedate_timestamp.weekOfYear",
@@ -3769,6 +4964,10 @@ TigerWorkspaceCatalogWithAvailableItems {
             "description": "Generic Month (M1-M12)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_closedate_timestamp.monthOfYear",
+                  "type": "attribute",
+                },
                 "description": "Generic Month (M1-M12)",
                 "displayFormType": undefined,
                 "id": "dt_closedate_timestamp.monthOfYear",
@@ -3791,7 +4990,12 @@ TigerWorkspaceCatalogWithAvailableItems {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_closedate_timestamp.monthOfYear",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_closedate_timestamp.monthOfYear",
+              "type": "attribute",
+            },
             "description": "Generic Month (M1-M12)",
+            "displayFormType": undefined,
             "id": "dt_closedate_timestamp.monthOfYear",
             "ref": Object {
               "identifier": "dt_closedate_timestamp.monthOfYear",
@@ -3808,6 +5012,10 @@ TigerWorkspaceCatalogWithAvailableItems {
             "description": "Generic Quarter (Q1-Q4)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_closedate_timestamp.quarterOfYear",
+                  "type": "attribute",
+                },
                 "description": "Generic Quarter (Q1-Q4)",
                 "displayFormType": undefined,
                 "id": "dt_closedate_timestamp.quarterOfYear",
@@ -3830,7 +5038,12 @@ TigerWorkspaceCatalogWithAvailableItems {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_closedate_timestamp.quarterOfYear",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_closedate_timestamp.quarterOfYear",
+              "type": "attribute",
+            },
             "description": "Generic Quarter (Q1-Q4)",
+            "displayFormType": undefined,
             "id": "dt_closedate_timestamp.quarterOfYear",
             "ref": Object {
               "identifier": "dt_closedate_timestamp.quarterOfYear",
@@ -3866,6 +5079,10 @@ TigerWorkspaceCatalogWithAvailableItems {
             "description": "Minute",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_oppcreated_timestamp.minute",
+                  "type": "attribute",
+                },
                 "description": "Minute",
                 "displayFormType": undefined,
                 "id": "dt_oppcreated_timestamp.minute",
@@ -3888,7 +5105,12 @@ TigerWorkspaceCatalogWithAvailableItems {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_oppcreated_timestamp.minute",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_oppcreated_timestamp.minute",
+              "type": "attribute",
+            },
             "description": "Minute",
+            "displayFormType": undefined,
             "id": "dt_oppcreated_timestamp.minute",
             "ref": Object {
               "identifier": "dt_oppcreated_timestamp.minute",
@@ -3905,6 +5127,10 @@ TigerWorkspaceCatalogWithAvailableItems {
             "description": "Hour",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_oppcreated_timestamp.hour",
+                  "type": "attribute",
+                },
                 "description": "Hour",
                 "displayFormType": undefined,
                 "id": "dt_oppcreated_timestamp.hour",
@@ -3927,7 +5153,12 @@ TigerWorkspaceCatalogWithAvailableItems {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_oppcreated_timestamp.hour",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_oppcreated_timestamp.hour",
+              "type": "attribute",
+            },
             "description": "Hour",
+            "displayFormType": undefined,
             "id": "dt_oppcreated_timestamp.hour",
             "ref": Object {
               "identifier": "dt_oppcreated_timestamp.hour",
@@ -3944,6 +5175,10 @@ TigerWorkspaceCatalogWithAvailableItems {
             "description": "Date",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_oppcreated_timestamp.day",
+                  "type": "attribute",
+                },
                 "description": "Date",
                 "displayFormType": undefined,
                 "id": "dt_oppcreated_timestamp.day",
@@ -3966,7 +5201,12 @@ TigerWorkspaceCatalogWithAvailableItems {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_oppcreated_timestamp.day",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_oppcreated_timestamp.day",
+              "type": "attribute",
+            },
             "description": "Date",
+            "displayFormType": undefined,
             "id": "dt_oppcreated_timestamp.day",
             "ref": Object {
               "identifier": "dt_oppcreated_timestamp.day",
@@ -3983,6 +5223,10 @@ TigerWorkspaceCatalogWithAvailableItems {
             "description": "Week and Year (W52/2020)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_oppcreated_timestamp.week",
+                  "type": "attribute",
+                },
                 "description": "Week and Year (W52/2020)",
                 "displayFormType": undefined,
                 "id": "dt_oppcreated_timestamp.week",
@@ -4005,7 +5249,12 @@ TigerWorkspaceCatalogWithAvailableItems {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_oppcreated_timestamp.week",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_oppcreated_timestamp.week",
+              "type": "attribute",
+            },
             "description": "Week and Year (W52/2020)",
+            "displayFormType": undefined,
             "id": "dt_oppcreated_timestamp.week",
             "ref": Object {
               "identifier": "dt_oppcreated_timestamp.week",
@@ -4022,6 +5271,10 @@ TigerWorkspaceCatalogWithAvailableItems {
             "description": "Month and Year (12/2020)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_oppcreated_timestamp.month",
+                  "type": "attribute",
+                },
                 "description": "Month and Year (12/2020)",
                 "displayFormType": undefined,
                 "id": "dt_oppcreated_timestamp.month",
@@ -4044,7 +5297,12 @@ TigerWorkspaceCatalogWithAvailableItems {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_oppcreated_timestamp.month",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_oppcreated_timestamp.month",
+              "type": "attribute",
+            },
             "description": "Month and Year (12/2020)",
+            "displayFormType": undefined,
             "id": "dt_oppcreated_timestamp.month",
             "ref": Object {
               "identifier": "dt_oppcreated_timestamp.month",
@@ -4061,6 +5319,10 @@ TigerWorkspaceCatalogWithAvailableItems {
             "description": "Quarter and Year (Q1/2020)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_oppcreated_timestamp.quarter",
+                  "type": "attribute",
+                },
                 "description": "Quarter and Year (Q1/2020)",
                 "displayFormType": undefined,
                 "id": "dt_oppcreated_timestamp.quarter",
@@ -4083,7 +5345,12 @@ TigerWorkspaceCatalogWithAvailableItems {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_oppcreated_timestamp.quarter",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_oppcreated_timestamp.quarter",
+              "type": "attribute",
+            },
             "description": "Quarter and Year (Q1/2020)",
+            "displayFormType": undefined,
             "id": "dt_oppcreated_timestamp.quarter",
             "ref": Object {
               "identifier": "dt_oppcreated_timestamp.quarter",
@@ -4100,6 +5367,10 @@ TigerWorkspaceCatalogWithAvailableItems {
             "description": "Year",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_oppcreated_timestamp.year",
+                  "type": "attribute",
+                },
                 "description": "Year",
                 "displayFormType": undefined,
                 "id": "dt_oppcreated_timestamp.year",
@@ -4122,7 +5393,12 @@ TigerWorkspaceCatalogWithAvailableItems {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_oppcreated_timestamp.year",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_oppcreated_timestamp.year",
+              "type": "attribute",
+            },
             "description": "Year",
+            "displayFormType": undefined,
             "id": "dt_oppcreated_timestamp.year",
             "ref": Object {
               "identifier": "dt_oppcreated_timestamp.year",
@@ -4139,6 +5415,10 @@ TigerWorkspaceCatalogWithAvailableItems {
             "description": "Generic Minute of the Hour(MI1-MI60)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_oppcreated_timestamp.minuteOfHour",
+                  "type": "attribute",
+                },
                 "description": "Generic Minute of the Hour(MI1-MI60)",
                 "displayFormType": undefined,
                 "id": "dt_oppcreated_timestamp.minuteOfHour",
@@ -4161,7 +5441,12 @@ TigerWorkspaceCatalogWithAvailableItems {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_oppcreated_timestamp.minuteOfHour",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_oppcreated_timestamp.minuteOfHour",
+              "type": "attribute",
+            },
             "description": "Generic Minute of the Hour(MI1-MI60)",
+            "displayFormType": undefined,
             "id": "dt_oppcreated_timestamp.minuteOfHour",
             "ref": Object {
               "identifier": "dt_oppcreated_timestamp.minuteOfHour",
@@ -4178,6 +5463,10 @@ TigerWorkspaceCatalogWithAvailableItems {
             "description": "Generic Hour of the Day(H1-H24)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_oppcreated_timestamp.hourOfDay",
+                  "type": "attribute",
+                },
                 "description": "Generic Hour of the Day(H1-H24)",
                 "displayFormType": undefined,
                 "id": "dt_oppcreated_timestamp.hourOfDay",
@@ -4200,7 +5489,12 @@ TigerWorkspaceCatalogWithAvailableItems {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_oppcreated_timestamp.hourOfDay",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_oppcreated_timestamp.hourOfDay",
+              "type": "attribute",
+            },
             "description": "Generic Hour of the Day(H1-H24)",
+            "displayFormType": undefined,
             "id": "dt_oppcreated_timestamp.hourOfDay",
             "ref": Object {
               "identifier": "dt_oppcreated_timestamp.hourOfDay",
@@ -4217,6 +5511,10 @@ TigerWorkspaceCatalogWithAvailableItems {
             "description": "Generic Day of the Week (D1-D7)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_oppcreated_timestamp.dayOfWeek",
+                  "type": "attribute",
+                },
                 "description": "Generic Day of the Week (D1-D7)",
                 "displayFormType": undefined,
                 "id": "dt_oppcreated_timestamp.dayOfWeek",
@@ -4239,7 +5537,12 @@ TigerWorkspaceCatalogWithAvailableItems {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_oppcreated_timestamp.dayOfWeek",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_oppcreated_timestamp.dayOfWeek",
+              "type": "attribute",
+            },
             "description": "Generic Day of the Week (D1-D7)",
+            "displayFormType": undefined,
             "id": "dt_oppcreated_timestamp.dayOfWeek",
             "ref": Object {
               "identifier": "dt_oppcreated_timestamp.dayOfWeek",
@@ -4256,6 +5559,10 @@ TigerWorkspaceCatalogWithAvailableItems {
             "description": "Generic Day of the Month (D1-D31)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_oppcreated_timestamp.dayOfMonth",
+                  "type": "attribute",
+                },
                 "description": "Generic Day of the Month (D1-D31)",
                 "displayFormType": undefined,
                 "id": "dt_oppcreated_timestamp.dayOfMonth",
@@ -4278,7 +5585,12 @@ TigerWorkspaceCatalogWithAvailableItems {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_oppcreated_timestamp.dayOfMonth",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_oppcreated_timestamp.dayOfMonth",
+              "type": "attribute",
+            },
             "description": "Generic Day of the Month (D1-D31)",
+            "displayFormType": undefined,
             "id": "dt_oppcreated_timestamp.dayOfMonth",
             "ref": Object {
               "identifier": "dt_oppcreated_timestamp.dayOfMonth",
@@ -4295,6 +5607,10 @@ TigerWorkspaceCatalogWithAvailableItems {
             "description": "Generic Day of the Year (D1-D366)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_oppcreated_timestamp.dayOfYear",
+                  "type": "attribute",
+                },
                 "description": "Generic Day of the Year (D1-D366)",
                 "displayFormType": undefined,
                 "id": "dt_oppcreated_timestamp.dayOfYear",
@@ -4317,7 +5633,12 @@ TigerWorkspaceCatalogWithAvailableItems {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_oppcreated_timestamp.dayOfYear",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_oppcreated_timestamp.dayOfYear",
+              "type": "attribute",
+            },
             "description": "Generic Day of the Year (D1-D366)",
+            "displayFormType": undefined,
             "id": "dt_oppcreated_timestamp.dayOfYear",
             "ref": Object {
               "identifier": "dt_oppcreated_timestamp.dayOfYear",
@@ -4334,6 +5655,10 @@ TigerWorkspaceCatalogWithAvailableItems {
             "description": "Generic Week (W1-W53)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_oppcreated_timestamp.weekOfYear",
+                  "type": "attribute",
+                },
                 "description": "Generic Week (W1-W53)",
                 "displayFormType": undefined,
                 "id": "dt_oppcreated_timestamp.weekOfYear",
@@ -4356,7 +5681,12 @@ TigerWorkspaceCatalogWithAvailableItems {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_oppcreated_timestamp.weekOfYear",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_oppcreated_timestamp.weekOfYear",
+              "type": "attribute",
+            },
             "description": "Generic Week (W1-W53)",
+            "displayFormType": undefined,
             "id": "dt_oppcreated_timestamp.weekOfYear",
             "ref": Object {
               "identifier": "dt_oppcreated_timestamp.weekOfYear",
@@ -4373,6 +5703,10 @@ TigerWorkspaceCatalogWithAvailableItems {
             "description": "Generic Month (M1-M12)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_oppcreated_timestamp.monthOfYear",
+                  "type": "attribute",
+                },
                 "description": "Generic Month (M1-M12)",
                 "displayFormType": undefined,
                 "id": "dt_oppcreated_timestamp.monthOfYear",
@@ -4395,7 +5729,12 @@ TigerWorkspaceCatalogWithAvailableItems {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_oppcreated_timestamp.monthOfYear",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_oppcreated_timestamp.monthOfYear",
+              "type": "attribute",
+            },
             "description": "Generic Month (M1-M12)",
+            "displayFormType": undefined,
             "id": "dt_oppcreated_timestamp.monthOfYear",
             "ref": Object {
               "identifier": "dt_oppcreated_timestamp.monthOfYear",
@@ -4412,6 +5751,10 @@ TigerWorkspaceCatalogWithAvailableItems {
             "description": "Generic Quarter (Q1-Q4)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_oppcreated_timestamp.quarterOfYear",
+                  "type": "attribute",
+                },
                 "description": "Generic Quarter (Q1-Q4)",
                 "displayFormType": undefined,
                 "id": "dt_oppcreated_timestamp.quarterOfYear",
@@ -4434,7 +5777,12 @@ TigerWorkspaceCatalogWithAvailableItems {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_oppcreated_timestamp.quarterOfYear",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_oppcreated_timestamp.quarterOfYear",
+              "type": "attribute",
+            },
             "description": "Generic Quarter (Q1-Q4)",
+            "displayFormType": undefined,
             "id": "dt_oppcreated_timestamp.quarterOfYear",
             "ref": Object {
               "identifier": "dt_oppcreated_timestamp.quarterOfYear",
@@ -4470,6 +5818,10 @@ TigerWorkspaceCatalogWithAvailableItems {
             "description": "Minute",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_snapshotdate_timestamp.minute",
+                  "type": "attribute",
+                },
                 "description": "Minute",
                 "displayFormType": undefined,
                 "id": "dt_snapshotdate_timestamp.minute",
@@ -4492,7 +5844,12 @@ TigerWorkspaceCatalogWithAvailableItems {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_snapshotdate_timestamp.minute",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_snapshotdate_timestamp.minute",
+              "type": "attribute",
+            },
             "description": "Minute",
+            "displayFormType": undefined,
             "id": "dt_snapshotdate_timestamp.minute",
             "ref": Object {
               "identifier": "dt_snapshotdate_timestamp.minute",
@@ -4509,6 +5866,10 @@ TigerWorkspaceCatalogWithAvailableItems {
             "description": "Hour",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_snapshotdate_timestamp.hour",
+                  "type": "attribute",
+                },
                 "description": "Hour",
                 "displayFormType": undefined,
                 "id": "dt_snapshotdate_timestamp.hour",
@@ -4531,7 +5892,12 @@ TigerWorkspaceCatalogWithAvailableItems {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_snapshotdate_timestamp.hour",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_snapshotdate_timestamp.hour",
+              "type": "attribute",
+            },
             "description": "Hour",
+            "displayFormType": undefined,
             "id": "dt_snapshotdate_timestamp.hour",
             "ref": Object {
               "identifier": "dt_snapshotdate_timestamp.hour",
@@ -4548,6 +5914,10 @@ TigerWorkspaceCatalogWithAvailableItems {
             "description": "Date",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_snapshotdate_timestamp.day",
+                  "type": "attribute",
+                },
                 "description": "Date",
                 "displayFormType": undefined,
                 "id": "dt_snapshotdate_timestamp.day",
@@ -4570,7 +5940,12 @@ TigerWorkspaceCatalogWithAvailableItems {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_snapshotdate_timestamp.day",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_snapshotdate_timestamp.day",
+              "type": "attribute",
+            },
             "description": "Date",
+            "displayFormType": undefined,
             "id": "dt_snapshotdate_timestamp.day",
             "ref": Object {
               "identifier": "dt_snapshotdate_timestamp.day",
@@ -4587,6 +5962,10 @@ TigerWorkspaceCatalogWithAvailableItems {
             "description": "Week and Year (W52/2020)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_snapshotdate_timestamp.week",
+                  "type": "attribute",
+                },
                 "description": "Week and Year (W52/2020)",
                 "displayFormType": undefined,
                 "id": "dt_snapshotdate_timestamp.week",
@@ -4609,7 +5988,12 @@ TigerWorkspaceCatalogWithAvailableItems {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_snapshotdate_timestamp.week",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_snapshotdate_timestamp.week",
+              "type": "attribute",
+            },
             "description": "Week and Year (W52/2020)",
+            "displayFormType": undefined,
             "id": "dt_snapshotdate_timestamp.week",
             "ref": Object {
               "identifier": "dt_snapshotdate_timestamp.week",
@@ -4626,6 +6010,10 @@ TigerWorkspaceCatalogWithAvailableItems {
             "description": "Month and Year (12/2020)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_snapshotdate_timestamp.month",
+                  "type": "attribute",
+                },
                 "description": "Month and Year (12/2020)",
                 "displayFormType": undefined,
                 "id": "dt_snapshotdate_timestamp.month",
@@ -4648,7 +6036,12 @@ TigerWorkspaceCatalogWithAvailableItems {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_snapshotdate_timestamp.month",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_snapshotdate_timestamp.month",
+              "type": "attribute",
+            },
             "description": "Month and Year (12/2020)",
+            "displayFormType": undefined,
             "id": "dt_snapshotdate_timestamp.month",
             "ref": Object {
               "identifier": "dt_snapshotdate_timestamp.month",
@@ -4665,6 +6058,10 @@ TigerWorkspaceCatalogWithAvailableItems {
             "description": "Quarter and Year (Q1/2020)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_snapshotdate_timestamp.quarter",
+                  "type": "attribute",
+                },
                 "description": "Quarter and Year (Q1/2020)",
                 "displayFormType": undefined,
                 "id": "dt_snapshotdate_timestamp.quarter",
@@ -4687,7 +6084,12 @@ TigerWorkspaceCatalogWithAvailableItems {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_snapshotdate_timestamp.quarter",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_snapshotdate_timestamp.quarter",
+              "type": "attribute",
+            },
             "description": "Quarter and Year (Q1/2020)",
+            "displayFormType": undefined,
             "id": "dt_snapshotdate_timestamp.quarter",
             "ref": Object {
               "identifier": "dt_snapshotdate_timestamp.quarter",
@@ -4704,6 +6106,10 @@ TigerWorkspaceCatalogWithAvailableItems {
             "description": "Year",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_snapshotdate_timestamp.year",
+                  "type": "attribute",
+                },
                 "description": "Year",
                 "displayFormType": undefined,
                 "id": "dt_snapshotdate_timestamp.year",
@@ -4726,7 +6132,12 @@ TigerWorkspaceCatalogWithAvailableItems {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_snapshotdate_timestamp.year",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_snapshotdate_timestamp.year",
+              "type": "attribute",
+            },
             "description": "Year",
+            "displayFormType": undefined,
             "id": "dt_snapshotdate_timestamp.year",
             "ref": Object {
               "identifier": "dt_snapshotdate_timestamp.year",
@@ -4743,6 +6154,10 @@ TigerWorkspaceCatalogWithAvailableItems {
             "description": "Generic Minute of the Hour(MI1-MI60)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_snapshotdate_timestamp.minuteOfHour",
+                  "type": "attribute",
+                },
                 "description": "Generic Minute of the Hour(MI1-MI60)",
                 "displayFormType": undefined,
                 "id": "dt_snapshotdate_timestamp.minuteOfHour",
@@ -4765,7 +6180,12 @@ TigerWorkspaceCatalogWithAvailableItems {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_snapshotdate_timestamp.minuteOfHour",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_snapshotdate_timestamp.minuteOfHour",
+              "type": "attribute",
+            },
             "description": "Generic Minute of the Hour(MI1-MI60)",
+            "displayFormType": undefined,
             "id": "dt_snapshotdate_timestamp.minuteOfHour",
             "ref": Object {
               "identifier": "dt_snapshotdate_timestamp.minuteOfHour",
@@ -4782,6 +6202,10 @@ TigerWorkspaceCatalogWithAvailableItems {
             "description": "Generic Hour of the Day(H1-H24)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_snapshotdate_timestamp.hourOfDay",
+                  "type": "attribute",
+                },
                 "description": "Generic Hour of the Day(H1-H24)",
                 "displayFormType": undefined,
                 "id": "dt_snapshotdate_timestamp.hourOfDay",
@@ -4804,7 +6228,12 @@ TigerWorkspaceCatalogWithAvailableItems {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_snapshotdate_timestamp.hourOfDay",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_snapshotdate_timestamp.hourOfDay",
+              "type": "attribute",
+            },
             "description": "Generic Hour of the Day(H1-H24)",
+            "displayFormType": undefined,
             "id": "dt_snapshotdate_timestamp.hourOfDay",
             "ref": Object {
               "identifier": "dt_snapshotdate_timestamp.hourOfDay",
@@ -4821,6 +6250,10 @@ TigerWorkspaceCatalogWithAvailableItems {
             "description": "Generic Day of the Week (D1-D7)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_snapshotdate_timestamp.dayOfWeek",
+                  "type": "attribute",
+                },
                 "description": "Generic Day of the Week (D1-D7)",
                 "displayFormType": undefined,
                 "id": "dt_snapshotdate_timestamp.dayOfWeek",
@@ -4843,7 +6276,12 @@ TigerWorkspaceCatalogWithAvailableItems {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_snapshotdate_timestamp.dayOfWeek",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_snapshotdate_timestamp.dayOfWeek",
+              "type": "attribute",
+            },
             "description": "Generic Day of the Week (D1-D7)",
+            "displayFormType": undefined,
             "id": "dt_snapshotdate_timestamp.dayOfWeek",
             "ref": Object {
               "identifier": "dt_snapshotdate_timestamp.dayOfWeek",
@@ -4860,6 +6298,10 @@ TigerWorkspaceCatalogWithAvailableItems {
             "description": "Generic Day of the Month (D1-D31)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_snapshotdate_timestamp.dayOfMonth",
+                  "type": "attribute",
+                },
                 "description": "Generic Day of the Month (D1-D31)",
                 "displayFormType": undefined,
                 "id": "dt_snapshotdate_timestamp.dayOfMonth",
@@ -4882,7 +6324,12 @@ TigerWorkspaceCatalogWithAvailableItems {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_snapshotdate_timestamp.dayOfMonth",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_snapshotdate_timestamp.dayOfMonth",
+              "type": "attribute",
+            },
             "description": "Generic Day of the Month (D1-D31)",
+            "displayFormType": undefined,
             "id": "dt_snapshotdate_timestamp.dayOfMonth",
             "ref": Object {
               "identifier": "dt_snapshotdate_timestamp.dayOfMonth",
@@ -4899,6 +6346,10 @@ TigerWorkspaceCatalogWithAvailableItems {
             "description": "Generic Day of the Year (D1-D366)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_snapshotdate_timestamp.dayOfYear",
+                  "type": "attribute",
+                },
                 "description": "Generic Day of the Year (D1-D366)",
                 "displayFormType": undefined,
                 "id": "dt_snapshotdate_timestamp.dayOfYear",
@@ -4921,7 +6372,12 @@ TigerWorkspaceCatalogWithAvailableItems {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_snapshotdate_timestamp.dayOfYear",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_snapshotdate_timestamp.dayOfYear",
+              "type": "attribute",
+            },
             "description": "Generic Day of the Year (D1-D366)",
+            "displayFormType": undefined,
             "id": "dt_snapshotdate_timestamp.dayOfYear",
             "ref": Object {
               "identifier": "dt_snapshotdate_timestamp.dayOfYear",
@@ -4938,6 +6394,10 @@ TigerWorkspaceCatalogWithAvailableItems {
             "description": "Generic Week (W1-W53)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_snapshotdate_timestamp.weekOfYear",
+                  "type": "attribute",
+                },
                 "description": "Generic Week (W1-W53)",
                 "displayFormType": undefined,
                 "id": "dt_snapshotdate_timestamp.weekOfYear",
@@ -4960,7 +6420,12 @@ TigerWorkspaceCatalogWithAvailableItems {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_snapshotdate_timestamp.weekOfYear",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_snapshotdate_timestamp.weekOfYear",
+              "type": "attribute",
+            },
             "description": "Generic Week (W1-W53)",
+            "displayFormType": undefined,
             "id": "dt_snapshotdate_timestamp.weekOfYear",
             "ref": Object {
               "identifier": "dt_snapshotdate_timestamp.weekOfYear",
@@ -4977,6 +6442,10 @@ TigerWorkspaceCatalogWithAvailableItems {
             "description": "Generic Month (M1-M12)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_snapshotdate_timestamp.monthOfYear",
+                  "type": "attribute",
+                },
                 "description": "Generic Month (M1-M12)",
                 "displayFormType": undefined,
                 "id": "dt_snapshotdate_timestamp.monthOfYear",
@@ -4999,7 +6468,12 @@ TigerWorkspaceCatalogWithAvailableItems {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_snapshotdate_timestamp.monthOfYear",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_snapshotdate_timestamp.monthOfYear",
+              "type": "attribute",
+            },
             "description": "Generic Month (M1-M12)",
+            "displayFormType": undefined,
             "id": "dt_snapshotdate_timestamp.monthOfYear",
             "ref": Object {
               "identifier": "dt_snapshotdate_timestamp.monthOfYear",
@@ -5016,6 +6490,10 @@ TigerWorkspaceCatalogWithAvailableItems {
             "description": "Generic Quarter (Q1-Q4)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_snapshotdate_timestamp.quarterOfYear",
+                  "type": "attribute",
+                },
                 "description": "Generic Quarter (Q1-Q4)",
                 "displayFormType": undefined,
                 "id": "dt_snapshotdate_timestamp.quarterOfYear",
@@ -5038,7 +6516,12 @@ TigerWorkspaceCatalogWithAvailableItems {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_snapshotdate_timestamp.quarterOfYear",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_snapshotdate_timestamp.quarterOfYear",
+              "type": "attribute",
+            },
             "description": "Generic Quarter (Q1-Q4)",
+            "displayFormType": undefined,
             "id": "dt_snapshotdate_timestamp.quarterOfYear",
             "ref": Object {
               "identifier": "dt_snapshotdate_timestamp.quarterOfYear",
@@ -5074,6 +6557,10 @@ TigerWorkspaceCatalogWithAvailableItems {
             "description": "Minute",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_timeline_timestamp.minute",
+                  "type": "attribute",
+                },
                 "description": "Minute",
                 "displayFormType": undefined,
                 "id": "dt_timeline_timestamp.minute",
@@ -5096,7 +6583,12 @@ TigerWorkspaceCatalogWithAvailableItems {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_timeline_timestamp.minute",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_timeline_timestamp.minute",
+              "type": "attribute",
+            },
             "description": "Minute",
+            "displayFormType": undefined,
             "id": "dt_timeline_timestamp.minute",
             "ref": Object {
               "identifier": "dt_timeline_timestamp.minute",
@@ -5113,6 +6605,10 @@ TigerWorkspaceCatalogWithAvailableItems {
             "description": "Hour",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_timeline_timestamp.hour",
+                  "type": "attribute",
+                },
                 "description": "Hour",
                 "displayFormType": undefined,
                 "id": "dt_timeline_timestamp.hour",
@@ -5135,7 +6631,12 @@ TigerWorkspaceCatalogWithAvailableItems {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_timeline_timestamp.hour",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_timeline_timestamp.hour",
+              "type": "attribute",
+            },
             "description": "Hour",
+            "displayFormType": undefined,
             "id": "dt_timeline_timestamp.hour",
             "ref": Object {
               "identifier": "dt_timeline_timestamp.hour",
@@ -5152,6 +6653,10 @@ TigerWorkspaceCatalogWithAvailableItems {
             "description": "Date",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_timeline_timestamp.day",
+                  "type": "attribute",
+                },
                 "description": "Date",
                 "displayFormType": undefined,
                 "id": "dt_timeline_timestamp.day",
@@ -5174,7 +6679,12 @@ TigerWorkspaceCatalogWithAvailableItems {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_timeline_timestamp.day",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_timeline_timestamp.day",
+              "type": "attribute",
+            },
             "description": "Date",
+            "displayFormType": undefined,
             "id": "dt_timeline_timestamp.day",
             "ref": Object {
               "identifier": "dt_timeline_timestamp.day",
@@ -5191,6 +6701,10 @@ TigerWorkspaceCatalogWithAvailableItems {
             "description": "Week and Year (W52/2020)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_timeline_timestamp.week",
+                  "type": "attribute",
+                },
                 "description": "Week and Year (W52/2020)",
                 "displayFormType": undefined,
                 "id": "dt_timeline_timestamp.week",
@@ -5213,7 +6727,12 @@ TigerWorkspaceCatalogWithAvailableItems {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_timeline_timestamp.week",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_timeline_timestamp.week",
+              "type": "attribute",
+            },
             "description": "Week and Year (W52/2020)",
+            "displayFormType": undefined,
             "id": "dt_timeline_timestamp.week",
             "ref": Object {
               "identifier": "dt_timeline_timestamp.week",
@@ -5230,6 +6749,10 @@ TigerWorkspaceCatalogWithAvailableItems {
             "description": "Month and Year (12/2020)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_timeline_timestamp.month",
+                  "type": "attribute",
+                },
                 "description": "Month and Year (12/2020)",
                 "displayFormType": undefined,
                 "id": "dt_timeline_timestamp.month",
@@ -5252,7 +6775,12 @@ TigerWorkspaceCatalogWithAvailableItems {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_timeline_timestamp.month",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_timeline_timestamp.month",
+              "type": "attribute",
+            },
             "description": "Month and Year (12/2020)",
+            "displayFormType": undefined,
             "id": "dt_timeline_timestamp.month",
             "ref": Object {
               "identifier": "dt_timeline_timestamp.month",
@@ -5269,6 +6797,10 @@ TigerWorkspaceCatalogWithAvailableItems {
             "description": "Quarter and Year (Q1/2020)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_timeline_timestamp.quarter",
+                  "type": "attribute",
+                },
                 "description": "Quarter and Year (Q1/2020)",
                 "displayFormType": undefined,
                 "id": "dt_timeline_timestamp.quarter",
@@ -5291,7 +6823,12 @@ TigerWorkspaceCatalogWithAvailableItems {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_timeline_timestamp.quarter",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_timeline_timestamp.quarter",
+              "type": "attribute",
+            },
             "description": "Quarter and Year (Q1/2020)",
+            "displayFormType": undefined,
             "id": "dt_timeline_timestamp.quarter",
             "ref": Object {
               "identifier": "dt_timeline_timestamp.quarter",
@@ -5308,6 +6845,10 @@ TigerWorkspaceCatalogWithAvailableItems {
             "description": "Year",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_timeline_timestamp.year",
+                  "type": "attribute",
+                },
                 "description": "Year",
                 "displayFormType": undefined,
                 "id": "dt_timeline_timestamp.year",
@@ -5330,7 +6871,12 @@ TigerWorkspaceCatalogWithAvailableItems {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_timeline_timestamp.year",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_timeline_timestamp.year",
+              "type": "attribute",
+            },
             "description": "Year",
+            "displayFormType": undefined,
             "id": "dt_timeline_timestamp.year",
             "ref": Object {
               "identifier": "dt_timeline_timestamp.year",
@@ -5347,6 +6893,10 @@ TigerWorkspaceCatalogWithAvailableItems {
             "description": "Generic Minute of the Hour(MI1-MI60)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_timeline_timestamp.minuteOfHour",
+                  "type": "attribute",
+                },
                 "description": "Generic Minute of the Hour(MI1-MI60)",
                 "displayFormType": undefined,
                 "id": "dt_timeline_timestamp.minuteOfHour",
@@ -5369,7 +6919,12 @@ TigerWorkspaceCatalogWithAvailableItems {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_timeline_timestamp.minuteOfHour",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_timeline_timestamp.minuteOfHour",
+              "type": "attribute",
+            },
             "description": "Generic Minute of the Hour(MI1-MI60)",
+            "displayFormType": undefined,
             "id": "dt_timeline_timestamp.minuteOfHour",
             "ref": Object {
               "identifier": "dt_timeline_timestamp.minuteOfHour",
@@ -5386,6 +6941,10 @@ TigerWorkspaceCatalogWithAvailableItems {
             "description": "Generic Hour of the Day(H1-H24)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_timeline_timestamp.hourOfDay",
+                  "type": "attribute",
+                },
                 "description": "Generic Hour of the Day(H1-H24)",
                 "displayFormType": undefined,
                 "id": "dt_timeline_timestamp.hourOfDay",
@@ -5408,7 +6967,12 @@ TigerWorkspaceCatalogWithAvailableItems {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_timeline_timestamp.hourOfDay",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_timeline_timestamp.hourOfDay",
+              "type": "attribute",
+            },
             "description": "Generic Hour of the Day(H1-H24)",
+            "displayFormType": undefined,
             "id": "dt_timeline_timestamp.hourOfDay",
             "ref": Object {
               "identifier": "dt_timeline_timestamp.hourOfDay",
@@ -5425,6 +6989,10 @@ TigerWorkspaceCatalogWithAvailableItems {
             "description": "Generic Day of the Week (D1-D7)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_timeline_timestamp.dayOfWeek",
+                  "type": "attribute",
+                },
                 "description": "Generic Day of the Week (D1-D7)",
                 "displayFormType": undefined,
                 "id": "dt_timeline_timestamp.dayOfWeek",
@@ -5447,7 +7015,12 @@ TigerWorkspaceCatalogWithAvailableItems {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_timeline_timestamp.dayOfWeek",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_timeline_timestamp.dayOfWeek",
+              "type": "attribute",
+            },
             "description": "Generic Day of the Week (D1-D7)",
+            "displayFormType": undefined,
             "id": "dt_timeline_timestamp.dayOfWeek",
             "ref": Object {
               "identifier": "dt_timeline_timestamp.dayOfWeek",
@@ -5464,6 +7037,10 @@ TigerWorkspaceCatalogWithAvailableItems {
             "description": "Generic Day of the Month (D1-D31)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_timeline_timestamp.dayOfMonth",
+                  "type": "attribute",
+                },
                 "description": "Generic Day of the Month (D1-D31)",
                 "displayFormType": undefined,
                 "id": "dt_timeline_timestamp.dayOfMonth",
@@ -5486,7 +7063,12 @@ TigerWorkspaceCatalogWithAvailableItems {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_timeline_timestamp.dayOfMonth",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_timeline_timestamp.dayOfMonth",
+              "type": "attribute",
+            },
             "description": "Generic Day of the Month (D1-D31)",
+            "displayFormType": undefined,
             "id": "dt_timeline_timestamp.dayOfMonth",
             "ref": Object {
               "identifier": "dt_timeline_timestamp.dayOfMonth",
@@ -5503,6 +7085,10 @@ TigerWorkspaceCatalogWithAvailableItems {
             "description": "Generic Day of the Year (D1-D366)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_timeline_timestamp.dayOfYear",
+                  "type": "attribute",
+                },
                 "description": "Generic Day of the Year (D1-D366)",
                 "displayFormType": undefined,
                 "id": "dt_timeline_timestamp.dayOfYear",
@@ -5525,7 +7111,12 @@ TigerWorkspaceCatalogWithAvailableItems {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_timeline_timestamp.dayOfYear",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_timeline_timestamp.dayOfYear",
+              "type": "attribute",
+            },
             "description": "Generic Day of the Year (D1-D366)",
+            "displayFormType": undefined,
             "id": "dt_timeline_timestamp.dayOfYear",
             "ref": Object {
               "identifier": "dt_timeline_timestamp.dayOfYear",
@@ -5542,6 +7133,10 @@ TigerWorkspaceCatalogWithAvailableItems {
             "description": "Generic Week (W1-W53)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_timeline_timestamp.weekOfYear",
+                  "type": "attribute",
+                },
                 "description": "Generic Week (W1-W53)",
                 "displayFormType": undefined,
                 "id": "dt_timeline_timestamp.weekOfYear",
@@ -5564,7 +7159,12 @@ TigerWorkspaceCatalogWithAvailableItems {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_timeline_timestamp.weekOfYear",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_timeline_timestamp.weekOfYear",
+              "type": "attribute",
+            },
             "description": "Generic Week (W1-W53)",
+            "displayFormType": undefined,
             "id": "dt_timeline_timestamp.weekOfYear",
             "ref": Object {
               "identifier": "dt_timeline_timestamp.weekOfYear",
@@ -5581,6 +7181,10 @@ TigerWorkspaceCatalogWithAvailableItems {
             "description": "Generic Month (M1-M12)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_timeline_timestamp.monthOfYear",
+                  "type": "attribute",
+                },
                 "description": "Generic Month (M1-M12)",
                 "displayFormType": undefined,
                 "id": "dt_timeline_timestamp.monthOfYear",
@@ -5603,7 +7207,12 @@ TigerWorkspaceCatalogWithAvailableItems {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_timeline_timestamp.monthOfYear",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_timeline_timestamp.monthOfYear",
+              "type": "attribute",
+            },
             "description": "Generic Month (M1-M12)",
+            "displayFormType": undefined,
             "id": "dt_timeline_timestamp.monthOfYear",
             "ref": Object {
               "identifier": "dt_timeline_timestamp.monthOfYear",
@@ -5620,6 +7229,10 @@ TigerWorkspaceCatalogWithAvailableItems {
             "description": "Generic Quarter (Q1-Q4)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_timeline_timestamp.quarterOfYear",
+                  "type": "attribute",
+                },
                 "description": "Generic Quarter (Q1-Q4)",
                 "displayFormType": undefined,
                 "id": "dt_timeline_timestamp.quarterOfYear",
@@ -5642,7 +7255,12 @@ TigerWorkspaceCatalogWithAvailableItems {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_timeline_timestamp.quarterOfYear",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_timeline_timestamp.quarterOfYear",
+              "type": "attribute",
+            },
             "description": "Generic Quarter (Q1-Q4)",
+            "displayFormType": undefined,
             "id": "dt_timeline_timestamp.quarterOfYear",
             "ref": Object {
               "identifier": "dt_timeline_timestamp.quarterOfYear",
@@ -5894,6 +7512,40 @@ TigerWorkspaceCatalog {
     Object {
       "attribute": Object {
         "description": "Account",
+        "displayForms": Array [
+          Object {
+            "attribute": Object {
+              "identifier": "attr.f_account.account",
+              "type": "attribute",
+            },
+            "description": "",
+            "displayFormType": undefined,
+            "id": "label.f_account.account",
+            "ref": Object {
+              "identifier": "label.f_account.account",
+              "type": "displayForm",
+            },
+            "title": "Name",
+            "type": "displayForm",
+            "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/labels/label.f_account.account",
+          },
+          Object {
+            "attribute": Object {
+              "identifier": "attr.f_account.account",
+              "type": "attribute",
+            },
+            "description": "",
+            "displayFormType": undefined,
+            "id": "label.f_account.account.accountid",
+            "ref": Object {
+              "identifier": "label.f_account.account.accountid",
+              "type": "displayForm",
+            },
+            "title": "Account",
+            "type": "displayForm",
+            "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/labels/label.f_account.account.accountid",
+          },
+        ],
         "id": "attr.f_account.account",
         "ref": Object {
           "identifier": "attr.f_account.account",
@@ -5904,7 +7556,12 @@ TigerWorkspaceCatalog {
         "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/attr.f_account.account",
       },
       "defaultDisplayForm": Object {
+        "attribute": Object {
+          "identifier": "attr.f_account.account",
+          "type": "attribute",
+        },
         "description": "",
+        "displayFormType": undefined,
         "id": "label.f_account.account",
         "ref": Object {
           "identifier": "label.f_account.account",
@@ -5916,6 +7573,10 @@ TigerWorkspaceCatalog {
       },
       "displayForms": Array [
         Object {
+          "attribute": Object {
+            "identifier": "attr.f_account.account",
+            "type": "attribute",
+          },
           "description": "",
           "displayFormType": undefined,
           "id": "label.f_account.account",
@@ -5928,6 +7589,10 @@ TigerWorkspaceCatalog {
           "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/labels/label.f_account.account",
         },
         Object {
+          "attribute": Object {
+            "identifier": "attr.f_account.account",
+            "type": "attribute",
+          },
           "description": "",
           "displayFormType": undefined,
           "id": "label.f_account.account.accountid",
@@ -5952,6 +7617,24 @@ TigerWorkspaceCatalog {
     Object {
       "attribute": Object {
         "description": "Account",
+        "displayForms": Array [
+          Object {
+            "attribute": Object {
+              "identifier": "f_account.id",
+              "type": "attribute",
+            },
+            "description": "Id",
+            "displayFormType": undefined,
+            "id": "f_account.id",
+            "ref": Object {
+              "identifier": "f_account.id",
+              "type": "displayForm",
+            },
+            "title": "Account Id",
+            "type": "displayForm",
+            "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/labels/f_account.id",
+          },
+        ],
         "id": "f_account.id",
         "ref": Object {
           "identifier": "f_account.id",
@@ -5962,7 +7645,12 @@ TigerWorkspaceCatalog {
         "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/f_account.id",
       },
       "defaultDisplayForm": Object {
+        "attribute": Object {
+          "identifier": "f_account.id",
+          "type": "attribute",
+        },
         "description": "Id",
+        "displayFormType": undefined,
         "id": "f_account.id",
         "ref": Object {
           "identifier": "f_account.id",
@@ -5974,6 +7662,10 @@ TigerWorkspaceCatalog {
       },
       "displayForms": Array [
         Object {
+          "attribute": Object {
+            "identifier": "f_account.id",
+            "type": "attribute",
+          },
           "description": "Id",
           "displayFormType": undefined,
           "id": "f_account.id",
@@ -5998,6 +7690,40 @@ TigerWorkspaceCatalog {
     Object {
       "attribute": Object {
         "description": "Activity",
+        "displayForms": Array [
+          Object {
+            "attribute": Object {
+              "identifier": "attr.f_activity.activity",
+              "type": "attribute",
+            },
+            "description": "",
+            "displayFormType": undefined,
+            "id": "label.f_activity.activity",
+            "ref": Object {
+              "identifier": "label.f_activity.activity",
+              "type": "displayForm",
+            },
+            "title": "Activity",
+            "type": "displayForm",
+            "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/labels/label.f_activity.activity",
+          },
+          Object {
+            "attribute": Object {
+              "identifier": "attr.f_activity.activity",
+              "type": "attribute",
+            },
+            "description": "",
+            "displayFormType": undefined,
+            "id": "label.f_activity.activity.name",
+            "ref": Object {
+              "identifier": "label.f_activity.activity.name",
+              "type": "displayForm",
+            },
+            "title": "Subject",
+            "type": "displayForm",
+            "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/labels/label.f_activity.activity.name",
+          },
+        ],
         "id": "attr.f_activity.activity",
         "ref": Object {
           "identifier": "attr.f_activity.activity",
@@ -6008,7 +7734,12 @@ TigerWorkspaceCatalog {
         "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/attr.f_activity.activity",
       },
       "defaultDisplayForm": Object {
+        "attribute": Object {
+          "identifier": "attr.f_activity.activity",
+          "type": "attribute",
+        },
         "description": "",
+        "displayFormType": undefined,
         "id": "label.f_activity.activity.name",
         "ref": Object {
           "identifier": "label.f_activity.activity.name",
@@ -6020,6 +7751,10 @@ TigerWorkspaceCatalog {
       },
       "displayForms": Array [
         Object {
+          "attribute": Object {
+            "identifier": "attr.f_activity.activity",
+            "type": "attribute",
+          },
           "description": "",
           "displayFormType": undefined,
           "id": "label.f_activity.activity",
@@ -6032,6 +7767,10 @@ TigerWorkspaceCatalog {
           "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/labels/label.f_activity.activity",
         },
         Object {
+          "attribute": Object {
+            "identifier": "attr.f_activity.activity",
+            "type": "attribute",
+          },
           "description": "",
           "displayFormType": undefined,
           "id": "label.f_activity.activity.name",
@@ -6076,6 +7815,24 @@ TigerWorkspaceCatalog {
     Object {
       "attribute": Object {
         "description": "Activity Id",
+        "displayForms": Array [
+          Object {
+            "attribute": Object {
+              "identifier": "f_activity.id",
+              "type": "attribute",
+            },
+            "description": "Id",
+            "displayFormType": undefined,
+            "id": "f_activity.id",
+            "ref": Object {
+              "identifier": "f_activity.id",
+              "type": "displayForm",
+            },
+            "title": "Activity Id",
+            "type": "displayForm",
+            "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/labels/f_activity.id",
+          },
+        ],
         "id": "f_activity.id",
         "ref": Object {
           "identifier": "f_activity.id",
@@ -6086,7 +7843,12 @@ TigerWorkspaceCatalog {
         "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/f_activity.id",
       },
       "defaultDisplayForm": Object {
+        "attribute": Object {
+          "identifier": "f_activity.id",
+          "type": "attribute",
+        },
         "description": "Id",
+        "displayFormType": undefined,
         "id": "f_activity.id",
         "ref": Object {
           "identifier": "f_activity.id",
@@ -6098,6 +7860,10 @@ TigerWorkspaceCatalog {
       },
       "displayForms": Array [
         Object {
+          "attribute": Object {
+            "identifier": "f_activity.id",
+            "type": "attribute",
+          },
           "description": "Id",
           "displayFormType": undefined,
           "id": "f_activity.id",
@@ -6122,6 +7888,24 @@ TigerWorkspaceCatalog {
     Object {
       "attribute": Object {
         "description": "Activity Type",
+        "displayForms": Array [
+          Object {
+            "attribute": Object {
+              "identifier": "f_activity.activitytype_id",
+              "type": "attribute",
+            },
+            "description": "Activitytype id",
+            "displayFormType": undefined,
+            "id": "f_activity.activitytype_id",
+            "ref": Object {
+              "identifier": "f_activity.activitytype_id",
+              "type": "displayForm",
+            },
+            "title": "Activity Type",
+            "type": "displayForm",
+            "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/labels/f_activity.activitytype_id",
+          },
+        ],
         "id": "f_activity.activitytype_id",
         "ref": Object {
           "identifier": "f_activity.activitytype_id",
@@ -6132,7 +7916,12 @@ TigerWorkspaceCatalog {
         "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/f_activity.activitytype_id",
       },
       "defaultDisplayForm": Object {
+        "attribute": Object {
+          "identifier": "f_activity.activitytype_id",
+          "type": "attribute",
+        },
         "description": "Activitytype id",
+        "displayFormType": undefined,
         "id": "f_activity.activitytype_id",
         "ref": Object {
           "identifier": "f_activity.activitytype_id",
@@ -6144,6 +7933,10 @@ TigerWorkspaceCatalog {
       },
       "displayForms": Array [
         Object {
+          "attribute": Object {
+            "identifier": "f_activity.activitytype_id",
+            "type": "attribute",
+          },
           "description": "Activitytype id",
           "displayFormType": undefined,
           "id": "f_activity.activitytype_id",
@@ -6280,6 +8073,24 @@ TigerWorkspaceCatalog {
     Object {
       "attribute": Object {
         "description": "Department",
+        "displayForms": Array [
+          Object {
+            "attribute": Object {
+              "identifier": "f_owner.department_id",
+              "type": "attribute",
+            },
+            "description": "Department id",
+            "displayFormType": undefined,
+            "id": "f_owner.department_id",
+            "ref": Object {
+              "identifier": "f_owner.department_id",
+              "type": "displayForm",
+            },
+            "title": "Department",
+            "type": "displayForm",
+            "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/labels/f_owner.department_id",
+          },
+        ],
         "id": "f_owner.department_id",
         "ref": Object {
           "identifier": "f_owner.department_id",
@@ -6290,7 +8101,12 @@ TigerWorkspaceCatalog {
         "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/f_owner.department_id",
       },
       "defaultDisplayForm": Object {
+        "attribute": Object {
+          "identifier": "f_owner.department_id",
+          "type": "attribute",
+        },
         "description": "Department id",
+        "displayFormType": undefined,
         "id": "f_owner.department_id",
         "ref": Object {
           "identifier": "f_owner.department_id",
@@ -6302,6 +8118,10 @@ TigerWorkspaceCatalog {
       },
       "displayForms": Array [
         Object {
+          "attribute": Object {
+            "identifier": "f_owner.department_id",
+            "type": "attribute",
+          },
           "description": "Department id",
           "displayFormType": undefined,
           "id": "f_owner.department_id",
@@ -6346,6 +8166,24 @@ TigerWorkspaceCatalog {
     Object {
       "attribute": Object {
         "description": "Forecast Category",
+        "displayForms": Array [
+          Object {
+            "attribute": Object {
+              "identifier": "f_opportunitysnapshot.forecastcategory_id",
+              "type": "attribute",
+            },
+            "description": "Forecastcategory id",
+            "displayFormType": undefined,
+            "id": "f_opportunitysnapshot.forecastcategory_id",
+            "ref": Object {
+              "identifier": "f_opportunitysnapshot.forecastcategory_id",
+              "type": "displayForm",
+            },
+            "title": "Forecast Category",
+            "type": "displayForm",
+            "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/labels/f_opportunitysnapshot.forecastcategory_id",
+          },
+        ],
         "id": "f_opportunitysnapshot.forecastcategory_id",
         "ref": Object {
           "identifier": "f_opportunitysnapshot.forecastcategory_id",
@@ -6356,7 +8194,12 @@ TigerWorkspaceCatalog {
         "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/f_opportunitysnapshot.forecastcategory_id",
       },
       "defaultDisplayForm": Object {
+        "attribute": Object {
+          "identifier": "f_opportunitysnapshot.forecastcategory_id",
+          "type": "attribute",
+        },
         "description": "Forecastcategory id",
+        "displayFormType": undefined,
         "id": "f_opportunitysnapshot.forecastcategory_id",
         "ref": Object {
           "identifier": "f_opportunitysnapshot.forecastcategory_id",
@@ -6368,6 +8211,10 @@ TigerWorkspaceCatalog {
       },
       "displayForms": Array [
         Object {
+          "attribute": Object {
+            "identifier": "f_opportunitysnapshot.forecastcategory_id",
+            "type": "attribute",
+          },
           "description": "Forecastcategory id",
           "displayFormType": undefined,
           "id": "f_opportunitysnapshot.forecastcategory_id",
@@ -6392,6 +8239,24 @@ TigerWorkspaceCatalog {
     Object {
       "attribute": Object {
         "description": "Is Active?",
+        "displayForms": Array [
+          Object {
+            "attribute": Object {
+              "identifier": "f_stage.isactive_id",
+              "type": "attribute",
+            },
+            "description": "Isactive id",
+            "displayFormType": undefined,
+            "id": "f_stage.isactive_id",
+            "ref": Object {
+              "identifier": "f_stage.isactive_id",
+              "type": "displayForm",
+            },
+            "title": "Is Active?",
+            "type": "displayForm",
+            "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/labels/f_stage.isactive_id",
+          },
+        ],
         "id": "f_stage.isactive_id",
         "ref": Object {
           "identifier": "f_stage.isactive_id",
@@ -6402,7 +8267,12 @@ TigerWorkspaceCatalog {
         "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/f_stage.isactive_id",
       },
       "defaultDisplayForm": Object {
+        "attribute": Object {
+          "identifier": "f_stage.isactive_id",
+          "type": "attribute",
+        },
         "description": "Isactive id",
+        "displayFormType": undefined,
         "id": "f_stage.isactive_id",
         "ref": Object {
           "identifier": "f_stage.isactive_id",
@@ -6414,6 +8284,10 @@ TigerWorkspaceCatalog {
       },
       "displayForms": Array [
         Object {
+          "attribute": Object {
+            "identifier": "f_stage.isactive_id",
+            "type": "attribute",
+          },
           "description": "Isactive id",
           "displayFormType": undefined,
           "id": "f_stage.isactive_id",
@@ -6438,6 +8312,24 @@ TigerWorkspaceCatalog {
     Object {
       "attribute": Object {
         "description": "Is Closed?",
+        "displayForms": Array [
+          Object {
+            "attribute": Object {
+              "identifier": "f_activity.isclosed_id",
+              "type": "attribute",
+            },
+            "description": "Isclosed id",
+            "displayFormType": undefined,
+            "id": "f_activity.isclosed_id",
+            "ref": Object {
+              "identifier": "f_activity.isclosed_id",
+              "type": "displayForm",
+            },
+            "title": "Is Closed?",
+            "type": "displayForm",
+            "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/labels/f_activity.isclosed_id",
+          },
+        ],
         "id": "f_activity.isclosed_id",
         "ref": Object {
           "identifier": "f_activity.isclosed_id",
@@ -6448,7 +8340,12 @@ TigerWorkspaceCatalog {
         "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/f_activity.isclosed_id",
       },
       "defaultDisplayForm": Object {
+        "attribute": Object {
+          "identifier": "f_activity.isclosed_id",
+          "type": "attribute",
+        },
         "description": "Isclosed id",
+        "displayFormType": undefined,
         "id": "f_activity.isclosed_id",
         "ref": Object {
           "identifier": "f_activity.isclosed_id",
@@ -6460,6 +8357,10 @@ TigerWorkspaceCatalog {
       },
       "displayForms": Array [
         Object {
+          "attribute": Object {
+            "identifier": "f_activity.isclosed_id",
+            "type": "attribute",
+          },
           "description": "Isclosed id",
           "displayFormType": undefined,
           "id": "f_activity.isclosed_id",
@@ -6484,6 +8385,24 @@ TigerWorkspaceCatalog {
     Object {
       "attribute": Object {
         "description": "Is Closed?",
+        "displayForms": Array [
+          Object {
+            "attribute": Object {
+              "identifier": "f_stage.isclosed_id",
+              "type": "attribute",
+            },
+            "description": "Isclosed id",
+            "displayFormType": undefined,
+            "id": "f_stage.isclosed_id",
+            "ref": Object {
+              "identifier": "f_stage.isclosed_id",
+              "type": "displayForm",
+            },
+            "title": "Is Closed?",
+            "type": "displayForm",
+            "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/labels/f_stage.isclosed_id",
+          },
+        ],
         "id": "f_stage.isclosed_id",
         "ref": Object {
           "identifier": "f_stage.isclosed_id",
@@ -6494,7 +8413,12 @@ TigerWorkspaceCatalog {
         "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/f_stage.isclosed_id",
       },
       "defaultDisplayForm": Object {
+        "attribute": Object {
+          "identifier": "f_stage.isclosed_id",
+          "type": "attribute",
+        },
         "description": "Isclosed id",
+        "displayFormType": undefined,
         "id": "f_stage.isclosed_id",
         "ref": Object {
           "identifier": "f_stage.isclosed_id",
@@ -6506,6 +8430,10 @@ TigerWorkspaceCatalog {
       },
       "displayForms": Array [
         Object {
+          "attribute": Object {
+            "identifier": "f_stage.isclosed_id",
+            "type": "attribute",
+          },
           "description": "Isclosed id",
           "displayFormType": undefined,
           "id": "f_stage.isclosed_id",
@@ -6530,6 +8458,24 @@ TigerWorkspaceCatalog {
     Object {
       "attribute": Object {
         "description": "Is Task?",
+        "displayForms": Array [
+          Object {
+            "attribute": Object {
+              "identifier": "f_activity.istask_id",
+              "type": "attribute",
+            },
+            "description": "Istask id",
+            "displayFormType": undefined,
+            "id": "f_activity.istask_id",
+            "ref": Object {
+              "identifier": "f_activity.istask_id",
+              "type": "displayForm",
+            },
+            "title": "Is Task?",
+            "type": "displayForm",
+            "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/labels/f_activity.istask_id",
+          },
+        ],
         "id": "f_activity.istask_id",
         "ref": Object {
           "identifier": "f_activity.istask_id",
@@ -6540,7 +8486,12 @@ TigerWorkspaceCatalog {
         "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/f_activity.istask_id",
       },
       "defaultDisplayForm": Object {
+        "attribute": Object {
+          "identifier": "f_activity.istask_id",
+          "type": "attribute",
+        },
         "description": "Istask id",
+        "displayFormType": undefined,
         "id": "f_activity.istask_id",
         "ref": Object {
           "identifier": "f_activity.istask_id",
@@ -6552,6 +8503,10 @@ TigerWorkspaceCatalog {
       },
       "displayForms": Array [
         Object {
+          "attribute": Object {
+            "identifier": "f_activity.istask_id",
+            "type": "attribute",
+          },
           "description": "Istask id",
           "displayFormType": undefined,
           "id": "f_activity.istask_id",
@@ -6576,6 +8531,24 @@ TigerWorkspaceCatalog {
     Object {
       "attribute": Object {
         "description": "Is Won?",
+        "displayForms": Array [
+          Object {
+            "attribute": Object {
+              "identifier": "f_stage.iswon_id",
+              "type": "attribute",
+            },
+            "description": "Iswon id",
+            "displayFormType": undefined,
+            "id": "f_stage.iswon_id",
+            "ref": Object {
+              "identifier": "f_stage.iswon_id",
+              "type": "displayForm",
+            },
+            "title": "Is Won?",
+            "type": "displayForm",
+            "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/labels/f_stage.iswon_id",
+          },
+        ],
         "id": "f_stage.iswon_id",
         "ref": Object {
           "identifier": "f_stage.iswon_id",
@@ -6586,7 +8559,12 @@ TigerWorkspaceCatalog {
         "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/f_stage.iswon_id",
       },
       "defaultDisplayForm": Object {
+        "attribute": Object {
+          "identifier": "f_stage.iswon_id",
+          "type": "attribute",
+        },
         "description": "Iswon id",
+        "displayFormType": undefined,
         "id": "f_stage.iswon_id",
         "ref": Object {
           "identifier": "f_stage.iswon_id",
@@ -6598,6 +8576,10 @@ TigerWorkspaceCatalog {
       },
       "displayForms": Array [
         Object {
+          "attribute": Object {
+            "identifier": "f_stage.iswon_id",
+            "type": "attribute",
+          },
           "description": "Iswon id",
           "displayFormType": undefined,
           "id": "f_stage.iswon_id",
@@ -6698,6 +8680,24 @@ TigerWorkspaceCatalog {
     Object {
       "attribute": Object {
         "description": "Opp. Snapshot",
+        "displayForms": Array [
+          Object {
+            "attribute": Object {
+              "identifier": "attr.f_opportunitysnapshot.oppsnapshot",
+              "type": "attribute",
+            },
+            "description": "",
+            "displayFormType": undefined,
+            "id": "label.f_opportunitysnapshot.oppsnapshot",
+            "ref": Object {
+              "identifier": "label.f_opportunitysnapshot.oppsnapshot",
+              "type": "displayForm",
+            },
+            "title": "Opp. Snapshot",
+            "type": "displayForm",
+            "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/labels/label.f_opportunitysnapshot.oppsnapshot",
+          },
+        ],
         "id": "attr.f_opportunitysnapshot.oppsnapshot",
         "ref": Object {
           "identifier": "attr.f_opportunitysnapshot.oppsnapshot",
@@ -6708,7 +8708,12 @@ TigerWorkspaceCatalog {
         "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/attr.f_opportunitysnapshot.oppsnapshot",
       },
       "defaultDisplayForm": Object {
+        "attribute": Object {
+          "identifier": "attr.f_opportunitysnapshot.oppsnapshot",
+          "type": "attribute",
+        },
         "description": "",
+        "displayFormType": undefined,
         "id": "label.f_opportunitysnapshot.oppsnapshot",
         "ref": Object {
           "identifier": "label.f_opportunitysnapshot.oppsnapshot",
@@ -6720,6 +8725,10 @@ TigerWorkspaceCatalog {
       },
       "displayForms": Array [
         Object {
+          "attribute": Object {
+            "identifier": "attr.f_opportunitysnapshot.oppsnapshot",
+            "type": "attribute",
+          },
           "description": "",
           "displayFormType": undefined,
           "id": "label.f_opportunitysnapshot.oppsnapshot",
@@ -6764,6 +8773,24 @@ TigerWorkspaceCatalog {
     Object {
       "attribute": Object {
         "description": "Opp. Snapshot Id",
+        "displayForms": Array [
+          Object {
+            "attribute": Object {
+              "identifier": "f_opportunitysnapshot.id",
+              "type": "attribute",
+            },
+            "description": "Id",
+            "displayFormType": undefined,
+            "id": "f_opportunitysnapshot.id",
+            "ref": Object {
+              "identifier": "f_opportunitysnapshot.id",
+              "type": "displayForm",
+            },
+            "title": "Opp. Snapshot Id",
+            "type": "displayForm",
+            "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/labels/f_opportunitysnapshot.id",
+          },
+        ],
         "id": "f_opportunitysnapshot.id",
         "ref": Object {
           "identifier": "f_opportunitysnapshot.id",
@@ -6774,7 +8801,12 @@ TigerWorkspaceCatalog {
         "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/f_opportunitysnapshot.id",
       },
       "defaultDisplayForm": Object {
+        "attribute": Object {
+          "identifier": "f_opportunitysnapshot.id",
+          "type": "attribute",
+        },
         "description": "Id",
+        "displayFormType": undefined,
         "id": "f_opportunitysnapshot.id",
         "ref": Object {
           "identifier": "f_opportunitysnapshot.id",
@@ -6786,6 +8818,10 @@ TigerWorkspaceCatalog {
       },
       "displayForms": Array [
         Object {
+          "attribute": Object {
+            "identifier": "f_opportunitysnapshot.id",
+            "type": "attribute",
+          },
           "description": "Id",
           "displayFormType": undefined,
           "id": "f_opportunitysnapshot.id",
@@ -6810,6 +8846,56 @@ TigerWorkspaceCatalog {
     Object {
       "attribute": Object {
         "description": "Opportunity",
+        "displayForms": Array [
+          Object {
+            "attribute": Object {
+              "identifier": "attr.f_opportunity.opportunity",
+              "type": "attribute",
+            },
+            "description": "",
+            "displayFormType": undefined,
+            "id": "label.f_opportunity.opportunity.opportunity",
+            "ref": Object {
+              "identifier": "label.f_opportunity.opportunity.opportunity",
+              "type": "displayForm",
+            },
+            "title": "Opportunity",
+            "type": "displayForm",
+            "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/labels/label.f_opportunity.opportunity.opportunity",
+          },
+          Object {
+            "attribute": Object {
+              "identifier": "attr.f_opportunity.opportunity",
+              "type": "attribute",
+            },
+            "description": "",
+            "displayFormType": undefined,
+            "id": "label.f_opportunity.opportunity.sfdcurl",
+            "ref": Object {
+              "identifier": "label.f_opportunity.opportunity.sfdcurl",
+              "type": "displayForm",
+            },
+            "title": "SFDC URL",
+            "type": "displayForm",
+            "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/labels/label.f_opportunity.opportunity.sfdcurl",
+          },
+          Object {
+            "attribute": Object {
+              "identifier": "attr.f_opportunity.opportunity",
+              "type": "attribute",
+            },
+            "description": "",
+            "displayFormType": undefined,
+            "id": "label.f_opportunity.opportunity",
+            "ref": Object {
+              "identifier": "label.f_opportunity.opportunity",
+              "type": "displayForm",
+            },
+            "title": "Opportunity Name",
+            "type": "displayForm",
+            "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/labels/label.f_opportunity.opportunity",
+          },
+        ],
         "id": "attr.f_opportunity.opportunity",
         "ref": Object {
           "identifier": "attr.f_opportunity.opportunity",
@@ -6820,7 +8906,12 @@ TigerWorkspaceCatalog {
         "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/attr.f_opportunity.opportunity",
       },
       "defaultDisplayForm": Object {
+        "attribute": Object {
+          "identifier": "attr.f_opportunity.opportunity",
+          "type": "attribute",
+        },
         "description": "",
+        "displayFormType": undefined,
         "id": "label.f_opportunity.opportunity",
         "ref": Object {
           "identifier": "label.f_opportunity.opportunity",
@@ -6832,6 +8923,10 @@ TigerWorkspaceCatalog {
       },
       "displayForms": Array [
         Object {
+          "attribute": Object {
+            "identifier": "attr.f_opportunity.opportunity",
+            "type": "attribute",
+          },
           "description": "",
           "displayFormType": undefined,
           "id": "label.f_opportunity.opportunity.opportunity",
@@ -6844,6 +8939,10 @@ TigerWorkspaceCatalog {
           "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/labels/label.f_opportunity.opportunity.opportunity",
         },
         Object {
+          "attribute": Object {
+            "identifier": "attr.f_opportunity.opportunity",
+            "type": "attribute",
+          },
           "description": "",
           "displayFormType": undefined,
           "id": "label.f_opportunity.opportunity.sfdcurl",
@@ -6856,6 +8955,10 @@ TigerWorkspaceCatalog {
           "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/labels/label.f_opportunity.opportunity.sfdcurl",
         },
         Object {
+          "attribute": Object {
+            "identifier": "attr.f_opportunity.opportunity",
+            "type": "attribute",
+          },
           "description": "",
           "displayFormType": undefined,
           "id": "label.f_opportunity.opportunity",
@@ -6880,6 +8983,24 @@ TigerWorkspaceCatalog {
     Object {
       "attribute": Object {
         "description": "Opportunity Id",
+        "displayForms": Array [
+          Object {
+            "attribute": Object {
+              "identifier": "f_opportunity.id",
+              "type": "attribute",
+            },
+            "description": "Id",
+            "displayFormType": undefined,
+            "id": "f_opportunity.id",
+            "ref": Object {
+              "identifier": "f_opportunity.id",
+              "type": "displayForm",
+            },
+            "title": "Opportunity Id",
+            "type": "displayForm",
+            "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/labels/f_opportunity.id",
+          },
+        ],
         "id": "f_opportunity.id",
         "ref": Object {
           "identifier": "f_opportunity.id",
@@ -6890,7 +9011,12 @@ TigerWorkspaceCatalog {
         "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/f_opportunity.id",
       },
       "defaultDisplayForm": Object {
+        "attribute": Object {
+          "identifier": "f_opportunity.id",
+          "type": "attribute",
+        },
         "description": "Id",
+        "displayFormType": undefined,
         "id": "f_opportunity.id",
         "ref": Object {
           "identifier": "f_opportunity.id",
@@ -6902,6 +9028,10 @@ TigerWorkspaceCatalog {
       },
       "displayForms": Array [
         Object {
+          "attribute": Object {
+            "identifier": "f_opportunity.id",
+            "type": "attribute",
+          },
           "description": "Id",
           "displayFormType": undefined,
           "id": "f_opportunity.id",
@@ -6926,6 +9056,24 @@ TigerWorkspaceCatalog {
     Object {
       "attribute": Object {
         "description": "Id",
+        "displayForms": Array [
+          Object {
+            "attribute": Object {
+              "identifier": "f_owner.id",
+              "type": "attribute",
+            },
+            "description": "Id",
+            "displayFormType": undefined,
+            "id": "f_owner.id",
+            "ref": Object {
+              "identifier": "f_owner.id",
+              "type": "displayForm",
+            },
+            "title": "Owner Id",
+            "type": "displayForm",
+            "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/labels/f_owner.id",
+          },
+        ],
         "id": "f_owner.id",
         "ref": Object {
           "identifier": "f_owner.id",
@@ -6936,7 +9084,12 @@ TigerWorkspaceCatalog {
         "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/f_owner.id",
       },
       "defaultDisplayForm": Object {
+        "attribute": Object {
+          "identifier": "f_owner.id",
+          "type": "attribute",
+        },
         "description": "Id",
+        "displayFormType": undefined,
         "id": "f_owner.id",
         "ref": Object {
           "identifier": "f_owner.id",
@@ -6948,6 +9101,10 @@ TigerWorkspaceCatalog {
       },
       "displayForms": Array [
         Object {
+          "attribute": Object {
+            "identifier": "f_owner.id",
+            "type": "attribute",
+          },
           "description": "Id",
           "displayFormType": undefined,
           "id": "f_owner.id",
@@ -6972,6 +9129,24 @@ TigerWorkspaceCatalog {
     Object {
       "attribute": Object {
         "description": "Priority",
+        "displayForms": Array [
+          Object {
+            "attribute": Object {
+              "identifier": "f_activity.priority_id",
+              "type": "attribute",
+            },
+            "description": "Priority id",
+            "displayFormType": undefined,
+            "id": "f_activity.priority_id",
+            "ref": Object {
+              "identifier": "f_activity.priority_id",
+              "type": "displayForm",
+            },
+            "title": "Priority",
+            "type": "displayForm",
+            "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/labels/f_activity.priority_id",
+          },
+        ],
         "id": "f_activity.priority_id",
         "ref": Object {
           "identifier": "f_activity.priority_id",
@@ -6982,7 +9157,12 @@ TigerWorkspaceCatalog {
         "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/f_activity.priority_id",
       },
       "defaultDisplayForm": Object {
+        "attribute": Object {
+          "identifier": "f_activity.priority_id",
+          "type": "attribute",
+        },
         "description": "Priority id",
+        "displayFormType": undefined,
         "id": "f_activity.priority_id",
         "ref": Object {
           "identifier": "f_activity.priority_id",
@@ -6994,6 +9174,10 @@ TigerWorkspaceCatalog {
       },
       "displayForms": Array [
         Object {
+          "attribute": Object {
+            "identifier": "f_activity.priority_id",
+            "type": "attribute",
+          },
           "description": "Priority id",
           "displayFormType": undefined,
           "id": "f_activity.priority_id",
@@ -7056,6 +9240,40 @@ TigerWorkspaceCatalog {
     Object {
       "attribute": Object {
         "description": "Product",
+        "displayForms": Array [
+          Object {
+            "attribute": Object {
+              "identifier": "attr.f_product.product",
+              "type": "attribute",
+            },
+            "description": "",
+            "displayFormType": undefined,
+            "id": "label.f_product.product.productid",
+            "ref": Object {
+              "identifier": "label.f_product.product.productid",
+              "type": "displayForm",
+            },
+            "title": "Product",
+            "type": "displayForm",
+            "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/labels/label.f_product.product.productid",
+          },
+          Object {
+            "attribute": Object {
+              "identifier": "attr.f_product.product",
+              "type": "attribute",
+            },
+            "description": "",
+            "displayFormType": undefined,
+            "id": "label.f_product.product",
+            "ref": Object {
+              "identifier": "label.f_product.product",
+              "type": "displayForm",
+            },
+            "title": "Product Name",
+            "type": "displayForm",
+            "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/labels/label.f_product.product",
+          },
+        ],
         "id": "attr.f_product.product",
         "ref": Object {
           "identifier": "attr.f_product.product",
@@ -7066,7 +9284,12 @@ TigerWorkspaceCatalog {
         "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/attr.f_product.product",
       },
       "defaultDisplayForm": Object {
+        "attribute": Object {
+          "identifier": "attr.f_product.product",
+          "type": "attribute",
+        },
         "description": "",
+        "displayFormType": undefined,
         "id": "label.f_product.product",
         "ref": Object {
           "identifier": "label.f_product.product",
@@ -7078,6 +9301,10 @@ TigerWorkspaceCatalog {
       },
       "displayForms": Array [
         Object {
+          "attribute": Object {
+            "identifier": "attr.f_product.product",
+            "type": "attribute",
+          },
           "description": "",
           "displayFormType": undefined,
           "id": "label.f_product.product.productid",
@@ -7090,6 +9317,10 @@ TigerWorkspaceCatalog {
           "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/labels/label.f_product.product.productid",
         },
         Object {
+          "attribute": Object {
+            "identifier": "attr.f_product.product",
+            "type": "attribute",
+          },
           "description": "",
           "displayFormType": undefined,
           "id": "label.f_product.product",
@@ -7114,6 +9345,24 @@ TigerWorkspaceCatalog {
     Object {
       "attribute": Object {
         "description": "Product",
+        "displayForms": Array [
+          Object {
+            "attribute": Object {
+              "identifier": "f_product.id",
+              "type": "attribute",
+            },
+            "description": "Id",
+            "displayFormType": undefined,
+            "id": "f_product.id",
+            "ref": Object {
+              "identifier": "f_product.id",
+              "type": "displayForm",
+            },
+            "title": "Product Id",
+            "type": "displayForm",
+            "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/labels/f_product.id",
+          },
+        ],
         "id": "f_product.id",
         "ref": Object {
           "identifier": "f_product.id",
@@ -7124,7 +9373,12 @@ TigerWorkspaceCatalog {
         "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/f_product.id",
       },
       "defaultDisplayForm": Object {
+        "attribute": Object {
+          "identifier": "f_product.id",
+          "type": "attribute",
+        },
         "description": "Id",
+        "displayFormType": undefined,
         "id": "f_product.id",
         "ref": Object {
           "identifier": "f_product.id",
@@ -7136,6 +9390,10 @@ TigerWorkspaceCatalog {
       },
       "displayForms": Array [
         Object {
+          "attribute": Object {
+            "identifier": "f_product.id",
+            "type": "attribute",
+          },
           "description": "Id",
           "displayFormType": undefined,
           "id": "f_product.id",
@@ -7160,6 +9418,24 @@ TigerWorkspaceCatalog {
     Object {
       "attribute": Object {
         "description": "Region",
+        "displayForms": Array [
+          Object {
+            "attribute": Object {
+              "identifier": "f_owner.region_id",
+              "type": "attribute",
+            },
+            "description": "Region id",
+            "displayFormType": undefined,
+            "id": "f_owner.region_id",
+            "ref": Object {
+              "identifier": "f_owner.region_id",
+              "type": "displayForm",
+            },
+            "title": "Region",
+            "type": "displayForm",
+            "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/labels/f_owner.region_id",
+          },
+        ],
         "id": "f_owner.region_id",
         "ref": Object {
           "identifier": "f_owner.region_id",
@@ -7170,7 +9446,12 @@ TigerWorkspaceCatalog {
         "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/f_owner.region_id",
       },
       "defaultDisplayForm": Object {
+        "attribute": Object {
+          "identifier": "f_owner.region_id",
+          "type": "attribute",
+        },
         "description": "Region id",
+        "displayFormType": undefined,
         "id": "f_owner.region_id",
         "ref": Object {
           "identifier": "f_owner.region_id",
@@ -7182,6 +9463,10 @@ TigerWorkspaceCatalog {
       },
       "displayForms": Array [
         Object {
+          "attribute": Object {
+            "identifier": "f_owner.region_id",
+            "type": "attribute",
+          },
           "description": "Region id",
           "displayFormType": undefined,
           "id": "f_owner.region_id",
@@ -7206,6 +9491,40 @@ TigerWorkspaceCatalog {
     Object {
       "attribute": Object {
         "description": "",
+        "displayForms": Array [
+          Object {
+            "attribute": Object {
+              "identifier": "attr.f_owner.salesrep",
+              "type": "attribute",
+            },
+            "description": "",
+            "displayFormType": undefined,
+            "id": "label.f_owner.salesrep",
+            "ref": Object {
+              "identifier": "label.f_owner.salesrep",
+              "type": "displayForm",
+            },
+            "title": "Owner Name",
+            "type": "displayForm",
+            "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/labels/label.f_owner.salesrep",
+          },
+          Object {
+            "attribute": Object {
+              "identifier": "attr.f_owner.salesrep",
+              "type": "attribute",
+            },
+            "description": "",
+            "displayFormType": undefined,
+            "id": "label.f_owner.salesrep.owner",
+            "ref": Object {
+              "identifier": "label.f_owner.salesrep.owner",
+              "type": "displayForm",
+            },
+            "title": "Owner",
+            "type": "displayForm",
+            "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/labels/label.f_owner.salesrep.owner",
+          },
+        ],
         "id": "attr.f_owner.salesrep",
         "ref": Object {
           "identifier": "attr.f_owner.salesrep",
@@ -7216,7 +9535,12 @@ TigerWorkspaceCatalog {
         "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/attr.f_owner.salesrep",
       },
       "defaultDisplayForm": Object {
+        "attribute": Object {
+          "identifier": "attr.f_owner.salesrep",
+          "type": "attribute",
+        },
         "description": "",
+        "displayFormType": undefined,
         "id": "label.f_owner.salesrep",
         "ref": Object {
           "identifier": "label.f_owner.salesrep",
@@ -7228,6 +9552,10 @@ TigerWorkspaceCatalog {
       },
       "displayForms": Array [
         Object {
+          "attribute": Object {
+            "identifier": "attr.f_owner.salesrep",
+            "type": "attribute",
+          },
           "description": "",
           "displayFormType": undefined,
           "id": "label.f_owner.salesrep",
@@ -7240,6 +9568,10 @@ TigerWorkspaceCatalog {
           "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/labels/label.f_owner.salesrep",
         },
         Object {
+          "attribute": Object {
+            "identifier": "attr.f_owner.salesrep",
+            "type": "attribute",
+          },
           "description": "",
           "displayFormType": undefined,
           "id": "label.f_owner.salesrep.owner",
@@ -7282,6 +9614,24 @@ TigerWorkspaceCatalog {
     Object {
       "attribute": Object {
         "description": "Stage History",
+        "displayForms": Array [
+          Object {
+            "attribute": Object {
+              "identifier": "attr.f_stagehistory.stagehistory",
+              "type": "attribute",
+            },
+            "description": "",
+            "displayFormType": undefined,
+            "id": "label.f_stagehistory.stagehistory",
+            "ref": Object {
+              "identifier": "label.f_stagehistory.stagehistory",
+              "type": "displayForm",
+            },
+            "title": "Stage History",
+            "type": "displayForm",
+            "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/labels/label.f_stagehistory.stagehistory",
+          },
+        ],
         "id": "attr.f_stagehistory.stagehistory",
         "ref": Object {
           "identifier": "attr.f_stagehistory.stagehistory",
@@ -7292,7 +9642,12 @@ TigerWorkspaceCatalog {
         "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/attr.f_stagehistory.stagehistory",
       },
       "defaultDisplayForm": Object {
+        "attribute": Object {
+          "identifier": "attr.f_stagehistory.stagehistory",
+          "type": "attribute",
+        },
         "description": "",
+        "displayFormType": undefined,
         "id": "label.f_stagehistory.stagehistory",
         "ref": Object {
           "identifier": "label.f_stagehistory.stagehistory",
@@ -7304,6 +9659,10 @@ TigerWorkspaceCatalog {
       },
       "displayForms": Array [
         Object {
+          "attribute": Object {
+            "identifier": "attr.f_stagehistory.stagehistory",
+            "type": "attribute",
+          },
           "description": "",
           "displayFormType": undefined,
           "id": "label.f_stagehistory.stagehistory",
@@ -7328,6 +9687,24 @@ TigerWorkspaceCatalog {
     Object {
       "attribute": Object {
         "description": "Stage History Id",
+        "displayForms": Array [
+          Object {
+            "attribute": Object {
+              "identifier": "f_stagehistory.id",
+              "type": "attribute",
+            },
+            "description": "Id",
+            "displayFormType": undefined,
+            "id": "f_stagehistory.id",
+            "ref": Object {
+              "identifier": "f_stagehistory.id",
+              "type": "displayForm",
+            },
+            "title": "Stage History Id",
+            "type": "displayForm",
+            "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/labels/f_stagehistory.id",
+          },
+        ],
         "id": "f_stagehistory.id",
         "ref": Object {
           "identifier": "f_stagehistory.id",
@@ -7338,7 +9715,12 @@ TigerWorkspaceCatalog {
         "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/f_stagehistory.id",
       },
       "defaultDisplayForm": Object {
+        "attribute": Object {
+          "identifier": "f_stagehistory.id",
+          "type": "attribute",
+        },
         "description": "Id",
+        "displayFormType": undefined,
         "id": "f_stagehistory.id",
         "ref": Object {
           "identifier": "f_stagehistory.id",
@@ -7350,6 +9732,10 @@ TigerWorkspaceCatalog {
       },
       "displayForms": Array [
         Object {
+          "attribute": Object {
+            "identifier": "f_stagehistory.id",
+            "type": "attribute",
+          },
           "description": "Id",
           "displayFormType": undefined,
           "id": "f_stagehistory.id",
@@ -7374,6 +9760,24 @@ TigerWorkspaceCatalog {
     Object {
       "attribute": Object {
         "description": "Stage Id",
+        "displayForms": Array [
+          Object {
+            "attribute": Object {
+              "identifier": "f_stage.id",
+              "type": "attribute",
+            },
+            "description": "Id",
+            "displayFormType": undefined,
+            "id": "f_stage.id",
+            "ref": Object {
+              "identifier": "f_stage.id",
+              "type": "displayForm",
+            },
+            "title": "Stage Id",
+            "type": "displayForm",
+            "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/labels/f_stage.id",
+          },
+        ],
         "id": "f_stage.id",
         "ref": Object {
           "identifier": "f_stage.id",
@@ -7384,7 +9788,12 @@ TigerWorkspaceCatalog {
         "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/f_stage.id",
       },
       "defaultDisplayForm": Object {
+        "attribute": Object {
+          "identifier": "f_stage.id",
+          "type": "attribute",
+        },
         "description": "Id",
+        "displayFormType": undefined,
         "id": "f_stage.id",
         "ref": Object {
           "identifier": "f_stage.id",
@@ -7396,6 +9805,10 @@ TigerWorkspaceCatalog {
       },
       "displayForms": Array [
         Object {
+          "attribute": Object {
+            "identifier": "f_stage.id",
+            "type": "attribute",
+          },
           "description": "Id",
           "displayFormType": undefined,
           "id": "f_stage.id",
@@ -7420,6 +9833,56 @@ TigerWorkspaceCatalog {
     Object {
       "attribute": Object {
         "description": "Stage Name",
+        "displayForms": Array [
+          Object {
+            "attribute": Object {
+              "identifier": "attr.f_stage.stagename",
+              "type": "attribute",
+            },
+            "description": "",
+            "displayFormType": undefined,
+            "id": "label.f_stage.stagename.order",
+            "ref": Object {
+              "identifier": "label.f_stage.stagename.order",
+              "type": "displayForm",
+            },
+            "title": "Order",
+            "type": "displayForm",
+            "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/labels/label.f_stage.stagename.order",
+          },
+          Object {
+            "attribute": Object {
+              "identifier": "attr.f_stage.stagename",
+              "type": "attribute",
+            },
+            "description": "",
+            "displayFormType": undefined,
+            "id": "label.f_stage.stagename.stagename",
+            "ref": Object {
+              "identifier": "label.f_stage.stagename.stagename",
+              "type": "displayForm",
+            },
+            "title": "Stage Name",
+            "type": "displayForm",
+            "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/labels/label.f_stage.stagename.stagename",
+          },
+          Object {
+            "attribute": Object {
+              "identifier": "attr.f_stage.stagename",
+              "type": "attribute",
+            },
+            "description": "",
+            "displayFormType": undefined,
+            "id": "label.f_stage.stagename",
+            "ref": Object {
+              "identifier": "label.f_stage.stagename",
+              "type": "displayForm",
+            },
+            "title": "Stage Name",
+            "type": "displayForm",
+            "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/labels/label.f_stage.stagename",
+          },
+        ],
         "id": "attr.f_stage.stagename",
         "ref": Object {
           "identifier": "attr.f_stage.stagename",
@@ -7430,7 +9893,12 @@ TigerWorkspaceCatalog {
         "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/attr.f_stage.stagename",
       },
       "defaultDisplayForm": Object {
+        "attribute": Object {
+          "identifier": "attr.f_stage.stagename",
+          "type": "attribute",
+        },
         "description": "",
+        "displayFormType": undefined,
         "id": "label.f_stage.stagename",
         "ref": Object {
           "identifier": "label.f_stage.stagename",
@@ -7442,6 +9910,10 @@ TigerWorkspaceCatalog {
       },
       "displayForms": Array [
         Object {
+          "attribute": Object {
+            "identifier": "attr.f_stage.stagename",
+            "type": "attribute",
+          },
           "description": "",
           "displayFormType": undefined,
           "id": "label.f_stage.stagename.order",
@@ -7454,6 +9926,10 @@ TigerWorkspaceCatalog {
           "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/labels/label.f_stage.stagename.order",
         },
         Object {
+          "attribute": Object {
+            "identifier": "attr.f_stage.stagename",
+            "type": "attribute",
+          },
           "description": "",
           "displayFormType": undefined,
           "id": "label.f_stage.stagename.stagename",
@@ -7466,6 +9942,10 @@ TigerWorkspaceCatalog {
           "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/labels/label.f_stage.stagename.stagename",
         },
         Object {
+          "attribute": Object {
+            "identifier": "attr.f_stage.stagename",
+            "type": "attribute",
+          },
           "description": "",
           "displayFormType": undefined,
           "id": "label.f_stage.stagename",
@@ -7490,6 +9970,24 @@ TigerWorkspaceCatalog {
     Object {
       "attribute": Object {
         "description": "Status",
+        "displayForms": Array [
+          Object {
+            "attribute": Object {
+              "identifier": "f_activity.status_id",
+              "type": "attribute",
+            },
+            "description": "Status id",
+            "displayFormType": undefined,
+            "id": "f_activity.status_id",
+            "ref": Object {
+              "identifier": "f_activity.status_id",
+              "type": "displayForm",
+            },
+            "title": "Status",
+            "type": "displayForm",
+            "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/labels/f_activity.status_id",
+          },
+        ],
         "id": "f_activity.status_id",
         "ref": Object {
           "identifier": "f_activity.status_id",
@@ -7500,7 +9998,12 @@ TigerWorkspaceCatalog {
         "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/f_activity.status_id",
       },
       "defaultDisplayForm": Object {
+        "attribute": Object {
+          "identifier": "f_activity.status_id",
+          "type": "attribute",
+        },
         "description": "Status id",
+        "displayFormType": undefined,
         "id": "f_activity.status_id",
         "ref": Object {
           "identifier": "f_activity.status_id",
@@ -7512,6 +10015,10 @@ TigerWorkspaceCatalog {
       },
       "displayForms": Array [
         Object {
+          "attribute": Object {
+            "identifier": "f_activity.status_id",
+            "type": "attribute",
+          },
           "description": "Status id",
           "displayFormType": undefined,
           "id": "f_activity.status_id",
@@ -7536,6 +10043,24 @@ TigerWorkspaceCatalog {
     Object {
       "attribute": Object {
         "description": "Status",
+        "displayForms": Array [
+          Object {
+            "attribute": Object {
+              "identifier": "f_stage.status_id",
+              "type": "attribute",
+            },
+            "description": "Status id",
+            "displayFormType": undefined,
+            "id": "f_stage.status_id",
+            "ref": Object {
+              "identifier": "f_stage.status_id",
+              "type": "displayForm",
+            },
+            "title": "Status",
+            "type": "displayForm",
+            "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/labels/f_stage.status_id",
+          },
+        ],
         "id": "f_stage.status_id",
         "ref": Object {
           "identifier": "f_stage.status_id",
@@ -7546,7 +10071,12 @@ TigerWorkspaceCatalog {
         "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/f_stage.status_id",
       },
       "defaultDisplayForm": Object {
+        "attribute": Object {
+          "identifier": "f_stage.status_id",
+          "type": "attribute",
+        },
         "description": "Status id",
+        "displayFormType": undefined,
         "id": "f_stage.status_id",
         "ref": Object {
           "identifier": "f_stage.status_id",
@@ -7558,6 +10088,10 @@ TigerWorkspaceCatalog {
       },
       "displayForms": Array [
         Object {
+          "attribute": Object {
+            "identifier": "f_stage.status_id",
+            "type": "attribute",
+          },
           "description": "Status id",
           "displayFormType": undefined,
           "id": "f_stage.status_id",
@@ -7582,6 +10116,24 @@ TigerWorkspaceCatalog {
     Object {
       "attribute": Object {
         "description": "Timeline",
+        "displayForms": Array [
+          Object {
+            "attribute": Object {
+              "identifier": "f_timeline.id",
+              "type": "attribute",
+            },
+            "description": "Id",
+            "displayFormType": undefined,
+            "id": "f_timeline.id",
+            "ref": Object {
+              "identifier": "f_timeline.id",
+              "type": "displayForm",
+            },
+            "title": "Timeline",
+            "type": "displayForm",
+            "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/labels/f_timeline.id",
+          },
+        ],
         "id": "f_timeline.id",
         "ref": Object {
           "identifier": "f_timeline.id",
@@ -7592,7 +10144,12 @@ TigerWorkspaceCatalog {
         "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/f_timeline.id",
       },
       "defaultDisplayForm": Object {
+        "attribute": Object {
+          "identifier": "f_timeline.id",
+          "type": "attribute",
+        },
         "description": "Id",
+        "displayFormType": undefined,
         "id": "f_timeline.id",
         "ref": Object {
           "identifier": "f_timeline.id",
@@ -7604,6 +10161,10 @@ TigerWorkspaceCatalog {
       },
       "displayForms": Array [
         Object {
+          "attribute": Object {
+            "identifier": "f_timeline.id",
+            "type": "attribute",
+          },
           "description": "Id",
           "displayFormType": undefined,
           "id": "f_timeline.id",
@@ -7829,6 +10390,10 @@ TigerWorkspaceCatalog {
             "description": "Minute",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_activity_timestamp.minute",
+                  "type": "attribute",
+                },
                 "description": "Minute",
                 "displayFormType": undefined,
                 "id": "dt_activity_timestamp.minute",
@@ -7851,7 +10416,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_activity_timestamp.minute",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_activity_timestamp.minute",
+              "type": "attribute",
+            },
             "description": "Minute",
+            "displayFormType": undefined,
             "id": "dt_activity_timestamp.minute",
             "ref": Object {
               "identifier": "dt_activity_timestamp.minute",
@@ -7868,6 +10438,10 @@ TigerWorkspaceCatalog {
             "description": "Hour",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_activity_timestamp.hour",
+                  "type": "attribute",
+                },
                 "description": "Hour",
                 "displayFormType": undefined,
                 "id": "dt_activity_timestamp.hour",
@@ -7890,7 +10464,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_activity_timestamp.hour",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_activity_timestamp.hour",
+              "type": "attribute",
+            },
             "description": "Hour",
+            "displayFormType": undefined,
             "id": "dt_activity_timestamp.hour",
             "ref": Object {
               "identifier": "dt_activity_timestamp.hour",
@@ -7907,6 +10486,10 @@ TigerWorkspaceCatalog {
             "description": "Date",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_activity_timestamp.day",
+                  "type": "attribute",
+                },
                 "description": "Date",
                 "displayFormType": undefined,
                 "id": "dt_activity_timestamp.day",
@@ -7929,7 +10512,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_activity_timestamp.day",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_activity_timestamp.day",
+              "type": "attribute",
+            },
             "description": "Date",
+            "displayFormType": undefined,
             "id": "dt_activity_timestamp.day",
             "ref": Object {
               "identifier": "dt_activity_timestamp.day",
@@ -7946,6 +10534,10 @@ TigerWorkspaceCatalog {
             "description": "Week and Year (W52/2020)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_activity_timestamp.week",
+                  "type": "attribute",
+                },
                 "description": "Week and Year (W52/2020)",
                 "displayFormType": undefined,
                 "id": "dt_activity_timestamp.week",
@@ -7968,7 +10560,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_activity_timestamp.week",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_activity_timestamp.week",
+              "type": "attribute",
+            },
             "description": "Week and Year (W52/2020)",
+            "displayFormType": undefined,
             "id": "dt_activity_timestamp.week",
             "ref": Object {
               "identifier": "dt_activity_timestamp.week",
@@ -7985,6 +10582,10 @@ TigerWorkspaceCatalog {
             "description": "Month and Year (12/2020)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_activity_timestamp.month",
+                  "type": "attribute",
+                },
                 "description": "Month and Year (12/2020)",
                 "displayFormType": undefined,
                 "id": "dt_activity_timestamp.month",
@@ -8007,7 +10608,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_activity_timestamp.month",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_activity_timestamp.month",
+              "type": "attribute",
+            },
             "description": "Month and Year (12/2020)",
+            "displayFormType": undefined,
             "id": "dt_activity_timestamp.month",
             "ref": Object {
               "identifier": "dt_activity_timestamp.month",
@@ -8024,6 +10630,10 @@ TigerWorkspaceCatalog {
             "description": "Quarter and Year (Q1/2020)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_activity_timestamp.quarter",
+                  "type": "attribute",
+                },
                 "description": "Quarter and Year (Q1/2020)",
                 "displayFormType": undefined,
                 "id": "dt_activity_timestamp.quarter",
@@ -8046,7 +10656,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_activity_timestamp.quarter",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_activity_timestamp.quarter",
+              "type": "attribute",
+            },
             "description": "Quarter and Year (Q1/2020)",
+            "displayFormType": undefined,
             "id": "dt_activity_timestamp.quarter",
             "ref": Object {
               "identifier": "dt_activity_timestamp.quarter",
@@ -8063,6 +10678,10 @@ TigerWorkspaceCatalog {
             "description": "Year",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_activity_timestamp.year",
+                  "type": "attribute",
+                },
                 "description": "Year",
                 "displayFormType": undefined,
                 "id": "dt_activity_timestamp.year",
@@ -8085,7 +10704,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_activity_timestamp.year",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_activity_timestamp.year",
+              "type": "attribute",
+            },
             "description": "Year",
+            "displayFormType": undefined,
             "id": "dt_activity_timestamp.year",
             "ref": Object {
               "identifier": "dt_activity_timestamp.year",
@@ -8102,6 +10726,10 @@ TigerWorkspaceCatalog {
             "description": "Generic Minute of the Hour(MI1-MI60)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_activity_timestamp.minuteOfHour",
+                  "type": "attribute",
+                },
                 "description": "Generic Minute of the Hour(MI1-MI60)",
                 "displayFormType": undefined,
                 "id": "dt_activity_timestamp.minuteOfHour",
@@ -8124,7 +10752,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_activity_timestamp.minuteOfHour",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_activity_timestamp.minuteOfHour",
+              "type": "attribute",
+            },
             "description": "Generic Minute of the Hour(MI1-MI60)",
+            "displayFormType": undefined,
             "id": "dt_activity_timestamp.minuteOfHour",
             "ref": Object {
               "identifier": "dt_activity_timestamp.minuteOfHour",
@@ -8141,6 +10774,10 @@ TigerWorkspaceCatalog {
             "description": "Generic Hour of the Day(H1-H24)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_activity_timestamp.hourOfDay",
+                  "type": "attribute",
+                },
                 "description": "Generic Hour of the Day(H1-H24)",
                 "displayFormType": undefined,
                 "id": "dt_activity_timestamp.hourOfDay",
@@ -8163,7 +10800,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_activity_timestamp.hourOfDay",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_activity_timestamp.hourOfDay",
+              "type": "attribute",
+            },
             "description": "Generic Hour of the Day(H1-H24)",
+            "displayFormType": undefined,
             "id": "dt_activity_timestamp.hourOfDay",
             "ref": Object {
               "identifier": "dt_activity_timestamp.hourOfDay",
@@ -8180,6 +10822,10 @@ TigerWorkspaceCatalog {
             "description": "Generic Day of the Week (D1-D7)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_activity_timestamp.dayOfWeek",
+                  "type": "attribute",
+                },
                 "description": "Generic Day of the Week (D1-D7)",
                 "displayFormType": undefined,
                 "id": "dt_activity_timestamp.dayOfWeek",
@@ -8202,7 +10848,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_activity_timestamp.dayOfWeek",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_activity_timestamp.dayOfWeek",
+              "type": "attribute",
+            },
             "description": "Generic Day of the Week (D1-D7)",
+            "displayFormType": undefined,
             "id": "dt_activity_timestamp.dayOfWeek",
             "ref": Object {
               "identifier": "dt_activity_timestamp.dayOfWeek",
@@ -8219,6 +10870,10 @@ TigerWorkspaceCatalog {
             "description": "Generic Day of the Month (D1-D31)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_activity_timestamp.dayOfMonth",
+                  "type": "attribute",
+                },
                 "description": "Generic Day of the Month (D1-D31)",
                 "displayFormType": undefined,
                 "id": "dt_activity_timestamp.dayOfMonth",
@@ -8241,7 +10896,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_activity_timestamp.dayOfMonth",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_activity_timestamp.dayOfMonth",
+              "type": "attribute",
+            },
             "description": "Generic Day of the Month (D1-D31)",
+            "displayFormType": undefined,
             "id": "dt_activity_timestamp.dayOfMonth",
             "ref": Object {
               "identifier": "dt_activity_timestamp.dayOfMonth",
@@ -8258,6 +10918,10 @@ TigerWorkspaceCatalog {
             "description": "Generic Day of the Year (D1-D366)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_activity_timestamp.dayOfYear",
+                  "type": "attribute",
+                },
                 "description": "Generic Day of the Year (D1-D366)",
                 "displayFormType": undefined,
                 "id": "dt_activity_timestamp.dayOfYear",
@@ -8280,7 +10944,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_activity_timestamp.dayOfYear",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_activity_timestamp.dayOfYear",
+              "type": "attribute",
+            },
             "description": "Generic Day of the Year (D1-D366)",
+            "displayFormType": undefined,
             "id": "dt_activity_timestamp.dayOfYear",
             "ref": Object {
               "identifier": "dt_activity_timestamp.dayOfYear",
@@ -8297,6 +10966,10 @@ TigerWorkspaceCatalog {
             "description": "Generic Week (W1-W53)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_activity_timestamp.weekOfYear",
+                  "type": "attribute",
+                },
                 "description": "Generic Week (W1-W53)",
                 "displayFormType": undefined,
                 "id": "dt_activity_timestamp.weekOfYear",
@@ -8319,7 +10992,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_activity_timestamp.weekOfYear",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_activity_timestamp.weekOfYear",
+              "type": "attribute",
+            },
             "description": "Generic Week (W1-W53)",
+            "displayFormType": undefined,
             "id": "dt_activity_timestamp.weekOfYear",
             "ref": Object {
               "identifier": "dt_activity_timestamp.weekOfYear",
@@ -8336,6 +11014,10 @@ TigerWorkspaceCatalog {
             "description": "Generic Month (M1-M12)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_activity_timestamp.monthOfYear",
+                  "type": "attribute",
+                },
                 "description": "Generic Month (M1-M12)",
                 "displayFormType": undefined,
                 "id": "dt_activity_timestamp.monthOfYear",
@@ -8358,7 +11040,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_activity_timestamp.monthOfYear",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_activity_timestamp.monthOfYear",
+              "type": "attribute",
+            },
             "description": "Generic Month (M1-M12)",
+            "displayFormType": undefined,
             "id": "dt_activity_timestamp.monthOfYear",
             "ref": Object {
               "identifier": "dt_activity_timestamp.monthOfYear",
@@ -8375,6 +11062,10 @@ TigerWorkspaceCatalog {
             "description": "Generic Quarter (Q1-Q4)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_activity_timestamp.quarterOfYear",
+                  "type": "attribute",
+                },
                 "description": "Generic Quarter (Q1-Q4)",
                 "displayFormType": undefined,
                 "id": "dt_activity_timestamp.quarterOfYear",
@@ -8397,7 +11088,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_activity_timestamp.quarterOfYear",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_activity_timestamp.quarterOfYear",
+              "type": "attribute",
+            },
             "description": "Generic Quarter (Q1-Q4)",
+            "displayFormType": undefined,
             "id": "dt_activity_timestamp.quarterOfYear",
             "ref": Object {
               "identifier": "dt_activity_timestamp.quarterOfYear",
@@ -8433,6 +11129,10 @@ TigerWorkspaceCatalog {
             "description": "Minute",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_closedate_timestamp.minute",
+                  "type": "attribute",
+                },
                 "description": "Minute",
                 "displayFormType": undefined,
                 "id": "dt_closedate_timestamp.minute",
@@ -8455,7 +11155,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_closedate_timestamp.minute",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_closedate_timestamp.minute",
+              "type": "attribute",
+            },
             "description": "Minute",
+            "displayFormType": undefined,
             "id": "dt_closedate_timestamp.minute",
             "ref": Object {
               "identifier": "dt_closedate_timestamp.minute",
@@ -8472,6 +11177,10 @@ TigerWorkspaceCatalog {
             "description": "Hour",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_closedate_timestamp.hour",
+                  "type": "attribute",
+                },
                 "description": "Hour",
                 "displayFormType": undefined,
                 "id": "dt_closedate_timestamp.hour",
@@ -8494,7 +11203,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_closedate_timestamp.hour",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_closedate_timestamp.hour",
+              "type": "attribute",
+            },
             "description": "Hour",
+            "displayFormType": undefined,
             "id": "dt_closedate_timestamp.hour",
             "ref": Object {
               "identifier": "dt_closedate_timestamp.hour",
@@ -8511,6 +11225,10 @@ TigerWorkspaceCatalog {
             "description": "Date",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_closedate_timestamp.day",
+                  "type": "attribute",
+                },
                 "description": "Date",
                 "displayFormType": undefined,
                 "id": "dt_closedate_timestamp.day",
@@ -8533,7 +11251,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_closedate_timestamp.day",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_closedate_timestamp.day",
+              "type": "attribute",
+            },
             "description": "Date",
+            "displayFormType": undefined,
             "id": "dt_closedate_timestamp.day",
             "ref": Object {
               "identifier": "dt_closedate_timestamp.day",
@@ -8550,6 +11273,10 @@ TigerWorkspaceCatalog {
             "description": "Week and Year (W52/2020)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_closedate_timestamp.week",
+                  "type": "attribute",
+                },
                 "description": "Week and Year (W52/2020)",
                 "displayFormType": undefined,
                 "id": "dt_closedate_timestamp.week",
@@ -8572,7 +11299,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_closedate_timestamp.week",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_closedate_timestamp.week",
+              "type": "attribute",
+            },
             "description": "Week and Year (W52/2020)",
+            "displayFormType": undefined,
             "id": "dt_closedate_timestamp.week",
             "ref": Object {
               "identifier": "dt_closedate_timestamp.week",
@@ -8589,6 +11321,10 @@ TigerWorkspaceCatalog {
             "description": "Month and Year (12/2020)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_closedate_timestamp.month",
+                  "type": "attribute",
+                },
                 "description": "Month and Year (12/2020)",
                 "displayFormType": undefined,
                 "id": "dt_closedate_timestamp.month",
@@ -8611,7 +11347,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_closedate_timestamp.month",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_closedate_timestamp.month",
+              "type": "attribute",
+            },
             "description": "Month and Year (12/2020)",
+            "displayFormType": undefined,
             "id": "dt_closedate_timestamp.month",
             "ref": Object {
               "identifier": "dt_closedate_timestamp.month",
@@ -8628,6 +11369,10 @@ TigerWorkspaceCatalog {
             "description": "Quarter and Year (Q1/2020)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_closedate_timestamp.quarter",
+                  "type": "attribute",
+                },
                 "description": "Quarter and Year (Q1/2020)",
                 "displayFormType": undefined,
                 "id": "dt_closedate_timestamp.quarter",
@@ -8650,7 +11395,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_closedate_timestamp.quarter",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_closedate_timestamp.quarter",
+              "type": "attribute",
+            },
             "description": "Quarter and Year (Q1/2020)",
+            "displayFormType": undefined,
             "id": "dt_closedate_timestamp.quarter",
             "ref": Object {
               "identifier": "dt_closedate_timestamp.quarter",
@@ -8667,6 +11417,10 @@ TigerWorkspaceCatalog {
             "description": "Year",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_closedate_timestamp.year",
+                  "type": "attribute",
+                },
                 "description": "Year",
                 "displayFormType": undefined,
                 "id": "dt_closedate_timestamp.year",
@@ -8689,7 +11443,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_closedate_timestamp.year",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_closedate_timestamp.year",
+              "type": "attribute",
+            },
             "description": "Year",
+            "displayFormType": undefined,
             "id": "dt_closedate_timestamp.year",
             "ref": Object {
               "identifier": "dt_closedate_timestamp.year",
@@ -8706,6 +11465,10 @@ TigerWorkspaceCatalog {
             "description": "Generic Minute of the Hour(MI1-MI60)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_closedate_timestamp.minuteOfHour",
+                  "type": "attribute",
+                },
                 "description": "Generic Minute of the Hour(MI1-MI60)",
                 "displayFormType": undefined,
                 "id": "dt_closedate_timestamp.minuteOfHour",
@@ -8728,7 +11491,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_closedate_timestamp.minuteOfHour",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_closedate_timestamp.minuteOfHour",
+              "type": "attribute",
+            },
             "description": "Generic Minute of the Hour(MI1-MI60)",
+            "displayFormType": undefined,
             "id": "dt_closedate_timestamp.minuteOfHour",
             "ref": Object {
               "identifier": "dt_closedate_timestamp.minuteOfHour",
@@ -8745,6 +11513,10 @@ TigerWorkspaceCatalog {
             "description": "Generic Hour of the Day(H1-H24)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_closedate_timestamp.hourOfDay",
+                  "type": "attribute",
+                },
                 "description": "Generic Hour of the Day(H1-H24)",
                 "displayFormType": undefined,
                 "id": "dt_closedate_timestamp.hourOfDay",
@@ -8767,7 +11539,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_closedate_timestamp.hourOfDay",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_closedate_timestamp.hourOfDay",
+              "type": "attribute",
+            },
             "description": "Generic Hour of the Day(H1-H24)",
+            "displayFormType": undefined,
             "id": "dt_closedate_timestamp.hourOfDay",
             "ref": Object {
               "identifier": "dt_closedate_timestamp.hourOfDay",
@@ -8784,6 +11561,10 @@ TigerWorkspaceCatalog {
             "description": "Generic Day of the Week (D1-D7)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_closedate_timestamp.dayOfWeek",
+                  "type": "attribute",
+                },
                 "description": "Generic Day of the Week (D1-D7)",
                 "displayFormType": undefined,
                 "id": "dt_closedate_timestamp.dayOfWeek",
@@ -8806,7 +11587,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_closedate_timestamp.dayOfWeek",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_closedate_timestamp.dayOfWeek",
+              "type": "attribute",
+            },
             "description": "Generic Day of the Week (D1-D7)",
+            "displayFormType": undefined,
             "id": "dt_closedate_timestamp.dayOfWeek",
             "ref": Object {
               "identifier": "dt_closedate_timestamp.dayOfWeek",
@@ -8823,6 +11609,10 @@ TigerWorkspaceCatalog {
             "description": "Generic Day of the Month (D1-D31)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_closedate_timestamp.dayOfMonth",
+                  "type": "attribute",
+                },
                 "description": "Generic Day of the Month (D1-D31)",
                 "displayFormType": undefined,
                 "id": "dt_closedate_timestamp.dayOfMonth",
@@ -8845,7 +11635,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_closedate_timestamp.dayOfMonth",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_closedate_timestamp.dayOfMonth",
+              "type": "attribute",
+            },
             "description": "Generic Day of the Month (D1-D31)",
+            "displayFormType": undefined,
             "id": "dt_closedate_timestamp.dayOfMonth",
             "ref": Object {
               "identifier": "dt_closedate_timestamp.dayOfMonth",
@@ -8862,6 +11657,10 @@ TigerWorkspaceCatalog {
             "description": "Generic Day of the Year (D1-D366)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_closedate_timestamp.dayOfYear",
+                  "type": "attribute",
+                },
                 "description": "Generic Day of the Year (D1-D366)",
                 "displayFormType": undefined,
                 "id": "dt_closedate_timestamp.dayOfYear",
@@ -8884,7 +11683,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_closedate_timestamp.dayOfYear",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_closedate_timestamp.dayOfYear",
+              "type": "attribute",
+            },
             "description": "Generic Day of the Year (D1-D366)",
+            "displayFormType": undefined,
             "id": "dt_closedate_timestamp.dayOfYear",
             "ref": Object {
               "identifier": "dt_closedate_timestamp.dayOfYear",
@@ -8901,6 +11705,10 @@ TigerWorkspaceCatalog {
             "description": "Generic Week (W1-W53)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_closedate_timestamp.weekOfYear",
+                  "type": "attribute",
+                },
                 "description": "Generic Week (W1-W53)",
                 "displayFormType": undefined,
                 "id": "dt_closedate_timestamp.weekOfYear",
@@ -8923,7 +11731,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_closedate_timestamp.weekOfYear",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_closedate_timestamp.weekOfYear",
+              "type": "attribute",
+            },
             "description": "Generic Week (W1-W53)",
+            "displayFormType": undefined,
             "id": "dt_closedate_timestamp.weekOfYear",
             "ref": Object {
               "identifier": "dt_closedate_timestamp.weekOfYear",
@@ -8940,6 +11753,10 @@ TigerWorkspaceCatalog {
             "description": "Generic Month (M1-M12)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_closedate_timestamp.monthOfYear",
+                  "type": "attribute",
+                },
                 "description": "Generic Month (M1-M12)",
                 "displayFormType": undefined,
                 "id": "dt_closedate_timestamp.monthOfYear",
@@ -8962,7 +11779,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_closedate_timestamp.monthOfYear",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_closedate_timestamp.monthOfYear",
+              "type": "attribute",
+            },
             "description": "Generic Month (M1-M12)",
+            "displayFormType": undefined,
             "id": "dt_closedate_timestamp.monthOfYear",
             "ref": Object {
               "identifier": "dt_closedate_timestamp.monthOfYear",
@@ -8979,6 +11801,10 @@ TigerWorkspaceCatalog {
             "description": "Generic Quarter (Q1-Q4)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_closedate_timestamp.quarterOfYear",
+                  "type": "attribute",
+                },
                 "description": "Generic Quarter (Q1-Q4)",
                 "displayFormType": undefined,
                 "id": "dt_closedate_timestamp.quarterOfYear",
@@ -9001,7 +11827,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_closedate_timestamp.quarterOfYear",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_closedate_timestamp.quarterOfYear",
+              "type": "attribute",
+            },
             "description": "Generic Quarter (Q1-Q4)",
+            "displayFormType": undefined,
             "id": "dt_closedate_timestamp.quarterOfYear",
             "ref": Object {
               "identifier": "dt_closedate_timestamp.quarterOfYear",
@@ -9037,6 +11868,10 @@ TigerWorkspaceCatalog {
             "description": "Minute",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_oppcreated_timestamp.minute",
+                  "type": "attribute",
+                },
                 "description": "Minute",
                 "displayFormType": undefined,
                 "id": "dt_oppcreated_timestamp.minute",
@@ -9059,7 +11894,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_oppcreated_timestamp.minute",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_oppcreated_timestamp.minute",
+              "type": "attribute",
+            },
             "description": "Minute",
+            "displayFormType": undefined,
             "id": "dt_oppcreated_timestamp.minute",
             "ref": Object {
               "identifier": "dt_oppcreated_timestamp.minute",
@@ -9076,6 +11916,10 @@ TigerWorkspaceCatalog {
             "description": "Hour",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_oppcreated_timestamp.hour",
+                  "type": "attribute",
+                },
                 "description": "Hour",
                 "displayFormType": undefined,
                 "id": "dt_oppcreated_timestamp.hour",
@@ -9098,7 +11942,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_oppcreated_timestamp.hour",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_oppcreated_timestamp.hour",
+              "type": "attribute",
+            },
             "description": "Hour",
+            "displayFormType": undefined,
             "id": "dt_oppcreated_timestamp.hour",
             "ref": Object {
               "identifier": "dt_oppcreated_timestamp.hour",
@@ -9115,6 +11964,10 @@ TigerWorkspaceCatalog {
             "description": "Date",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_oppcreated_timestamp.day",
+                  "type": "attribute",
+                },
                 "description": "Date",
                 "displayFormType": undefined,
                 "id": "dt_oppcreated_timestamp.day",
@@ -9137,7 +11990,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_oppcreated_timestamp.day",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_oppcreated_timestamp.day",
+              "type": "attribute",
+            },
             "description": "Date",
+            "displayFormType": undefined,
             "id": "dt_oppcreated_timestamp.day",
             "ref": Object {
               "identifier": "dt_oppcreated_timestamp.day",
@@ -9154,6 +12012,10 @@ TigerWorkspaceCatalog {
             "description": "Week and Year (W52/2020)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_oppcreated_timestamp.week",
+                  "type": "attribute",
+                },
                 "description": "Week and Year (W52/2020)",
                 "displayFormType": undefined,
                 "id": "dt_oppcreated_timestamp.week",
@@ -9176,7 +12038,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_oppcreated_timestamp.week",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_oppcreated_timestamp.week",
+              "type": "attribute",
+            },
             "description": "Week and Year (W52/2020)",
+            "displayFormType": undefined,
             "id": "dt_oppcreated_timestamp.week",
             "ref": Object {
               "identifier": "dt_oppcreated_timestamp.week",
@@ -9193,6 +12060,10 @@ TigerWorkspaceCatalog {
             "description": "Month and Year (12/2020)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_oppcreated_timestamp.month",
+                  "type": "attribute",
+                },
                 "description": "Month and Year (12/2020)",
                 "displayFormType": undefined,
                 "id": "dt_oppcreated_timestamp.month",
@@ -9215,7 +12086,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_oppcreated_timestamp.month",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_oppcreated_timestamp.month",
+              "type": "attribute",
+            },
             "description": "Month and Year (12/2020)",
+            "displayFormType": undefined,
             "id": "dt_oppcreated_timestamp.month",
             "ref": Object {
               "identifier": "dt_oppcreated_timestamp.month",
@@ -9232,6 +12108,10 @@ TigerWorkspaceCatalog {
             "description": "Quarter and Year (Q1/2020)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_oppcreated_timestamp.quarter",
+                  "type": "attribute",
+                },
                 "description": "Quarter and Year (Q1/2020)",
                 "displayFormType": undefined,
                 "id": "dt_oppcreated_timestamp.quarter",
@@ -9254,7 +12134,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_oppcreated_timestamp.quarter",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_oppcreated_timestamp.quarter",
+              "type": "attribute",
+            },
             "description": "Quarter and Year (Q1/2020)",
+            "displayFormType": undefined,
             "id": "dt_oppcreated_timestamp.quarter",
             "ref": Object {
               "identifier": "dt_oppcreated_timestamp.quarter",
@@ -9271,6 +12156,10 @@ TigerWorkspaceCatalog {
             "description": "Year",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_oppcreated_timestamp.year",
+                  "type": "attribute",
+                },
                 "description": "Year",
                 "displayFormType": undefined,
                 "id": "dt_oppcreated_timestamp.year",
@@ -9293,7 +12182,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_oppcreated_timestamp.year",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_oppcreated_timestamp.year",
+              "type": "attribute",
+            },
             "description": "Year",
+            "displayFormType": undefined,
             "id": "dt_oppcreated_timestamp.year",
             "ref": Object {
               "identifier": "dt_oppcreated_timestamp.year",
@@ -9310,6 +12204,10 @@ TigerWorkspaceCatalog {
             "description": "Generic Minute of the Hour(MI1-MI60)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_oppcreated_timestamp.minuteOfHour",
+                  "type": "attribute",
+                },
                 "description": "Generic Minute of the Hour(MI1-MI60)",
                 "displayFormType": undefined,
                 "id": "dt_oppcreated_timestamp.minuteOfHour",
@@ -9332,7 +12230,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_oppcreated_timestamp.minuteOfHour",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_oppcreated_timestamp.minuteOfHour",
+              "type": "attribute",
+            },
             "description": "Generic Minute of the Hour(MI1-MI60)",
+            "displayFormType": undefined,
             "id": "dt_oppcreated_timestamp.minuteOfHour",
             "ref": Object {
               "identifier": "dt_oppcreated_timestamp.minuteOfHour",
@@ -9349,6 +12252,10 @@ TigerWorkspaceCatalog {
             "description": "Generic Hour of the Day(H1-H24)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_oppcreated_timestamp.hourOfDay",
+                  "type": "attribute",
+                },
                 "description": "Generic Hour of the Day(H1-H24)",
                 "displayFormType": undefined,
                 "id": "dt_oppcreated_timestamp.hourOfDay",
@@ -9371,7 +12278,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_oppcreated_timestamp.hourOfDay",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_oppcreated_timestamp.hourOfDay",
+              "type": "attribute",
+            },
             "description": "Generic Hour of the Day(H1-H24)",
+            "displayFormType": undefined,
             "id": "dt_oppcreated_timestamp.hourOfDay",
             "ref": Object {
               "identifier": "dt_oppcreated_timestamp.hourOfDay",
@@ -9388,6 +12300,10 @@ TigerWorkspaceCatalog {
             "description": "Generic Day of the Week (D1-D7)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_oppcreated_timestamp.dayOfWeek",
+                  "type": "attribute",
+                },
                 "description": "Generic Day of the Week (D1-D7)",
                 "displayFormType": undefined,
                 "id": "dt_oppcreated_timestamp.dayOfWeek",
@@ -9410,7 +12326,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_oppcreated_timestamp.dayOfWeek",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_oppcreated_timestamp.dayOfWeek",
+              "type": "attribute",
+            },
             "description": "Generic Day of the Week (D1-D7)",
+            "displayFormType": undefined,
             "id": "dt_oppcreated_timestamp.dayOfWeek",
             "ref": Object {
               "identifier": "dt_oppcreated_timestamp.dayOfWeek",
@@ -9427,6 +12348,10 @@ TigerWorkspaceCatalog {
             "description": "Generic Day of the Month (D1-D31)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_oppcreated_timestamp.dayOfMonth",
+                  "type": "attribute",
+                },
                 "description": "Generic Day of the Month (D1-D31)",
                 "displayFormType": undefined,
                 "id": "dt_oppcreated_timestamp.dayOfMonth",
@@ -9449,7 +12374,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_oppcreated_timestamp.dayOfMonth",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_oppcreated_timestamp.dayOfMonth",
+              "type": "attribute",
+            },
             "description": "Generic Day of the Month (D1-D31)",
+            "displayFormType": undefined,
             "id": "dt_oppcreated_timestamp.dayOfMonth",
             "ref": Object {
               "identifier": "dt_oppcreated_timestamp.dayOfMonth",
@@ -9466,6 +12396,10 @@ TigerWorkspaceCatalog {
             "description": "Generic Day of the Year (D1-D366)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_oppcreated_timestamp.dayOfYear",
+                  "type": "attribute",
+                },
                 "description": "Generic Day of the Year (D1-D366)",
                 "displayFormType": undefined,
                 "id": "dt_oppcreated_timestamp.dayOfYear",
@@ -9488,7 +12422,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_oppcreated_timestamp.dayOfYear",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_oppcreated_timestamp.dayOfYear",
+              "type": "attribute",
+            },
             "description": "Generic Day of the Year (D1-D366)",
+            "displayFormType": undefined,
             "id": "dt_oppcreated_timestamp.dayOfYear",
             "ref": Object {
               "identifier": "dt_oppcreated_timestamp.dayOfYear",
@@ -9505,6 +12444,10 @@ TigerWorkspaceCatalog {
             "description": "Generic Week (W1-W53)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_oppcreated_timestamp.weekOfYear",
+                  "type": "attribute",
+                },
                 "description": "Generic Week (W1-W53)",
                 "displayFormType": undefined,
                 "id": "dt_oppcreated_timestamp.weekOfYear",
@@ -9527,7 +12470,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_oppcreated_timestamp.weekOfYear",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_oppcreated_timestamp.weekOfYear",
+              "type": "attribute",
+            },
             "description": "Generic Week (W1-W53)",
+            "displayFormType": undefined,
             "id": "dt_oppcreated_timestamp.weekOfYear",
             "ref": Object {
               "identifier": "dt_oppcreated_timestamp.weekOfYear",
@@ -9544,6 +12492,10 @@ TigerWorkspaceCatalog {
             "description": "Generic Month (M1-M12)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_oppcreated_timestamp.monthOfYear",
+                  "type": "attribute",
+                },
                 "description": "Generic Month (M1-M12)",
                 "displayFormType": undefined,
                 "id": "dt_oppcreated_timestamp.monthOfYear",
@@ -9566,7 +12518,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_oppcreated_timestamp.monthOfYear",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_oppcreated_timestamp.monthOfYear",
+              "type": "attribute",
+            },
             "description": "Generic Month (M1-M12)",
+            "displayFormType": undefined,
             "id": "dt_oppcreated_timestamp.monthOfYear",
             "ref": Object {
               "identifier": "dt_oppcreated_timestamp.monthOfYear",
@@ -9583,6 +12540,10 @@ TigerWorkspaceCatalog {
             "description": "Generic Quarter (Q1-Q4)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_oppcreated_timestamp.quarterOfYear",
+                  "type": "attribute",
+                },
                 "description": "Generic Quarter (Q1-Q4)",
                 "displayFormType": undefined,
                 "id": "dt_oppcreated_timestamp.quarterOfYear",
@@ -9605,7 +12566,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_oppcreated_timestamp.quarterOfYear",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_oppcreated_timestamp.quarterOfYear",
+              "type": "attribute",
+            },
             "description": "Generic Quarter (Q1-Q4)",
+            "displayFormType": undefined,
             "id": "dt_oppcreated_timestamp.quarterOfYear",
             "ref": Object {
               "identifier": "dt_oppcreated_timestamp.quarterOfYear",
@@ -9641,6 +12607,10 @@ TigerWorkspaceCatalog {
             "description": "Minute",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_snapshotdate_timestamp.minute",
+                  "type": "attribute",
+                },
                 "description": "Minute",
                 "displayFormType": undefined,
                 "id": "dt_snapshotdate_timestamp.minute",
@@ -9663,7 +12633,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_snapshotdate_timestamp.minute",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_snapshotdate_timestamp.minute",
+              "type": "attribute",
+            },
             "description": "Minute",
+            "displayFormType": undefined,
             "id": "dt_snapshotdate_timestamp.minute",
             "ref": Object {
               "identifier": "dt_snapshotdate_timestamp.minute",
@@ -9680,6 +12655,10 @@ TigerWorkspaceCatalog {
             "description": "Hour",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_snapshotdate_timestamp.hour",
+                  "type": "attribute",
+                },
                 "description": "Hour",
                 "displayFormType": undefined,
                 "id": "dt_snapshotdate_timestamp.hour",
@@ -9702,7 +12681,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_snapshotdate_timestamp.hour",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_snapshotdate_timestamp.hour",
+              "type": "attribute",
+            },
             "description": "Hour",
+            "displayFormType": undefined,
             "id": "dt_snapshotdate_timestamp.hour",
             "ref": Object {
               "identifier": "dt_snapshotdate_timestamp.hour",
@@ -9719,6 +12703,10 @@ TigerWorkspaceCatalog {
             "description": "Date",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_snapshotdate_timestamp.day",
+                  "type": "attribute",
+                },
                 "description": "Date",
                 "displayFormType": undefined,
                 "id": "dt_snapshotdate_timestamp.day",
@@ -9741,7 +12729,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_snapshotdate_timestamp.day",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_snapshotdate_timestamp.day",
+              "type": "attribute",
+            },
             "description": "Date",
+            "displayFormType": undefined,
             "id": "dt_snapshotdate_timestamp.day",
             "ref": Object {
               "identifier": "dt_snapshotdate_timestamp.day",
@@ -9758,6 +12751,10 @@ TigerWorkspaceCatalog {
             "description": "Week and Year (W52/2020)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_snapshotdate_timestamp.week",
+                  "type": "attribute",
+                },
                 "description": "Week and Year (W52/2020)",
                 "displayFormType": undefined,
                 "id": "dt_snapshotdate_timestamp.week",
@@ -9780,7 +12777,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_snapshotdate_timestamp.week",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_snapshotdate_timestamp.week",
+              "type": "attribute",
+            },
             "description": "Week and Year (W52/2020)",
+            "displayFormType": undefined,
             "id": "dt_snapshotdate_timestamp.week",
             "ref": Object {
               "identifier": "dt_snapshotdate_timestamp.week",
@@ -9797,6 +12799,10 @@ TigerWorkspaceCatalog {
             "description": "Month and Year (12/2020)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_snapshotdate_timestamp.month",
+                  "type": "attribute",
+                },
                 "description": "Month and Year (12/2020)",
                 "displayFormType": undefined,
                 "id": "dt_snapshotdate_timestamp.month",
@@ -9819,7 +12825,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_snapshotdate_timestamp.month",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_snapshotdate_timestamp.month",
+              "type": "attribute",
+            },
             "description": "Month and Year (12/2020)",
+            "displayFormType": undefined,
             "id": "dt_snapshotdate_timestamp.month",
             "ref": Object {
               "identifier": "dt_snapshotdate_timestamp.month",
@@ -9836,6 +12847,10 @@ TigerWorkspaceCatalog {
             "description": "Quarter and Year (Q1/2020)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_snapshotdate_timestamp.quarter",
+                  "type": "attribute",
+                },
                 "description": "Quarter and Year (Q1/2020)",
                 "displayFormType": undefined,
                 "id": "dt_snapshotdate_timestamp.quarter",
@@ -9858,7 +12873,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_snapshotdate_timestamp.quarter",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_snapshotdate_timestamp.quarter",
+              "type": "attribute",
+            },
             "description": "Quarter and Year (Q1/2020)",
+            "displayFormType": undefined,
             "id": "dt_snapshotdate_timestamp.quarter",
             "ref": Object {
               "identifier": "dt_snapshotdate_timestamp.quarter",
@@ -9875,6 +12895,10 @@ TigerWorkspaceCatalog {
             "description": "Year",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_snapshotdate_timestamp.year",
+                  "type": "attribute",
+                },
                 "description": "Year",
                 "displayFormType": undefined,
                 "id": "dt_snapshotdate_timestamp.year",
@@ -9897,7 +12921,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_snapshotdate_timestamp.year",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_snapshotdate_timestamp.year",
+              "type": "attribute",
+            },
             "description": "Year",
+            "displayFormType": undefined,
             "id": "dt_snapshotdate_timestamp.year",
             "ref": Object {
               "identifier": "dt_snapshotdate_timestamp.year",
@@ -9914,6 +12943,10 @@ TigerWorkspaceCatalog {
             "description": "Generic Minute of the Hour(MI1-MI60)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_snapshotdate_timestamp.minuteOfHour",
+                  "type": "attribute",
+                },
                 "description": "Generic Minute of the Hour(MI1-MI60)",
                 "displayFormType": undefined,
                 "id": "dt_snapshotdate_timestamp.minuteOfHour",
@@ -9936,7 +12969,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_snapshotdate_timestamp.minuteOfHour",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_snapshotdate_timestamp.minuteOfHour",
+              "type": "attribute",
+            },
             "description": "Generic Minute of the Hour(MI1-MI60)",
+            "displayFormType": undefined,
             "id": "dt_snapshotdate_timestamp.minuteOfHour",
             "ref": Object {
               "identifier": "dt_snapshotdate_timestamp.minuteOfHour",
@@ -9953,6 +12991,10 @@ TigerWorkspaceCatalog {
             "description": "Generic Hour of the Day(H1-H24)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_snapshotdate_timestamp.hourOfDay",
+                  "type": "attribute",
+                },
                 "description": "Generic Hour of the Day(H1-H24)",
                 "displayFormType": undefined,
                 "id": "dt_snapshotdate_timestamp.hourOfDay",
@@ -9975,7 +13017,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_snapshotdate_timestamp.hourOfDay",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_snapshotdate_timestamp.hourOfDay",
+              "type": "attribute",
+            },
             "description": "Generic Hour of the Day(H1-H24)",
+            "displayFormType": undefined,
             "id": "dt_snapshotdate_timestamp.hourOfDay",
             "ref": Object {
               "identifier": "dt_snapshotdate_timestamp.hourOfDay",
@@ -9992,6 +13039,10 @@ TigerWorkspaceCatalog {
             "description": "Generic Day of the Week (D1-D7)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_snapshotdate_timestamp.dayOfWeek",
+                  "type": "attribute",
+                },
                 "description": "Generic Day of the Week (D1-D7)",
                 "displayFormType": undefined,
                 "id": "dt_snapshotdate_timestamp.dayOfWeek",
@@ -10014,7 +13065,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_snapshotdate_timestamp.dayOfWeek",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_snapshotdate_timestamp.dayOfWeek",
+              "type": "attribute",
+            },
             "description": "Generic Day of the Week (D1-D7)",
+            "displayFormType": undefined,
             "id": "dt_snapshotdate_timestamp.dayOfWeek",
             "ref": Object {
               "identifier": "dt_snapshotdate_timestamp.dayOfWeek",
@@ -10031,6 +13087,10 @@ TigerWorkspaceCatalog {
             "description": "Generic Day of the Month (D1-D31)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_snapshotdate_timestamp.dayOfMonth",
+                  "type": "attribute",
+                },
                 "description": "Generic Day of the Month (D1-D31)",
                 "displayFormType": undefined,
                 "id": "dt_snapshotdate_timestamp.dayOfMonth",
@@ -10053,7 +13113,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_snapshotdate_timestamp.dayOfMonth",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_snapshotdate_timestamp.dayOfMonth",
+              "type": "attribute",
+            },
             "description": "Generic Day of the Month (D1-D31)",
+            "displayFormType": undefined,
             "id": "dt_snapshotdate_timestamp.dayOfMonth",
             "ref": Object {
               "identifier": "dt_snapshotdate_timestamp.dayOfMonth",
@@ -10070,6 +13135,10 @@ TigerWorkspaceCatalog {
             "description": "Generic Day of the Year (D1-D366)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_snapshotdate_timestamp.dayOfYear",
+                  "type": "attribute",
+                },
                 "description": "Generic Day of the Year (D1-D366)",
                 "displayFormType": undefined,
                 "id": "dt_snapshotdate_timestamp.dayOfYear",
@@ -10092,7 +13161,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_snapshotdate_timestamp.dayOfYear",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_snapshotdate_timestamp.dayOfYear",
+              "type": "attribute",
+            },
             "description": "Generic Day of the Year (D1-D366)",
+            "displayFormType": undefined,
             "id": "dt_snapshotdate_timestamp.dayOfYear",
             "ref": Object {
               "identifier": "dt_snapshotdate_timestamp.dayOfYear",
@@ -10109,6 +13183,10 @@ TigerWorkspaceCatalog {
             "description": "Generic Week (W1-W53)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_snapshotdate_timestamp.weekOfYear",
+                  "type": "attribute",
+                },
                 "description": "Generic Week (W1-W53)",
                 "displayFormType": undefined,
                 "id": "dt_snapshotdate_timestamp.weekOfYear",
@@ -10131,7 +13209,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_snapshotdate_timestamp.weekOfYear",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_snapshotdate_timestamp.weekOfYear",
+              "type": "attribute",
+            },
             "description": "Generic Week (W1-W53)",
+            "displayFormType": undefined,
             "id": "dt_snapshotdate_timestamp.weekOfYear",
             "ref": Object {
               "identifier": "dt_snapshotdate_timestamp.weekOfYear",
@@ -10148,6 +13231,10 @@ TigerWorkspaceCatalog {
             "description": "Generic Month (M1-M12)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_snapshotdate_timestamp.monthOfYear",
+                  "type": "attribute",
+                },
                 "description": "Generic Month (M1-M12)",
                 "displayFormType": undefined,
                 "id": "dt_snapshotdate_timestamp.monthOfYear",
@@ -10170,7 +13257,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_snapshotdate_timestamp.monthOfYear",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_snapshotdate_timestamp.monthOfYear",
+              "type": "attribute",
+            },
             "description": "Generic Month (M1-M12)",
+            "displayFormType": undefined,
             "id": "dt_snapshotdate_timestamp.monthOfYear",
             "ref": Object {
               "identifier": "dt_snapshotdate_timestamp.monthOfYear",
@@ -10187,6 +13279,10 @@ TigerWorkspaceCatalog {
             "description": "Generic Quarter (Q1-Q4)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_snapshotdate_timestamp.quarterOfYear",
+                  "type": "attribute",
+                },
                 "description": "Generic Quarter (Q1-Q4)",
                 "displayFormType": undefined,
                 "id": "dt_snapshotdate_timestamp.quarterOfYear",
@@ -10209,7 +13305,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_snapshotdate_timestamp.quarterOfYear",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_snapshotdate_timestamp.quarterOfYear",
+              "type": "attribute",
+            },
             "description": "Generic Quarter (Q1-Q4)",
+            "displayFormType": undefined,
             "id": "dt_snapshotdate_timestamp.quarterOfYear",
             "ref": Object {
               "identifier": "dt_snapshotdate_timestamp.quarterOfYear",
@@ -10245,6 +13346,10 @@ TigerWorkspaceCatalog {
             "description": "Minute",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_timeline_timestamp.minute",
+                  "type": "attribute",
+                },
                 "description": "Minute",
                 "displayFormType": undefined,
                 "id": "dt_timeline_timestamp.minute",
@@ -10267,7 +13372,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_timeline_timestamp.minute",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_timeline_timestamp.minute",
+              "type": "attribute",
+            },
             "description": "Minute",
+            "displayFormType": undefined,
             "id": "dt_timeline_timestamp.minute",
             "ref": Object {
               "identifier": "dt_timeline_timestamp.minute",
@@ -10284,6 +13394,10 @@ TigerWorkspaceCatalog {
             "description": "Hour",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_timeline_timestamp.hour",
+                  "type": "attribute",
+                },
                 "description": "Hour",
                 "displayFormType": undefined,
                 "id": "dt_timeline_timestamp.hour",
@@ -10306,7 +13420,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_timeline_timestamp.hour",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_timeline_timestamp.hour",
+              "type": "attribute",
+            },
             "description": "Hour",
+            "displayFormType": undefined,
             "id": "dt_timeline_timestamp.hour",
             "ref": Object {
               "identifier": "dt_timeline_timestamp.hour",
@@ -10323,6 +13442,10 @@ TigerWorkspaceCatalog {
             "description": "Date",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_timeline_timestamp.day",
+                  "type": "attribute",
+                },
                 "description": "Date",
                 "displayFormType": undefined,
                 "id": "dt_timeline_timestamp.day",
@@ -10345,7 +13468,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_timeline_timestamp.day",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_timeline_timestamp.day",
+              "type": "attribute",
+            },
             "description": "Date",
+            "displayFormType": undefined,
             "id": "dt_timeline_timestamp.day",
             "ref": Object {
               "identifier": "dt_timeline_timestamp.day",
@@ -10362,6 +13490,10 @@ TigerWorkspaceCatalog {
             "description": "Week and Year (W52/2020)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_timeline_timestamp.week",
+                  "type": "attribute",
+                },
                 "description": "Week and Year (W52/2020)",
                 "displayFormType": undefined,
                 "id": "dt_timeline_timestamp.week",
@@ -10384,7 +13516,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_timeline_timestamp.week",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_timeline_timestamp.week",
+              "type": "attribute",
+            },
             "description": "Week and Year (W52/2020)",
+            "displayFormType": undefined,
             "id": "dt_timeline_timestamp.week",
             "ref": Object {
               "identifier": "dt_timeline_timestamp.week",
@@ -10401,6 +13538,10 @@ TigerWorkspaceCatalog {
             "description": "Month and Year (12/2020)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_timeline_timestamp.month",
+                  "type": "attribute",
+                },
                 "description": "Month and Year (12/2020)",
                 "displayFormType": undefined,
                 "id": "dt_timeline_timestamp.month",
@@ -10423,7 +13564,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_timeline_timestamp.month",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_timeline_timestamp.month",
+              "type": "attribute",
+            },
             "description": "Month and Year (12/2020)",
+            "displayFormType": undefined,
             "id": "dt_timeline_timestamp.month",
             "ref": Object {
               "identifier": "dt_timeline_timestamp.month",
@@ -10440,6 +13586,10 @@ TigerWorkspaceCatalog {
             "description": "Quarter and Year (Q1/2020)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_timeline_timestamp.quarter",
+                  "type": "attribute",
+                },
                 "description": "Quarter and Year (Q1/2020)",
                 "displayFormType": undefined,
                 "id": "dt_timeline_timestamp.quarter",
@@ -10462,7 +13612,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_timeline_timestamp.quarter",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_timeline_timestamp.quarter",
+              "type": "attribute",
+            },
             "description": "Quarter and Year (Q1/2020)",
+            "displayFormType": undefined,
             "id": "dt_timeline_timestamp.quarter",
             "ref": Object {
               "identifier": "dt_timeline_timestamp.quarter",
@@ -10479,6 +13634,10 @@ TigerWorkspaceCatalog {
             "description": "Year",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_timeline_timestamp.year",
+                  "type": "attribute",
+                },
                 "description": "Year",
                 "displayFormType": undefined,
                 "id": "dt_timeline_timestamp.year",
@@ -10501,7 +13660,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_timeline_timestamp.year",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_timeline_timestamp.year",
+              "type": "attribute",
+            },
             "description": "Year",
+            "displayFormType": undefined,
             "id": "dt_timeline_timestamp.year",
             "ref": Object {
               "identifier": "dt_timeline_timestamp.year",
@@ -10518,6 +13682,10 @@ TigerWorkspaceCatalog {
             "description": "Generic Minute of the Hour(MI1-MI60)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_timeline_timestamp.minuteOfHour",
+                  "type": "attribute",
+                },
                 "description": "Generic Minute of the Hour(MI1-MI60)",
                 "displayFormType": undefined,
                 "id": "dt_timeline_timestamp.minuteOfHour",
@@ -10540,7 +13708,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_timeline_timestamp.minuteOfHour",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_timeline_timestamp.minuteOfHour",
+              "type": "attribute",
+            },
             "description": "Generic Minute of the Hour(MI1-MI60)",
+            "displayFormType": undefined,
             "id": "dt_timeline_timestamp.minuteOfHour",
             "ref": Object {
               "identifier": "dt_timeline_timestamp.minuteOfHour",
@@ -10557,6 +13730,10 @@ TigerWorkspaceCatalog {
             "description": "Generic Hour of the Day(H1-H24)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_timeline_timestamp.hourOfDay",
+                  "type": "attribute",
+                },
                 "description": "Generic Hour of the Day(H1-H24)",
                 "displayFormType": undefined,
                 "id": "dt_timeline_timestamp.hourOfDay",
@@ -10579,7 +13756,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_timeline_timestamp.hourOfDay",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_timeline_timestamp.hourOfDay",
+              "type": "attribute",
+            },
             "description": "Generic Hour of the Day(H1-H24)",
+            "displayFormType": undefined,
             "id": "dt_timeline_timestamp.hourOfDay",
             "ref": Object {
               "identifier": "dt_timeline_timestamp.hourOfDay",
@@ -10596,6 +13778,10 @@ TigerWorkspaceCatalog {
             "description": "Generic Day of the Week (D1-D7)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_timeline_timestamp.dayOfWeek",
+                  "type": "attribute",
+                },
                 "description": "Generic Day of the Week (D1-D7)",
                 "displayFormType": undefined,
                 "id": "dt_timeline_timestamp.dayOfWeek",
@@ -10618,7 +13804,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_timeline_timestamp.dayOfWeek",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_timeline_timestamp.dayOfWeek",
+              "type": "attribute",
+            },
             "description": "Generic Day of the Week (D1-D7)",
+            "displayFormType": undefined,
             "id": "dt_timeline_timestamp.dayOfWeek",
             "ref": Object {
               "identifier": "dt_timeline_timestamp.dayOfWeek",
@@ -10635,6 +13826,10 @@ TigerWorkspaceCatalog {
             "description": "Generic Day of the Month (D1-D31)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_timeline_timestamp.dayOfMonth",
+                  "type": "attribute",
+                },
                 "description": "Generic Day of the Month (D1-D31)",
                 "displayFormType": undefined,
                 "id": "dt_timeline_timestamp.dayOfMonth",
@@ -10657,7 +13852,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_timeline_timestamp.dayOfMonth",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_timeline_timestamp.dayOfMonth",
+              "type": "attribute",
+            },
             "description": "Generic Day of the Month (D1-D31)",
+            "displayFormType": undefined,
             "id": "dt_timeline_timestamp.dayOfMonth",
             "ref": Object {
               "identifier": "dt_timeline_timestamp.dayOfMonth",
@@ -10674,6 +13874,10 @@ TigerWorkspaceCatalog {
             "description": "Generic Day of the Year (D1-D366)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_timeline_timestamp.dayOfYear",
+                  "type": "attribute",
+                },
                 "description": "Generic Day of the Year (D1-D366)",
                 "displayFormType": undefined,
                 "id": "dt_timeline_timestamp.dayOfYear",
@@ -10696,7 +13900,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_timeline_timestamp.dayOfYear",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_timeline_timestamp.dayOfYear",
+              "type": "attribute",
+            },
             "description": "Generic Day of the Year (D1-D366)",
+            "displayFormType": undefined,
             "id": "dt_timeline_timestamp.dayOfYear",
             "ref": Object {
               "identifier": "dt_timeline_timestamp.dayOfYear",
@@ -10713,6 +13922,10 @@ TigerWorkspaceCatalog {
             "description": "Generic Week (W1-W53)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_timeline_timestamp.weekOfYear",
+                  "type": "attribute",
+                },
                 "description": "Generic Week (W1-W53)",
                 "displayFormType": undefined,
                 "id": "dt_timeline_timestamp.weekOfYear",
@@ -10735,7 +13948,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_timeline_timestamp.weekOfYear",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_timeline_timestamp.weekOfYear",
+              "type": "attribute",
+            },
             "description": "Generic Week (W1-W53)",
+            "displayFormType": undefined,
             "id": "dt_timeline_timestamp.weekOfYear",
             "ref": Object {
               "identifier": "dt_timeline_timestamp.weekOfYear",
@@ -10752,6 +13970,10 @@ TigerWorkspaceCatalog {
             "description": "Generic Month (M1-M12)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_timeline_timestamp.monthOfYear",
+                  "type": "attribute",
+                },
                 "description": "Generic Month (M1-M12)",
                 "displayFormType": undefined,
                 "id": "dt_timeline_timestamp.monthOfYear",
@@ -10774,7 +13996,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_timeline_timestamp.monthOfYear",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_timeline_timestamp.monthOfYear",
+              "type": "attribute",
+            },
             "description": "Generic Month (M1-M12)",
+            "displayFormType": undefined,
             "id": "dt_timeline_timestamp.monthOfYear",
             "ref": Object {
               "identifier": "dt_timeline_timestamp.monthOfYear",
@@ -10791,6 +14018,10 @@ TigerWorkspaceCatalog {
             "description": "Generic Quarter (Q1-Q4)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_timeline_timestamp.quarterOfYear",
+                  "type": "attribute",
+                },
                 "description": "Generic Quarter (Q1-Q4)",
                 "displayFormType": undefined,
                 "id": "dt_timeline_timestamp.quarterOfYear",
@@ -10813,7 +14044,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_timeline_timestamp.quarterOfYear",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_timeline_timestamp.quarterOfYear",
+              "type": "attribute",
+            },
             "description": "Generic Quarter (Q1-Q4)",
+            "displayFormType": undefined,
             "id": "dt_timeline_timestamp.quarterOfYear",
             "ref": Object {
               "identifier": "dt_timeline_timestamp.quarterOfYear",
@@ -10870,6 +14106,10 @@ TigerWorkspaceCatalog {
             "description": "Minute",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_activity_timestamp.minute",
+                  "type": "attribute",
+                },
                 "description": "Minute",
                 "displayFormType": undefined,
                 "id": "dt_activity_timestamp.minute",
@@ -10892,7 +14132,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_activity_timestamp.minute",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_activity_timestamp.minute",
+              "type": "attribute",
+            },
             "description": "Minute",
+            "displayFormType": undefined,
             "id": "dt_activity_timestamp.minute",
             "ref": Object {
               "identifier": "dt_activity_timestamp.minute",
@@ -10909,6 +14154,10 @@ TigerWorkspaceCatalog {
             "description": "Hour",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_activity_timestamp.hour",
+                  "type": "attribute",
+                },
                 "description": "Hour",
                 "displayFormType": undefined,
                 "id": "dt_activity_timestamp.hour",
@@ -10931,7 +14180,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_activity_timestamp.hour",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_activity_timestamp.hour",
+              "type": "attribute",
+            },
             "description": "Hour",
+            "displayFormType": undefined,
             "id": "dt_activity_timestamp.hour",
             "ref": Object {
               "identifier": "dt_activity_timestamp.hour",
@@ -10948,6 +14202,10 @@ TigerWorkspaceCatalog {
             "description": "Date",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_activity_timestamp.day",
+                  "type": "attribute",
+                },
                 "description": "Date",
                 "displayFormType": undefined,
                 "id": "dt_activity_timestamp.day",
@@ -10970,7 +14228,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_activity_timestamp.day",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_activity_timestamp.day",
+              "type": "attribute",
+            },
             "description": "Date",
+            "displayFormType": undefined,
             "id": "dt_activity_timestamp.day",
             "ref": Object {
               "identifier": "dt_activity_timestamp.day",
@@ -10987,6 +14250,10 @@ TigerWorkspaceCatalog {
             "description": "Week and Year (W52/2020)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_activity_timestamp.week",
+                  "type": "attribute",
+                },
                 "description": "Week and Year (W52/2020)",
                 "displayFormType": undefined,
                 "id": "dt_activity_timestamp.week",
@@ -11009,7 +14276,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_activity_timestamp.week",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_activity_timestamp.week",
+              "type": "attribute",
+            },
             "description": "Week and Year (W52/2020)",
+            "displayFormType": undefined,
             "id": "dt_activity_timestamp.week",
             "ref": Object {
               "identifier": "dt_activity_timestamp.week",
@@ -11026,6 +14298,10 @@ TigerWorkspaceCatalog {
             "description": "Month and Year (12/2020)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_activity_timestamp.month",
+                  "type": "attribute",
+                },
                 "description": "Month and Year (12/2020)",
                 "displayFormType": undefined,
                 "id": "dt_activity_timestamp.month",
@@ -11048,7 +14324,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_activity_timestamp.month",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_activity_timestamp.month",
+              "type": "attribute",
+            },
             "description": "Month and Year (12/2020)",
+            "displayFormType": undefined,
             "id": "dt_activity_timestamp.month",
             "ref": Object {
               "identifier": "dt_activity_timestamp.month",
@@ -11065,6 +14346,10 @@ TigerWorkspaceCatalog {
             "description": "Quarter and Year (Q1/2020)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_activity_timestamp.quarter",
+                  "type": "attribute",
+                },
                 "description": "Quarter and Year (Q1/2020)",
                 "displayFormType": undefined,
                 "id": "dt_activity_timestamp.quarter",
@@ -11087,7 +14372,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_activity_timestamp.quarter",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_activity_timestamp.quarter",
+              "type": "attribute",
+            },
             "description": "Quarter and Year (Q1/2020)",
+            "displayFormType": undefined,
             "id": "dt_activity_timestamp.quarter",
             "ref": Object {
               "identifier": "dt_activity_timestamp.quarter",
@@ -11104,6 +14394,10 @@ TigerWorkspaceCatalog {
             "description": "Year",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_activity_timestamp.year",
+                  "type": "attribute",
+                },
                 "description": "Year",
                 "displayFormType": undefined,
                 "id": "dt_activity_timestamp.year",
@@ -11126,7 +14420,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_activity_timestamp.year",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_activity_timestamp.year",
+              "type": "attribute",
+            },
             "description": "Year",
+            "displayFormType": undefined,
             "id": "dt_activity_timestamp.year",
             "ref": Object {
               "identifier": "dt_activity_timestamp.year",
@@ -11143,6 +14442,10 @@ TigerWorkspaceCatalog {
             "description": "Generic Minute of the Hour(MI1-MI60)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_activity_timestamp.minuteOfHour",
+                  "type": "attribute",
+                },
                 "description": "Generic Minute of the Hour(MI1-MI60)",
                 "displayFormType": undefined,
                 "id": "dt_activity_timestamp.minuteOfHour",
@@ -11165,7 +14468,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_activity_timestamp.minuteOfHour",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_activity_timestamp.minuteOfHour",
+              "type": "attribute",
+            },
             "description": "Generic Minute of the Hour(MI1-MI60)",
+            "displayFormType": undefined,
             "id": "dt_activity_timestamp.minuteOfHour",
             "ref": Object {
               "identifier": "dt_activity_timestamp.minuteOfHour",
@@ -11182,6 +14490,10 @@ TigerWorkspaceCatalog {
             "description": "Generic Hour of the Day(H1-H24)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_activity_timestamp.hourOfDay",
+                  "type": "attribute",
+                },
                 "description": "Generic Hour of the Day(H1-H24)",
                 "displayFormType": undefined,
                 "id": "dt_activity_timestamp.hourOfDay",
@@ -11204,7 +14516,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_activity_timestamp.hourOfDay",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_activity_timestamp.hourOfDay",
+              "type": "attribute",
+            },
             "description": "Generic Hour of the Day(H1-H24)",
+            "displayFormType": undefined,
             "id": "dt_activity_timestamp.hourOfDay",
             "ref": Object {
               "identifier": "dt_activity_timestamp.hourOfDay",
@@ -11221,6 +14538,10 @@ TigerWorkspaceCatalog {
             "description": "Generic Day of the Week (D1-D7)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_activity_timestamp.dayOfWeek",
+                  "type": "attribute",
+                },
                 "description": "Generic Day of the Week (D1-D7)",
                 "displayFormType": undefined,
                 "id": "dt_activity_timestamp.dayOfWeek",
@@ -11243,7 +14564,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_activity_timestamp.dayOfWeek",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_activity_timestamp.dayOfWeek",
+              "type": "attribute",
+            },
             "description": "Generic Day of the Week (D1-D7)",
+            "displayFormType": undefined,
             "id": "dt_activity_timestamp.dayOfWeek",
             "ref": Object {
               "identifier": "dt_activity_timestamp.dayOfWeek",
@@ -11260,6 +14586,10 @@ TigerWorkspaceCatalog {
             "description": "Generic Day of the Month (D1-D31)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_activity_timestamp.dayOfMonth",
+                  "type": "attribute",
+                },
                 "description": "Generic Day of the Month (D1-D31)",
                 "displayFormType": undefined,
                 "id": "dt_activity_timestamp.dayOfMonth",
@@ -11282,7 +14612,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_activity_timestamp.dayOfMonth",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_activity_timestamp.dayOfMonth",
+              "type": "attribute",
+            },
             "description": "Generic Day of the Month (D1-D31)",
+            "displayFormType": undefined,
             "id": "dt_activity_timestamp.dayOfMonth",
             "ref": Object {
               "identifier": "dt_activity_timestamp.dayOfMonth",
@@ -11299,6 +14634,10 @@ TigerWorkspaceCatalog {
             "description": "Generic Day of the Year (D1-D366)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_activity_timestamp.dayOfYear",
+                  "type": "attribute",
+                },
                 "description": "Generic Day of the Year (D1-D366)",
                 "displayFormType": undefined,
                 "id": "dt_activity_timestamp.dayOfYear",
@@ -11321,7 +14660,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_activity_timestamp.dayOfYear",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_activity_timestamp.dayOfYear",
+              "type": "attribute",
+            },
             "description": "Generic Day of the Year (D1-D366)",
+            "displayFormType": undefined,
             "id": "dt_activity_timestamp.dayOfYear",
             "ref": Object {
               "identifier": "dt_activity_timestamp.dayOfYear",
@@ -11338,6 +14682,10 @@ TigerWorkspaceCatalog {
             "description": "Generic Week (W1-W53)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_activity_timestamp.weekOfYear",
+                  "type": "attribute",
+                },
                 "description": "Generic Week (W1-W53)",
                 "displayFormType": undefined,
                 "id": "dt_activity_timestamp.weekOfYear",
@@ -11360,7 +14708,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_activity_timestamp.weekOfYear",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_activity_timestamp.weekOfYear",
+              "type": "attribute",
+            },
             "description": "Generic Week (W1-W53)",
+            "displayFormType": undefined,
             "id": "dt_activity_timestamp.weekOfYear",
             "ref": Object {
               "identifier": "dt_activity_timestamp.weekOfYear",
@@ -11377,6 +14730,10 @@ TigerWorkspaceCatalog {
             "description": "Generic Month (M1-M12)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_activity_timestamp.monthOfYear",
+                  "type": "attribute",
+                },
                 "description": "Generic Month (M1-M12)",
                 "displayFormType": undefined,
                 "id": "dt_activity_timestamp.monthOfYear",
@@ -11399,7 +14756,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_activity_timestamp.monthOfYear",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_activity_timestamp.monthOfYear",
+              "type": "attribute",
+            },
             "description": "Generic Month (M1-M12)",
+            "displayFormType": undefined,
             "id": "dt_activity_timestamp.monthOfYear",
             "ref": Object {
               "identifier": "dt_activity_timestamp.monthOfYear",
@@ -11416,6 +14778,10 @@ TigerWorkspaceCatalog {
             "description": "Generic Quarter (Q1-Q4)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_activity_timestamp.quarterOfYear",
+                  "type": "attribute",
+                },
                 "description": "Generic Quarter (Q1-Q4)",
                 "displayFormType": undefined,
                 "id": "dt_activity_timestamp.quarterOfYear",
@@ -11438,7 +14804,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_activity_timestamp.quarterOfYear",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_activity_timestamp.quarterOfYear",
+              "type": "attribute",
+            },
             "description": "Generic Quarter (Q1-Q4)",
+            "displayFormType": undefined,
             "id": "dt_activity_timestamp.quarterOfYear",
             "ref": Object {
               "identifier": "dt_activity_timestamp.quarterOfYear",
@@ -11474,6 +14845,10 @@ TigerWorkspaceCatalog {
             "description": "Minute",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_closedate_timestamp.minute",
+                  "type": "attribute",
+                },
                 "description": "Minute",
                 "displayFormType": undefined,
                 "id": "dt_closedate_timestamp.minute",
@@ -11496,7 +14871,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_closedate_timestamp.minute",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_closedate_timestamp.minute",
+              "type": "attribute",
+            },
             "description": "Minute",
+            "displayFormType": undefined,
             "id": "dt_closedate_timestamp.minute",
             "ref": Object {
               "identifier": "dt_closedate_timestamp.minute",
@@ -11513,6 +14893,10 @@ TigerWorkspaceCatalog {
             "description": "Hour",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_closedate_timestamp.hour",
+                  "type": "attribute",
+                },
                 "description": "Hour",
                 "displayFormType": undefined,
                 "id": "dt_closedate_timestamp.hour",
@@ -11535,7 +14919,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_closedate_timestamp.hour",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_closedate_timestamp.hour",
+              "type": "attribute",
+            },
             "description": "Hour",
+            "displayFormType": undefined,
             "id": "dt_closedate_timestamp.hour",
             "ref": Object {
               "identifier": "dt_closedate_timestamp.hour",
@@ -11552,6 +14941,10 @@ TigerWorkspaceCatalog {
             "description": "Date",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_closedate_timestamp.day",
+                  "type": "attribute",
+                },
                 "description": "Date",
                 "displayFormType": undefined,
                 "id": "dt_closedate_timestamp.day",
@@ -11574,7 +14967,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_closedate_timestamp.day",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_closedate_timestamp.day",
+              "type": "attribute",
+            },
             "description": "Date",
+            "displayFormType": undefined,
             "id": "dt_closedate_timestamp.day",
             "ref": Object {
               "identifier": "dt_closedate_timestamp.day",
@@ -11591,6 +14989,10 @@ TigerWorkspaceCatalog {
             "description": "Week and Year (W52/2020)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_closedate_timestamp.week",
+                  "type": "attribute",
+                },
                 "description": "Week and Year (W52/2020)",
                 "displayFormType": undefined,
                 "id": "dt_closedate_timestamp.week",
@@ -11613,7 +15015,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_closedate_timestamp.week",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_closedate_timestamp.week",
+              "type": "attribute",
+            },
             "description": "Week and Year (W52/2020)",
+            "displayFormType": undefined,
             "id": "dt_closedate_timestamp.week",
             "ref": Object {
               "identifier": "dt_closedate_timestamp.week",
@@ -11630,6 +15037,10 @@ TigerWorkspaceCatalog {
             "description": "Month and Year (12/2020)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_closedate_timestamp.month",
+                  "type": "attribute",
+                },
                 "description": "Month and Year (12/2020)",
                 "displayFormType": undefined,
                 "id": "dt_closedate_timestamp.month",
@@ -11652,7 +15063,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_closedate_timestamp.month",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_closedate_timestamp.month",
+              "type": "attribute",
+            },
             "description": "Month and Year (12/2020)",
+            "displayFormType": undefined,
             "id": "dt_closedate_timestamp.month",
             "ref": Object {
               "identifier": "dt_closedate_timestamp.month",
@@ -11669,6 +15085,10 @@ TigerWorkspaceCatalog {
             "description": "Quarter and Year (Q1/2020)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_closedate_timestamp.quarter",
+                  "type": "attribute",
+                },
                 "description": "Quarter and Year (Q1/2020)",
                 "displayFormType": undefined,
                 "id": "dt_closedate_timestamp.quarter",
@@ -11691,7 +15111,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_closedate_timestamp.quarter",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_closedate_timestamp.quarter",
+              "type": "attribute",
+            },
             "description": "Quarter and Year (Q1/2020)",
+            "displayFormType": undefined,
             "id": "dt_closedate_timestamp.quarter",
             "ref": Object {
               "identifier": "dt_closedate_timestamp.quarter",
@@ -11708,6 +15133,10 @@ TigerWorkspaceCatalog {
             "description": "Year",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_closedate_timestamp.year",
+                  "type": "attribute",
+                },
                 "description": "Year",
                 "displayFormType": undefined,
                 "id": "dt_closedate_timestamp.year",
@@ -11730,7 +15159,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_closedate_timestamp.year",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_closedate_timestamp.year",
+              "type": "attribute",
+            },
             "description": "Year",
+            "displayFormType": undefined,
             "id": "dt_closedate_timestamp.year",
             "ref": Object {
               "identifier": "dt_closedate_timestamp.year",
@@ -11747,6 +15181,10 @@ TigerWorkspaceCatalog {
             "description": "Generic Minute of the Hour(MI1-MI60)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_closedate_timestamp.minuteOfHour",
+                  "type": "attribute",
+                },
                 "description": "Generic Minute of the Hour(MI1-MI60)",
                 "displayFormType": undefined,
                 "id": "dt_closedate_timestamp.minuteOfHour",
@@ -11769,7 +15207,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_closedate_timestamp.minuteOfHour",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_closedate_timestamp.minuteOfHour",
+              "type": "attribute",
+            },
             "description": "Generic Minute of the Hour(MI1-MI60)",
+            "displayFormType": undefined,
             "id": "dt_closedate_timestamp.minuteOfHour",
             "ref": Object {
               "identifier": "dt_closedate_timestamp.minuteOfHour",
@@ -11786,6 +15229,10 @@ TigerWorkspaceCatalog {
             "description": "Generic Hour of the Day(H1-H24)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_closedate_timestamp.hourOfDay",
+                  "type": "attribute",
+                },
                 "description": "Generic Hour of the Day(H1-H24)",
                 "displayFormType": undefined,
                 "id": "dt_closedate_timestamp.hourOfDay",
@@ -11808,7 +15255,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_closedate_timestamp.hourOfDay",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_closedate_timestamp.hourOfDay",
+              "type": "attribute",
+            },
             "description": "Generic Hour of the Day(H1-H24)",
+            "displayFormType": undefined,
             "id": "dt_closedate_timestamp.hourOfDay",
             "ref": Object {
               "identifier": "dt_closedate_timestamp.hourOfDay",
@@ -11825,6 +15277,10 @@ TigerWorkspaceCatalog {
             "description": "Generic Day of the Week (D1-D7)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_closedate_timestamp.dayOfWeek",
+                  "type": "attribute",
+                },
                 "description": "Generic Day of the Week (D1-D7)",
                 "displayFormType": undefined,
                 "id": "dt_closedate_timestamp.dayOfWeek",
@@ -11847,7 +15303,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_closedate_timestamp.dayOfWeek",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_closedate_timestamp.dayOfWeek",
+              "type": "attribute",
+            },
             "description": "Generic Day of the Week (D1-D7)",
+            "displayFormType": undefined,
             "id": "dt_closedate_timestamp.dayOfWeek",
             "ref": Object {
               "identifier": "dt_closedate_timestamp.dayOfWeek",
@@ -11864,6 +15325,10 @@ TigerWorkspaceCatalog {
             "description": "Generic Day of the Month (D1-D31)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_closedate_timestamp.dayOfMonth",
+                  "type": "attribute",
+                },
                 "description": "Generic Day of the Month (D1-D31)",
                 "displayFormType": undefined,
                 "id": "dt_closedate_timestamp.dayOfMonth",
@@ -11886,7 +15351,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_closedate_timestamp.dayOfMonth",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_closedate_timestamp.dayOfMonth",
+              "type": "attribute",
+            },
             "description": "Generic Day of the Month (D1-D31)",
+            "displayFormType": undefined,
             "id": "dt_closedate_timestamp.dayOfMonth",
             "ref": Object {
               "identifier": "dt_closedate_timestamp.dayOfMonth",
@@ -11903,6 +15373,10 @@ TigerWorkspaceCatalog {
             "description": "Generic Day of the Year (D1-D366)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_closedate_timestamp.dayOfYear",
+                  "type": "attribute",
+                },
                 "description": "Generic Day of the Year (D1-D366)",
                 "displayFormType": undefined,
                 "id": "dt_closedate_timestamp.dayOfYear",
@@ -11925,7 +15399,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_closedate_timestamp.dayOfYear",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_closedate_timestamp.dayOfYear",
+              "type": "attribute",
+            },
             "description": "Generic Day of the Year (D1-D366)",
+            "displayFormType": undefined,
             "id": "dt_closedate_timestamp.dayOfYear",
             "ref": Object {
               "identifier": "dt_closedate_timestamp.dayOfYear",
@@ -11942,6 +15421,10 @@ TigerWorkspaceCatalog {
             "description": "Generic Week (W1-W53)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_closedate_timestamp.weekOfYear",
+                  "type": "attribute",
+                },
                 "description": "Generic Week (W1-W53)",
                 "displayFormType": undefined,
                 "id": "dt_closedate_timestamp.weekOfYear",
@@ -11964,7 +15447,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_closedate_timestamp.weekOfYear",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_closedate_timestamp.weekOfYear",
+              "type": "attribute",
+            },
             "description": "Generic Week (W1-W53)",
+            "displayFormType": undefined,
             "id": "dt_closedate_timestamp.weekOfYear",
             "ref": Object {
               "identifier": "dt_closedate_timestamp.weekOfYear",
@@ -11981,6 +15469,10 @@ TigerWorkspaceCatalog {
             "description": "Generic Month (M1-M12)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_closedate_timestamp.monthOfYear",
+                  "type": "attribute",
+                },
                 "description": "Generic Month (M1-M12)",
                 "displayFormType": undefined,
                 "id": "dt_closedate_timestamp.monthOfYear",
@@ -12003,7 +15495,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_closedate_timestamp.monthOfYear",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_closedate_timestamp.monthOfYear",
+              "type": "attribute",
+            },
             "description": "Generic Month (M1-M12)",
+            "displayFormType": undefined,
             "id": "dt_closedate_timestamp.monthOfYear",
             "ref": Object {
               "identifier": "dt_closedate_timestamp.monthOfYear",
@@ -12020,6 +15517,10 @@ TigerWorkspaceCatalog {
             "description": "Generic Quarter (Q1-Q4)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_closedate_timestamp.quarterOfYear",
+                  "type": "attribute",
+                },
                 "description": "Generic Quarter (Q1-Q4)",
                 "displayFormType": undefined,
                 "id": "dt_closedate_timestamp.quarterOfYear",
@@ -12042,7 +15543,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_closedate_timestamp.quarterOfYear",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_closedate_timestamp.quarterOfYear",
+              "type": "attribute",
+            },
             "description": "Generic Quarter (Q1-Q4)",
+            "displayFormType": undefined,
             "id": "dt_closedate_timestamp.quarterOfYear",
             "ref": Object {
               "identifier": "dt_closedate_timestamp.quarterOfYear",
@@ -12078,6 +15584,10 @@ TigerWorkspaceCatalog {
             "description": "Minute",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_oppcreated_timestamp.minute",
+                  "type": "attribute",
+                },
                 "description": "Minute",
                 "displayFormType": undefined,
                 "id": "dt_oppcreated_timestamp.minute",
@@ -12100,7 +15610,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_oppcreated_timestamp.minute",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_oppcreated_timestamp.minute",
+              "type": "attribute",
+            },
             "description": "Minute",
+            "displayFormType": undefined,
             "id": "dt_oppcreated_timestamp.minute",
             "ref": Object {
               "identifier": "dt_oppcreated_timestamp.minute",
@@ -12117,6 +15632,10 @@ TigerWorkspaceCatalog {
             "description": "Hour",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_oppcreated_timestamp.hour",
+                  "type": "attribute",
+                },
                 "description": "Hour",
                 "displayFormType": undefined,
                 "id": "dt_oppcreated_timestamp.hour",
@@ -12139,7 +15658,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_oppcreated_timestamp.hour",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_oppcreated_timestamp.hour",
+              "type": "attribute",
+            },
             "description": "Hour",
+            "displayFormType": undefined,
             "id": "dt_oppcreated_timestamp.hour",
             "ref": Object {
               "identifier": "dt_oppcreated_timestamp.hour",
@@ -12156,6 +15680,10 @@ TigerWorkspaceCatalog {
             "description": "Date",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_oppcreated_timestamp.day",
+                  "type": "attribute",
+                },
                 "description": "Date",
                 "displayFormType": undefined,
                 "id": "dt_oppcreated_timestamp.day",
@@ -12178,7 +15706,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_oppcreated_timestamp.day",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_oppcreated_timestamp.day",
+              "type": "attribute",
+            },
             "description": "Date",
+            "displayFormType": undefined,
             "id": "dt_oppcreated_timestamp.day",
             "ref": Object {
               "identifier": "dt_oppcreated_timestamp.day",
@@ -12195,6 +15728,10 @@ TigerWorkspaceCatalog {
             "description": "Week and Year (W52/2020)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_oppcreated_timestamp.week",
+                  "type": "attribute",
+                },
                 "description": "Week and Year (W52/2020)",
                 "displayFormType": undefined,
                 "id": "dt_oppcreated_timestamp.week",
@@ -12217,7 +15754,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_oppcreated_timestamp.week",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_oppcreated_timestamp.week",
+              "type": "attribute",
+            },
             "description": "Week and Year (W52/2020)",
+            "displayFormType": undefined,
             "id": "dt_oppcreated_timestamp.week",
             "ref": Object {
               "identifier": "dt_oppcreated_timestamp.week",
@@ -12234,6 +15776,10 @@ TigerWorkspaceCatalog {
             "description": "Month and Year (12/2020)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_oppcreated_timestamp.month",
+                  "type": "attribute",
+                },
                 "description": "Month and Year (12/2020)",
                 "displayFormType": undefined,
                 "id": "dt_oppcreated_timestamp.month",
@@ -12256,7 +15802,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_oppcreated_timestamp.month",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_oppcreated_timestamp.month",
+              "type": "attribute",
+            },
             "description": "Month and Year (12/2020)",
+            "displayFormType": undefined,
             "id": "dt_oppcreated_timestamp.month",
             "ref": Object {
               "identifier": "dt_oppcreated_timestamp.month",
@@ -12273,6 +15824,10 @@ TigerWorkspaceCatalog {
             "description": "Quarter and Year (Q1/2020)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_oppcreated_timestamp.quarter",
+                  "type": "attribute",
+                },
                 "description": "Quarter and Year (Q1/2020)",
                 "displayFormType": undefined,
                 "id": "dt_oppcreated_timestamp.quarter",
@@ -12295,7 +15850,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_oppcreated_timestamp.quarter",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_oppcreated_timestamp.quarter",
+              "type": "attribute",
+            },
             "description": "Quarter and Year (Q1/2020)",
+            "displayFormType": undefined,
             "id": "dt_oppcreated_timestamp.quarter",
             "ref": Object {
               "identifier": "dt_oppcreated_timestamp.quarter",
@@ -12312,6 +15872,10 @@ TigerWorkspaceCatalog {
             "description": "Year",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_oppcreated_timestamp.year",
+                  "type": "attribute",
+                },
                 "description": "Year",
                 "displayFormType": undefined,
                 "id": "dt_oppcreated_timestamp.year",
@@ -12334,7 +15898,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_oppcreated_timestamp.year",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_oppcreated_timestamp.year",
+              "type": "attribute",
+            },
             "description": "Year",
+            "displayFormType": undefined,
             "id": "dt_oppcreated_timestamp.year",
             "ref": Object {
               "identifier": "dt_oppcreated_timestamp.year",
@@ -12351,6 +15920,10 @@ TigerWorkspaceCatalog {
             "description": "Generic Minute of the Hour(MI1-MI60)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_oppcreated_timestamp.minuteOfHour",
+                  "type": "attribute",
+                },
                 "description": "Generic Minute of the Hour(MI1-MI60)",
                 "displayFormType": undefined,
                 "id": "dt_oppcreated_timestamp.minuteOfHour",
@@ -12373,7 +15946,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_oppcreated_timestamp.minuteOfHour",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_oppcreated_timestamp.minuteOfHour",
+              "type": "attribute",
+            },
             "description": "Generic Minute of the Hour(MI1-MI60)",
+            "displayFormType": undefined,
             "id": "dt_oppcreated_timestamp.minuteOfHour",
             "ref": Object {
               "identifier": "dt_oppcreated_timestamp.minuteOfHour",
@@ -12390,6 +15968,10 @@ TigerWorkspaceCatalog {
             "description": "Generic Hour of the Day(H1-H24)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_oppcreated_timestamp.hourOfDay",
+                  "type": "attribute",
+                },
                 "description": "Generic Hour of the Day(H1-H24)",
                 "displayFormType": undefined,
                 "id": "dt_oppcreated_timestamp.hourOfDay",
@@ -12412,7 +15994,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_oppcreated_timestamp.hourOfDay",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_oppcreated_timestamp.hourOfDay",
+              "type": "attribute",
+            },
             "description": "Generic Hour of the Day(H1-H24)",
+            "displayFormType": undefined,
             "id": "dt_oppcreated_timestamp.hourOfDay",
             "ref": Object {
               "identifier": "dt_oppcreated_timestamp.hourOfDay",
@@ -12429,6 +16016,10 @@ TigerWorkspaceCatalog {
             "description": "Generic Day of the Week (D1-D7)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_oppcreated_timestamp.dayOfWeek",
+                  "type": "attribute",
+                },
                 "description": "Generic Day of the Week (D1-D7)",
                 "displayFormType": undefined,
                 "id": "dt_oppcreated_timestamp.dayOfWeek",
@@ -12451,7 +16042,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_oppcreated_timestamp.dayOfWeek",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_oppcreated_timestamp.dayOfWeek",
+              "type": "attribute",
+            },
             "description": "Generic Day of the Week (D1-D7)",
+            "displayFormType": undefined,
             "id": "dt_oppcreated_timestamp.dayOfWeek",
             "ref": Object {
               "identifier": "dt_oppcreated_timestamp.dayOfWeek",
@@ -12468,6 +16064,10 @@ TigerWorkspaceCatalog {
             "description": "Generic Day of the Month (D1-D31)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_oppcreated_timestamp.dayOfMonth",
+                  "type": "attribute",
+                },
                 "description": "Generic Day of the Month (D1-D31)",
                 "displayFormType": undefined,
                 "id": "dt_oppcreated_timestamp.dayOfMonth",
@@ -12490,7 +16090,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_oppcreated_timestamp.dayOfMonth",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_oppcreated_timestamp.dayOfMonth",
+              "type": "attribute",
+            },
             "description": "Generic Day of the Month (D1-D31)",
+            "displayFormType": undefined,
             "id": "dt_oppcreated_timestamp.dayOfMonth",
             "ref": Object {
               "identifier": "dt_oppcreated_timestamp.dayOfMonth",
@@ -12507,6 +16112,10 @@ TigerWorkspaceCatalog {
             "description": "Generic Day of the Year (D1-D366)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_oppcreated_timestamp.dayOfYear",
+                  "type": "attribute",
+                },
                 "description": "Generic Day of the Year (D1-D366)",
                 "displayFormType": undefined,
                 "id": "dt_oppcreated_timestamp.dayOfYear",
@@ -12529,7 +16138,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_oppcreated_timestamp.dayOfYear",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_oppcreated_timestamp.dayOfYear",
+              "type": "attribute",
+            },
             "description": "Generic Day of the Year (D1-D366)",
+            "displayFormType": undefined,
             "id": "dt_oppcreated_timestamp.dayOfYear",
             "ref": Object {
               "identifier": "dt_oppcreated_timestamp.dayOfYear",
@@ -12546,6 +16160,10 @@ TigerWorkspaceCatalog {
             "description": "Generic Week (W1-W53)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_oppcreated_timestamp.weekOfYear",
+                  "type": "attribute",
+                },
                 "description": "Generic Week (W1-W53)",
                 "displayFormType": undefined,
                 "id": "dt_oppcreated_timestamp.weekOfYear",
@@ -12568,7 +16186,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_oppcreated_timestamp.weekOfYear",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_oppcreated_timestamp.weekOfYear",
+              "type": "attribute",
+            },
             "description": "Generic Week (W1-W53)",
+            "displayFormType": undefined,
             "id": "dt_oppcreated_timestamp.weekOfYear",
             "ref": Object {
               "identifier": "dt_oppcreated_timestamp.weekOfYear",
@@ -12585,6 +16208,10 @@ TigerWorkspaceCatalog {
             "description": "Generic Month (M1-M12)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_oppcreated_timestamp.monthOfYear",
+                  "type": "attribute",
+                },
                 "description": "Generic Month (M1-M12)",
                 "displayFormType": undefined,
                 "id": "dt_oppcreated_timestamp.monthOfYear",
@@ -12607,7 +16234,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_oppcreated_timestamp.monthOfYear",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_oppcreated_timestamp.monthOfYear",
+              "type": "attribute",
+            },
             "description": "Generic Month (M1-M12)",
+            "displayFormType": undefined,
             "id": "dt_oppcreated_timestamp.monthOfYear",
             "ref": Object {
               "identifier": "dt_oppcreated_timestamp.monthOfYear",
@@ -12624,6 +16256,10 @@ TigerWorkspaceCatalog {
             "description": "Generic Quarter (Q1-Q4)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_oppcreated_timestamp.quarterOfYear",
+                  "type": "attribute",
+                },
                 "description": "Generic Quarter (Q1-Q4)",
                 "displayFormType": undefined,
                 "id": "dt_oppcreated_timestamp.quarterOfYear",
@@ -12646,7 +16282,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_oppcreated_timestamp.quarterOfYear",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_oppcreated_timestamp.quarterOfYear",
+              "type": "attribute",
+            },
             "description": "Generic Quarter (Q1-Q4)",
+            "displayFormType": undefined,
             "id": "dt_oppcreated_timestamp.quarterOfYear",
             "ref": Object {
               "identifier": "dt_oppcreated_timestamp.quarterOfYear",
@@ -12682,6 +16323,10 @@ TigerWorkspaceCatalog {
             "description": "Minute",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_snapshotdate_timestamp.minute",
+                  "type": "attribute",
+                },
                 "description": "Minute",
                 "displayFormType": undefined,
                 "id": "dt_snapshotdate_timestamp.minute",
@@ -12704,7 +16349,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_snapshotdate_timestamp.minute",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_snapshotdate_timestamp.minute",
+              "type": "attribute",
+            },
             "description": "Minute",
+            "displayFormType": undefined,
             "id": "dt_snapshotdate_timestamp.minute",
             "ref": Object {
               "identifier": "dt_snapshotdate_timestamp.minute",
@@ -12721,6 +16371,10 @@ TigerWorkspaceCatalog {
             "description": "Hour",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_snapshotdate_timestamp.hour",
+                  "type": "attribute",
+                },
                 "description": "Hour",
                 "displayFormType": undefined,
                 "id": "dt_snapshotdate_timestamp.hour",
@@ -12743,7 +16397,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_snapshotdate_timestamp.hour",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_snapshotdate_timestamp.hour",
+              "type": "attribute",
+            },
             "description": "Hour",
+            "displayFormType": undefined,
             "id": "dt_snapshotdate_timestamp.hour",
             "ref": Object {
               "identifier": "dt_snapshotdate_timestamp.hour",
@@ -12760,6 +16419,10 @@ TigerWorkspaceCatalog {
             "description": "Date",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_snapshotdate_timestamp.day",
+                  "type": "attribute",
+                },
                 "description": "Date",
                 "displayFormType": undefined,
                 "id": "dt_snapshotdate_timestamp.day",
@@ -12782,7 +16445,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_snapshotdate_timestamp.day",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_snapshotdate_timestamp.day",
+              "type": "attribute",
+            },
             "description": "Date",
+            "displayFormType": undefined,
             "id": "dt_snapshotdate_timestamp.day",
             "ref": Object {
               "identifier": "dt_snapshotdate_timestamp.day",
@@ -12799,6 +16467,10 @@ TigerWorkspaceCatalog {
             "description": "Week and Year (W52/2020)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_snapshotdate_timestamp.week",
+                  "type": "attribute",
+                },
                 "description": "Week and Year (W52/2020)",
                 "displayFormType": undefined,
                 "id": "dt_snapshotdate_timestamp.week",
@@ -12821,7 +16493,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_snapshotdate_timestamp.week",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_snapshotdate_timestamp.week",
+              "type": "attribute",
+            },
             "description": "Week and Year (W52/2020)",
+            "displayFormType": undefined,
             "id": "dt_snapshotdate_timestamp.week",
             "ref": Object {
               "identifier": "dt_snapshotdate_timestamp.week",
@@ -12838,6 +16515,10 @@ TigerWorkspaceCatalog {
             "description": "Month and Year (12/2020)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_snapshotdate_timestamp.month",
+                  "type": "attribute",
+                },
                 "description": "Month and Year (12/2020)",
                 "displayFormType": undefined,
                 "id": "dt_snapshotdate_timestamp.month",
@@ -12860,7 +16541,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_snapshotdate_timestamp.month",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_snapshotdate_timestamp.month",
+              "type": "attribute",
+            },
             "description": "Month and Year (12/2020)",
+            "displayFormType": undefined,
             "id": "dt_snapshotdate_timestamp.month",
             "ref": Object {
               "identifier": "dt_snapshotdate_timestamp.month",
@@ -12877,6 +16563,10 @@ TigerWorkspaceCatalog {
             "description": "Quarter and Year (Q1/2020)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_snapshotdate_timestamp.quarter",
+                  "type": "attribute",
+                },
                 "description": "Quarter and Year (Q1/2020)",
                 "displayFormType": undefined,
                 "id": "dt_snapshotdate_timestamp.quarter",
@@ -12899,7 +16589,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_snapshotdate_timestamp.quarter",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_snapshotdate_timestamp.quarter",
+              "type": "attribute",
+            },
             "description": "Quarter and Year (Q1/2020)",
+            "displayFormType": undefined,
             "id": "dt_snapshotdate_timestamp.quarter",
             "ref": Object {
               "identifier": "dt_snapshotdate_timestamp.quarter",
@@ -12916,6 +16611,10 @@ TigerWorkspaceCatalog {
             "description": "Year",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_snapshotdate_timestamp.year",
+                  "type": "attribute",
+                },
                 "description": "Year",
                 "displayFormType": undefined,
                 "id": "dt_snapshotdate_timestamp.year",
@@ -12938,7 +16637,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_snapshotdate_timestamp.year",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_snapshotdate_timestamp.year",
+              "type": "attribute",
+            },
             "description": "Year",
+            "displayFormType": undefined,
             "id": "dt_snapshotdate_timestamp.year",
             "ref": Object {
               "identifier": "dt_snapshotdate_timestamp.year",
@@ -12955,6 +16659,10 @@ TigerWorkspaceCatalog {
             "description": "Generic Minute of the Hour(MI1-MI60)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_snapshotdate_timestamp.minuteOfHour",
+                  "type": "attribute",
+                },
                 "description": "Generic Minute of the Hour(MI1-MI60)",
                 "displayFormType": undefined,
                 "id": "dt_snapshotdate_timestamp.minuteOfHour",
@@ -12977,7 +16685,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_snapshotdate_timestamp.minuteOfHour",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_snapshotdate_timestamp.minuteOfHour",
+              "type": "attribute",
+            },
             "description": "Generic Minute of the Hour(MI1-MI60)",
+            "displayFormType": undefined,
             "id": "dt_snapshotdate_timestamp.minuteOfHour",
             "ref": Object {
               "identifier": "dt_snapshotdate_timestamp.minuteOfHour",
@@ -12994,6 +16707,10 @@ TigerWorkspaceCatalog {
             "description": "Generic Hour of the Day(H1-H24)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_snapshotdate_timestamp.hourOfDay",
+                  "type": "attribute",
+                },
                 "description": "Generic Hour of the Day(H1-H24)",
                 "displayFormType": undefined,
                 "id": "dt_snapshotdate_timestamp.hourOfDay",
@@ -13016,7 +16733,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_snapshotdate_timestamp.hourOfDay",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_snapshotdate_timestamp.hourOfDay",
+              "type": "attribute",
+            },
             "description": "Generic Hour of the Day(H1-H24)",
+            "displayFormType": undefined,
             "id": "dt_snapshotdate_timestamp.hourOfDay",
             "ref": Object {
               "identifier": "dt_snapshotdate_timestamp.hourOfDay",
@@ -13033,6 +16755,10 @@ TigerWorkspaceCatalog {
             "description": "Generic Day of the Week (D1-D7)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_snapshotdate_timestamp.dayOfWeek",
+                  "type": "attribute",
+                },
                 "description": "Generic Day of the Week (D1-D7)",
                 "displayFormType": undefined,
                 "id": "dt_snapshotdate_timestamp.dayOfWeek",
@@ -13055,7 +16781,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_snapshotdate_timestamp.dayOfWeek",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_snapshotdate_timestamp.dayOfWeek",
+              "type": "attribute",
+            },
             "description": "Generic Day of the Week (D1-D7)",
+            "displayFormType": undefined,
             "id": "dt_snapshotdate_timestamp.dayOfWeek",
             "ref": Object {
               "identifier": "dt_snapshotdate_timestamp.dayOfWeek",
@@ -13072,6 +16803,10 @@ TigerWorkspaceCatalog {
             "description": "Generic Day of the Month (D1-D31)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_snapshotdate_timestamp.dayOfMonth",
+                  "type": "attribute",
+                },
                 "description": "Generic Day of the Month (D1-D31)",
                 "displayFormType": undefined,
                 "id": "dt_snapshotdate_timestamp.dayOfMonth",
@@ -13094,7 +16829,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_snapshotdate_timestamp.dayOfMonth",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_snapshotdate_timestamp.dayOfMonth",
+              "type": "attribute",
+            },
             "description": "Generic Day of the Month (D1-D31)",
+            "displayFormType": undefined,
             "id": "dt_snapshotdate_timestamp.dayOfMonth",
             "ref": Object {
               "identifier": "dt_snapshotdate_timestamp.dayOfMonth",
@@ -13111,6 +16851,10 @@ TigerWorkspaceCatalog {
             "description": "Generic Day of the Year (D1-D366)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_snapshotdate_timestamp.dayOfYear",
+                  "type": "attribute",
+                },
                 "description": "Generic Day of the Year (D1-D366)",
                 "displayFormType": undefined,
                 "id": "dt_snapshotdate_timestamp.dayOfYear",
@@ -13133,7 +16877,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_snapshotdate_timestamp.dayOfYear",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_snapshotdate_timestamp.dayOfYear",
+              "type": "attribute",
+            },
             "description": "Generic Day of the Year (D1-D366)",
+            "displayFormType": undefined,
             "id": "dt_snapshotdate_timestamp.dayOfYear",
             "ref": Object {
               "identifier": "dt_snapshotdate_timestamp.dayOfYear",
@@ -13150,6 +16899,10 @@ TigerWorkspaceCatalog {
             "description": "Generic Week (W1-W53)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_snapshotdate_timestamp.weekOfYear",
+                  "type": "attribute",
+                },
                 "description": "Generic Week (W1-W53)",
                 "displayFormType": undefined,
                 "id": "dt_snapshotdate_timestamp.weekOfYear",
@@ -13172,7 +16925,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_snapshotdate_timestamp.weekOfYear",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_snapshotdate_timestamp.weekOfYear",
+              "type": "attribute",
+            },
             "description": "Generic Week (W1-W53)",
+            "displayFormType": undefined,
             "id": "dt_snapshotdate_timestamp.weekOfYear",
             "ref": Object {
               "identifier": "dt_snapshotdate_timestamp.weekOfYear",
@@ -13189,6 +16947,10 @@ TigerWorkspaceCatalog {
             "description": "Generic Month (M1-M12)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_snapshotdate_timestamp.monthOfYear",
+                  "type": "attribute",
+                },
                 "description": "Generic Month (M1-M12)",
                 "displayFormType": undefined,
                 "id": "dt_snapshotdate_timestamp.monthOfYear",
@@ -13211,7 +16973,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_snapshotdate_timestamp.monthOfYear",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_snapshotdate_timestamp.monthOfYear",
+              "type": "attribute",
+            },
             "description": "Generic Month (M1-M12)",
+            "displayFormType": undefined,
             "id": "dt_snapshotdate_timestamp.monthOfYear",
             "ref": Object {
               "identifier": "dt_snapshotdate_timestamp.monthOfYear",
@@ -13228,6 +16995,10 @@ TigerWorkspaceCatalog {
             "description": "Generic Quarter (Q1-Q4)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_snapshotdate_timestamp.quarterOfYear",
+                  "type": "attribute",
+                },
                 "description": "Generic Quarter (Q1-Q4)",
                 "displayFormType": undefined,
                 "id": "dt_snapshotdate_timestamp.quarterOfYear",
@@ -13250,7 +17021,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_snapshotdate_timestamp.quarterOfYear",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_snapshotdate_timestamp.quarterOfYear",
+              "type": "attribute",
+            },
             "description": "Generic Quarter (Q1-Q4)",
+            "displayFormType": undefined,
             "id": "dt_snapshotdate_timestamp.quarterOfYear",
             "ref": Object {
               "identifier": "dt_snapshotdate_timestamp.quarterOfYear",
@@ -13286,6 +17062,10 @@ TigerWorkspaceCatalog {
             "description": "Minute",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_timeline_timestamp.minute",
+                  "type": "attribute",
+                },
                 "description": "Minute",
                 "displayFormType": undefined,
                 "id": "dt_timeline_timestamp.minute",
@@ -13308,7 +17088,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_timeline_timestamp.minute",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_timeline_timestamp.minute",
+              "type": "attribute",
+            },
             "description": "Minute",
+            "displayFormType": undefined,
             "id": "dt_timeline_timestamp.minute",
             "ref": Object {
               "identifier": "dt_timeline_timestamp.minute",
@@ -13325,6 +17110,10 @@ TigerWorkspaceCatalog {
             "description": "Hour",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_timeline_timestamp.hour",
+                  "type": "attribute",
+                },
                 "description": "Hour",
                 "displayFormType": undefined,
                 "id": "dt_timeline_timestamp.hour",
@@ -13347,7 +17136,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_timeline_timestamp.hour",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_timeline_timestamp.hour",
+              "type": "attribute",
+            },
             "description": "Hour",
+            "displayFormType": undefined,
             "id": "dt_timeline_timestamp.hour",
             "ref": Object {
               "identifier": "dt_timeline_timestamp.hour",
@@ -13364,6 +17158,10 @@ TigerWorkspaceCatalog {
             "description": "Date",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_timeline_timestamp.day",
+                  "type": "attribute",
+                },
                 "description": "Date",
                 "displayFormType": undefined,
                 "id": "dt_timeline_timestamp.day",
@@ -13386,7 +17184,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_timeline_timestamp.day",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_timeline_timestamp.day",
+              "type": "attribute",
+            },
             "description": "Date",
+            "displayFormType": undefined,
             "id": "dt_timeline_timestamp.day",
             "ref": Object {
               "identifier": "dt_timeline_timestamp.day",
@@ -13403,6 +17206,10 @@ TigerWorkspaceCatalog {
             "description": "Week and Year (W52/2020)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_timeline_timestamp.week",
+                  "type": "attribute",
+                },
                 "description": "Week and Year (W52/2020)",
                 "displayFormType": undefined,
                 "id": "dt_timeline_timestamp.week",
@@ -13425,7 +17232,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_timeline_timestamp.week",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_timeline_timestamp.week",
+              "type": "attribute",
+            },
             "description": "Week and Year (W52/2020)",
+            "displayFormType": undefined,
             "id": "dt_timeline_timestamp.week",
             "ref": Object {
               "identifier": "dt_timeline_timestamp.week",
@@ -13442,6 +17254,10 @@ TigerWorkspaceCatalog {
             "description": "Month and Year (12/2020)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_timeline_timestamp.month",
+                  "type": "attribute",
+                },
                 "description": "Month and Year (12/2020)",
                 "displayFormType": undefined,
                 "id": "dt_timeline_timestamp.month",
@@ -13464,7 +17280,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_timeline_timestamp.month",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_timeline_timestamp.month",
+              "type": "attribute",
+            },
             "description": "Month and Year (12/2020)",
+            "displayFormType": undefined,
             "id": "dt_timeline_timestamp.month",
             "ref": Object {
               "identifier": "dt_timeline_timestamp.month",
@@ -13481,6 +17302,10 @@ TigerWorkspaceCatalog {
             "description": "Quarter and Year (Q1/2020)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_timeline_timestamp.quarter",
+                  "type": "attribute",
+                },
                 "description": "Quarter and Year (Q1/2020)",
                 "displayFormType": undefined,
                 "id": "dt_timeline_timestamp.quarter",
@@ -13503,7 +17328,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_timeline_timestamp.quarter",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_timeline_timestamp.quarter",
+              "type": "attribute",
+            },
             "description": "Quarter and Year (Q1/2020)",
+            "displayFormType": undefined,
             "id": "dt_timeline_timestamp.quarter",
             "ref": Object {
               "identifier": "dt_timeline_timestamp.quarter",
@@ -13520,6 +17350,10 @@ TigerWorkspaceCatalog {
             "description": "Year",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_timeline_timestamp.year",
+                  "type": "attribute",
+                },
                 "description": "Year",
                 "displayFormType": undefined,
                 "id": "dt_timeline_timestamp.year",
@@ -13542,7 +17376,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_timeline_timestamp.year",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_timeline_timestamp.year",
+              "type": "attribute",
+            },
             "description": "Year",
+            "displayFormType": undefined,
             "id": "dt_timeline_timestamp.year",
             "ref": Object {
               "identifier": "dt_timeline_timestamp.year",
@@ -13559,6 +17398,10 @@ TigerWorkspaceCatalog {
             "description": "Generic Minute of the Hour(MI1-MI60)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_timeline_timestamp.minuteOfHour",
+                  "type": "attribute",
+                },
                 "description": "Generic Minute of the Hour(MI1-MI60)",
                 "displayFormType": undefined,
                 "id": "dt_timeline_timestamp.minuteOfHour",
@@ -13581,7 +17424,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_timeline_timestamp.minuteOfHour",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_timeline_timestamp.minuteOfHour",
+              "type": "attribute",
+            },
             "description": "Generic Minute of the Hour(MI1-MI60)",
+            "displayFormType": undefined,
             "id": "dt_timeline_timestamp.minuteOfHour",
             "ref": Object {
               "identifier": "dt_timeline_timestamp.minuteOfHour",
@@ -13598,6 +17446,10 @@ TigerWorkspaceCatalog {
             "description": "Generic Hour of the Day(H1-H24)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_timeline_timestamp.hourOfDay",
+                  "type": "attribute",
+                },
                 "description": "Generic Hour of the Day(H1-H24)",
                 "displayFormType": undefined,
                 "id": "dt_timeline_timestamp.hourOfDay",
@@ -13620,7 +17472,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_timeline_timestamp.hourOfDay",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_timeline_timestamp.hourOfDay",
+              "type": "attribute",
+            },
             "description": "Generic Hour of the Day(H1-H24)",
+            "displayFormType": undefined,
             "id": "dt_timeline_timestamp.hourOfDay",
             "ref": Object {
               "identifier": "dt_timeline_timestamp.hourOfDay",
@@ -13637,6 +17494,10 @@ TigerWorkspaceCatalog {
             "description": "Generic Day of the Week (D1-D7)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_timeline_timestamp.dayOfWeek",
+                  "type": "attribute",
+                },
                 "description": "Generic Day of the Week (D1-D7)",
                 "displayFormType": undefined,
                 "id": "dt_timeline_timestamp.dayOfWeek",
@@ -13659,7 +17520,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_timeline_timestamp.dayOfWeek",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_timeline_timestamp.dayOfWeek",
+              "type": "attribute",
+            },
             "description": "Generic Day of the Week (D1-D7)",
+            "displayFormType": undefined,
             "id": "dt_timeline_timestamp.dayOfWeek",
             "ref": Object {
               "identifier": "dt_timeline_timestamp.dayOfWeek",
@@ -13676,6 +17542,10 @@ TigerWorkspaceCatalog {
             "description": "Generic Day of the Month (D1-D31)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_timeline_timestamp.dayOfMonth",
+                  "type": "attribute",
+                },
                 "description": "Generic Day of the Month (D1-D31)",
                 "displayFormType": undefined,
                 "id": "dt_timeline_timestamp.dayOfMonth",
@@ -13698,7 +17568,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_timeline_timestamp.dayOfMonth",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_timeline_timestamp.dayOfMonth",
+              "type": "attribute",
+            },
             "description": "Generic Day of the Month (D1-D31)",
+            "displayFormType": undefined,
             "id": "dt_timeline_timestamp.dayOfMonth",
             "ref": Object {
               "identifier": "dt_timeline_timestamp.dayOfMonth",
@@ -13715,6 +17590,10 @@ TigerWorkspaceCatalog {
             "description": "Generic Day of the Year (D1-D366)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_timeline_timestamp.dayOfYear",
+                  "type": "attribute",
+                },
                 "description": "Generic Day of the Year (D1-D366)",
                 "displayFormType": undefined,
                 "id": "dt_timeline_timestamp.dayOfYear",
@@ -13737,7 +17616,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_timeline_timestamp.dayOfYear",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_timeline_timestamp.dayOfYear",
+              "type": "attribute",
+            },
             "description": "Generic Day of the Year (D1-D366)",
+            "displayFormType": undefined,
             "id": "dt_timeline_timestamp.dayOfYear",
             "ref": Object {
               "identifier": "dt_timeline_timestamp.dayOfYear",
@@ -13754,6 +17638,10 @@ TigerWorkspaceCatalog {
             "description": "Generic Week (W1-W53)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_timeline_timestamp.weekOfYear",
+                  "type": "attribute",
+                },
                 "description": "Generic Week (W1-W53)",
                 "displayFormType": undefined,
                 "id": "dt_timeline_timestamp.weekOfYear",
@@ -13776,7 +17664,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_timeline_timestamp.weekOfYear",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_timeline_timestamp.weekOfYear",
+              "type": "attribute",
+            },
             "description": "Generic Week (W1-W53)",
+            "displayFormType": undefined,
             "id": "dt_timeline_timestamp.weekOfYear",
             "ref": Object {
               "identifier": "dt_timeline_timestamp.weekOfYear",
@@ -13793,6 +17686,10 @@ TigerWorkspaceCatalog {
             "description": "Generic Month (M1-M12)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_timeline_timestamp.monthOfYear",
+                  "type": "attribute",
+                },
                 "description": "Generic Month (M1-M12)",
                 "displayFormType": undefined,
                 "id": "dt_timeline_timestamp.monthOfYear",
@@ -13815,7 +17712,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_timeline_timestamp.monthOfYear",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_timeline_timestamp.monthOfYear",
+              "type": "attribute",
+            },
             "description": "Generic Month (M1-M12)",
+            "displayFormType": undefined,
             "id": "dt_timeline_timestamp.monthOfYear",
             "ref": Object {
               "identifier": "dt_timeline_timestamp.monthOfYear",
@@ -13832,6 +17734,10 @@ TigerWorkspaceCatalog {
             "description": "Generic Quarter (Q1-Q4)",
             "displayForms": Array [
               Object {
+                "attribute": Object {
+                  "identifier": "dt_timeline_timestamp.quarterOfYear",
+                  "type": "attribute",
+                },
                 "description": "Generic Quarter (Q1-Q4)",
                 "displayFormType": undefined,
                 "id": "dt_timeline_timestamp.quarterOfYear",
@@ -13854,7 +17760,12 @@ TigerWorkspaceCatalog {
             "uri": "https://staging.anywhere.gooddata.com/api/v1/entities/workspaces/4dc4e033e611421791adea58d34d958c/attributes/dt_timeline_timestamp.quarterOfYear",
           },
           "defaultDisplayForm": Object {
+            "attribute": Object {
+              "identifier": "dt_timeline_timestamp.quarterOfYear",
+              "type": "attribute",
+            },
             "description": "Generic Quarter (Q1-Q4)",
+            "displayFormType": undefined,
             "id": "dt_timeline_timestamp.quarterOfYear",
             "ref": Object {
               "identifier": "dt_timeline_timestamp.quarterOfYear",


### PR DESCRIPTION
We did not fill the `attribute` and `displayForms` fields correctly.

This was fixed and the conversion logic was unified a bit.

JIRA: RAIL-4626

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
