### PR TITLE
BUGFIX: TNT-1164 Omit comparing Bubble props by lodash/isEqual

### DIFF
--- a/libs/sdk-ui-kit/src/Bubble/Bubble.tsx
+++ b/libs/sdk-ui-kit/src/Bubble/Bubble.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import keys from "lodash/keys";
 import cloneDeep from "lodash/cloneDeep";
 import isEqual from "lodash/isEqual";
+import isReactEqual from "react-fast-compare";
 import result from "lodash/result";
 import noop from "lodash/noop";
 import cx from "classnames";
@@ -124,7 +125,7 @@ export class Bubble extends React.Component<IBubbleProps, IBubbleState> {
     }
 
     shouldComponentUpdate(nextProps: IBubbleProps, nextState: IBubbleState): boolean {
-        const propsChanged = !isEqual(this.props, nextProps);
+        const propsChanged = !isReactEqual(this.props, nextProps);
         const alignmentChanged = !isEqual(this.state.optimalAlignPoints, nextState.optimalAlignPoints);
 
         return propsChanged || alignmentChanged;


### PR DESCRIPTION
JIRA: TNT-1164

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
