### PR TITLE
RELATED: RAIL-4626 fix attribute filter configuration on tiger

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/dashboardDropdownBody/configuration/AttributeFilterConfiguration.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/dashboardDropdownBody/configuration/AttributeFilterConfiguration.tsx
@@ -7,6 +7,7 @@ import {
     useDashboardSelector,
     selectOtherContextAttributeFilters,
     selectFilterContextAttributeFilters,
+    selectSupportsElementsQueryParentFiltering,
 } from "../../../../../model";
 import { IDashboardAttributeFilter, ObjRef } from "@gooddata/sdk-model";
 import { ParentFiltersList } from "./parentFilters/ParentFiltersList";
@@ -40,6 +41,7 @@ export const AttributeFilterConfiguration: React.FC<IAttributeFilterConfiguratio
     const neighborFilters: IDashboardAttributeFilter[] = useDashboardSelector(
         selectOtherContextAttributeFilters(filterRef),
     );
+    const isDependentFiltersEnabled = useDashboardSelector(selectSupportsElementsQueryParentFiltering);
 
     const neighborFilterDisplayForms = useMemo(() => {
         return neighborFilters.map((filter) => filter.attributeFilter.displayForm);
@@ -88,7 +90,9 @@ export const AttributeFilterConfiguration: React.FC<IAttributeFilterConfiguratio
     return (
         <div className="s-attribute-filter-dropdown-configuration attribute-filter-dropdown-configuration">
             <ConfigurationPanelHeader />
-            {parents.length > 0 ? <ConfigurationCategory categoryTitle={filterByText} /> : null}
+            {isDependentFiltersEnabled && parents.length > 0 ? (
+                <ConfigurationCategory categoryTitle={filterByText} />
+            ) : null}
             <ParentFiltersList
                 currentFilterLocalId={currentFilter.attributeFilter.localIdentifier!}
                 parents={parents}

--- a/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/dashboardDropdownBody/configuration/parentFilters/ParentFiltersList.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/dashboardDropdownBody/configuration/parentFilters/ParentFiltersList.tsx
@@ -3,15 +3,12 @@ import React from "react";
 
 import { IAttributeMetadataObject, ObjRef } from "@gooddata/sdk-model";
 import { ParentFiltersListItem } from "./ParentFiltersListItem";
-import { LoadingComponent } from "@gooddata/sdk-ui";
 import {
     useDashboardSelector,
     selectSupportsElementsQueryParentFiltering,
     IDashboardAttributeFilterParentItem,
     IConnectingAttribute,
 } from "../../../../../../model";
-
-const LOADING_MASK_HEIGHT = 150;
 
 interface IConfigurationParentItemsProps {
     currentFilterLocalId: string;
@@ -36,15 +33,6 @@ export const ParentFiltersList: React.FC<IConfigurationParentItemsProps> = (prop
 
     if (!isDependentFiltersEnabled || parents.length < 1) {
         return null;
-    }
-
-    if (!parents.length) {
-        return (
-            <LoadingComponent
-                height={LOADING_MASK_HEIGHT}
-                className="s-attribute-filter-dropdown-configuration-loading"
-            />
-        );
     }
 
     return (


### PR DESCRIPTION
On tiger, we must not call the parent filter query, it would always end up in an error state.
Also, remove unreachable code in ParentFiltersList, the parent.length === 0 is handled in the previous if.

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
