### PR TITLE
RELATED: RAIL-4663 fix KPI dataset picker

### DIFF
--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -5978,7 +5978,7 @@ export const selectIsWhiteLabeled: OutputSelector<DashboardState, boolean, (res:
 export const selectIsWidgetLoadingAdditionalDataByWidgetRef: (ref: ObjRef) => OutputSelector<DashboardState, boolean, (res: ObjRef[]) => boolean>;
 
 // @internal (undocumented)
-export const selectKpiDateDatasetAutoOpen: OutputSelector<DashboardState, boolean, (res: UiState) => boolean>;
+export const selectKpiDateDatasetAutoSelect: OutputSelector<DashboardState, boolean, (res: UiState) => boolean>;
 
 // @internal (undocumented)
 export const selectKpiDeleteDialogWidgetCoordinates: OutputSelector<DashboardState, ILayoutCoordinates | undefined, (res: UiState) => ILayoutCoordinates | undefined>;
@@ -6295,7 +6295,7 @@ setConfigurationPanelOpened: CaseReducer<UiState, {
 payload: boolean;
 type: string;
 }>;
-setKpiDateDatasetAutoOpen: CaseReducer<UiState, {
+setKpiDateDatasetAutoSelect: CaseReducer<UiState, {
 payload: boolean;
 type: string;
 }>;
@@ -6395,7 +6395,7 @@ export interface UiState {
         highlightedWidgetRef: ObjRef | undefined;
     };
     // (undocumented)
-    kpiDateDatasetAutoOpen: boolean;
+    kpiDateDatasetAutoSelect: boolean;
     // (undocumented)
     kpiDeleteDialog: {
         widgetCoordinates: ILayoutCoordinates | undefined;

--- a/libs/sdk-ui-dashboard/src/_staging/dateDatasets/getRecommendedCatalogDateDataset.ts
+++ b/libs/sdk-ui-dashboard/src/_staging/dateDatasets/getRecommendedCatalogDateDataset.ts
@@ -1,0 +1,20 @@
+// (C) 2022 GoodData Corporation
+import { ICatalogDateDataset } from "@gooddata/sdk-model";
+import { getRecommendedDateDataset } from "@gooddata/sdk-ui-kit";
+
+export function getRecommendedCatalogDateDataset(
+    dateDatasets: readonly ICatalogDateDataset[],
+): ICatalogDateDataset | undefined {
+    const recommendedDateDataSetId = getRecommendedDateDataset(
+        dateDatasets.map((ds) => {
+            return {
+                id: ds.dataSet.id,
+                title: ds.dataSet.title,
+            };
+        }),
+    )?.id;
+
+    return recommendedDateDataSetId
+        ? dateDatasets.find((ds) => ds.dataSet.id === recommendedDateDataSetId)
+        : undefined;
+}

--- a/libs/sdk-ui-dashboard/src/model/store/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/index.ts
@@ -227,7 +227,7 @@ export {
     selectScheduleEmailDialogDefaultAttachment,
     selectSelectedWidgetRef,
     selectConfigurationPanelOpened,
-    selectKpiDateDatasetAutoOpen,
+    selectKpiDateDatasetAutoSelect,
     selectIsDeleteDialogOpen,
     selectIsKpiDeleteDialogOpen,
     selectKpiDeleteDialogWidgetCoordinates,

--- a/libs/sdk-ui-dashboard/src/model/store/ui/uiReducers.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/ui/uiReducers.ts
@@ -107,8 +107,8 @@ const setConfigurationPanelOpened: UiReducer<PayloadAction<boolean>> = (state, a
     state.configurationPanelOpened = action.payload;
 };
 
-const setKpiDateDatasetAutoOpen: UiReducer<PayloadAction<boolean>> = (state, action) => {
-    state.kpiDateDatasetAutoOpen = action.payload;
+const setKpiDateDatasetAutoSelect: UiReducer<PayloadAction<boolean>> = (state, action) => {
+    state.kpiDateDatasetAutoSelect = action.payload;
 };
 
 const requestInsightListUpdate: UiReducer = (state) => {
@@ -235,7 +235,7 @@ export const uiReducers = {
     selectWidget,
     clearWidgetSelection,
     setConfigurationPanelOpened,
-    setKpiDateDatasetAutoOpen,
+    setKpiDateDatasetAutoSelect,
     requestInsightListUpdate,
     setWidgetLoadingAdditionalDataStarted,
     setWidgetLoadingAdditionalDataStopped,

--- a/libs/sdk-ui-dashboard/src/model/store/ui/uiSelectors.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/ui/uiSelectors.ts
@@ -170,9 +170,9 @@ export const selectConfigurationPanelOpened = createSelector(
 /**
  * @internal
  */
-export const selectKpiDateDatasetAutoOpen = createSelector(
+export const selectKpiDateDatasetAutoSelect = createSelector(
     selectSelf,
-    (state) => state.kpiDateDatasetAutoOpen,
+    (state) => state.kpiDateDatasetAutoSelect,
 );
 
 /**

--- a/libs/sdk-ui-dashboard/src/model/store/ui/uiState.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/ui/uiState.ts
@@ -46,7 +46,7 @@ export interface UiState {
     };
     selectedWidgetRef: ObjRef | undefined;
     configurationPanelOpened: boolean;
-    kpiDateDatasetAutoOpen: boolean;
+    kpiDateDatasetAutoSelect: boolean;
     insightListLastUpdateRequested: number;
     widgetsLoadingAdditionalData: ObjRef[];
     filterAttributeSelectionOpen: boolean;
@@ -93,7 +93,7 @@ export const uiInitialState: UiState = {
     },
     selectedWidgetRef: undefined,
     configurationPanelOpened: true,
-    kpiDateDatasetAutoOpen: false,
+    kpiDateDatasetAutoSelect: false,
     insightListLastUpdateRequested: 0,
     widgetsLoadingAdditionalData: [],
     filterAttributeSelectionOpen: false,

--- a/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/useKpiPlaceholderDropHandler.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/useKpiPlaceholderDropHandler.ts
@@ -25,7 +25,7 @@ export function useKpiPlaceholderDropHandler(sectionIndex: number, itemIndex: nu
             const ref = event.payload.itemsAdded[0].widget!.ref;
             dispatch(uiActions.selectWidget(idRef(KPI_PLACEHOLDER_WIDGET_ID)));
             dispatch(uiActions.setConfigurationPanelOpened(true));
-            dispatch(uiActions.setKpiDateDatasetAutoOpen(true));
+            dispatch(uiActions.setKpiDateDatasetAutoSelect(true));
             dispatch(uiActions.setWidgetLoadingAdditionalDataStarted(ref));
         },
     });

--- a/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/useNewSectionKpiPlaceholderDropHandler.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/useNewSectionKpiPlaceholderDropHandler.ts
@@ -25,7 +25,7 @@ export function useNewSectionKpiPlaceholderDropHandler(sectionIndex: number) {
             const ref = event.payload.section.items[0].widget!.ref;
             dispatch(uiActions.selectWidget(idRef(KPI_PLACEHOLDER_WIDGET_ID)));
             dispatch(uiActions.setConfigurationPanelOpened(true));
-            dispatch(uiActions.setKpiDateDatasetAutoOpen(true));
+            dispatch(uiActions.setKpiDateDatasetAutoSelect(true));
             dispatch(uiActions.setWidgetLoadingAdditionalDataStarted(ref));
         },
     });

--- a/libs/sdk-ui-dashboard/src/presentation/widget/common/configuration/DateDatasetFilter.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/common/configuration/DateDatasetFilter.tsx
@@ -19,6 +19,7 @@ interface IDateDatasetFilterProps {
     dateFromVisualization?: ICatalogDateDataset;
     dateFilterCheckboxDisabled: boolean;
     shouldPickDateDataset?: boolean;
+    shouldOpenDateDatasetPicker?: boolean;
     isLoadingAdditionalData?: boolean;
     onDateDatasetChanged?: (id: string) => void;
 }
@@ -31,6 +32,7 @@ export const DateDatasetFilter: React.FC<IDateDatasetFilterProps> = (props) => {
         dateFromVisualization,
         isDatasetsLoading,
         shouldPickDateDataset,
+        shouldOpenDateDatasetPicker,
         onDateDatasetChanged,
         isLoadingAdditionalData,
     } = props;
@@ -98,7 +100,7 @@ export const DateDatasetFilter: React.FC<IDateDatasetFilterProps> = (props) => {
                     selectedDateDatasetHidden={selectedDateDatasetHiddenByObjectAvailability}
                     unrelatedDateDataset={unrelatedDateDataset}
                     onDateDatasetChange={handleDateDatasetChanged}
-                    autoOpen={shouldPickDateDataset}
+                    autoOpen={shouldOpenDateDatasetPicker}
                     isLoading={isDropdownLoading}
                 />
             )}

--- a/libs/sdk-ui-dashboard/src/presentation/widget/common/configuration/useDateFilterConfigurationHandling.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/common/configuration/useDateFilterConfigurationHandling.ts
@@ -11,25 +11,8 @@ import {
     enableKpiWidgetDateFilter,
     useDashboardCommandProcessing,
 } from "../../../../model";
-import { getRecommendedDateDataset } from "@gooddata/sdk-ui-kit";
 import { safeSerializeObjRef } from "../../../../_staging/metadata/safeSerializeObjRef";
-
-function getRecommendedCatalogDateDataset(
-    dateDatasets: readonly ICatalogDateDataset[],
-): ICatalogDateDataset | undefined {
-    const recommendedDateDataSetId = getRecommendedDateDataset(
-        dateDatasets.map((ds) => {
-            return {
-                id: ds.dataSet.id,
-                title: ds.dataSet.title,
-            };
-        }),
-    )?.id;
-
-    return recommendedDateDataSetId
-        ? dateDatasets.find((ds) => ds.dataSet.id === recommendedDateDataSetId)
-        : undefined;
-}
+import { getRecommendedCatalogDateDataset } from "../../../../_staging/dateDatasets/getRecommendedCatalogDateDataset";
 
 export function useDateFilterConfigurationHandling(
     widget: IWidget,


### PR DESCRIPTION
Only automatically open the picker if a non-recommended was preselected.

JIRA: RAIL-4663

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
