### PR TITLE
RELATED: RAIL-4664 prevent Bad Request

### DIFF
--- a/libs/sdk-ui-dashboard/src/model/queryServices/queryWidgetAlertCount.ts
+++ b/libs/sdk-ui-dashboard/src/model/queryServices/queryWidgetAlertCount.ts
@@ -8,6 +8,7 @@ import { QueryWidgetAlertCount } from "../queries/widgets";
 import { selectWidgetByRef } from "../store/layout/layoutSelectors";
 import { createQueryService } from "../store/_infra/queryService";
 import { DashboardContext } from "../types/commonTypes";
+import { isTemporaryIdentity } from "../utils/dashboardItemUtils";
 
 export const QueryWidgetAlertCountService = createQueryService(
     "GDC.DASH/QUERY.WIDGET.ALERT_COUNT",
@@ -29,7 +30,8 @@ function* queryService(ctx: DashboardContext, query: QueryWidgetAlertCount): Sag
         );
     }
 
-    if (!isKpiWidget(widget)) {
+    // just added KPIs with temporary identity cannot have alerts, do not try to load their count, it will fail
+    if (!isKpiWidget(widget) || isTemporaryIdentity(widget)) {
         return 0;
     }
 


### PR DESCRIPTION
Do not call alert count query for KPIs with temporary identity. Non-persisted KPIs never have any alerts, so return 0 right away.

JIRA: RAIL-4664

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
