### PR TITLE
RELATED: RAIL-4659 fix date dataset config

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/useNewSectionInsightListItemDropHandler.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/useNewSectionInsightListItemDropHandler.ts
@@ -37,9 +37,9 @@ export function useNewSectionInsightListItemDropHandler(sectionIndex: number) {
     const { run: replaceSectionItemLoader } = useDashboardCommandProcessing({
         commandCreator: replaceSectionItem,
         errorEvent: "GDC.DASH/EVT.COMMAND.FAILED",
-        successEvent: "GDC.DASH/EVT.FLUID_LAYOUT.SECTION_ADDED",
+        successEvent: "GDC.DASH/EVT.FLUID_LAYOUT.ITEM_REPLACED",
         onSuccess: (event) => {
-            const ref = event.payload.section.items[0].widget!.ref;
+            const ref = event.payload.items[0].widget!.ref;
             dispatch(uiActions.selectWidget(ref));
             dispatch(uiActions.setConfigurationPanelOpened(true));
             dispatch(uiActions.setWidgetLoadingAdditionalDataStarted(ref));

--- a/libs/sdk-ui-dashboard/src/presentation/widget/common/configuration/useDateFilterConfigurationHandling.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/common/configuration/useDateFilterConfigurationHandling.ts
@@ -1,7 +1,6 @@
 // (C) 2022 GoodData Corporation
 import { useCallback, useState } from "react";
 import { ICatalogDateDataset, idRef, isInsightWidget, IWidget, ObjRef, widgetRef } from "@gooddata/sdk-model";
-import invariant from "ts-invariant";
 import first from "lodash/first";
 
 import {
@@ -76,10 +75,9 @@ export function useDateFilterConfigurationHandling(
     const handleDateFilterEnabled = useCallback(
         (enabled: boolean, dateDatasetRef: ObjRef | undefined) => {
             const getPreselectedDateDataset = () => {
-                invariant(
-                    relatedDateDatasets?.length,
-                    "Date filtering enabled without a date dataset available.",
-                );
+                if (!relatedDateDatasets?.length) {
+                    return null;
+                }
 
                 // preselect the recommended if any, or the first one
                 const recommendedDateDataSet = getRecommendedCatalogDateDataset(relatedDateDatasets);
@@ -98,7 +96,7 @@ export function useDateFilterConfigurationHandling(
                     enable(ref, dateDatasetRef);
                 } else {
                     const preselectedDateDataSetRef = getPreselectedDateDataset();
-                    enable(ref, preselectedDateDataSetRef);
+                    enable(ref, preselectedDateDataSetRef ?? "default");
                 }
             } else {
                 disable(ref);

--- a/libs/sdk-ui-dashboard/src/presentation/widget/common/configuration/useIsSelectedDatasetHidden.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/common/configuration/useIsSelectedDatasetHidden.ts
@@ -46,7 +46,7 @@ export function useIsSelectedDatasetHidden(selectedDateDatasetRef: ObjRef | unde
     );
 
     const selectedDateDatasetHiddenByObjectAvailability = useMemo(() => {
-        if (!visibleDateDatasets) {
+        if (!visibleDateDatasets || !selectedDateDatasetRef) {
             return false;
         }
 

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/configuration/InsightDateDataSetFilter.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/configuration/InsightDateDataSetFilter.tsx
@@ -1,30 +1,4 @@
 // (C) 2007-2022 GoodData Corporation
-// import { connect } from "react-redux";
-// import { getRecommendedDateDataset } from "@gooddata/sdk-ui-kit";
-//
-// import DateDataSetFilter, {
-//     IDateDataSetFilterDispatchProps,
-//     IDateDataSetFilterStateProps,
-// } from "../common/DateDataSetFilter";
-// import { getSelectedWidgetRef } from "../../modules/Core/services/DashboardService";
-// import { autoOpenChanged } from "../../modules/Core/actions/VisualizationActions";
-// import { dateDataSetFilterEnabled, dateDataSetSelected } from "../../modules/Core/actions/EditModeActions";
-// import {
-//     areDateDataSetsLoading,
-//     getRelatedDateDataSets,
-//     getSelectedDateDataSet,
-// } from "../../modules/VisualizationsCache";
-// import { AppState } from "../../modules/Core/typings/state";
-// import { IProcessedDateDataset } from "../../modules/Core/typings/DateDataSets";
-// import {
-//     getDateFilterCheckboxDisabled,
-//     getWidgetByRef,
-//     getWidgetType,
-//     getDateFilterEnabled,
-//     getDateFilterLoading,
-//     getDateFilterAutoOpen,
-//     getVisualizationDateDataSet,
-// } from "../../modules/Widgets";
 import React, { useEffect } from "react";
 import { DateDatasetFilter } from "../../common";
 import { IInsightWidget, isInsightWidget, widgetRef } from "@gooddata/sdk-model";


### PR DESCRIPTION
* Make sure it does not crash if user enables it for insight with no related datasets
* Fix preselecting date dataset for the first insight added to an empty dashboard
* Remove commented-out code

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
