### PR TITLE
RELATED: RAIL-4668 confirm drill changes

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/localization/bundles/en-US.json
+++ b/libs/sdk-ui-dashboard/src/presentation/localization/bundles/en-US.json
@@ -97,6 +97,16 @@
         "comment": "Title of the link to collapse text of a notification message.",
         "limit": 0
     },
+    "messages.drill.InteractionConfiguredSuccess": {
+        "value": "Interaction configured.",
+        "comment": "Dialog. Configure of drill interaction is created.",
+        "limit": 0
+    },
+    "messages.drill.InteractionUpdatedSuccess": {
+        "value": "Interaction updated.",
+        "comment": "Dialog. Configure of drill interaction is updated.",
+        "limit": 0
+    },
     "filterBar.showAll": {
         "value": "Show all",
         "comment": "",

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/configuration/InsightDrillConfigPanel.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/configuration/InsightDrillConfigPanel.tsx
@@ -1,7 +1,7 @@
 // (C) 2019-2022 GoodData Corporation
 import { InsightDrillDefinition, isInsightWidget, ObjRef } from "@gooddata/sdk-model";
 import React, { useState } from "react";
-import { FormattedMessage } from "react-intl";
+import { defineMessages, FormattedMessage } from "react-intl";
 import { Typography } from "@gooddata/sdk-ui-kit";
 import { InsightDrillConfigList } from "./InsightDrillConfigList";
 import {
@@ -12,6 +12,7 @@ import {
     selectWidgetByRef,
     useDashboardDispatch,
     useDashboardSelector,
+    useToastMessages,
 } from "../../../../model";
 import { DrillOriginSelector } from "./DrillOriginSelector/DrillOriginSelector";
 import invariant from "ts-invariant";
@@ -21,6 +22,11 @@ import { IDrillConfigItem, isAvailableDrillTargetMeasure } from "../../../drill/
 import { IAvailableDrillTargetItem } from "../../../drill/DrillSelect/types";
 import { IAvailableDrillTargets } from "@gooddata/sdk-ui";
 import { ZoomInsightConfiguration } from "./ZoomInsightConfiguration";
+
+const messages = defineMessages({
+    added: { id: "messages.drill.InteractionConfiguredSuccess" },
+    modified: { id: "messages.drill.InteractionUpdatedSuccess" },
+});
 
 const mergeDrillConfigItems = (
     drillConfigItems: IDrillConfigItem[],
@@ -146,6 +152,8 @@ export const InsightDrillConfigPanel: React.FunctionComponent<IDrillConfigPanelP
 
     const settings = useDashboardSelector(selectSettings);
 
+    const { addSuccess } = useToastMessages();
+
     return (
         <>
             {!!settings.enableKDZooming && <ZoomInsightConfiguration widget={widget} />}
@@ -165,6 +173,12 @@ export const InsightDrillConfigPanel: React.FunctionComponent<IDrillConfigPanelP
                     }}
                     onSetup={(drill: InsightDrillDefinition, changedItem: IDrillConfigItem) => {
                         dispatch(modifyDrillsForInsightWidget(widgetRef, [drill]));
+                        // interaction is new if it has an incomplete item associated with it
+                        const isNew = incompleteItems.some(
+                            (incompleteItem) =>
+                                incompleteItem.localIdentifier === changedItem.localIdentifier,
+                        );
+                        addSuccess(isNew ? messages.added : messages.modified, { duration: 3000 });
                         deleteIncompleteItem(changedItem);
                     }}
                     onIncompleteChange={onChangeItem}


### PR DESCRIPTION
Show a toast message when a drill is changed or created.

JIRA: RAIL-4668

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
