### PR TITLE
RELATED: RAIL-4655, RAIL-4660 rework how section work when dragging

### DIFF
--- a/libs/sdk-ui-dashboard/src/model/store/ui/uiReducers.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/ui/uiReducers.ts
@@ -166,10 +166,12 @@ const clearDraggingWidgetSource: UiReducer<PayloadAction<void>> = (state) => {
 
 const setDraggingWidgetTarget: UiReducer<PayloadAction<ILayoutCoordinates>> = (state, action) => {
     state.draggingWidgetTarget = action.payload;
+    state.activeSectionIndex = action.payload.sectionIndex;
 };
 
 const clearDraggingWidgetTarget: UiReducer<PayloadAction<void>> = (state) => {
     state.draggingWidgetTarget = undefined;
+    state.activeSectionIndex = undefined;
 };
 
 const setWidgetsOverlay: UiReducer<PayloadAction<Record<string, IDashboardWidgetOverlay>>> = (

--- a/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/SectionHotspot.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/SectionHotspot.tsx
@@ -3,7 +3,6 @@ import cx from "classnames";
 import React, { useEffect } from "react";
 import { useDashboardDispatch } from "../../../model";
 import {
-    isBaseDraggableMovingItem,
     isInsightDraggableItem,
     isInsightDraggableListItem,
     isInsightPlaceholderDraggableItem,
@@ -56,13 +55,6 @@ export const SectionHotspot: React.FC<ISectionHotspotProps> = (props) => {
                 if (isKpiPlaceholderDraggableItem(item)) {
                     handleKpiPlaceholderDrop();
                 }
-            },
-            canDrop: (item) => {
-                if (isBaseDraggableMovingItem(item)) {
-                    const isAdjacentSection = index === item.sectionIndex || index === item.sectionIndex + 1;
-                    return !(item.isOnlyItemInSection && isAdjacentSection);
-                }
-                return true;
             },
         },
         [dispatch, index, handleInsightListItemDrop, handleKpiPlaceholderDrop, handleInsightPlaceholderDrop],

--- a/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/index.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/index.ts
@@ -10,6 +10,7 @@ export * from "./WidgetDropZoneColumn";
 export * from "./EmptyDashboardDropZone";
 export * from "./LoadingDashboardWidget";
 export * from "./useIsDraggingCurrentItem";
+export * from "./useShouldHideCurrentSectionWhenDragging";
 export * from "./useWidgetDragEndHandler";
 export * from "./useWidgetDragHoverHandlers";
 export * from "./DashboardLayoutSectionBorder";

--- a/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/useShouldHideCurrentSectionWhenDragging.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/useShouldHideCurrentSectionWhenDragging.ts
@@ -1,0 +1,16 @@
+// (C) 2022 GoodData Corporation
+import { useMemo } from "react";
+
+import { selectDraggingWidgetSource, useDashboardSelector } from "../../../model";
+
+export function useShouldHideCurrentSectionWhenDragging(sectionIndex: number) {
+    const dragItem = useDashboardSelector(selectDraggingWidgetSource);
+
+    return useMemo(() => {
+        if (!dragItem) {
+            return false;
+        }
+
+        return dragItem.sectionIndex === sectionIndex && dragItem.isOnlyItemInSection;
+    }, [dragItem, sectionIndex]);
+}

--- a/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayoutRenderer/EditableDashboardLayoutSectionRenderer.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayoutRenderer/EditableDashboardLayoutSectionRenderer.tsx
@@ -2,7 +2,11 @@
 import React from "react";
 import { IDashboardLayoutSectionRenderer } from "./interfaces";
 import cx from "classnames";
-import { DashboardLayoutSectionBorder, DashboardLayoutSectionBorderStatus } from "../../dragAndDrop";
+import {
+    DashboardLayoutSectionBorder,
+    DashboardLayoutSectionBorderStatus,
+    useShouldHideCurrentSectionWhenDragging,
+} from "../../dragAndDrop";
 import { selectActiveSectionIndex, selectIsDraggingWidget, useDashboardSelector } from "../../../model";
 
 const isHiddenStyle = { height: 0, width: 0, overflow: "hidden", flex: 0 };
@@ -13,7 +17,11 @@ function useBorderStatus(sectionIndex: number): DashboardLayoutSectionBorderStat
     const activeSectionIndex = useDashboardSelector(selectActiveSectionIndex);
     const isActive = activeSectionIndex === sectionIndex;
 
-    return !isDraggingWidget && !isActive ? "invisible" : "muted";
+    if (isDraggingWidget) {
+        return "muted";
+    }
+
+    return !isActive ? "invisible" : "muted";
 }
 
 export const EditableDashboardLayoutSectionRenderer: IDashboardLayoutSectionRenderer<unknown> = (props) => {
@@ -21,11 +29,13 @@ export const EditableDashboardLayoutSectionRenderer: IDashboardLayoutSectionRend
 
     const style = isHidden ? isHiddenStyle : defaultStyle;
     const status = useBorderStatus(section.index());
+    const hideSection = useShouldHideCurrentSectionWhenDragging(section.index());
 
     return (
         <div
             className={cx(["gd-fluidlayout-row", "s-fluid-layout-row", className], {
                 "gd-fluidlayout-row-debug": debug,
+                hidden: hideSection,
             })}
             style={style}
         >

--- a/libs/sdk-ui-dashboard/styles/scss/layout.scss
+++ b/libs/sdk-ui-dashboard/styles/scss/layout.scss
@@ -67,6 +67,10 @@ $gd-dashboards-section-description-color: var(
 
 .gd-fluidlayout-row {
     position: relative;
+
+    &.hidden {
+        display: none;
+    }
 }
 
 .gd-fluidlayout-row-debug {


### PR DESCRIPTION
- hide source section if has only one (dragged) item
- remove adjacent section checking (case is covered by hiding all section)

JIRA: RAIL-4660

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
