### PR TITLE
RELATED: RAIL-4657 implement change widget insight command

### DIFF
--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/index.ts
@@ -69,6 +69,7 @@ import { changeInsightWidgetVisConfigurationHandler } from "./widgets/changeInsi
 import { moveSectionItemToNewSectionHandler } from "./layout/moveSectionItemToNewSectionHandler";
 import { changeKpiWidgetDescriptionHandler } from "./widgets/changeKpiWidgetDescriptionHandler";
 import { changeKpiWidgetConfigurationHandler } from "./widgets/changeKpiWidgetConfigurationHandler";
+import { changeInsightWidgetInsightHandler } from "./widgets/changeInsightWidgetInsightHandler";
 
 function* notImplementedCommand(ctx: DashboardContext, cmd: IDashboardCommand): SagaIterator<void> {
     yield dispatchDashboardEvent(commandRejected(ctx, cmd.correlationId));
@@ -123,7 +124,7 @@ export const DefaultCommandHandlers: {
     "GDC.DASH/CMD.INSIGHT_WIDGET.CHANGE_FILTER_SETTINGS": changeInsightWidgetFilterSettingsHandler,
     "GDC.DASH/CMD.INSIGHT_WIDGET.CHANGE_PROPERTIES": changeInsightWidgetVisPropertiesHandler,
     "GDC.DASH/CMD.INSIGHT_WIDGET.CHANGE_CONFIGURATION": changeInsightWidgetVisConfigurationHandler,
-    "GDC.DASH/CMD.INSIGHT_WIDGET.CHANGE_INSIGHT": notImplementedCommand,
+    "GDC.DASH/CMD.INSIGHT_WIDGET.CHANGE_INSIGHT": changeInsightWidgetInsightHandler,
     "GDC.DASH/CMD.INSIGHT_WIDGET.MODIFY_DRILLS": modifyDrillsForInsightWidgetHandler,
     "GDC.DASH/CMD.INSIGHT_WIDGET.REMOVE_DRILLS": removeDrillsForInsightWidgetHandler,
     "GDC.DASH/CMD.INSIGHT_WIDGET.REFRESH": refreshInsightWidgetHandler,

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/changeInsightWidgetInsightHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/changeInsightWidgetInsightHandler.ts
@@ -1,0 +1,86 @@
+// (C) 2021-2022 GoodData Corporation
+
+import { DashboardContext } from "../../types/commonTypes";
+import { ChangeInsightWidgetInsight } from "../../commands";
+import { SagaIterator } from "redux-saga";
+import { batchActions } from "redux-batched-actions";
+import invariant from "ts-invariant";
+import { DashboardInsightWidgetInsightSwitched } from "../../events";
+import { selectWidgetsMap } from "../../store/layout/layoutSelectors";
+import { call, put, SagaReturnType, select } from "redux-saga/effects";
+import { validateExistingInsightWidget } from "./validation/widgetValidations";
+import { layoutActions } from "../../store/layout";
+import { insightWidgetInsightChanged } from "../../events/insight";
+import { insightTitle, serializeObjRef, widgetTitle } from "@gooddata/sdk-model";
+import { invalidArgumentsProvided } from "../../events/general";
+import { insightsActions } from "../../store/insights";
+import { uiActions } from "../../store/ui";
+import { selectInsightByRef } from "../../store/insights/insightsSelectors";
+import { loadInsight } from "./common/loadInsight";
+
+export function* changeInsightWidgetInsightHandler(
+    ctx: DashboardContext,
+    cmd: ChangeInsightWidgetInsight,
+): SagaIterator<DashboardInsightWidgetInsightSwitched> {
+    const {
+        payload: { ref, insightRef, visualizationProperties },
+        correlationId,
+    } = cmd;
+
+    const widgets: ReturnType<typeof selectWidgetsMap> = yield select(selectWidgetsMap);
+
+    const insightWidget = validateExistingInsightWidget(widgets, cmd, ctx);
+    const originalInsight: ReturnType<ReturnType<typeof selectInsightByRef>> = yield select(
+        selectInsightByRef(insightWidget.insight),
+    );
+    invariant(originalInsight, "inconsistent store, original insight not already in store");
+
+    const originalInsightTitle = insightTitle(originalInsight);
+
+    // always load the insight in case it changed since we loaded the insight list
+    let insight: SagaReturnType<typeof loadInsight>;
+    try {
+        insight = yield call(loadInsight, ctx, insightRef);
+    } catch {
+        throw invalidArgumentsProvided(
+            ctx,
+            cmd,
+            `The insight with ref: ${serializeObjRef(insightRef)} was not found.`,
+        );
+    }
+
+    const hasCustomName = widgetTitle(insightWidget) !== originalInsightTitle;
+    const isTitleDifferent = insightTitle(insight) !== originalInsightTitle;
+
+    const shouldChangeTitle = !hasCustomName && isTitleDifferent;
+
+    yield put(
+        batchActions([
+            // upsert the internal insight list
+            insightsActions.upsertInsight(insight),
+            // refresh the visual insight list
+            uiActions.requestInsightListUpdate(),
+            /**
+             * Change the widget:
+             * - insight
+             * - properties if set
+             * - title if appropriate
+             */
+            layoutActions.replaceInsightWidgetInsight({
+                ref,
+                insightRef,
+                properties: visualizationProperties,
+                header: shouldChangeTitle
+                    ? {
+                          title: insightTitle(insight),
+                      }
+                    : undefined,
+                undo: {
+                    cmd,
+                },
+            }),
+        ]),
+    );
+
+    return insightWidgetInsightChanged(ctx, ref, insight, correlationId);
+}

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/common/loadInsight.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/common/loadInsight.ts
@@ -1,0 +1,7 @@
+// (C) 2022 GoodData Corporation
+import { IInsight, ObjRef } from "@gooddata/sdk-model";
+import { DashboardContext } from "../../../types/commonTypes";
+
+export function loadInsight(ctx: DashboardContext, insightRef: ObjRef): Promise<IInsight> {
+    return ctx.backend.workspace(ctx.workspace).insights().getInsight(insightRef);
+}

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/refreshInsightWidgetHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/refreshInsightWidgetHandler.ts
@@ -1,5 +1,5 @@
 // (C) 2022 GoodData Corporation
-import { IInsight, ObjRef, objRefToString } from "@gooddata/sdk-model";
+import { objRefToString } from "@gooddata/sdk-model";
 import { SagaIterator } from "redux-saga";
 import { call, put, select } from "redux-saga/effects";
 
@@ -11,10 +11,7 @@ import { validateExistingInsightWidget } from "./validation/widgetValidations";
 import { insightsActions } from "../../store/insights";
 import { invalidArgumentsProvided } from "../../events/general";
 import { DashboardInsightWidgetRefreshed, insightWidgetRefreshed } from "../../events/insight";
-
-function loadInsight(ctx: DashboardContext, insightRef: ObjRef): Promise<IInsight> {
-    return ctx.backend.workspace(ctx.workspace).insights().getInsight(insightRef);
-}
+import { loadInsight } from "./common/loadInsight";
 
 export function* refreshInsightWidgetHandler(
     ctx: DashboardContext,

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/tests/__snapshots__/changeInsightWidgetInsightHandler.test.ts.snap
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/tests/__snapshots__/changeInsightWidgetInsightHandler.test.ts.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`change insight widget vis properties handler should emit correct events 1`] = `
+Array [
+  Object {
+    "commandType": "GDC.DASH/CMD.INSIGHT_WIDGET.CHANGE_INSIGHT",
+    "correlationId": "testCorrelationId",
+    "type": "GDC.DASH/EVT.COMMAND.STARTED",
+  },
+  Object {
+    "correlationId": "testCorrelationId",
+    "type": "GDC.DASH/EVT.INSIGHT_WIDGET.INSIGHT_SWITCHED",
+  },
+]
+`;

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/tests/changeInsightWidgetInsightHandler.test.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/tests/changeInsightWidgetInsightHandler.test.ts
@@ -1,0 +1,100 @@
+// (C) 2022 GoodData Corporation
+
+import { ChangeInsightWidgetInsight, changeInsightWidgetInsight } from "../../../commands";
+import { DashboardCommandFailed, DashboardInsightWidgetInsightSwitched } from "../../../events";
+import { PivotTableWithRowAndColumnAttributes } from "../../../tests/fixtures/Insights.fixtures";
+import { TestCorrelation } from "../../../tests/fixtures/Dashboard.fixtures";
+import { DashboardTester, preloadedTesterFactory } from "../../../tests/DashboardTester";
+import { selectAnalyticalWidgetByRef } from "../../../store/layout/layoutSelectors";
+import {
+    SimpleDashboardIdentifier,
+    SimpleSortedTableWidgetRef,
+    KpiWidgetRef,
+} from "../../../tests/fixtures/SimpleDashboard.fixtures";
+import { IInsightWidget, insightRef, uriRef } from "@gooddata/sdk-model";
+
+describe("change insight widget vis properties handler", () => {
+    let Tester: DashboardTester;
+    beforeEach(
+        preloadedTesterFactory((tester) => {
+            Tester = tester;
+        }, SimpleDashboardIdentifier),
+    );
+
+    it("should change the insight for existing insight widget", async () => {
+        const ref = SimpleSortedTableWidgetRef;
+        const insight = insightRef(PivotTableWithRowAndColumnAttributes);
+
+        const event: DashboardInsightWidgetInsightSwitched = await Tester.dispatchAndWaitFor(
+            changeInsightWidgetInsight(ref, insight, undefined, TestCorrelation),
+            "GDC.DASH/EVT.INSIGHT_WIDGET.INSIGHT_SWITCHED",
+        );
+
+        expect(insightRef(event.payload.insight)).toEqual(insight);
+        const widgetState = selectAnalyticalWidgetByRef(ref)(Tester.state()) as IInsightWidget;
+        expect(widgetState!.insight).toEqual(insight);
+    });
+
+    it("should change the insight and the visualization properties for existing insight widget", async () => {
+        const ref = SimpleSortedTableWidgetRef;
+        const insight = insightRef(PivotTableWithRowAndColumnAttributes);
+        const properties = { foo: "bar" };
+
+        await Tester.dispatchAndWaitFor(
+            changeInsightWidgetInsight(ref, insight, properties, TestCorrelation),
+            "GDC.DASH/EVT.INSIGHT_WIDGET.INSIGHT_SWITCHED",
+        );
+
+        const widgetState = selectAnalyticalWidgetByRef(ref)(Tester.state()) as IInsightWidget;
+        expect(widgetState!.properties).toEqual(properties);
+    });
+
+    it("should fail if trying to change the insight of KPI widget", async () => {
+        const ref = KpiWidgetRef;
+        const insight = insightRef(PivotTableWithRowAndColumnAttributes);
+
+        const event: DashboardCommandFailed<ChangeInsightWidgetInsight> = await Tester.dispatchAndWaitFor(
+            changeInsightWidgetInsight(ref, insight, undefined, TestCorrelation),
+            "GDC.DASH/EVT.COMMAND.FAILED",
+        );
+
+        expect(event.payload.reason).toEqual("USER_ERROR");
+        expect(event.correlationId).toEqual(TestCorrelation);
+    });
+
+    it("should fail if trying to change the insight of non-existent widget", async () => {
+        const insight = insightRef(PivotTableWithRowAndColumnAttributes);
+
+        const event: DashboardCommandFailed<ChangeInsightWidgetInsight> = await Tester.dispatchAndWaitFor(
+            changeInsightWidgetInsight(uriRef("missing"), insight, undefined, TestCorrelation),
+            "GDC.DASH/EVT.COMMAND.FAILED",
+        );
+
+        expect(event.payload.reason).toEqual("USER_ERROR");
+        expect(event.correlationId).toEqual(TestCorrelation);
+    });
+
+    it("should fail if trying to change the insight for non-existing insight", async () => {
+        const ref = SimpleSortedTableWidgetRef;
+
+        const event: DashboardCommandFailed<ChangeInsightWidgetInsight> = await Tester.dispatchAndWaitFor(
+            changeInsightWidgetInsight(ref, uriRef("missing"), undefined, TestCorrelation),
+            "GDC.DASH/EVT.COMMAND.FAILED",
+        );
+
+        expect(event.payload.reason).toEqual("USER_ERROR");
+        expect(event.correlationId).toEqual(TestCorrelation);
+    });
+
+    it("should emit correct events", async () => {
+        const ref = SimpleSortedTableWidgetRef;
+        const insight = insightRef(PivotTableWithRowAndColumnAttributes);
+
+        await Tester.dispatchAndWaitFor(
+            changeInsightWidgetInsight(ref, insight, undefined, TestCorrelation),
+            "GDC.DASH/EVT.INSIGHT_WIDGET.INSIGHT_SWITCHED",
+        );
+
+        expect(Tester.emittedEventsDigest()).toMatchSnapshot();
+    });
+});

--- a/libs/sdk-ui-dashboard/src/model/store/layout/layoutReducers.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/layout/layoutReducers.ts
@@ -458,6 +458,36 @@ const replaceInsightWidgetVisConfiguration: LayoutReducer<ReplaceWidgetVisConfig
 //
 //
 
+type ReplaceWidgetInsight = {
+    ref: ObjRef;
+    insightRef: ObjRef;
+    properties: VisualizationProperties | undefined;
+    header: WidgetHeader | undefined;
+};
+
+const replaceInsightWidgetInsight: LayoutReducer<ReplaceWidgetInsight> = (state, action) => {
+    invariant(state.layout);
+
+    const { insightRef, properties, ref, header } = action.payload;
+    const widget = getWidgetByRef(state, ref);
+
+    invariant(isInsightWidget(widget));
+
+    if (properties) {
+        widget.properties = properties;
+    }
+
+    if (header?.title) {
+        widget.title = header.title;
+    }
+
+    widget.insight = insightRef;
+};
+
+//
+//
+//
+
 type ReplaceWidgetFilterSettings = {
     ref: ObjRef;
     ignoreDashboardFilters?: IDashboardFilterReference[];
@@ -630,6 +660,7 @@ export const layoutReducers = {
     replaceWidgetDrills: withUndo(replaceWidgetDrill),
     replaceInsightWidgetVisProperties: withUndo(replaceInsightWidgetVisProperties),
     replaceInsightWidgetVisConfiguration: withUndo(replaceInsightWidgetVisConfiguration),
+    replaceInsightWidgetInsight: withUndo(replaceInsightWidgetInsight),
     replaceWidgetFilterSettings: withUndo(replaceWidgetFilterSettings),
     replaceWidgetDateDataset: withUndo(replaceWidgetDateDataset),
     replaceKpiWidgetMeasure: withUndo(replaceKpiWidgetMeasure),


### PR DESCRIPTION
Implement the command to change the insight for an existing insight widget.

It replaces the insight with the freshly loaded value of the insight, changes its title if appropriate and optionally sets the visualization properties. It also forces refresh of the insight list.

JIRA: RAIL-4657

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
