### PR TITLE
RELATED: RAIL-4658, RAIL-4662 fix save as filters and status indicator tooltip

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/saveAs/DefaultSaveAsDialog/SaveAsDialogRenderer.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/saveAs/DefaultSaveAsDialog/SaveAsDialogRenderer.tsx
@@ -76,7 +76,11 @@ export class SaveAsNewDashboardDialog extends React.PureComponent<
     onSubmit = (): void => {
         const title = this.state.dashboardTitle.trim();
         if (this.canCreateDashboard() && title !== "") {
-            this.props.onSubmit(title, true, true);
+            this.props.onSubmit(
+                title,
+                true, // switch to the new dashboard
+                false, // do not reuse the filter context, create a new one with the current filter state
+            );
         }
     };
 

--- a/libs/sdk-ui-dashboard/src/presentation/topBar/topBar/DefaultTopBar.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/topBar/topBar/DefaultTopBar.tsx
@@ -66,7 +66,8 @@ export const useTopBarProps = (): ITopBarProps => {
         },
         shareStatusProps: {
             shareStatus: shareInfo.shareStatus,
-            isUnderStrictControl: !!persistedDashboard?.isUnderStrictControl,
+            // new dashboards are considered under strict control as well for the share status purposes
+            isUnderStrictControl: !persistedDashboard || !!persistedDashboard.isUnderStrictControl,
         },
         lockedStatusProps: {
             isLocked: !!shareInfo.isLocked,


### PR DESCRIPTION
- RAIL-4658 - fix status indicator tooltip text for new dashboards
- RAIL-4662 - fix save as using the old filters instead of the current ones

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
