### PR TITLE
RELATED: RAIL-4675 fix indexing and manipulation of attributes filters in reducer

### DIFF
--- a/libs/sdk-backend-bear/src/convertors/fromBackend/DashboardConverter/filterContext.ts
+++ b/libs/sdk-backend-bear/src/convertors/fromBackend/DashboardConverter/filterContext.ts
@@ -71,8 +71,8 @@ export const convertFilterContextItem = (
         dateFilter: {
             granularity,
             type,
-            from,
-            to,
+            from: type === "relative" ? Number(from) : from,
+            to: type === "relative" ? Number(to) : to,
         },
     };
     if (attribute) {

--- a/libs/sdk-backend-bear/src/convertors/fromBackend/tests/__snapshots__/DashboardConverter.test.ts.snap
+++ b/libs/sdk-backend-bear/src/convertors/fromBackend/tests/__snapshots__/DashboardConverter.test.ts.snap
@@ -120,9 +120,9 @@ Object {
           "attribute": Object {
             "uri": "testAttr",
           },
-          "from": "-10",
+          "from": -10,
           "granularity": "GDC.time.month",
-          "to": "0",
+          "to": 0,
           "type": "relative",
         },
       },

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/filterContext/attributeFilter/tests/__snapshots__/moveAttributeFilterHandler.test.ts.snap
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/filterContext/attributeFilter/tests/__snapshots__/moveAttributeFilterHandler.test.ts.snap
@@ -53,7 +53,7 @@ Object {
       "uris": Array [],
     },
     "displayForm": Object {
-      "uri": "/gdc/md/referenceworkspace/obj/1089",
+      "uri": "/gdc/md/referenceworkspace/obj/1071",
     },
     "filterElementsBy": Array [],
     "localIdentifier": Any<String>,


### PR DESCRIPTION

- Fix indexing and manipulation of attributes filters in reducer
- Fix fromBackend conversion of date filter

JIRA: RAIL-4675

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
