### PR TITLE
FEATURE: SD-2507 - Change layout of Visualization color palette screen

### DIFF
--- a/libs/sdk-ui-kit/api/sdk-ui-kit.api.md
+++ b/libs/sdk-ui-kit/api/sdk-ui-kit.api.md
@@ -3595,6 +3595,8 @@ export interface IStylingSettingWidgetProps<T> {
     // (undocumented)
     onApply?: (ref: ObjRef) => void;
     // (undocumented)
+    onCancel?: () => void;
+    // (undocumented)
     onHelpClick?: () => void;
     // (undocumented)
     onItemDelete?: (ref: ObjRef) => void;
@@ -3608,6 +3610,10 @@ export interface IStylingSettingWidgetProps<T> {
     onListActionClick?: () => void;
     // (undocumented)
     selectedItemRef?: ObjRef;
+    // (undocumented)
+    shouldDisableApplyButton?: boolean;
+    // (undocumented)
+    shouldDisableCancelButton?: boolean;
     // (undocumented)
     title: string;
     // (undocumented)

--- a/libs/sdk-ui-kit/src/SettingWidget/StylingSettingWidget/StylingSettingWidget.tsx
+++ b/libs/sdk-ui-kit/src/SettingWidget/StylingSettingWidget/StylingSettingWidget.tsx
@@ -34,7 +34,10 @@ export interface IStylingSettingWidgetProps<T> {
     footerHelpTitle?: string;
     footerMobileMessage?: string;
     className?: string;
+    shouldDisableCancelButton?: boolean;
+    shouldDisableApplyButton?: boolean;
     onApply?: (ref: ObjRef) => void;
+    onCancel?: () => void;
     onListActionClick?: () => void;
     onItemEdit?: (modifiedItem: IStylingPickerItem<T>) => void;
     onItemDelete?: (ref: ObjRef) => void;
@@ -59,7 +62,10 @@ const StylingSettingWidgetCore = <T extends StylingPickerItemContent>(
         footerHelpLink,
         footerHelpTitle,
         footerMobileMessage,
+        shouldDisableCancelButton,
+        shouldDisableApplyButton,
         onApply,
+        onCancel,
         onListActionClick,
         onItemEdit,
         onItemDelete,
@@ -102,6 +108,7 @@ const StylingSettingWidgetCore = <T extends StylingPickerItemContent>(
 
     const handleCancel = useCallback(() => {
         setCurrentItemRef(selectedItemRef);
+        onCancel?.();
     }, [selectedItemRef]);
 
     const handleApply = useCallback(() => {
@@ -148,13 +155,13 @@ const StylingSettingWidgetCore = <T extends StylingPickerItemContent>(
                         <Button
                             className="gd-button-secondary"
                             onClick={handleCancel}
-                            disabled={isApplyButtonDisabled}
+                            disabled={shouldDisableCancelButton ?? isApplyButtonDisabled}
                             value={intl.formatMessage({ id: "cancel" })}
                         />
                         <Button
                             className="gd-button-action"
                             onClick={handleApply}
-                            disabled={isApplyButtonDisabled}
+                            disabled={shouldDisableApplyButton ?? isApplyButtonDisabled}
                             value={intl.formatMessage({ id: "apply" })}
                         />
                     </FooterButtons>

--- a/libs/sdk-ui-kit/src/SettingWidget/tests/StylingSettingWidget.test.tsx
+++ b/libs/sdk-ui-kit/src/SettingWidget/tests/StylingSettingWidget.test.tsx
@@ -122,6 +122,18 @@ describe("StylingPicker", () => {
         expect(screen.queryByLabelText("second_theme")).not.toBeChecked();
     });
 
+    it("should call onCancel when shouldDisableCancelButton is false and cancel button is clicked", async () => {
+        const selectedItemRef = customItemsMock[0].ref;
+        const onCancel = jest.fn();
+        renderComponent({ selectedItemRef, shouldDisableCancelButton: false, onCancel });
+
+        await userEvent.click(screen.getByText("Cancel"));
+
+        await waitFor(() => {
+            expect(onCancel).toHaveBeenCalled();
+        });
+    });
+
     it("should call onListButtonClick when list action link is clicked", async () => {
         const onListActionClick = jest.fn();
         renderComponent({ onListActionClick });


### PR DESCRIPTION
- Adding props to control disabled buttons color palette dialog
JIRA: SD-2507

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
