### PR TITLE
RELATED: RAIL-4438 prevent passing redundant persisted dashboard

### DIFF
--- a/libs/sdk-ui-loaders/src/dashboard/dashboardLoader.tsx
+++ b/libs/sdk-ui-loaders/src/dashboard/dashboardLoader.tsx
@@ -333,7 +333,9 @@ export class DashboardLoader implements IDashboardLoader {
             ...extensionProps,
             workspace,
             dashboard: isDashboard(dashboard) ? dashboard : dashboardWithPlugins?.dashboard,
-            persistedDashboard: dashboardWithPlugins?.dashboard,
+            // do not pass persisted dashboard if we did not pass a dashboard object to the dashboard prop
+            // it would be redundant as they are equal
+            persistedDashboard: isDashboard(dashboard) ? dashboardWithPlugins?.dashboard : undefined,
         };
 
         /*


### PR DESCRIPTION
When dashboard and persistedDashboard would be the same, do no pass persistedDashboard to save some extra loading down the line.

JIRA: RAIL-4438

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
