### PR TITLE
RELATED: RAIL-4693 use execution warnings in filter config

### DIFF
--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -104,6 +104,7 @@ import { IPositiveAttributeFilter } from '@gooddata/sdk-model';
 import { IPushData } from '@gooddata/sdk-ui';
 import { IRelativeDateFilter } from '@gooddata/sdk-model';
 import { IRenderListItemProps } from '@gooddata/sdk-ui-kit';
+import { IResultWarning } from '@gooddata/sdk-model';
 import { IScheduledMail } from '@gooddata/sdk-model';
 import { IScheduledMailDefinition } from '@gooddata/sdk-model';
 import { ISeparators } from '@gooddata/sdk-model';
@@ -3586,6 +3587,8 @@ export interface IExecutionResultEnvelope {
     id: string;
     // (undocumented)
     isLoading: boolean;
+    // (undocumented)
+    warnings?: IResultWarning[];
 }
 
 // @alpha (undocumented)
@@ -6207,7 +6210,7 @@ export interface SetDrillForKpiWidgetPayload {
 }
 
 // @alpha
-export function setExecutionResultData(id: ObjRef | string, executionResult: IExecutionResult, correlationId?: string): UpsertExecutionResult;
+export function setExecutionResultData(id: ObjRef | string, executionResult: IExecutionResult, executionWarnings: IResultWarning[] | undefined, correlationId?: string): UpsertExecutionResult;
 
 // @alpha
 export function setExecutionResultError(id: ObjRef | string, error: GoodDataSdkError, correlationId?: string): UpsertExecutionResult;
@@ -7164,7 +7167,7 @@ export function useWidgetDragEndHandler(): () => void;
 export function useWidgetExecutionsHandler(widgetRef: ObjRef): {
     onLoadingChanged: OnLoadingChanged;
     onError: OnError;
-    onSuccess: (executionResult: IExecutionResult) => void;
+    onSuccess: (executionResult: IExecutionResult, warnings: IResultWarning[] | undefined) => void;
     onPushData: (data: IPushData) => void;
 };
 

--- a/libs/sdk-ui-dashboard/src/model/commands/executionResults.ts
+++ b/libs/sdk-ui-dashboard/src/model/commands/executionResults.ts
@@ -1,7 +1,7 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 
 import { IExecutionResult } from "@gooddata/sdk-backend-spi";
-import { ObjRef, serializeObjRef } from "@gooddata/sdk-model";
+import { IResultWarning, ObjRef, serializeObjRef } from "@gooddata/sdk-model";
 import { GoodDataSdkError } from "@gooddata/sdk-ui";
 import isString from "lodash/isString";
 import { IExecutionResultEnvelope } from "../store/executionResults/types";
@@ -47,6 +47,7 @@ export function setExecutionResultLoading(
             isLoading: true,
             executionResult: undefined,
             error: undefined,
+            warnings: undefined,
         },
         correlationId,
     );
@@ -68,6 +69,7 @@ export function setExecutionResultError(
             isLoading: false,
             error,
             executionResult: undefined,
+            warnings: undefined,
         },
         correlationId,
     );
