### PR TITLE
FEATURE: RAIL-4437 Indicate that a section or a widget are added by a widget in edit mode

### DIFF
--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -3238,7 +3238,7 @@ export interface IDashboardEventsContext {
 }
 
 // @public
-export interface IDashboardExtensionProps extends IDashboardEventing, IDashboardCustomizationProps, IDashboardThemingProps {
+export interface IDashboardExtensionProps extends IDashboardEventing, IDashboardCustomizationProps, IDashboardWidgetsOverlayProps, IDashboardThemingProps {
     additionalReduxContext?: React_2.Context<ReactReduxContextValue>;
 }
 
@@ -3424,6 +3424,8 @@ export interface IDashboardStoreProviderProps {
     // (undocumented)
     persistedDashboard?: IDashboard;
     // (undocumented)
+    widgetsOverlayFn?: WidgetsOverlayFn;
+    // (undocumented)
     workspace?: string;
 }
 
@@ -3437,6 +3439,12 @@ export interface IDashboardThemingProps {
 // @public
 export interface IDashboardWidgetCustomizer {
     addCustomWidget(widgetType: string, Component: CustomDashboardWidgetComponent): IDashboardWidgetCustomizer;
+}
+
+// @alpha (undocumented)
+export interface IDashboardWidgetOverlay {
+    modification?: "insertedByPlugin" | "modifiedByPlugin";
+    showOverlay: boolean;
 }
 
 // @public
@@ -3467,6 +3475,12 @@ export interface IDashboardWidgetProps {
     widget?: ExtendedDashboardWidget;
     // @alpha
     workspace?: string;
+}
+
+// @public
+export interface IDashboardWidgetsOverlayProps {
+    // @alpha
+    widgetsOverlayFn?: WidgetsOverlayFn;
 }
 
 // @public
@@ -6029,6 +6043,9 @@ export const selectRenderMode: OutputSelector<DashboardState, RenderMode, (res: 
 // @alpha (undocumented)
 export const selectScheduleEmailDialogDefaultAttachment: OutputSelector<DashboardState, UriRef | IdentifierRef | undefined, (res: UiState) => UriRef | IdentifierRef | undefined>;
 
+// @internal (undocumented)
+export const selectSectionModification: (refs: (ObjRef | undefined)[]) => OutputSelector<DashboardState, ("insertedByPlugin" | "modifiedByPlugin")[], (res: Record<string, IDashboardWidgetOverlay>) => ("insertedByPlugin" | "modifiedByPlugin")[]>;
+
 // @alpha (undocumented)
 export const selectSelectedFilterIndex: OutputSelector<DashboardState, number | undefined, (res: UiState) => number | undefined>;
 
@@ -6091,6 +6108,12 @@ export const selectWidgets: OutputSelector<DashboardState, ExtendedDashboardWidg
 
 // @internal
 export const selectWidgetsMap: OutputSelector<DashboardState, ObjRefMap<ExtendedDashboardWidget>, (res: ExtendedDashboardWidget[]) => ObjRefMap<ExtendedDashboardWidget>>;
+
+// @internal (undocumented)
+export const selectWidgetsModification: (refs: (ObjRef | undefined)[]) => OutputSelector<DashboardState, ("insertedByPlugin" | "modifiedByPlugin")[], (res: Record<string, IDashboardWidgetOverlay>) => ("insertedByPlugin" | "modifiedByPlugin")[]>;
+
+// @internal (undocumented)
+export const selectWidgetsOverlayState: (refs: (ObjRef | undefined)[]) => OutputSelector<DashboardState, boolean, (res: Record<string, IDashboardWidgetOverlay>) => boolean>;
 
 // @internal (undocumented)
 export interface SetAttributeFilterDisplayForm extends IDashboardCommand {
@@ -6326,6 +6349,18 @@ clearDraggingWidgetTarget: CaseReducer<UiState, {
 payload: void;
 type: string;
 }>;
+toggleWidgetsOverlay: CaseReducer<UiState, {
+payload: {
+refs: (UriRef | IdentifierRef | undefined)[];
+visible: boolean;
+};
+type: string;
+}>;
+setWidgetsOverlay: CaseReducer<UiState, {
+payload: Record<string, IDashboardWidgetOverlay>;
+type: string;
+}>;
+hideAllWidgetsOverlay: CaseReducer<UiState, AnyAction>;
 }>;
 
 // @alpha (undocumented)
@@ -6394,6 +6429,8 @@ export interface UiState {
     toastMessages: IToastMessage[];
     // (undocumented)
     widgetsLoadingAdditionalData: ObjRef[];
+    // (undocumented)
+    widgetsOverlay: Record<string, IDashboardWidgetOverlay>;
 }
 
 // @alpha
@@ -7125,6 +7162,9 @@ export type WidgetFilterOperation = FilterOpEnableDateFilter | FilterOpDisableDa
 export interface WidgetHeader {
     title?: string;
 }
+
+// @alpha (undocumented)
+export type WidgetsOverlayFn = (dashboard: IDashboard<ExtendedDashboardWidget>) => Record<string, IDashboardWidgetOverlay>;
 
 // @internal (undocumented)
 export interface WidthResizerDragItem {

--- a/libs/sdk-ui-dashboard/src/_staging/dashboard/fluidLayout/facade/interfaces.ts
+++ b/libs/sdk-ui-dashboard/src/_staging/dashboard/fluidLayout/facade/interfaces.ts
@@ -29,6 +29,7 @@ export interface IDashboardLayoutItemFacade<TWidget> {
     sizeForScreen(screen: ScreenSize): IDashboardLayoutSize | undefined;
     widget(): TWidget | undefined;
     section(): IDashboardLayoutSectionFacade<TWidget>;
+    ref(): ObjRef | undefined;
     // item predicates
     indexIs(index: number): boolean;
     isFirst(): boolean;

--- a/libs/sdk-ui-dashboard/src/_staging/dashboard/fluidLayout/facade/item.ts
+++ b/libs/sdk-ui-dashboard/src/_staging/dashboard/fluidLayout/facade/item.ts
@@ -24,6 +24,7 @@ import {
     ScreenSize,
     isDashboardLayout,
     isDashboardLayoutItem,
+    isObjRef,
 } from "@gooddata/sdk-model";
 import { IDashboardLayoutItemFacade, IDashboardLayoutSectionFacade } from "./interfaces";
 
@@ -70,6 +71,13 @@ export class DashboardLayoutItemFacade<TWidget> implements IDashboardLayoutItemF
 
     public widget(): TWidget | undefined {
         return this.item.widget;
+    }
+
+    public ref(): ObjRef | undefined {
+        if (isObjRef(this.item.widget)) {
+            return this.item.widget;
+        }
+        return undefined;
     }
 
     public widgetEquals(widget: TWidget | undefined): boolean {

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/common/stateInitializers.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/common/stateInitializers.ts
@@ -143,6 +143,7 @@ export function* actionsToInitializeExistingDashboard(
     const privateCtx: PrivateDashboardContext = yield call(getPrivateContext);
     const customizedDashboard =
         privateCtx?.existingDashboardTransformFn?.(sanitizedDashboard) ?? sanitizedDashboard;
+    const modifiedWidgets = privateCtx?.widgetsOverlayFn?.(customizedDashboard) ?? {};
 
     const filterContextDefinition = dashboardFilterContextDefinition(customizedDashboard, dateFilterConfig);
     const filterContextIdentity = dashboardFilterContextIdentity(customizedDashboard);
@@ -179,5 +180,6 @@ export function* actionsToInitializeExistingDashboard(
         }),
         metaActions.setDashboardTitle(dashboard.title), // even when using persistedDashboard, use the working title of the dashboard
         uiActions.clearWidgetSelection(),
+        uiActions.setWidgetsOverlay(modifiedWidgets),
     ];
 }

--- a/libs/sdk-ui-dashboard/src/model/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/index.ts
@@ -25,6 +25,8 @@ export {
     IResolvedAttributeFilterValues,
     IResolvedDateFilterValue,
     IResolvedFilterValues,
+    WidgetsOverlayFn,
+    IDashboardWidgetOverlay,
 } from "./types/commonTypes";
 export {
     ICustomWidget,

--- a/libs/sdk-ui-dashboard/src/model/react/types.ts
+++ b/libs/sdk-ui-dashboard/src/model/react/types.ts
@@ -3,7 +3,7 @@ import { IAnalyticalBackend } from "@gooddata/sdk-backend-spi";
 import { ObjRef, IDashboard, IWorkspacePermissions } from "@gooddata/sdk-model";
 import { DashboardEventHandler } from "../eventHandlers/eventHandler";
 import { DashboardDispatch, DashboardState } from "../store";
-import { DashboardConfig, DashboardModelCustomizationFns } from "../types/commonTypes";
+import { DashboardConfig, DashboardModelCustomizationFns, WidgetsOverlayFn } from "../types/commonTypes";
 import React from "react";
 import { ReactReduxContextValue } from "react-redux";
 import { RenderMode } from "../../types";
@@ -29,5 +29,6 @@ export interface IDashboardStoreProviderProps {
     ) => void;
     additionalReduxContext?: React.Context<ReactReduxContextValue>;
     customizationFns?: DashboardModelCustomizationFns;
+    widgetsOverlayFn?: WidgetsOverlayFn;
     initialRenderMode?: RenderMode;
 }

--- a/libs/sdk-ui-dashboard/src/model/react/useInitializeDashboardStore.ts
+++ b/libs/sdk-ui-dashboard/src/model/react/useInitializeDashboardStore.ts
@@ -127,6 +127,7 @@ export const useInitializeDashboardStore = (
                 backgroundWorkers,
                 privateContext: {
                     ...props.customizationFns,
+                    widgetsOverlayFn: props.widgetsOverlayFn,
                     preloadedDashboard: isDashboard(dashboard) ? dashboard : undefined,
                 },
                 initialRenderMode: props.initialRenderMode ?? "view",

--- a/libs/sdk-ui-dashboard/src/model/store/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/index.ts
@@ -240,6 +240,9 @@ export {
     selectIsCancelEditModeDialogOpen,
     selectDraggingWidgetSource,
     selectDraggingWidgetTarget,
+    selectWidgetsOverlayState,
+    selectWidgetsModification,
+    selectSectionModification,
 } from "./ui/uiSelectors";
 export { uiActions } from "./ui";
 export { RenderModeState } from "./renderMode/renderModeState";

--- a/libs/sdk-ui-dashboard/src/model/store/ui/uiState.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/ui/uiState.ts
@@ -3,6 +3,7 @@ import { ObjRef } from "@gooddata/sdk-model";
 
 import { ILayoutCoordinates, IMenuButtonItemsVisibility, IToastMessage } from "../../../types";
 import { DraggableLayoutItem } from "../../../presentation/dragAndDrop/types";
+import { IDashboardWidgetOverlay } from "../../types/commonTypes";
 
 /**
  * @alpha
@@ -54,6 +55,7 @@ export interface UiState {
     toastMessages: IToastMessage[];
     draggingWidgetSource: DraggableLayoutItem | undefined;
     draggingWidgetTarget: ILayoutCoordinates | undefined;
+    widgetsOverlay: Record<string, IDashboardWidgetOverlay>;
 }
 
 export const uiInitialState: UiState = {
@@ -100,4 +102,5 @@ export const uiInitialState: UiState = {
     toastMessages: [],
     draggingWidgetSource: undefined,
     draggingWidgetTarget: undefined,
+    widgetsOverlay: {},
 };

--- a/libs/sdk-ui-dashboard/src/model/types/commonTypes.ts
+++ b/libs/sdk-ui-dashboard/src/model/types/commonTypes.ts
@@ -269,6 +269,15 @@ export type PrivateDashboardContext = DashboardModelCustomizationFns & {
      * loading dashboard from backend.
      */
     preloadedDashboard?: IDashboard;
+    /**
+     * Provide a function that will be used during dashboard initialization and can add overlays with some info
+     * about modification or insertion by plugin
+     *
+     * @remarks
+     *
+     * -  If the function is not defined, then no overlays will be rendered
+     */
+    widgetsOverlayFn?: WidgetsOverlayFn;
 };
 
 /**
@@ -293,6 +302,39 @@ export interface DashboardModelCustomizationFns {
      *    dashboard will be used as-is.
      */
     existingDashboardTransformFn?: DashboardTransformFn;
+}
+
+/**
+ * @alpha
+ */
+export type WidgetsOverlayFn = (
+    dashboard: IDashboard<ExtendedDashboardWidget>,
+) => Record<string, IDashboardWidgetOverlay>;
+
+/**
+ * @alpha
+ */
+export interface IDashboardWidgetOverlay {
+    /**
+     * Overlay over widget is display
+     *
+     * @alpha
+     */
+    showOverlay: boolean;
+
+    /**
+     * Modifications type for widget
+     *
+     * @remarks
+     * "insertedByPlugin"
+     * Widget is inserted by plugin and is not originally in layout
+     *
+     * "modifiedByPlugin"
+     * Widget is originally in layout but was modified by plugin by adding some decorators, tags, providers and so on
+     *
+     * @alpha
+     */
+    modification?: "insertedByPlugin" | "modifiedByPlugin";
 }
 
 /**

--- a/libs/sdk-ui-dashboard/src/plugins/customizationApis/layoutCustomizer.ts
+++ b/libs/sdk-ui-dashboard/src/plugins/customizationApis/layoutCustomizer.ts
@@ -4,12 +4,16 @@ import { IDashboardCustomizationLogger } from "./customizationLogging";
 import { FluidLayoutCustomizer } from "./fluidLayoutCustomizer";
 import { IDashboardLayout } from "@gooddata/sdk-model";
 import { DashboardTransformFn, ExtendedDashboardWidget } from "../../model";
+import { CustomizerMutationsContext } from "./types";
 
 export class DefaultLayoutCustomizer implements IDashboardLayoutCustomizer {
     private sealed = false;
     private readonly fluidLayoutTransformations: FluidLayoutCustomizationFn[] = [];
 
-    constructor(private readonly logger: IDashboardCustomizationLogger) {}
+    constructor(
+        private readonly logger: IDashboardCustomizationLogger,
+        private readonly mutationContext: CustomizerMutationsContext,
+    ) {}
 
     public customizeFluidLayout = (
         customizationFn: FluidLayoutCustomizationFn,
@@ -52,7 +56,7 @@ export class DefaultLayoutCustomizer implements IDashboardLayoutCustomizer {
 
             const newLayout = snapshot.reduce((currentLayout, fn) => {
                 // Create a new fluid layout customizer just for this round of processing
-                const customizer = new FluidLayoutCustomizer(this.logger);
+                const customizer = new FluidLayoutCustomizer(this.logger, this.mutationContext);
 
                 try {
                     // call out to the plugin-provided function with the current value of the layout & the

--- a/libs/sdk-ui-dashboard/src/plugins/customizationApis/tests/fluidLayoutCustomizer.test.ts
+++ b/libs/sdk-ui-dashboard/src/plugins/customizationApis/tests/fluidLayoutCustomizer.test.ts
@@ -4,6 +4,7 @@ import { FluidLayoutCustomizer } from "../fluidLayoutCustomizer";
 import { IDashboardLayout, IDashboardLayoutSection, IDashboardLayoutItem } from "@gooddata/sdk-model";
 import { ExtendedDashboardWidget, ICustomWidget, newCustomWidget } from "../../../model";
 import { DashboardCustomizationLogger } from "../customizationLogging";
+import { createCustomizerMutationsContext, CustomizerMutationsContext } from "../types";
 
 const EmptyLayout: IDashboardLayout<ExtendedDashboardWidget> = {
     type: "IDashboardLayout",
@@ -36,9 +37,11 @@ function createTestItem(widget: ICustomWidget): IDashboardLayoutItem<ICustomWidg
 // has its own battery of tests
 describe("fluid layout customizer", () => {
     let Customizer: FluidLayoutCustomizer;
+    let mutationContext: CustomizerMutationsContext;
 
     beforeEach(() => {
-        Customizer = new FluidLayoutCustomizer(new DashboardCustomizationLogger());
+        mutationContext = createCustomizerMutationsContext();
+        Customizer = new FluidLayoutCustomizer(new DashboardCustomizationLogger(), mutationContext);
     });
 
     it("should add new section with custom widgets", () => {
@@ -57,6 +60,14 @@ describe("fluid layout customizer", () => {
 
         const updatedNonEmptyLayout = Customizer.applyTransformations(LayoutWithOneSection);
         expect(updatedNonEmptyLayout.sections[1]).toEqual(newSection);
+        expect(mutationContext).toEqual({
+            kpi: [],
+            insight: [],
+            layouts: {
+                "1": "inserted",
+                "2": "inserted",
+            },
+        });
     });
 
     it("should not add empty section", () => {
@@ -69,6 +80,11 @@ describe("fluid layout customizer", () => {
 
         const updatedEmptyLayout = Customizer.applyTransformations(EmptyLayout);
         expect(updatedEmptyLayout.sections.length).toEqual(0);
+        expect(mutationContext).toEqual({
+            kpi: [],
+            insight: [],
+            layouts: {},
+        });
     });
 
     it("should not add section with item that has no widget", () => {
@@ -91,6 +107,11 @@ describe("fluid layout customizer", () => {
 
         const updatedEmptyLayout = Customizer.applyTransformations(EmptyLayout);
         expect(updatedEmptyLayout.sections.length).toEqual(0);
+        expect(mutationContext).toEqual({
+            kpi: [],
+            insight: [],
+            layouts: {},
+        });
     });
 
     it("should add new item into an existing section", () => {
@@ -100,6 +121,13 @@ describe("fluid layout customizer", () => {
         const updatedNonEmptyLayout = Customizer.applyTransformations(LayoutWithOneSection);
 
         expect(updatedNonEmptyLayout.sections[0].items).toEqual([item]);
+        expect(mutationContext).toEqual({
+            kpi: [],
+            insight: [],
+            layouts: {
+                "1": "inserted",
+            },
+        });
     });
 
     it("should not add item without widget", () => {
@@ -114,6 +142,11 @@ describe("fluid layout customizer", () => {
 
         const updatedNonEmptyLayout = Customizer.applyTransformations(LayoutWithOneSection);
         expect(updatedNonEmptyLayout.sections[0]).toEqual(LayoutWithOneSection.sections[0]);
+        expect(mutationContext).toEqual({
+            kpi: [],
+            insight: [],
+            layouts: {},
+        });
     });
 
     it("should first add new items then new sections", () => {
@@ -130,5 +163,14 @@ describe("fluid layout customizer", () => {
 
         expect(updatedNonEmptyLayout.sections[0]).toEqual(newSection);
         expect(updatedNonEmptyLayout.sections[1].items).toEqual([newItem]);
+
+        expect(mutationContext).toEqual({
+            kpi: [],
+            insight: [],
+            layouts: {
+                "1": "inserted",
+                "2": "inserted",
+            },
+        });
     });
 });

--- a/libs/sdk-ui-dashboard/src/plugins/customizationApis/tests/kpiCustomizer.test.tsx
+++ b/libs/sdk-ui-dashboard/src/plugins/customizationApis/tests/kpiCustomizer.test.tsx
@@ -12,6 +12,7 @@ import { render } from "@testing-library/react";
 import invariant from "ts-invariant";
 import { DefaultKpiCustomizer } from "../kpiCustomizer";
 import { DashboardCustomizationLogger } from "../customizationLogging";
+import { createCustomizerMutationsContext, CustomizerMutationsContext } from "../types";
 
 //
 //
@@ -107,10 +108,13 @@ function renderToHtml(customizer: DefaultKpiCustomizer, widget: IKpiWidget) {
 
 describe("KPI customizer", () => {
     let Customizer: DefaultKpiCustomizer;
+    let mutationContext: CustomizerMutationsContext;
 
     beforeEach(() => {
+        mutationContext = createCustomizerMutationsContext();
         Customizer = new DefaultKpiCustomizer(
             new DashboardCustomizationLogger(),
+            mutationContext,
             DefaultTestComponentProvider,
         );
     });
@@ -128,6 +132,11 @@ describe("KPI customizer", () => {
             Customizer.withCustomProvider(provider);
 
             expect(renderToHtml(Customizer, TestKpiWidgetWithCustomTitle)).toMatchSnapshot();
+            expect(mutationContext).toEqual({
+                kpi: ["provider"],
+                insight: [],
+                layouts: {},
+            });
         });
 
         it("should fallback to default component if insight does not match provider criteria", () => {
@@ -138,6 +147,11 @@ describe("KPI customizer", () => {
             Customizer.withCustomProvider(provider);
 
             expect(renderToHtml(Customizer, TestKpiWidget)).toMatchSnapshot();
+            expect(mutationContext).toEqual({
+                kpi: ["provider"],
+                insight: [],
+                layouts: {},
+            });
         });
 
         it("should use component from latest registered provider that matches the insight", () => {
@@ -159,6 +173,11 @@ describe("KPI customizer", () => {
 
             // component from last registered and matching provider is `fromCustomProvider3`
             expect(renderToHtml(Customizer, TestKpiWidgetWithCustomTitle)).toMatchSnapshot();
+            expect(mutationContext).toEqual({
+                kpi: ["provider"],
+                insight: [],
+                layouts: {},
+            });
         });
     });
 
@@ -168,6 +187,11 @@ describe("KPI customizer", () => {
             Customizer.withCustomDecorator(factory);
 
             expect(renderToHtml(Customizer, TestKpiWidget)).toMatchSnapshot();
+            expect(mutationContext).toEqual({
+                kpi: ["decorator"],
+                insight: [],
+                layouts: {},
+            });
         });
 
         it("should decorate custom component registered for an insight", () => {
@@ -181,6 +205,11 @@ describe("KPI customizer", () => {
             Customizer.withCustomProvider(provider);
 
             expect(renderToHtml(Customizer, TestKpiWidgetWithCustomTitle)).toMatchSnapshot();
+            expect(mutationContext).toEqual({
+                kpi: ["decorator", "provider"],
+                insight: [],
+                layouts: {},
+            });
         });
 
         it("should decorate default component if insight does not match custom component criteria ", () => {
@@ -193,6 +222,11 @@ describe("KPI customizer", () => {
             Customizer.withCustomProvider(provider);
 
             expect(renderToHtml(Customizer, TestKpiWidget)).toMatchSnapshot();
+            expect(mutationContext).toEqual({
+                kpi: ["decorator", "provider"],
+                insight: [],
+                layouts: {},
+            });
         });
 
         it("should decorate if insight matches criteria", () => {
@@ -203,6 +237,11 @@ describe("KPI customizer", () => {
             Customizer.withCustomDecorator(factory);
 
             expect(renderToHtml(Customizer, TestKpiWidgetWithCustomTitle)).toMatchSnapshot();
+            expect(mutationContext).toEqual({
+                kpi: ["decorator"],
+                insight: [],
+                layouts: {},
+            });
         });
 
         it("should not decorate if insight does not match criteria", () => {
@@ -213,6 +252,11 @@ describe("KPI customizer", () => {
             Customizer.withCustomDecorator(factory);
 
             expect(renderToHtml(Customizer, TestKpiWidget)).toMatchSnapshot();
+            expect(mutationContext).toEqual({
+                kpi: ["decorator"],
+                insight: [],
+                layouts: {},
+            });
         });
 
         it("should use multiple decorators if insight matches criteria", () => {
@@ -229,6 +273,11 @@ describe("KPI customizer", () => {
 
             // decoration starts from last register; so need to see decorator2 -> decorator1 -> default component
             expect(renderToHtml(Customizer, TestKpiWidgetWithCustomTitle)).toMatchSnapshot();
+            expect(mutationContext).toEqual({
+                kpi: ["decorator"],
+                insight: [],
+                layouts: {},
+            });
         });
 
         it("should use multiple decorators and custom component if insight matches criteria", () => {
@@ -250,6 +299,11 @@ describe("KPI customizer", () => {
 
             // decoration starts from last register; so need to see decorator2 -> decorator1 -> custom component
             expect(renderToHtml(Customizer, TestKpiWidgetWithCustomTitle)).toMatchSnapshot();
+            expect(mutationContext).toEqual({
+                kpi: ["decorator", "provider"],
+                insight: [],
+                layouts: {},
+            });
         });
 
         it("should only use only those decorators that match criteria and then use custom component", () => {
@@ -269,6 +323,11 @@ describe("KPI customizer", () => {
 
             // This will use decorator2 on top of customProvider1
             expect(renderToHtml(Customizer, TestKpiWidgetWithCustomTitle)).toMatchSnapshot();
+            expect(mutationContext).toEqual({
+                kpi: ["decorator", "provider"],
+                insight: [],
+                layouts: {},
+            });
         });
     });
 });

--- a/libs/sdk-ui-dashboard/src/plugins/customizationApis/tests/layoutCustomizer.test.ts
+++ b/libs/sdk-ui-dashboard/src/plugins/customizationApis/tests/layoutCustomizer.test.ts
@@ -4,6 +4,7 @@ import { DashboardCustomizationLogger } from "../customizationLogging";
 import { DefaultLayoutCustomizer } from "../layoutCustomizer";
 import { ExtendedDashboardWidget } from "../../../model";
 import { idRef, IDashboard } from "@gooddata/sdk-model";
+import { createCustomizerMutationsContext } from "../types";
 
 const EmptyDashboard: IDashboard<ExtendedDashboardWidget> = {
     type: "IDashboard",
@@ -25,7 +26,10 @@ describe("layout customizer", () => {
     let Customizer: DefaultLayoutCustomizer;
 
     beforeEach(() => {
-        Customizer = new DefaultLayoutCustomizer(new DashboardCustomizationLogger());
+        Customizer = new DefaultLayoutCustomizer(
+            new DashboardCustomizationLogger(),
+            createCustomizerMutationsContext(),
+        );
     });
 
     it("should allow fluid layout customization and deal with transform returning undefined", () => {

--- a/libs/sdk-ui-dashboard/src/plugins/customizationApis/types.ts
+++ b/libs/sdk-ui-dashboard/src/plugins/customizationApis/types.ts
@@ -1,0 +1,17 @@
+// (C) 2021-2022 GoodData Corporation
+
+export type CustomizerMutationsContext = {
+    insight: CustomizerMutationsType[];
+    kpi: CustomizerMutationsType[];
+    layouts: Record<string, CustomizerMutationsType>;
+};
+
+export type CustomizerMutationsType = "tag" | "provider" | "body" | "decorator" | "inserted";
+
+export function createCustomizerMutationsContext(): CustomizerMutationsContext {
+    return {
+        insight: [],
+        kpi: [],
+        layouts: {},
+    };
+}

--- a/libs/sdk-ui-dashboard/src/presentation/dashboard/components/DashboardRenderer.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/dashboard/components/DashboardRenderer.tsx
@@ -80,6 +80,7 @@ export const DashboardRenderer: React.FC<IDashboardProps> = (props: IDashboardPr
                         onEventingInitialized={props.onEventingInitialized}
                         additionalReduxContext={props.additionalReduxContext}
                         customizationFns={props.customizationFns}
+                        widgetsOverlayFn={props.widgetsOverlayFn}
                     >
                         <ToastMessageContextProvider>
                             <ExportDialogContextProvider>

--- a/libs/sdk-ui-dashboard/src/presentation/dashboard/types.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/dashboard/types.ts
@@ -11,6 +11,7 @@ import {
     DashboardEventHandler,
     DashboardModelCustomizationFns,
     DashboardState,
+    WidgetsOverlayFn,
 } from "../../model";
 import { CustomFilterBarComponent } from "../filterBar";
 import { CustomDashboardLayoutComponent, CustomEmptyLayoutDropZoneBodyComponent } from "../layout";
@@ -371,6 +372,24 @@ export interface IDashboardCustomizationProps extends IDashboardCustomComponentP
 }
 
 /**
+ * Properties for {@link Dashboard} widgets overlay.
+ *
+ * @remarks
+ * IMPORTANT: while this interface is marked as public, you also need to heed the maturity annotations
+ * on each property. A lot of these properties are at this moment alpha level.
+ *
+ * @public
+ */
+export interface IDashboardWidgetsOverlayProps {
+    /**
+     * Provide settings for widgets overlay
+     *
+     * @alpha
+     */
+    widgetsOverlayFn?: WidgetsOverlayFn;
+}
+
+/**
  * @public
  */
 export interface IDashboardThemingProps {
@@ -538,6 +557,7 @@ export interface IDashboardBaseProps {
 export interface IDashboardExtensionProps
     extends IDashboardEventing,
         IDashboardCustomizationProps,
+        IDashboardWidgetsOverlayProps,
         IDashboardThemingProps {
     /**
      * Pass instance of ReactReduxContext where the dashboard component's store should be saved.

--- a/libs/sdk-ui-dashboard/src/presentation/layout/DashboardItemOverlay/DashboardItemOverlay.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/layout/DashboardItemOverlay/DashboardItemOverlay.tsx
@@ -1,0 +1,91 @@
+// (C) 2020-2022 GoodData Corporation
+import React, { useState } from "react";
+import classNames from "classnames";
+import { Button } from "@gooddata/sdk-ui-kit";
+import Measure from "react-measure";
+import { useTheme } from "@gooddata/sdk-ui-theme-provider";
+import { FormattedMessage, useIntl } from "react-intl";
+import { IDashboardWidgetOverlay } from "../../../model";
+
+type DashboardItemOverlayProps = {
+    render?: boolean;
+    type: "row" | "column";
+    modifications: Required<IDashboardWidgetOverlay>["modification"][];
+    onHide?: () => void;
+};
+
+export const DashboardItemOverlay: React.FunctionComponent<DashboardItemOverlayProps> = ({
+    render,
+    type,
+    modifications,
+    onHide,
+}) => {
+    const intl = useIntl();
+    const added = modifications.includes("insertedByPlugin");
+    const modified = modifications.includes("modifiedByPlugin");
+
+    const theme = useTheme();
+    const [size, setSize] = useState<"big" | "small" | "none">("none");
+    const [height, setHeight] = useState(0);
+    const classes = classNames("gd-fluidlayout-item-changed", {
+        [type]: true,
+        [size]: true,
+        added: added,
+        modified: modified,
+    });
+    const show = render && (added || modified);
+
+    return show ? (
+        <Measure
+            client
+            onResize={(data) => {
+                if (data.client) {
+                    setSize(data.client.height < 100 ? "small" : "big");
+                    setHeight(data.client.height);
+                }
+            }}
+        >
+            {({ measureRef }) => (
+                <div className={classes} ref={measureRef}>
+                    <div className="gd-fluidlayout-item-changed-content">
+                        <div className="gd-fluidlayout-item-changed-icon" style={height ? { height } : {}}>
+                            <PluginIcon color={theme?.palette?.complementary?.c7} />
+                        </div>
+                        <div className="gd-fluidlayout-item-changed-info">
+                            <DashboardItemOverlayInfo added={added} modified={modified} />
+                        </div>
+                        <Button
+                            className="gd-button gd-button-link"
+                            value={intl.formatMessage({ id: "layout.widget.hideOverlay" })}
+                            onClick={onHide}
+                        />
+                    </div>
+                </div>
+            )}
+        </Measure>
+    ) : null;
+};
+
+const DashboardItemOverlayInfo: React.FunctionComponent<{ added: boolean; modified: boolean }> = ({
+    added,
+    modified,
+}) => {
+    if (added) {
+        return <FormattedMessage id="layout.widget.addedByPlugin" />;
+    }
+    if (modified) {
+        return <FormattedMessage id="layout.widget.modifiedByPlugin" />;
+    }
+    return null;
+};
+
+const PluginIcon: React.FunctionComponent<{ color?: string }> = ({ color }) => {
+    return (
+        <svg width="29" height="35" viewBox="0 0 29 35" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path
+                d="M15.6264 2.50847C14.8954 2.26481 14.1052 2.26481 13.3742 2.50847L13.2559 2.54788C11.124 3.25852 10.1752 5.74192 11.2901 7.69306L11.8345 8.64571C12.6873 10.1381 11.3879 11.9409 9.70247 11.6038L2.30263 10.1238C2.16491 10.0963 2.03641 10.2016 2.03641 10.342V32.3544C2.03641 32.4773 2.13606 32.577 2.25898 32.577H25.7456C25.859 32.577 25.9543 32.4917 25.9668 32.379L26.7587 25.2513C26.7776 25.0818 26.6066 24.955 26.4499 25.0222L23.9499 26.0936C21.5157 27.1368 18.6851 26.2215 17.3226 23.9506C16.3163 22.2735 16.3163 20.1783 17.3226 18.5012C18.6851 16.2303 21.5157 15.315 23.9499 16.3582L26.4499 17.4296C26.6066 17.4968 26.7776 17.37 26.7587 17.2005L25.9937 10.3154C25.9791 10.1838 25.8535 10.0939 25.7242 10.1227L19.3749 11.5336C17.6773 11.9109 16.3383 10.0943 17.2011 8.58438L17.7105 7.69306C18.8254 5.74192 17.8766 3.25852 15.7447 2.54788L15.6264 2.50847ZM12.8111 0.819283C13.9076 0.453794 15.093 0.453794 16.1895 0.819283L16.3077 0.858699C19.5056 1.92465 20.9288 5.64975 19.2564 8.57646L18.7471 9.46779C18.6512 9.63555 18.8 9.8374 18.9886 9.79548L25.338 8.38451C26.5014 8.12598 27.6318 8.93425 27.7634 10.1187L28.5284 17.0039C28.6979 18.5293 27.1592 19.6708 25.7485 19.0662L23.2485 17.9948C21.6327 17.3024 19.7538 17.9099 18.8494 19.4173C18.1815 20.5305 18.1815 21.9213 18.8494 23.0345C19.7538 24.5419 21.6327 25.1495 23.2485 24.457L25.7485 23.3856C27.1592 22.781 28.6979 23.9225 28.5284 25.448L27.7364 32.5756C27.6237 33.59 26.7663 34.3575 25.7456 34.3575H2.25898C1.15269 34.3575 0.255859 33.4607 0.255859 32.3544V10.342C0.255859 9.07798 1.41231 8.12991 2.65183 8.37782L10.0517 9.85778C10.2389 9.89524 10.3833 9.69493 10.2886 9.52911L9.74419 8.57646C8.07178 5.64975 9.49501 1.92465 12.6929 0.858699L12.8111 0.819283Z"
+                fill={color ?? "#687581"}
+            />
+        </svg>
+    );
+};

--- a/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayoutRenderer/utils/emptyFacade.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayoutRenderer/utils/emptyFacade.ts
@@ -6,6 +6,7 @@ export const emptyItemFacadeWithFullSize: IDashboardLayoutItemFacade<unknown> = 
     index: () => 0,
     raw: () => null as any, // TODO: should we allow this in the interface?
     widget: () => null,
+    ref: () => undefined,
     section: () => undefined as any, // TODO: should we allow this in the interface?
     size: () => ({ xl: { gridWidth: 12 } }),
     sizeForScreen: () => ({ gridWidth: 12 }),

--- a/libs/sdk-ui-dashboard/src/presentation/layout/refs.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/layout/refs.ts
@@ -1,0 +1,14 @@
+// (C) 2007-2022 GoodData Corporation
+import { ObjRef } from "@gooddata/sdk-model";
+import {
+    IDashboardLayoutSectionFacade,
+    IDashboardLayoutItemFacade,
+} from "../../_staging/dashboard/fluidLayout";
+
+export function getRefsForSection(section: IDashboardLayoutSectionFacade<unknown>): (ObjRef | undefined)[] {
+    return section.items().map((item) => item.ref());
+}
+
+export function getRefsForItem(item: IDashboardLayoutItemFacade<unknown>): (ObjRef | undefined)[] {
+    return [item.ref()];
+}

--- a/libs/sdk-ui-dashboard/src/presentation/localization/bundles/en-US.json
+++ b/libs/sdk-ui-dashboard/src/presentation/localization/bundles/en-US.json
@@ -1987,6 +1987,21 @@
         "comment": "Shown as red text inside of widget if resized under max limit.",
         "limit": 0
     },
+    "layout.widget.addedByPlugin": {
+        "value": "Added by plugin",
+        "comment": "",
+        "limit": 0
+    },
+    "layout.widget.modifiedByPlugin": {
+        "value": "Modified by plugin",
+        "comment": "",
+        "limit": 0
+    },
+    "layout.widget.hideOverlay": {
+        "value": "Hide overlay",
+        "comment": "",
+        "limit": 0
+    },
     "dropzone.new.row.desc": {
         "value": "Drop to create a{nbsp}<b>new section</b>",
         "comment": "Used as placeholder when user drags some widget and tries to drop it on dashboard. Dropping the widget over such placeholder creates new section of a dashboard. Do not translate HTML markup enclosed in <>. Translate words 'new section'.",

--- a/libs/sdk-ui-dashboard/styles/scss/layout.scss
+++ b/libs/sdk-ui-dashboard/styles/scss/layout.scss
@@ -280,3 +280,74 @@ $gd-dashboards-section-description-color: var(
         position: absolute !important;
     }
 }
+
+.gd-fluidlayout-item-changed {
+    position: absolute;
+    //need z-index over draggable overlay also
+    z-index: 11;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    display: flex;
+    align-content: center;
+    justify-content: center;
+    align-items: center;
+
+    &.none {
+        display: none;
+    }
+
+    &.added,
+    &.modified {
+        background: var(
+            --gd-dashboards-content-backgroundColor,
+            var(--gd-palette-complementary-0, rgba(255, 255, 255, 0.95))
+        );
+    }
+
+    .gd-fluidlayout-item-changed-content {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 8px;
+    }
+    &.small .gd-fluidlayout-item-changed-content {
+        display: flex;
+        flex-direction: row;
+        gap: 10px;
+        max-height: 100%;
+    }
+
+    .gd-fluidlayout-item-changed-icon {
+        display: flex;
+        align-items: center;
+
+        svg {
+            max-height: 100%;
+        }
+    }
+    &.small .gd-fluidlayout-item-changed-icon {
+        svg {
+            top: -4px;
+            position: relative;
+        }
+    }
+    &.big .gd-fluidlayout-item-changed-icon {
+        // stylelint-disable-next-line declaration-no-important
+        height: auto !important;
+    }
+
+    .gd-fluidlayout-item-changed-info {
+        display: block;
+        font-weight: 400;
+        font-size: 14px;
+        line-height: 19px;
+    }
+    .gd-button {
+        font-weight: 400;
+        font-size: 14px;
+        line-height: 19px;
+        color: var(--gd-palette-complementary-6, #94a1ad);
+    }
+}


### PR DESCRIPTION
When editing a dashboard with plugins, it would be helpful for the user to be able to tell which items were added by a plugin. These items often have hardcoded coordinates so they will behave counter-intuitively when the layout is changed with drag and drop.

JIRA: RAIL-4437

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
