### PR TITLE
RELATED: RAIL-4651 Missing resizer bar for widgets at the top/between position

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/dashboard/DashboardSidebar/SidebarConfigurationPanel.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/dashboard/DashboardSidebar/SidebarConfigurationPanel.tsx
@@ -14,7 +14,7 @@ export const SidebarConfigurationPanel: React.FC<Omit<ISidebarProps, "DefaultSid
     const { deselectWidgets } = useWidgetSelection();
     return (
         <div className="col gd-flex-item gd-sidebar-container" onClick={deselectWidgets}>
-            <div className="flex-panel-full-vh-height">
+            <div className="flex-panel-full-height">
                 <CreationPanel className={configurationPanelClassName} />
             </div>
             <DeleteDropZone />

--- a/libs/sdk-ui-dashboard/styles/scss/configurationPanel.scss
+++ b/libs/sdk-ui-dashboard/styles/scss/configurationPanel.scss
@@ -427,12 +427,12 @@
         }
     }
 
-    .flex-panel-full-vh-height {
+    .flex-panel-full-height {
         display: flex;
         flex-direction: column;
         align-items: stretch;
         align-content: stretch;
-        height: 100vh;
+        height: 100%;
 
         .flex-panel-item-stretch {
             display: flex;

--- a/libs/sdk-ui-dashboard/styles/scss/resizing.scss
+++ b/libs/sdk-ui-dashboard/styles/scss/resizing.scss
@@ -30,22 +30,22 @@ $gd-width-resizer-hotpost-height: 40px;
     cursor: col-resize;
 }
 
-.dash-height-resizer-hotspot,
-.height-resizer-drag-preview {
-    position: absolute;
-    z-index: 101;
-    display: flex;
-    align-items: center;
-    overflow: hidden;
-    height: $gd-width-resizer-hotpost-height;
-    cursor: row-resize;
-}
-
-.dash-height-resizer-hotspot {
-    width: 100%;
-}
-
 .sdk-edit-mode-on {
+    .dash-height-resizer-hotspot,
+    .height-resizer-drag-preview {
+        position: absolute;
+        z-index: 101;
+        display: flex;
+        align-items: center;
+        overflow: hidden;
+        height: $gd-width-resizer-hotpost-height;
+        cursor: row-resize;
+    }
+
+    .dash-height-resizer-hotspot {
+        width: 100%;
+    }
+
     .resizer-drag-preview,
     .height-resizer-drag-preview {
         z-index: 110;


### PR DESCRIPTION
fix: height resizer specific styles for SDK dashboard

JIRA: RAIL-4651

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
