### PR TITLE
RELATED: RAIL-4660 Empty section behavior when dragging

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayout.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayout.tsx
@@ -32,7 +32,7 @@ import {
 import { renderModeAwareDashboardLayoutSectionRenderer } from "./DefaultDashboardLayoutRenderer/RenderModeAwareDashboardLayoutSectionRenderer";
 import { renderModeAwareDashboardLayoutSectionHeaderRenderer } from "./DefaultDashboardLayoutRenderer/RenderModeAwareDashboardLayoutSectionHeaderRenderer";
 import { getMemoizedWidgetSanitizer } from "./DefaultDashboardLayoutUtils";
-import { SectionHotspot } from "../dragAndDrop";
+import { SectionHotspot, useIsDraggingWidget } from "../dragAndDrop";
 import { isInitialPlaceholderWidget } from "../../widgets";
 import { EmptyDashboardLayout } from "./EmptyDashboardLayout";
 
@@ -94,6 +94,8 @@ export const DefaultDashboardLayout = (props: IDashboardLayoutProps): JSX.Elemen
     const isExport = useDashboardSelector(selectIsExport);
     const renderMode = useDashboardSelector(selectRenderMode);
 
+    const isDraggingWidget = useIsDraggingWidget();
+
     const getInsightByRef = useCallback(
         (insightRef: ObjRef): IInsight | undefined => {
             return insights.get(insightRef);
@@ -153,6 +155,7 @@ export const DefaultDashboardLayout = (props: IDashboardLayoutProps): JSX.Elemen
                 sectionRenderer={renderModeAwareDashboardLayoutSectionRenderer}
                 sectionHeaderRenderer={renderModeAwareDashboardLayoutSectionHeaderRenderer}
                 renderMode={renderMode}
+                isDraggingWidget={isDraggingWidget}
             />
             {!!shouldRenderSectionHotspot && (
                 <SectionHotspot index={transformedLayout.sections.length} targetPosition="below" />

--- a/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayoutRenderer/DashboardLayout.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayoutRenderer/DashboardLayout.tsx
@@ -59,6 +59,7 @@ export function DashboardLayout<TWidget>(props: IDashboardLayoutRenderProps<TWid
         onMouseLeave,
         enableCustomHeight,
         renderMode = "view",
+        isDraggingWidget = false,
     } = props;
 
     const layoutRef = React.useRef<HTMLDivElement>(null);
@@ -137,6 +138,7 @@ export function DashboardLayout<TWidget>(props: IDashboardLayoutRenderProps<TWid
                                             widgetRenderer={widgetRendererWrapped}
                                             screen={screen}
                                             renderMode={renderMode}
+                                            isDraggingWidget={isDraggingWidget}
                                             getLayoutDimensions={getLayoutDimensions}
                                         />
                                     );

--- a/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayoutRenderer/DashboardLayoutGridRow.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayoutRenderer/DashboardLayoutGridRow.tsx
@@ -29,14 +29,12 @@ export interface DashboardLayoutGridRowProps<TWidget> {
     getLayoutDimensions: () => DOMRect;
     items: IDashboardLayoutItemFacade<TWidget>[];
     renderMode: RenderMode;
+    isDraggingWidget?: boolean;
 }
 
 const defaultItemKeyGetter: IDashboardLayoutItemKeyGetter<unknown> = ({ item }) => item.index().toString();
 
 export function DashboardLayoutGridRow<TWidget>(props: DashboardLayoutGridRowProps<TWidget>): JSX.Element {
-    // TODO this is not usable in old KD edit mode
-    const isDraggingWidget = false; //useIsDraggingWidget();
-
     const rowRef = useRef<HTMLDivElement>(null);
     const {
         section,
@@ -48,6 +46,7 @@ export function DashboardLayoutGridRow<TWidget>(props: DashboardLayoutGridRowPro
         screen,
         items,
         renderMode,
+        isDraggingWidget,
     } = props;
 
     const rowItems = items.map((item) => (

--- a/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayoutRenderer/DashboardLayoutSection.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayoutRenderer/DashboardLayoutSection.tsx
@@ -33,6 +33,7 @@ export interface IDashboardLayoutSectionProps<TWidget> {
     getLayoutDimensions: () => DOMRect;
     screen: ScreenSize;
     renderMode: RenderMode;
+    isDraggingWidget?: boolean;
 }
 
 const defaultSectionRenderer: IDashboardLayoutSectionRenderer<unknown> = (props) => (
@@ -57,6 +58,7 @@ export function DashboardLayoutSection<TWidget>(props: IDashboardLayoutSectionPr
         getLayoutDimensions,
         screen,
         renderMode,
+        isDraggingWidget,
     } = props;
     const renderProps = { section, screen, renderMode };
 
@@ -72,6 +74,7 @@ export function DashboardLayoutSection<TWidget>(props: IDashboardLayoutSectionPr
                 itemRenderer={itemRenderer}
                 widgetRenderer={widgetRenderer}
                 renderMode={renderMode}
+                isDraggingWidget={isDraggingWidget}
                 getLayoutDimensions={getLayoutDimensions}
             />
         );

--- a/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayoutRenderer/interfaces.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayoutRenderer/interfaces.ts
@@ -402,6 +402,11 @@ export interface IDashboardLayoutRenderProps<TWidget = IDashboardWidget> {
      * Dashboard render mode
      */
     renderMode?: RenderMode;
+
+    /**
+     * Indicate if dragging is in progress
+     */
+    isDraggingWidget?: boolean;
 }
 
 /**

--- a/libs/sdk-ui-dashboard/src/presentation/layout/test/useInKD/DashboardEditLayout.test.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/layout/test/useInKD/DashboardEditLayout.test.tsx
@@ -1,0 +1,34 @@
+// (C) 2019-2022 GoodData Corporation
+import { idRef } from "@gooddata/sdk-model";
+import React from "react";
+
+import * as Mocks from "./DashboardEditLayout/DashboardEditLayoutMocks";
+import {
+    RenderDashboardEditLayout,
+    IDashboardEditLayoutProps,
+} from "./DashboardEditLayout/DashboardEditLayout";
+import { IntlWrapper } from "@gooddata/sdk-ui";
+import { render } from "@testing-library/react";
+
+const dashboardEditLayout = Mocks.layoutMock([
+    Mocks.rowMock([[Mocks.widgetKpiPlaceholderMock()]]),
+    Mocks.rowMock([[Mocks.widgetDropzoneHotspotMock(idRef(""))]]),
+    Mocks.rowMock([[Mocks.widgetDropzoneMock()]]),
+    Mocks.rowMock([[Mocks.widgetMock()]]),
+]);
+
+function createComponent(customProps: Partial<IDashboardEditLayoutProps> = {}) {
+    return render(
+        <IntlWrapper>
+            <RenderDashboardEditLayout layout={dashboardEditLayout} {...customProps} />
+        </IntlWrapper>,
+    );
+}
+
+describe("DashboardEditLayout in KD", () => {
+    it("should render layout in KD old edit mode - layout must not have dependency on SDK state, use selectors, context...", () => {
+        const { container } = createComponent();
+
+        expect(container.getElementsByClassName("gd-dashboards")).toHaveLength(1);
+    });
+});

--- a/libs/sdk-ui-dashboard/src/presentation/layout/test/useInKD/DashboardEditLayout/DashboardEditLayout.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/layout/test/useInKD/DashboardEditLayout/DashboardEditLayout.tsx
@@ -1,0 +1,67 @@
+// (C) 2007-2022 GoodData Corporation
+import { objRefToString } from "@gooddata/sdk-model";
+import React, { Fragment } from "react";
+
+import { DashboardLayout } from "../../../DefaultDashboardLayoutRenderer/DashboardLayout";
+import { DashboardEditLayoutItemRenderer } from "./DashboardEditLayoutItemRenderer";
+import { DashboardEditLayoutRowRenderer } from "./DashboardEditLayoutRowRenderer";
+import { DashboardEditLayoutSectionHeaderRenderer } from "./DashboardEditLayoutSectionHeaderRenderer";
+import { DashboardEditLayoutSectionRenderer } from "./DashboardEditLayoutSectionRenderer";
+import { IDashboardEditLayout } from "./DashboardEditLayoutTypes";
+import { DashboardEditLayoutWidgetRenderer } from "./DashboardEditLayoutWidgetRenderer";
+
+export interface IDashboardEditLayoutStateProps {
+    isDragging?: boolean;
+    isResizingColumn?: boolean;
+    isResizingRow?: boolean;
+    shouldRenderSectionHotspots?: boolean;
+    layout: IDashboardEditLayout;
+    rowIdsByRowOrder?: any;
+    isEnableKDWidgetCustomHeight?: boolean;
+    shouldUseRowRenderer?: boolean;
+    isEditMode?: boolean;
+}
+
+export interface IDashboardEditLayoutDispatchProps {
+    removeDropZones?: () => void;
+}
+
+export type IDashboardEditLayoutProps = IDashboardEditLayoutStateProps & IDashboardEditLayoutDispatchProps;
+
+export const RenderDashboardEditLayout: React.FC<IDashboardEditLayoutProps> = (props) => {
+    const { layout, rowIdsByRowOrder, shouldUseRowRenderer } = props;
+
+    return (
+        layout && (
+            <DashboardLayout
+                layout={layout}
+                sectionKeyGetter={(p) =>
+                    rowIdsByRowOrder?.[p.section.index()] ?? p.section.index().toString()
+                }
+                sectionRenderer={(renderProps) => <DashboardEditLayoutSectionRenderer {...renderProps} />}
+                sectionHeaderRenderer={(renderProps) => (
+                    <DashboardEditLayoutSectionHeaderRenderer {...renderProps} />
+                )}
+                itemKeyGetter={(p) =>
+                    // We want to rerender kpi/insight, when we resize the widget (to recalculate rendered visualization size).
+                    objRefToString(p.item.widget()!.ref) + p.item.sizeForScreen(p.screen)!.gridWidth
+                }
+                itemRenderer={(renderProps) => <DashboardEditLayoutItemRenderer {...renderProps} />}
+                widgetRenderer={(renderProps) => <DashboardEditLayoutWidgetRenderer {...renderProps} />}
+                gridRowRenderer={(renderProps) =>
+                    shouldUseRowRenderer ? (
+                        <DashboardEditLayoutRowRenderer
+                            layoutItems={renderProps.items}
+                            screen={renderProps.screen}
+                            section={renderProps.section}
+                        >
+                            {renderProps.children}
+                        </DashboardEditLayoutRowRenderer>
+                    ) : (
+                        <Fragment>{renderProps.children}</Fragment>
+                    )
+                }
+            />
+        )
+    );
+};

--- a/libs/sdk-ui-dashboard/src/presentation/layout/test/useInKD/DashboardEditLayout/DashboardEditLayoutItemRenderer.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/layout/test/useInKD/DashboardEditLayout/DashboardEditLayoutItemRenderer.tsx
@@ -1,0 +1,55 @@
+// (C) 2007-2022 GoodData Corporation
+import React from "react";
+import cx from "classnames";
+
+import {
+    DashboardLayoutItemViewRenderer,
+    IDashboardLayoutItemRenderProps,
+} from "../../../DefaultDashboardLayoutRenderer";
+import { areObjRefsEqual, idRef, ObjRef } from "@gooddata/sdk-model";
+import { IDashboardEditLayoutContent } from "./DashboardEditLayoutTypes";
+
+export interface IDashboardEditLayoutItemRendererStateProps {
+    hiddenWidgetRef?: ObjRef;
+}
+
+export type IDashboardEditLayoutItemRendererOwnProps =
+    IDashboardLayoutItemRenderProps<IDashboardEditLayoutContent>;
+
+export type IDashboardEditLayoutItemRendererProps = IDashboardEditLayoutItemRendererOwnProps &
+    IDashboardEditLayoutItemRendererStateProps;
+
+export const RenderDashboardEditLayoutItemRenderer: React.FC<IDashboardEditLayoutItemRendererProps> = (
+    props,
+) => {
+    const { children, item, hiddenWidgetRef = idRef("hiddenWidget") } = props;
+
+    const content = item.widget();
+
+    const isLastInSection = item.isLast();
+    const isLastSection = item.section().isLast();
+    const isLast = isLastSection && isLastInSection;
+
+    const className = cx({
+        last: content?.type === "widget" ? isLast : false,
+    });
+
+    const isHidden = content && isHiddenContent(content, hiddenWidgetRef);
+
+    return (
+        // @ts-expect-error types are not compatible
+        <DashboardLayoutItemViewRenderer isHidden={isHidden} {...props} className={className}>
+            {children}
+        </DashboardLayoutItemViewRenderer>
+    );
+};
+
+export const DashboardEditLayoutItemRenderer = RenderDashboardEditLayoutItemRenderer;
+
+export const isHiddenContent = (content: IDashboardEditLayoutContent, hiddenWidgetRef: ObjRef) => {
+    if (content.type === "widgetDropzoneHotspot") {
+        return areObjRefsEqual(content.widgetRef, hiddenWidgetRef);
+    }
+
+    return areObjRefsEqual(content.ref, hiddenWidgetRef);
+};

--- a/libs/sdk-ui-dashboard/src/presentation/layout/test/useInKD/DashboardEditLayout/DashboardEditLayoutMocks.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/layout/test/useInKD/DashboardEditLayout/DashboardEditLayoutMocks.ts
@@ -1,0 +1,161 @@
+// (C) 2007-2022 GoodData Corporation
+import { idRef, ObjRef } from "@gooddata/sdk-model";
+import { VisType } from "@gooddata/sdk-ui";
+
+import { WidgetPosition, DropZoneType } from "./LayoutTypes";
+import { newInsight } from "../../../../../_staging/insight/insightBuilder";
+
+import {
+    IDashboardEditLayout,
+    IDashboardEditLayoutContentWidget,
+    IDashboardEditLayoutContentWidgetDropzone,
+    IDashboardEditLayoutContentWidgetDropzoneHotspot,
+    IDashboardEditLayoutContentWidgetKpiPlaceholder,
+    IDashboardEditLayoutContent,
+    IDashboardEditLayoutItem,
+    IDashboardEditLayoutContentWidgetNewInsightPlaceholder,
+} from "./DashboardEditLayoutTypes";
+
+export type DashboardEditLayoutContentGenerator = (
+    ref: ObjRef,
+    rowId?: string,
+) => IDashboardEditLayoutContent;
+export type DashboardEditLayoutRowMock = {
+    title?: string;
+    description?: string;
+    isDropzone?: boolean;
+    contentGeneratorColumnWidthAndHeightAsRatioTuples: (
+        | [DashboardEditLayoutContentGenerator, number, number | undefined]
+        | [DashboardEditLayoutContentGenerator, number]
+        | [DashboardEditLayoutContentGenerator]
+    )[];
+};
+
+export const widgetMock =
+    () =>
+    (ref: ObjRef): IDashboardEditLayoutContentWidget => {
+        return {
+            type: "widget",
+            ref,
+        };
+    };
+
+export const widgetDropzoneMock =
+    (visType: VisType = "bar", isInitialDropzone = false, position = WidgetPosition.next) =>
+    (ref: ObjRef): IDashboardEditLayoutContentWidgetDropzone => {
+        return {
+            type: "widgetDropzone",
+            dragZoneWidget: {
+                dropzone: {
+                    ref,
+                    widgetType: "insight",
+                    content: newInsight(`local:${visType}`, (m) => m.title("Some vis").uri("gdc/some/vis")),
+                    isInitialDropzone,
+                    position,
+                },
+            },
+            ref,
+        };
+    };
+
+export const widgetDropzoneHotspotMock =
+    (widgetRef: ObjRef, dropZoneType = DropZoneType.next) =>
+    (ref: ObjRef): IDashboardEditLayoutContentWidgetDropzoneHotspot => {
+        return {
+            type: "widgetDropzoneHotspot",
+            dropZoneType,
+            ref,
+            widgetRef,
+        };
+    };
+
+export const widgetKpiPlaceholderMock =
+    () =>
+    (ref: ObjRef): IDashboardEditLayoutContentWidgetKpiPlaceholder => {
+        return {
+            type: "widgetKpiPlaceholder",
+            ref,
+        };
+    };
+
+export const widgetNewInsightPlaceholderMock =
+    () =>
+    (ref: ObjRef): IDashboardEditLayoutContentWidgetNewInsightPlaceholder => {
+        return {
+            type: "widgetNewInsightPlaceholder",
+            ref,
+        };
+    };
+
+export const rowMock = (
+    contentGeneratorColumnWidthAndHeightAsRatioTuples: (
+        | [DashboardEditLayoutContentGenerator, number, number | undefined]
+        | [DashboardEditLayoutContentGenerator, number]
+        | [DashboardEditLayoutContentGenerator]
+    )[],
+    title?: string,
+    description?: string,
+    isDropzone?: boolean,
+): DashboardEditLayoutRowMock => {
+    return {
+        contentGeneratorColumnWidthAndHeightAsRatioTuples,
+        title,
+        description,
+        isDropzone,
+    };
+};
+
+export const getWidgetMockRef = (itemIndex: number, sectionIndex: number) =>
+    idRef(`widget_${itemIndex}_row_${sectionIndex}`);
+
+export const layoutMock = (rowMocks: DashboardEditLayoutRowMock[]): IDashboardEditLayout => {
+    const emptyLayout: IDashboardEditLayout = {
+        type: "IDashboardLayout",
+        sections: [],
+    };
+
+    return rowMocks.reduce((acc: IDashboardEditLayout, rowMock, sectionIndex) => {
+        const rowId = `row_${sectionIndex}`;
+
+        if (!acc.sections[sectionIndex]) {
+            acc.sections[sectionIndex] = {
+                type: "IDashboardLayoutSection",
+                items: [],
+                ...(rowMock.title || rowMock.description
+                    ? {
+                          header: {
+                              title: rowMock.title,
+                              description: rowMock.description,
+                          },
+                      }
+                    : {}),
+            };
+        }
+
+        return rowMock.contentGeneratorColumnWidthAndHeightAsRatioTuples.reduce(
+            (
+                acc2: IDashboardEditLayout,
+                [contentGenerator, gridWidth = 12, heightAsRatio = undefined],
+                itemIndex,
+            ) => {
+                const widgetRef = getWidgetMockRef(itemIndex, sectionIndex);
+                const widget = contentGenerator(widgetRef, rowId);
+                const item: IDashboardEditLayoutItem = {
+                    type: "IDashboardLayoutItem",
+                    size: {
+                        xl: {
+                            gridWidth,
+                        },
+                    },
+                    widget,
+                };
+                if (heightAsRatio) {
+                    item.size.xl.heightAsRatio = heightAsRatio;
+                }
+                acc2.sections[sectionIndex].items[itemIndex] = item;
+                return acc2;
+            },
+            acc,
+        );
+    }, emptyLayout);
+};

--- a/libs/sdk-ui-dashboard/src/presentation/layout/test/useInKD/DashboardEditLayout/DashboardEditLayoutRowRenderer.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/layout/test/useInKD/DashboardEditLayout/DashboardEditLayoutRowRenderer.tsx
@@ -1,0 +1,35 @@
+// (C) 2007-2022 GoodData Corporation
+import React, { Fragment, RefObject, useRef } from "react";
+
+import { ScreenSize } from "@gooddata/sdk-model";
+
+import {
+    IDashboardLayoutItemFacade,
+    IDashboardLayoutSectionFacade,
+} from "../../../DefaultDashboardLayoutRenderer";
+import { IDashboardEditLayoutContent } from "./DashboardEditLayoutTypes";
+
+export interface IDashboardEditLayoutRowRendererOwnProps {
+    layoutItems: IDashboardLayoutItemFacade<IDashboardEditLayoutContent>[];
+    screen: ScreenSize;
+    section: IDashboardLayoutSectionFacade<IDashboardEditLayoutContent>;
+    children?: React.ReactNode;
+}
+
+export type IDashboardEditLayoutRowRendererProps = IDashboardEditLayoutRowRendererOwnProps;
+
+export const RenderDashboardEditLayoutRowRenderer: React.FC<IDashboardEditLayoutRowRendererProps> = (
+    props,
+) => {
+    const { children } = props;
+    const rowId = "rowId";
+    const contentRef = useRef() as RefObject<HTMLDivElement>;
+    return (
+        <div key={rowId} ref={contentRef} className="gd-fluid-layout-row s-gd-fluid-layout-row">
+            <Fragment>{children}</Fragment>
+            {/* <HeightResizerHotspot contentRef={contentRef} layoutItems={layoutItems} screen={screen} /> */}
+        </div>
+    );
+};
+
+export const DashboardEditLayoutRowRenderer = RenderDashboardEditLayoutRowRenderer;

--- a/libs/sdk-ui-dashboard/src/presentation/layout/test/useInKD/DashboardEditLayout/DashboardEditLayoutRowRenderer.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/layout/test/useInKD/DashboardEditLayout/DashboardEditLayoutRowRenderer.tsx
@@ -27,7 +27,6 @@ export const RenderDashboardEditLayoutRowRenderer: React.FC<IDashboardEditLayout
     return (
         <div key={rowId} ref={contentRef} className="gd-fluid-layout-row s-gd-fluid-layout-row">
             <Fragment>{children}</Fragment>
-            {/* <HeightResizerHotspot contentRef={contentRef} layoutItems={layoutItems} screen={screen} /> */}
         </div>
     );
 };

--- a/libs/sdk-ui-dashboard/src/presentation/layout/test/useInKD/DashboardEditLayout/DashboardEditLayoutSectionBorder.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/layout/test/useInKD/DashboardEditLayout/DashboardEditLayoutSectionBorder.tsx
@@ -1,0 +1,49 @@
+// (C) 2019-2022 GoodData Corporation
+import React from "react";
+import cx from "classnames";
+
+import { DashboardEditLayoutSectionBorderMarker } from "./DashboardEditLayoutSectionBorderMarker";
+
+export type DashboardEditLayoutSectionBorderStatus = "active" | "muted" | "invisible";
+
+interface IDashboardEditLayoutSectionBorderProps {
+    children?: React.ReactNode;
+    status: DashboardEditLayoutSectionBorderStatus;
+}
+
+export const DashboardEditLayoutSectionBorder: React.FunctionComponent<
+    IDashboardEditLayoutSectionBorderProps
+> = (props) => (
+    <React.Fragment>
+        <div className={classNames("top", props.status)}>
+            <DashboardEditLayoutSectionBorderMarker
+                className="gd-fluidlayout-row-separator-icon gd-fluidlayout-row-separator-icon-left"
+                active={props.status === "active"}
+            />
+            <DashboardEditLayoutSectionBorderMarker
+                className="gd-fluidlayout-row-separator-icon gd-fluidlayout-row-separator-icon-right"
+                active={props.status === "active"}
+            />
+        </div>
+        {props.children}
+        <div className={classNames("bottom", props.status)}>
+            <DashboardEditLayoutSectionBorderMarker
+                className="gd-fluidlayout-row-separator-icon gd-fluidlayout-row-separator-icon-left"
+                active={props.status === "active"}
+            />
+            <DashboardEditLayoutSectionBorderMarker
+                className="gd-fluidlayout-row-separator-icon gd-fluidlayout-row-separator-icon-right"
+                active={props.status === "active"}
+            />
+        </div>
+    </React.Fragment>
+);
+
+type DashboardEditLayoutSectionBorderPosition = "top" | "bottom";
+
+function classNames(
+    position: DashboardEditLayoutSectionBorderPosition,
+    status: DashboardEditLayoutSectionBorderStatus,
+) {
+    return cx("gd-fluidlayout-row-separator", "s-fluidlayout-row-separator", position, status);
+}

--- a/libs/sdk-ui-dashboard/src/presentation/layout/test/useInKD/DashboardEditLayout/DashboardEditLayoutSectionBorderMarker.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/layout/test/useInKD/DashboardEditLayout/DashboardEditLayoutSectionBorderMarker.tsx
@@ -1,0 +1,36 @@
+// (C) 2020-2022 GoodData Corporation
+import React from "react";
+import { GD_COLOR_HIGHLIGHT, GD_COLOR_WHITE, INFO_TEXT_COLOR } from "@gooddata/sdk-ui-kit";
+
+export interface IDashboardEditLayoutSectionBorderMarkerProps {
+    active?: boolean;
+    className?: string;
+}
+
+export const DashboardEditLayoutSectionBorderMarker: React.FC<
+    IDashboardEditLayoutSectionBorderMarkerProps
+> = (props) => {
+    const { active, className } = props;
+
+    const background = active ? `var(--gd-palette-primary-base, ${GD_COLOR_HIGHLIGHT})` : "#E6E6E6";
+    const color = active ? GD_COLOR_WHITE : INFO_TEXT_COLOR;
+
+    return (
+        <svg
+            width="20"
+            height="20"
+            xmlns="http://www.w3.org/2000/svg"
+            xmlnsXlink="http://www.w3.org/1999/xlink"
+            className={className}
+        >
+            <g fill="none" fillRule="evenodd">
+                <circle cx="10" cy="10" r="10" fill={background} />
+                <path
+                    d="M6.5 9.5H14c.2761424 0 .5.22385763.5.5 0 .2761424-.2238576.5-.5.5H6.5V14c0 .2761424-.22385763.5-.5.5-.27614237 0-.5-.2238576-.5-.5V6c0-.27614237.22385763-.5.5-.5.27614237 0 .5.22385763.5.5v3.5z"
+                    fill={color}
+                    fillRule="nonzero"
+                />
+            </g>
+        </svg>
+    );
+};

--- a/libs/sdk-ui-dashboard/src/presentation/layout/test/useInKD/DashboardEditLayout/DashboardEditLayoutSectionHeader.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/layout/test/useInKD/DashboardEditLayout/DashboardEditLayoutSectionHeader.tsx
@@ -1,0 +1,34 @@
+// (C) 2019-2022 GoodData Corporation
+import * as React from "react";
+
+import { DashboardLayoutSectionHeader } from "../../../DefaultDashboardLayoutRenderer";
+
+export interface IDashboardEditLayoutSectionHeaderOwnProps {
+    title: string;
+    description: string;
+    rowId: string;
+}
+
+export type IDashboardEditLayoutSectionHeaderProps = IDashboardEditLayoutSectionHeaderOwnProps;
+
+export const RenderDashboardEditLayoutSectionHeader: React.FC<IDashboardEditLayoutSectionHeaderProps> = (
+    props,
+) => {
+    const { description, title } = props;
+
+    const isDashboardEditing = true;
+
+    return (
+        <DashboardLayoutSectionHeader
+            title={title}
+            description={description}
+            renderHeader={
+                isDashboardEditing
+                    ? "<SectionHeaderEditable title={title} description={description} rowId={rowId} />"
+                    : null
+            }
+        />
+    );
+};
+
+export const DashboardEditLayoutSectionHeader = RenderDashboardEditLayoutSectionHeader;

--- a/libs/sdk-ui-dashboard/src/presentation/layout/test/useInKD/DashboardEditLayout/DashboardEditLayoutSectionHeaderRenderer.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/layout/test/useInKD/DashboardEditLayout/DashboardEditLayoutSectionHeaderRenderer.tsx
@@ -1,0 +1,83 @@
+// (C) 2007-2022 GoodData Corporation
+import React from "react";
+
+import {
+    DashboardLayoutItemViewRenderer,
+    IDashboardLayoutItemFacade,
+    IDashboardLayoutSectionHeaderRenderProps,
+} from "../../../DefaultDashboardLayoutRenderer";
+import { DashboardEditLayoutSectionHeader } from "./DashboardEditLayoutSectionHeader";
+import { IDashboardEditLayoutContent } from "./DashboardEditLayoutTypes";
+
+type IDashboardLayoutSectionHeaderRendererOwnProps =
+    IDashboardLayoutSectionHeaderRenderProps<IDashboardEditLayoutContent>;
+
+type IDashboardLayoutSectionHeaderRendererProps = IDashboardLayoutSectionHeaderRendererOwnProps;
+
+const emptyItemFacadeWithFullSize: IDashboardLayoutItemFacade<any> = {
+    ref: () => undefined,
+    index: () => 0,
+    // @ts-expect-error this is mock
+    raw: () => null,
+    widget: () => null,
+    // @ts-expect-error this is mock
+    section: () => undefined,
+    size: () => ({ xl: { gridWidth: 12 } }),
+    sizeForScreen: () => ({ gridWidth: 12 }),
+    isLast: () => true,
+    widgetEquals: () => false,
+    widgetIs: () => false,
+    isEmpty: () => false,
+    hasSizeForScreen: () => false,
+    indexIs: () => false,
+    isFirst: () => true,
+    test: () => false,
+    testRaw: () => false,
+    isCustomItem: () => false,
+    isInsightWidgetDefinitionItem: () => false,
+    isInsightWidgetItem: () => false,
+    isKpiWidgetDefinitionItem: () => false,
+    isKpiWidgetItem: () => false,
+    isLayoutItem: () => false,
+    isWidgetDefinitionItem: () => false,
+    isWidgetItem: () => false,
+    isWidgetItemWithInsightRef: () => false,
+    isWidgetItemWithKpiRef: () => false,
+    isWidgetItemWithRef: () => false,
+};
+
+export const RenderDashboardEditLayoutSectionHeaderRenderer: React.FC<
+    IDashboardLayoutSectionHeaderRendererProps
+> = (props) => {
+    const { section, screen, DefaultSectionHeaderRenderer } = props;
+
+    const rowId = "rowId";
+    const hasJustOneDropZone = false;
+    const isDashboardEditing = true; // TODO state?
+
+    const header = section.header();
+
+    if (hasJustOneDropZone) {
+        return null;
+    }
+
+    if (isDashboardEditing) {
+        return (
+            <DashboardLayoutItemViewRenderer
+                DefaultItemRenderer={DashboardLayoutItemViewRenderer}
+                item={emptyItemFacadeWithFullSize}
+                screen={screen}
+            >
+                <DashboardEditLayoutSectionHeader
+                    title={header?.title || ""}
+                    description={header?.description || ""}
+                    rowId={rowId}
+                />
+            </DashboardLayoutItemViewRenderer>
+        );
+    }
+
+    return <DefaultSectionHeaderRenderer {...props} />;
+};
+
+export const DashboardEditLayoutSectionHeaderRenderer = RenderDashboardEditLayoutSectionHeaderRenderer;

--- a/libs/sdk-ui-dashboard/src/presentation/layout/test/useInKD/DashboardEditLayout/DashboardEditLayoutSectionRenderer.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/layout/test/useInKD/DashboardEditLayout/DashboardEditLayoutSectionRenderer.tsx
@@ -1,0 +1,62 @@
+// (C) 2007-2022 GoodData Corporation
+import cx from "classnames";
+import React, { useCallback, useState } from "react";
+
+import { IDashboardLayoutSectionRenderProps } from "../../../DefaultDashboardLayoutRenderer";
+import { DashboardEditLayoutSectionBorder } from "./DashboardEditLayoutSectionBorder";
+import { IDashboardEditLayoutContent } from "./DashboardEditLayoutTypes";
+
+export type IDashboardEditLayoutSectionRendererOwnProps =
+    IDashboardLayoutSectionRenderProps<IDashboardEditLayoutContent>;
+
+export type IDashboardEditLayoutSectionRendererProps = IDashboardEditLayoutSectionRendererOwnProps;
+export const RenderDashboardEditLayoutSectionRenderer: React.FC<IDashboardEditLayoutSectionRendererProps> = (
+    props,
+) => {
+    const { DefaultSectionRenderer, section, children } = props;
+
+    const { isDragging, isRowDropzoneVisible, activeHeaderRowId, rowId } = {
+        isDragging: false,
+        activeHeaderRowId: "active row id",
+        isRowDropzoneVisible: false,
+        rowId: "row id",
+    };
+
+    const [isActive, setIsActive] = useState(false);
+
+    const markRowAsActive = useCallback(() => setIsActive(true), [setIsActive]);
+    const markRowAsInactive = useCallback(() => setIsActive(false), [setIsActive]);
+
+    const isActivatedByHeader = rowId === activeHeaderRowId;
+    const isRowActive = (isActive || isActivatedByHeader) && isRowDropzoneVisible;
+
+    const className = cx({
+        active: isRowActive,
+    });
+
+    let rowBorderStatus: "muted" | "active" | "invisible" = isRowActive ? "active" : "muted";
+    if (!isDragging && !isActivatedByHeader) {
+        rowBorderStatus = "invisible";
+    }
+
+    const isHiddenSection = section.items().all().length === 0; //hide empty sections
+
+    return (
+        <DefaultSectionRenderer
+            {...props}
+            isHidden={isHiddenSection}
+            className={className}
+            {...(isDragging && {
+                onMouseEnter: markRowAsActive,
+                onMouseLeave: markRowAsInactive,
+                onMouseOver: markRowAsActive,
+            })}
+        >
+            <DashboardEditLayoutSectionBorder status={rowBorderStatus}>
+                {children}
+            </DashboardEditLayoutSectionBorder>
+        </DefaultSectionRenderer>
+    );
+};
+
+export const DashboardEditLayoutSectionRenderer = RenderDashboardEditLayoutSectionRenderer;

--- a/libs/sdk-ui-dashboard/src/presentation/layout/test/useInKD/DashboardEditLayout/DashboardEditLayoutTypes.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/layout/test/useInKD/DashboardEditLayout/DashboardEditLayoutTypes.ts
@@ -1,0 +1,89 @@
+// (C) 2019-2022 GoodData Corporation
+import { ObjRef, IDashboardLayout, IDashboardLayoutSection, IDashboardLayoutItem } from "@gooddata/sdk-model";
+
+import { DropZoneType, IDragZoneWidget } from "./LayoutTypes";
+
+export type DashboardEditLayoutContentType =
+    | "widget"
+    | "widgetDropzone"
+    | "widgetDropzoneHotspot"
+    | "widgetKpiPlaceholder"
+    | "widgetNewInsightPlaceholder";
+
+export interface IDashboardEditLayoutContentBase {
+    /**
+     * Dashboard edit layout content type - widget or drag and drop widget.
+     */
+    type: DashboardEditLayoutContentType;
+
+    /**
+     * Persisted widget identifier/uri, or widget temporary identifier
+     * for widgets added in edit mode (or custom drag and drop widgets).
+     */
+    ref: ObjRef;
+}
+
+export interface IDashboardEditLayoutContentWidget extends IDashboardEditLayoutContentBase {
+    /**
+     * Type
+     */
+    type: "widget";
+}
+
+export interface IDashboardEditLayoutContentWidgetDropzone extends IDashboardEditLayoutContentBase {
+    /**
+     * Type
+     */
+    type: "widgetDropzone";
+
+    /**
+     * Drag and drop widget details
+     */
+    dragZoneWidget: IDragZoneWidget;
+}
+
+export interface IDashboardEditLayoutContentWidgetDropzoneHotspot extends IDashboardEditLayoutContentBase {
+    /**
+     * Type
+     */
+    type: "widgetDropzoneHotspot";
+
+    /**
+     * Persisted widget identifier/uri, or widget temporary identifier
+     * for widgets added in edit mode.
+     */
+    widgetRef: ObjRef;
+
+    /**
+     * Drop zone position (prev / next)
+     */
+    dropZoneType: DropZoneType;
+}
+
+export interface IDashboardEditLayoutContentWidgetKpiPlaceholder extends IDashboardEditLayoutContentBase {
+    /**
+     * Type
+     */
+    type: "widgetKpiPlaceholder";
+}
+
+export interface IDashboardEditLayoutContentWidgetNewInsightPlaceholder
+    extends IDashboardEditLayoutContentBase {
+    /**
+     * Type
+     */
+    type: "widgetNewInsightPlaceholder";
+}
+
+export type IDashboardEditLayoutContent =
+    | IDashboardEditLayoutContentWidget
+    | IDashboardEditLayoutContentWidgetDropzone
+    | IDashboardEditLayoutContentWidgetDropzoneHotspot
+    | IDashboardEditLayoutContentWidgetKpiPlaceholder
+    | IDashboardEditLayoutContentWidgetNewInsightPlaceholder;
+
+export type IDashboardEditLayoutItem = IDashboardLayoutItem<IDashboardEditLayoutContent>;
+
+export type IDashboardEditLayoutSection = IDashboardLayoutSection<IDashboardEditLayoutContent>;
+
+export type IDashboardEditLayout = IDashboardLayout<IDashboardEditLayoutContent>;

--- a/libs/sdk-ui-dashboard/src/presentation/layout/test/useInKD/DashboardEditLayout/DashboardEditLayoutWidget.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/layout/test/useInKD/DashboardEditLayout/DashboardEditLayoutWidget.tsx
@@ -1,0 +1,16 @@
+// (C) 2007-2022 GoodData Corporation
+import { ScreenSize } from "@gooddata/sdk-model";
+import React from "react";
+
+import { IDashboardLayoutItemFacade } from "../../../DefaultDashboardLayoutRenderer";
+import { IDashboardEditLayoutContent } from "./DashboardEditLayoutTypes";
+
+export interface IDashboardEditLayoutWidgetProps {
+    item: IDashboardLayoutItemFacade<IDashboardEditLayoutContent>;
+    screen: ScreenSize;
+    contentRef?: React.RefObject<HTMLDivElement>;
+}
+
+export const DashboardEditLayoutWidget: React.FC<IDashboardEditLayoutWidgetProps> = () => {
+    return <div>Widget content MOCK</div>;
+};

--- a/libs/sdk-ui-dashboard/src/presentation/layout/test/useInKD/DashboardEditLayout/DashboardEditLayoutWidgetRenderer.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/layout/test/useInKD/DashboardEditLayout/DashboardEditLayoutWidgetRenderer.tsx
@@ -1,0 +1,61 @@
+// (C) 2007-2022 GoodData Corporation
+import cx from "classnames";
+import React, { useRef } from "react";
+
+import {
+    getDashboardLayoutItemHeightForRatioAndScreen,
+    IDashboardLayoutWidgetRenderProps,
+} from "../../../DefaultDashboardLayoutRenderer";
+import { IDashboardEditLayoutContent } from "./DashboardEditLayoutTypes";
+import { DashboardEditLayoutWidget } from "./DashboardEditLayoutWidget";
+
+type IDashboardEditLayoutWidgetRendererOwnProps =
+    IDashboardLayoutWidgetRenderProps<IDashboardEditLayoutContent>;
+
+export type IDashboardEditLayoutWidgetRendererProps = IDashboardEditLayoutWidgetRendererOwnProps;
+
+export const RenderDashboardEditLayoutWidgetRenderer: React.FC<IDashboardEditLayoutWidgetRendererProps> = (
+    props,
+) => {
+    const contentRef = useRef<HTMLDivElement>() as React.RefObject<HTMLDivElement>;
+
+    const { screen, item, DefaultWidgetRenderer } = props;
+
+    const { isEnableKDWidgetCustomHeight } = {
+        isEnableKDWidgetCustomHeight: false,
+    };
+    const widget = item.widget();
+    const currentSize = item.sizeForScreen(screen)!;
+
+    const { heightAsRatio = 100, gridHeight = 12 } = currentSize;
+
+    const isLastInSection = item.isLast();
+    const isLastSection = item.section().isLast();
+    const isLast = isLastSection && isLastInSection;
+    const classNames = cx({
+        last: widget?.type === "widget" ? isLast : false,
+        "custom-height": isEnableKDWidgetCustomHeight,
+    });
+
+    let height: number | undefined;
+    if (heightAsRatio) {
+        height = getDashboardLayoutItemHeightForRatioAndScreen(currentSize, screen);
+    } else if (gridHeight) {
+        height = undefined;
+    }
+
+    return (
+        <DefaultWidgetRenderer
+            {...props}
+            height={height}
+            minHeight={20}
+            allowOverflow={!!heightAsRatio}
+            className={classNames}
+            contentRef={contentRef}
+        >
+            <DashboardEditLayoutWidget contentRef={contentRef} item={item} screen={screen} />
+        </DefaultWidgetRenderer>
+    );
+};
+
+export const DashboardEditLayoutWidgetRenderer = RenderDashboardEditLayoutWidgetRenderer;

--- a/libs/sdk-ui-dashboard/src/presentation/layout/test/useInKD/DashboardEditLayout/LayoutTypes.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/layout/test/useInKD/DashboardEditLayout/LayoutTypes.ts
@@ -1,0 +1,31 @@
+// (C) 2007-2022 GoodData Corporation
+import { IInsight, IKpi, ObjRef, WidgetType } from "@gooddata/sdk-model";
+
+export type SdkCompliantWidgetContent = IKpi | IInsight;
+
+export enum WidgetCategory {
+    kpi = "kpi",
+    insight = "insight",
+    visualization = "visualization",
+    widget = "widget",
+}
+
+export enum DropZoneType {
+    prev = "prev",
+    next = "next",
+}
+
+export enum WidgetPosition {
+    prev = "prev",
+    next = "next",
+}
+
+export interface IDragZoneWidget {
+    dropzone: {
+        widgetType: WidgetType;
+        content?: SdkCompliantWidgetContent;
+        ref?: ObjRef;
+        position?: WidgetPosition;
+        isInitialDropzone?: boolean;
+    };
+}


### PR DESCRIPTION
test: check if layout haven't unwanted dependencies

- test if layout component render works without dashboard context
- should prevent problems in KD old edit mode

JIRA: RAIL-4660

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
