### PR TITLE
RELATED: RAIL-4684 disable save for empty dashboard

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/topBar/buttonBar/button/saveButton/DefaultSaveButton.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/topBar/buttonBar/button/saveButton/DefaultSaveButton.tsx
@@ -53,7 +53,7 @@ export function useSaveButtonProps(): ISaveButtonProps {
     const isDashboardDirty = useDashboardSelector(selectIsDashboardDirty);
 
     const isVisible = isEditing;
-    const isEnabled = isDashboardDirty;
+    const isEnabled = isDashboardDirty && !isEmptyDashboard && canSaveDashboard;
 
     const buttonValue = arePermissionsEnabled
         ? messages.controlButtonsSaveValue

--- a/libs/sdk-ui-dashboard/src/presentation/topBar/menuButton/useDefaultMenuItems.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/topBar/menuButton/useDefaultMenuItems.tsx
@@ -160,6 +160,7 @@ export const useDefaultMenuItems = function (): IMenuButtonItem[] {
     }, [
         defaultOnScheduleEmailing,
         defaultOnExportToPdf,
+        isEmptyLayout,
         isNewDashboard,
         isReadOnly,
         menuButtonItemsVisibility,


### PR DESCRIPTION
Disable both Save and Save as buttons when the dashboard is empty.

JIRA: RAIL-4684

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
