### PR TITLE
RELATED: RAIL-4674 fix EditableLabelWithBubble

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayoutRenderer/EditableHeader/EditableLabelWithBubble.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayoutRenderer/EditableHeader/EditableLabelWithBubble.tsx
@@ -55,14 +55,14 @@ export function EditableLabelWithBubble({
     }, [onEditingStart]);
 
     const onCancelCallback = useCallback(() => {
-        setEditing(true);
+        setEditing(false);
         setCurrentValue(value);
         onCancel?.();
     }, [onCancel, value]);
 
     const onSubmitCallback = useCallback(
         (newValue: string) => {
-            setEditing(true);
+            setEditing(false);
             setCurrentValue(newValue);
             onSubmit(newValue);
         },


### PR DESCRIPTION
There was a problem with ending the editing mode and the limit bubbles would always stay open.

JIRA: RAIL-4674

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
