### PR TITLE
RELATED: RAIL-4671 clean up df config on close

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/AttributeFilterParentFilteringContext.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/AttributeFilterParentFilteringContext.tsx
@@ -61,16 +61,26 @@ export const AttributeFilterParentFilteringProvider: React.FC<
         onParentSelect,
         onConnectingAttributeChanged,
         onParentFiltersChange,
-        onConfigurationClose,
+        onConfigurationClose: onParentFiltersClose,
     } = useParentsConfiguration(neighborFilters, currentFilter);
 
-    const { onDisplayFormSelect, filterDisplayForms, displayFormChanged, onDisplayFormChange } =
-        useDisplayFormConfiguration(currentFilter);
+    const {
+        onDisplayFormSelect,
+        filterDisplayForms,
+        displayFormChanged,
+        onDisplayFormChange,
+        onConfigurationClose: onDisplayFormClose,
+    } = useDisplayFormConfiguration(currentFilter);
 
     const onConfigurationSave = useCallback(() => {
         onParentFiltersChange();
         onDisplayFormChange();
     }, [onParentFiltersChange, onDisplayFormChange]);
+
+    const onConfigurationClose = useCallback(() => {
+        onParentFiltersClose();
+        onDisplayFormClose();
+    }, [onParentFiltersClose, onDisplayFormClose]);
 
     const showDisplayFormPicker = filterDisplayForms.availableDisplayForms.length > 1;
 

--- a/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/dashboardDropdownBody/configuration/hooks/useDisplayFormConfiguration.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/dashboardDropdownBody/configuration/hooks/useDisplayFormConfiguration.ts
@@ -53,10 +53,18 @@ export function useDisplayFormConfiguration(currentFilter: IDashboardAttributeFi
         }
     }, [filterDisplayForms, originalDisplayForm, currentFilter, changeDisplayFormCommand]);
 
+    const onConfigurationClose = useCallback(() => {
+        setFilterDisplayForms((old) => ({
+            ...old,
+            selectedDisplayForm: originalDisplayForm,
+        }));
+    }, [originalDisplayForm]);
+
     return {
         onDisplayFormSelect,
         filterDisplayForms,
         displayFormChanged,
         onDisplayFormChange,
+        onConfigurationClose,
     };
 }


### PR DESCRIPTION
When closing the display form config, reset the selected display form to the original one.

JIRA: RAIL-4671

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
