### PR TITLE
RELATED: RAIL-4682 enforce max attribute filter count

### DIFF
--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -5585,6 +5585,9 @@ export const selectAttributesWithDrillDown: OutputSelector<DashboardState, (ICat
 export const selectBackendCapabilities: OutputSelector<DashboardState, IBackendCapabilities, (res: BackendCapabilitiesState) => IBackendCapabilities>;
 
 // @public
+export const selectCanAddMoreAttributeFilters: OutputSelector<DashboardState, boolean, (res: IDashboardAttributeFilter[]) => boolean>;
+
+// @public
 export const selectCanCreateAnalyticalDashboard: OutputSelector<DashboardState, boolean, (res: IWorkspacePermissions) => boolean>;
 
 // @public
@@ -5915,7 +5918,7 @@ export const selectIsAnalyticalDesignerEnabled: OutputSelector<DashboardState, b
 export const selectIsCancelEditModeDialogOpen: OutputSelector<DashboardState, boolean, (res: UiState) => boolean>;
 
 // @internal
-export const selectIsCircularDependency: (currentFilterLocalId: string, neighborFilterLocalid: string) => OutputSelector<DashboardState, boolean, (res: string[]) => boolean>;
+export const selectIsCircularDependency: (currentFilterLocalId: string, neighborFilterLocalId: string) => OutputSelector<DashboardState, boolean, (res: string[]) => boolean>;
 
 // @internal
 export const selectIsDashboardDirty: OutputSelector<DashboardState, boolean, (res1: boolean, res2: IDashboardLayout<IWidget>, res3: boolean, res4: boolean, res5: boolean) => boolean>;

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/filterContext/attributeFilter/addAttributeFilterHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/filterContext/attributeFilter/addAttributeFilterHandler.ts
@@ -10,6 +10,7 @@ import { attributeFilterAdded } from "../../../events/filters";
 import { filterContextActions } from "../../../store/filterContext";
 import {
     selectAttributeFilterDisplayFormsMap,
+    selectCanAddMoreAttributeFilters,
     selectFilterContextAttributeFilterByDisplayForm,
     selectFilterContextAttributeFilters,
 } from "../../../store/filterContext/filterContextSelectors";
@@ -29,6 +30,18 @@ export function* addAttributeFilterHandler(
     cmd: AddAttributeFilter,
 ): SagaIterator<void> {
     const { displayForm, index, initialIsNegativeSelection, initialSelection, parentFilters } = cmd.payload;
+
+    const isUnderFilterCountLimit: ReturnType<typeof selectCanAddMoreAttributeFilters> = yield select(
+        selectCanAddMoreAttributeFilters,
+    );
+
+    if (!isUnderFilterCountLimit) {
+        throw invalidArgumentsProvided(
+            ctx,
+            cmd,
+            `Attempting to add filter, even though the limit on the count of filters has been reached.`,
+        );
+    }
 
     const allFilters: ReturnType<typeof selectFilterContextAttributeFilters> = yield select(
         selectFilterContextAttributeFilters,

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/render/tests/renderingWorker.test.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/render/tests/renderingWorker.test.ts
@@ -1,4 +1,4 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 import { initializeDashboard } from "../../../commands";
 import { DashboardTester } from "../../../tests/DashboardTester";
 import { EmptyDashboardIdentifier } from "../../../tests/fixtures/Dashboard.fixtures";
@@ -29,7 +29,7 @@ describe("renderingWorker", () => {
             await Tester.waitFor("GDC.DASH/EVT.RENDER.REQUESTED");
             await Tester.dispatchAndWaitFor(initializeDashboard(), "GDC.DASH/EVT.INITIALIZED");
             Tester.dispatch(requestAsyncRender(componentId));
-            await Tester.waitFor("GDC.DASH/EVT.RENDER.RESOLVED", maxTimeout);
+            await Tester.waitFor("GDC.DASH/EVT.RENDER.RESOLVED", maxTimeout + 100); // wait for a bit longer to stabilize this test
             expect(Tester.emittedEventsDigest()).toMatchSnapshot();
         });
     });

--- a/libs/sdk-ui-dashboard/src/model/store/filterContext/filterContextSelectors.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/filterContext/filterContextSelectors.ts
@@ -301,8 +301,26 @@ export const selectAttributeFilterDisplayFormByLocalId = createMemoizedSelector(
  * @internal
  */
 export const selectIsCircularDependency = createMemoizedSelector(
-    (currentFilterLocalId: string, neighborFilterLocalid: string) =>
+    (currentFilterLocalId: string, neighborFilterLocalId: string) =>
         createSelector(selectAttributeFilterDescendants(currentFilterLocalId), (descendants) => {
-            return descendants.some((descendant) => descendant === neighborFilterLocalid);
+            return descendants.some((descendant) => descendant === neighborFilterLocalId);
         }),
+);
+
+const MAX_ATTRIBUTE_FILTERS_COUNT = 30;
+
+/**
+ * This selector returns whether any more attribute filters can be added.
+ *
+ * @remarks
+ * It is expected that the selector is called only after the filter context state is correctly initialized.
+ * Invocations before initialization lead to invariant errors.
+ *
+ * @public
+ */
+export const selectCanAddMoreAttributeFilters = createSelector(
+    selectFilterContextAttributeFilters,
+    (attributeFilters) => {
+        return attributeFilters.length < MAX_ATTRIBUTE_FILTERS_COUNT;
+    },
 );

--- a/libs/sdk-ui-dashboard/src/model/store/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/index.ts
@@ -95,6 +95,7 @@ export {
     selectAttributeFilterDescendants,
     selectAttributeFilterDisplayFormByLocalId,
     selectIsCircularDependency,
+    selectCanAddMoreAttributeFilters,
 } from "./filterContext/filterContextSelectors";
 export {
     // Core drills

--- a/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableAttributeFilter/DraggableAttributeFilter.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableAttributeFilter/DraggableAttributeFilter.tsx
@@ -2,7 +2,12 @@
 import React, { useCallback, useMemo } from "react";
 import { IDashboardAttributeFilter } from "@gooddata/sdk-model";
 import classNames from "classnames";
-import { useDashboardSelector, selectIsInEditMode, selectSupportsElementUris } from "../../../model";
+import {
+    useDashboardSelector,
+    selectIsInEditMode,
+    selectSupportsElementUris,
+    selectCanAddMoreAttributeFilters,
+} from "../../../model";
 import { AttributeFilterDropZoneHint } from "./AttributeFilterDropZoneHint";
 import { CustomDashboardAttributeFilterComponent } from "../../filterBar/types";
 import { useDashboardDrag } from "../useDashboardDrag";
@@ -41,6 +46,7 @@ export function DraggableAttributeFilter({
     );
 
     const supportElementUris = useDashboardSelector(selectSupportsElementUris);
+    const canAddMoreAttributeFilters = useDashboardSelector(selectCanAddMoreAttributeFilters);
     const filterToUse = useMemo(() => {
         if (supportElementUris) {
             return filter;
@@ -61,6 +67,7 @@ export function DraggableAttributeFilter({
                     hintPosition="prev"
                     targetIndex={filterIndex}
                     onAddAttributePlaceholder={onAttributeFilterAdded}
+                    acceptPlaceholder={canAddMoreAttributeFilters}
                 />
             ) : null}
 
@@ -85,6 +92,7 @@ export function DraggableAttributeFilter({
                     hintPosition="next"
                     targetIndex={filterIndex}
                     onAddAttributePlaceholder={onAttributeFilterAdded}
+                    acceptPlaceholder={canAddMoreAttributeFilters}
                 />
             ) : null}
         </div>

--- a/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/CreatableAttributeFilter.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/CreatableAttributeFilter.tsx
@@ -4,16 +4,22 @@ import { Bubble, BubbleHoverTrigger } from "@gooddata/sdk-ui-kit";
 import { FormattedMessage } from "react-intl";
 import { DraggableAttributeFilterCreatePanelItem } from "../../dragAndDrop";
 import { AddAttributeFilterPlaceholder } from "./addAttributeFilter";
-import { useDashboardSelector, selectHasCatalogAttributes, selectIsWhiteLabeled } from "../../../model";
+import {
+    useDashboardSelector,
+    selectHasCatalogAttributes,
+    selectIsWhiteLabeled,
+    selectCanAddMoreAttributeFilters,
+} from "../../../model";
 
 /**
  * @internal
  */
 export function CreatableAttributeFilter() {
     const hasAttributes = useDashboardSelector(selectHasCatalogAttributes);
+    const canAddMoreAttributeFilters = useDashboardSelector(selectCanAddMoreAttributeFilters);
     const isWhiteLabeled = useDashboardSelector(selectIsWhiteLabeled);
 
-    const disabled = !hasAttributes;
+    const disabled = !hasAttributes || !canAddMoreAttributeFilters;
 
     const tooltip =
         disabled && !hasAttributes ? (

--- a/libs/sdk-ui-dashboard/src/presentation/filterBar/filterBar/DefaultFilterBar.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/filterBar/filterBar/DefaultFilterBar.tsx
@@ -23,6 +23,7 @@ import {
     useDashboardSelector,
     selectIsInEditMode,
     selectAttributeFilterDisplayFormsMap,
+    selectCanAddMoreAttributeFilters,
 } from "../../../model";
 import { useDashboardComponentsContext } from "../../dashboardContexts";
 import {
@@ -111,6 +112,7 @@ export function DefaultFilterBar(props: IFilterBarProps): JSX.Element {
         useDashboardComponentsContext();
     const supportElementUris = useDashboardSelector(selectSupportsElementUris);
     const displayFormsMap = useDashboardSelector(selectAttributeFilterDisplayFormsMap);
+    const canAddMoreAttributeFilters = useDashboardSelector(selectCanAddMoreAttributeFilters);
 
     if (isExport) {
         return <HiddenFilterBar {...props} />;
@@ -146,6 +148,7 @@ export function DefaultFilterBar(props: IFilterBarProps): JSX.Element {
                             hintPosition="next"
                             targetIndex={0}
                             onAddAttributePlaceholder={addAttributeFilterPlaceholder}
+                            acceptPlaceholder={canAddMoreAttributeFilters}
                         />
                     </>
                 )}
@@ -194,10 +197,12 @@ export function DefaultFilterBar(props: IFilterBarProps): JSX.Element {
                     );
                 }
             })}
-            <AttributeFilterDropZone
-                targetIndex={attributeFiltersCount}
-                onDrop={addAttributeFilterPlaceholder}
-            />
+            {canAddMoreAttributeFilters ? (
+                <AttributeFilterDropZone
+                    targetIndex={attributeFiltersCount}
+                    onDrop={addAttributeFilterPlaceholder}
+                />
+            ) : null}
             <div className="filter-bar-dropzone-container">
                 <AttributeFilterDropZoneHint
                     placement="outside"


### PR DESCRIPTION
This is enforced on both the UI and in the command handlers.
Also try to stabilize a problematic unit test.

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
