### PR TITLE
BUGFIX: TNT-1180 Discard custom description when config changed

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/configuration/InsightDescriptionConfig/InsightDescriptionConfig.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/configuration/InsightDescriptionConfig/InsightDescriptionConfig.tsx
@@ -126,7 +126,7 @@ export function InsightDescriptionConfig(props: IInsightDescriptionConfigProps) 
             if (config === "widget") {
                 setWidgetDescription(widget, insight?.insight.summary ?? "");
             }
-            if (config === "insight") {
+            if (config === "none" || config === "insight") {
                 setWidgetDescription(widget, "");
             }
         },

--- a/libs/sdk-ui-dashboard/src/presentation/widget/kpi/DefaultKpiConfigurationPanel/KpiDescriptionConfig.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/kpi/DefaultKpiConfigurationPanel/KpiDescriptionConfig.tsx
@@ -130,7 +130,7 @@ export function KpiDescriptionConfig(props: IKpiDescriptionConfigProps) {
             if (config === "kpi") {
                 setKpiDescription(kpi, getKpiMetricDescription(metrics, kpi.kpi.metric) ?? "");
             }
-            if (config === "metric") {
+            if (config === "none" || config === "metric") {
                 setKpiDescription(kpi, "");
             }
         },


### PR DESCRIPTION
When description config changed to None or Inherit, the previous custom value should be discarded.
Same for KPI.

JIRA: TNT-1180

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
