### PR TITLE
RELATED: RAIL-4653 fix config closing

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/widget/common/configuration/ConfigurationBubble.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/common/configuration/ConfigurationBubble.tsx
@@ -29,6 +29,9 @@ const arrowDirections: ArrowDirections = {
     "br br": "right",
 };
 
+const alignTo = ".s-dash-item.is-selected";
+const ignoreClicksOnByClass = [alignTo]; // do not close on click to the widget
+
 export const ConfigurationBubble: React.FC<IConfigurationBubbleProps> = (props) => {
     const { children, classNames, onClose } = props;
 
@@ -36,11 +39,12 @@ export const ConfigurationBubble: React.FC<IConfigurationBubbleProps> = (props) 
         <Bubble
             className={cx("bubble-light gd-configuration-bubble s-gd-configuration-bubble", classNames)}
             overlayClassName="gd-configuration-bubble-wrapper sdk-edit-mode-on"
-            alignTo={".s-dash-item.is-selected"}
+            alignTo={alignTo}
             alignPoints={alignPoints}
             arrowOffsets={arrowOffsets}
             arrowDirections={arrowDirections}
             closeOnOutsideClick
+            ignoreClicksOnByClass={ignoreClicksOnByClass}
             onClose={onClose}
         >
             {children}


### PR DESCRIPTION
Do not close the config bubble when clicking on the widget it is related to: this is how gdc-dashboards behave and its tests rely on it.

JIRA: RAIL-4653

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
