### PR TITLE
RELATED: RAIL-4437 avoid redux use in DashboardLayout

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/layout/DashboardItemOverlay/DashboardItemOverlayController.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/layout/DashboardItemOverlay/DashboardItemOverlayController.tsx
@@ -1,0 +1,42 @@
+// (C) 2022 GoodData Corporation
+import React from "react";
+import {
+    useDashboardSelector,
+    useDashboardDispatch,
+    selectWidgetsOverlayState,
+    selectSectionModification,
+    uiActions,
+} from "../../../model";
+import { IDashboardLayoutSectionFacade } from "../../../_staging/dashboard/fluidLayout";
+import { getRefsForSection } from "../refs";
+import { DashboardItemOverlay } from "./DashboardItemOverlay";
+
+interface IDashboardLayoutSectionOverlayControllerProps {
+    section: IDashboardLayoutSectionFacade<unknown>;
+}
+
+export const DashboardLayoutSectionOverlayController: React.FC<
+    IDashboardLayoutSectionOverlayControllerProps
+> = (props) => {
+    const { section } = props;
+    const dispatch = useDashboardDispatch();
+
+    const refs = getRefsForSection(section);
+    const overlayShow = useDashboardSelector(selectWidgetsOverlayState(refs));
+    const sectionModifications = useDashboardSelector(selectSectionModification(refs));
+    return (
+        <DashboardItemOverlay
+            type="column"
+            onHide={() =>
+                dispatch(
+                    uiActions.toggleWidgetsOverlay({
+                        visible: false,
+                        refs: section.items().map((item) => item.ref()),
+                    }),
+                )
+            }
+            render={overlayShow}
+            modifications={sectionModifications}
+        />
+    );
+};

--- a/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayoutRenderer/DashboardLayoutSection.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayoutRenderer/DashboardLayoutSection.tsx
@@ -4,15 +4,6 @@ import flatMap from "lodash/flatMap";
 import React from "react";
 import { RenderMode } from "../../../types";
 import { IDashboardLayoutSectionFacade } from "../../../_staging/dashboard/fluidLayout/facade/interfaces";
-import {
-    useDashboardSelector,
-    selectIsInEditMode,
-    useDashboardDispatch,
-    selectWidgetsOverlayState,
-    selectSectionModification,
-    uiActions,
-} from "../../../model";
-import { DashboardItemOverlay } from "../DashboardItemOverlay/DashboardItemOverlay";
 import { DashboardLayoutGridRow } from "./DashboardLayoutGridRow";
 import { DashboardLayoutSectionHeaderRenderer } from "./DashboardLayoutSectionHeaderRenderer";
 import { DashboardLayoutSectionRenderer } from "./DashboardLayoutSectionRenderer";
@@ -25,7 +16,7 @@ import {
     IDashboardLayoutSectionRenderer,
     IDashboardLayoutWidgetRenderer,
 } from "./interfaces";
-import { getRefsForSection } from "../refs";
+import { DashboardLayoutSectionOverlayController } from "../DashboardItemOverlay/DashboardItemOverlayController";
 
 /**
  * @alpha
@@ -69,13 +60,6 @@ export function DashboardLayoutSection<TWidget>(props: IDashboardLayoutSectionPr
     } = props;
     const renderProps = { section, screen, renderMode };
 
-    const dispatch = useDashboardDispatch();
-    const isInEditMode = useDashboardSelector(selectIsInEditMode);
-
-    const refs = getRefsForSection(section);
-    const overlayShow = useDashboardSelector(selectWidgetsOverlayState(refs));
-    const sectionModifications = useDashboardSelector(selectSectionModification(refs));
-
     const items = flatMap(section.items().asGridRows(screen), (itemsInRow, index) => {
         return (
             <DashboardLayoutGridRow
@@ -104,19 +88,7 @@ export function DashboardLayoutSection<TWidget>(props: IDashboardLayoutSectionPr
                     DefaultSectionHeaderRenderer: DashboardLayoutSectionHeaderRenderer,
                 })}
                 {items}
-                <DashboardItemOverlay
-                    type="column"
-                    onHide={() =>
-                        dispatch(
-                            uiActions.toggleWidgetsOverlay({
-                                visible: false,
-                                refs: section.items().map((item) => item.ref()),
-                            }),
-                        )
-                    }
-                    render={Boolean(isInEditMode && overlayShow)}
-                    modifications={sectionModifications}
-                />
+                {renderMode === "edit" ? <DashboardLayoutSectionOverlayController section={section} /> : null}
             </>
         ),
     });


### PR DESCRIPTION
This would make the DashboardLayout unusable outside of Dashboard component context, which we need to do for legacy edit mode.

JIRA: RAIL-4437

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
