### PR TITLE
BUGFIX: TNT-1171 Change default behavior for widget descriptions

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/widget/description/InsightWidgetDescriptionTrigger.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/description/InsightWidgetDescriptionTrigger.tsx
@@ -6,7 +6,7 @@ import { IInsightWidgetDescriptionTriggerProps } from "./types";
 
 export const InsightWidgetDescriptionTrigger: React.FC<IInsightWidgetDescriptionTriggerProps> = (props) => {
     const { widget, insight } = props;
-    const visible = widget.configuration?.description?.visible;
+    const visible = widget.configuration?.description?.visible ?? true;
     const description =
         widget.configuration?.description?.source === "widget" ? widget.description : insight.insight.summary;
 

--- a/libs/sdk-ui-dashboard/src/presentation/widget/kpi/ViewModeDashboardKpi/KpiAlerts/KpiDescriptionTrigger.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/kpi/ViewModeDashboardKpi/KpiAlerts/KpiDescriptionTrigger.tsx
@@ -12,7 +12,7 @@ const getKpiMetricDescription = (metrics: ICatalogMeasure[], ref: ObjRef): strin
 
 export const KpiDescriptionTrigger: React.FC<IKpiDescriptionTriggerProps> = (props) => {
     const { kpi } = props;
-    const visible = kpi.configuration?.description?.visible;
+    const visible = kpi.configuration?.description?.visible ?? true;
     const metrics = useDashboardSelector(selectCatalogMeasures);
 
     const description =


### PR DESCRIPTION
JIRA: TNT-1171

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