@@ -81,6 +83,7 @@ export function setExecutionResultError(
 export function setExecutionResultData(
     id: ObjRef | string,
     executionResult: IExecutionResult,
+    executionWarnings: IResultWarning[] | undefined,
     correlationId?: string,
 ): UpsertExecutionResult {
     return upsertExecutionResult(
@@ -89,6 +92,7 @@ export function setExecutionResultData(
             isLoading: false,
             error: undefined,
             executionResult,
+            warnings: executionWarnings,
         },
         correlationId,
     );

--- a/libs/sdk-ui-dashboard/src/model/react/useWidgetExecutionsHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/react/useWidgetExecutionsHandler.ts
@@ -1,6 +1,6 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 import { useCallback } from "react";
-import { ObjRef } from "@gooddata/sdk-model";
+import { IResultWarning, ObjRef } from "@gooddata/sdk-model";
 import { IPushData, OnError, OnLoadingChanged } from "@gooddata/sdk-ui";
 import { IExecutionResult } from "@gooddata/sdk-backend-spi";
 
@@ -24,8 +24,8 @@ export function useWidgetExecutionsHandler(widgetRef: ObjRef) {
     );
 
     const onSuccess = useCallback(
-        (executionResult: IExecutionResult) => {
-            setData(widgetRef, executionResult);
+        (executionResult: IExecutionResult, warnings: IResultWarning[] | undefined) => {
+            setData(widgetRef, executionResult, warnings);
         },
         [widgetRef],
     );
@@ -33,7 +33,7 @@ export function useWidgetExecutionsHandler(widgetRef: ObjRef) {
     const onPushData = useCallback(
         (data: IPushData): void => {
             if (data.dataView) {
-                onSuccess(data.dataView.result);
+                onSuccess(data.dataView.result, data.dataView.warnings);
             }
         },
         [widgetRef, onSuccess],

--- a/libs/sdk-ui-dashboard/src/model/store/executionResults/types.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/executionResults/types.ts
@@ -1,6 +1,7 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 
 import { IExecutionResult } from "@gooddata/sdk-backend-spi";
+import { IResultWarning } from "@gooddata/sdk-model";
 import { GoodDataSdkError } from "@gooddata/sdk-ui";
 
 /**
@@ -11,4 +12,5 @@ export interface IExecutionResultEnvelope {
     isLoading: boolean;
     executionResult?: IExecutionResult;
     error?: GoodDataSdkError;
+    warnings?: IResultWarning[];
 }

--- a/libs/sdk-ui-dashboard/src/presentation/widget/common/configuration/AttributeFilterConfigurationItem.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/common/configuration/AttributeFilterConfigurationItem.tsx
@@ -15,6 +15,7 @@ import {
 
 import { selectAttributeFilterDisplayFormsMap, useDashboardSelector } from "../../../../model";
 import { useAttributeFilterConfigurationHandling } from "./useAttributeFilterConfigurationHandling";
+import { useIsFilterNotApplied } from "./useIsFilterNotApplied";
 
 const tooltipAlignPoints: IAlignPoint[] = [{ align: "cl cr", offset: { x: -20, y: 0 } }];
 
@@ -40,13 +41,15 @@ export const AttributeFilterConfigurationItem: React.FC<IAttributeFilterConfigur
             }),
     );
 
+    const isFilterNotApplied = useIsFilterNotApplied(widget, displayFormRef);
+
     const { handleIgnoreChanged, status } = useAttributeFilterConfigurationHandling(
         widget,
         displayFormRef,
         setIsApplied,
     );
 
-    const isError = status === "error";
+    const isError = isApplied && (status === "error" || isFilterNotApplied);
     const isLoading = status === "loading";
 
     const classNames = cx(

--- a/libs/sdk-ui-dashboard/src/presentation/widget/common/configuration/useIsFilterNotApplied.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/common/configuration/useIsFilterNotApplied.ts
@@ -1,0 +1,31 @@
+// (C) 2022 GoodData Corporation
+import { areObjRefsEqual, isObjRef, IWidget, ObjRef, widgetRef } from "@gooddata/sdk-model";
+import {
+    selectAttributeFilterDisplayFormsMap,
+    selectExecutionResultByRef,
+    useDashboardSelector,
+} from "../../../../model";
+
+const WARNING_FILTER_NOT_APPLIED = "gdc.aqe.not_applied_filter.report";
+
+export function useIsFilterNotApplied(widget: IWidget, displayFormRef: ObjRef): boolean {
+    const execResult = useDashboardSelector(selectExecutionResultByRef(widgetRef(widget)));
+    const allWarnings = execResult?.warnings;
+
+    const dfMap = useDashboardSelector(selectAttributeFilterDisplayFormsMap);
+    const df = dfMap.get(displayFormRef);
+
+    if (!df) {
+        return true;
+    }
+
+    if (!allWarnings || !allWarnings.length) {
+        return false;
+    }
+
+    return allWarnings
+        .filter((warning) => warning.warningCode === WARNING_FILTER_NOT_APPLIED)
+        .some((warning) =>
+            warning.parameters?.some((param) => isObjRef(param) && areObjRefsEqual(param, df.attribute)),
+        );
+}

--- a/libs/sdk-ui-dashboard/src/presentation/widget/kpi/EditModeDashboardKpi/EditModeDashboardKpi.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/kpi/EditModeDashboardKpi/EditModeDashboardKpi.tsx
@@ -4,7 +4,7 @@ import cx from "classnames";
 import { useIntl } from "react-intl";
 import { widgetRef } from "@gooddata/sdk-model";
 import { IDataView } from "@gooddata/sdk-backend-spi";
-import { IDrillEventContext, useBackendStrict, useWorkspaceStrict } from "@gooddata/sdk-ui";
+import { IDrillEventContext, NoDataSdkError, useBackendStrict, useWorkspaceStrict } from "@gooddata/sdk-ui";
 
 import {
     useDashboardSelector,
@@ -164,6 +164,17 @@ export const EditModeDashboardKpi = (props: IDashboardKpiProps) => {
             executionsHandler.onError(error);
         }
     }, [error, executionsHandler, onError]);
+
+    useEffect(() => {
+        if (result) {
+            // empty data is considered an error for execution handling
+            if (result.rawData().isEmpty()) {
+                executionsHandler.onError(new NoDataSdkError());
+            } else {
+                executionsHandler.onSuccess(result.result(), result.warnings());
+            }
+        }
+    }, [result]);
 
     return (
         <DashboardItemKpi

--- a/libs/sdk-ui-dashboard/src/presentation/widget/kpi/ViewModeDashboardKpi/KpiExecutor.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/kpi/ViewModeDashboardKpi/KpiExecutor.tsx
@@ -178,7 +178,7 @@ const KpiExecutorCore: React.FC<IKpiExecutorProps> = (props) => {
             if (result.rawData().isEmpty()) {
                 executionsHandler.onError(new NoDataSdkError());
             } else {
-                executionsHandler.onSuccess(result.result());
+                executionsHandler.onSuccess(result.result(), result.warnings());
             }
         }
     }, [result]);


### PR DESCRIPTION
Similar to gdc-dashboards, when a widget has an execution warning for some of its filters, show an error message in the filter configuration for those filters.

JIRA: RAIL-4693

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
