### PR TITLE
RELATED: RAIL-4690 strip Date wrapper in warning

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/widget/common/configuration/DateDatasetDropdown.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/common/configuration/DateDatasetDropdown.tsx
@@ -14,6 +14,7 @@ import {
     ShortenedText,
 } from "@gooddata/sdk-ui-kit";
 import { stringUtils } from "@gooddata/util";
+import { removeDateFromTitle } from "./utils";
 
 const DEFAULT_HYPHEN_CHAR = "-";
 const alignPoints: IAlignPoint[] = [{ align: "bl tl" }, { align: "tl bl" }];
@@ -89,10 +90,6 @@ function catalogDateDatasetToDateDataset(ds: ICatalogDateDataset): IDateDataset 
         title: ds.dataSet.title,
         relevance: ds.relevance,
     };
-}
-
-function removeDateFromTitle(title: string) {
-    return title.trim().replace(/^Date \((.*)\)$/, "$1");
 }
 
 export const DateDatasetDropdown: React.FC<IDateDatasetDropdownProps> = (props) => {

--- a/libs/sdk-ui-dashboard/src/presentation/widget/common/configuration/DateDatasetPicker.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/common/configuration/DateDatasetPicker.tsx
@@ -4,7 +4,7 @@ import { ICatalogDateDataset, isInsightWidget, IWidget } from "@gooddata/sdk-mod
 import { FormattedMessage } from "react-intl";
 import Measure from "react-measure";
 import { DateDatasetDropdown } from "./DateDatasetDropdown";
-import { getUnrelatedDateDataset } from "./utils";
+import { getUnrelatedDateDataset, removeDateFromTitle } from "./utils";
 
 export interface IDateDatasetPickerProps {
     autoOpen?: boolean;
@@ -79,12 +79,12 @@ export const DateDatasetPicker: React.FC<IDateDatasetPickerProps> = (props) => {
                     {isInsightWidget(widget) ? (
                         <FormattedMessage
                             id="configurationPanel.unrelatedVizDateInfo"
-                            values={{ dateDataSet: unrelatedDateDataset.dataSet.title }}
+                            values={{ dateDataSet: removeDateFromTitle(unrelatedDateDataset.dataSet.title) }}
                         />
                     ) : (
                         <FormattedMessage
                             id="configurationPanel.unrelatedKpiDateInfo"
-                            values={{ dateDataSet: unrelatedDateDataset.dataSet.title }}
+                            values={{ dateDataSet: removeDateFromTitle(unrelatedDateDataset.dataSet.title) }}
                         />
                     )}
                 </div>

--- a/libs/sdk-ui-dashboard/src/presentation/widget/common/configuration/utils.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/common/configuration/utils.ts
@@ -37,3 +37,7 @@ export function getDateOptionsDisabledForInsight(insight: IInsightDefinition): b
     const measures = insightMeasures(insight);
     return isEmpty(measures) ? false : measures.every(isDateFiltered);
 }
+
+export function removeDateFromTitle(title: string): string {
+    return title.trim().replace(/^Date \((.*)\)$/, "$1");
+}


### PR DESCRIPTION
Similar to what we do in the picker itself, we need to strip the "Date ()" wrapper in the warning message about the no longer related date dataset.

JIRA: RAIL-4690

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
