### PR TITLE
RELATED: RAIL-4663 fix KPI date dropdown

### DIFF
--- a/libs/sdk-ui-dashboard/src/_staging/dateDatasets/getRecommendedCatalogDateDataset.ts
+++ b/libs/sdk-ui-dashboard/src/_staging/dateDatasets/getRecommendedCatalogDateDataset.ts
@@ -1,15 +1,16 @@
 // (C) 2022 GoodData Corporation
 import { ICatalogDateDataset } from "@gooddata/sdk-model";
-import { getRecommendedDateDataset } from "@gooddata/sdk-ui-kit";
+import { getRecommendedDateDataset, IDateDataset } from "@gooddata/sdk-ui-kit";
 
 export function getRecommendedCatalogDateDataset(
     dateDatasets: readonly ICatalogDateDataset[],
 ): ICatalogDateDataset | undefined {
     const recommendedDateDataSetId = getRecommendedDateDataset(
-        dateDatasets.map((ds) => {
+        dateDatasets.map((ds): IDateDataset => {
             return {
                 id: ds.dataSet.id,
                 title: ds.dataSet.title,
+                relevance: ds.relevance,
             };
         }),
     )?.id;

--- a/libs/sdk-ui-dashboard/src/presentation/widget/kpi/DefaultKpiConfigurationPanel/KpiWidgetDateDatasetFilter.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/kpi/DefaultKpiConfigurationPanel/KpiWidgetDateDatasetFilter.tsx
@@ -80,7 +80,7 @@ export const KpiWidgetDateDatasetFilter: React.FC<{
     const shouldOpenDateDatasetPicker =
         isKpiDateDatasetAutoSelect &&
         result?.dateDatasets &&
-        !!getRecommendedCatalogDateDataset(result?.dateDatasets);
+        !getRecommendedCatalogDateDataset(result.dateDatasets);
 
     useEffect(() => {
         return () => {


### PR DESCRIPTION
There was a problem with he logic (extra !) and the relevance was not passed to the recommendation logic properly.

JIRA: RAIL-4663

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
