### PR TITLE
RELATED: RAIL-4683 do not close configuration bubble on parent scroll

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/widget/common/configuration/ConfigurationBubble.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/common/configuration/ConfigurationBubble.tsx
@@ -44,6 +44,7 @@ export const ConfigurationBubble: React.FC<IConfigurationBubbleProps> = (props) 
             arrowOffsets={arrowOffsets}
             arrowDirections={arrowDirections}
             closeOnOutsideClick
+            closeOnParentScroll={false}
             ignoreClicksOnByClass={ignoreClicksOnByClass}
             onClose={onClose}
         >

--- a/libs/sdk-ui-kit/api/sdk-ui-kit.api.md
+++ b/libs/sdk-ui-kit/api/sdk-ui-kit.api.md
@@ -109,6 +109,7 @@ export class Bubble extends React_2.Component<IBubbleProps, IBubbleState> {
         arrowStyle: {};
         className: string;
         closeOnOutsideClick: boolean;
+        closeOnParentScroll: boolean;
         onClose: (...args: any[]) => void;
         onMouseEnter: (...args: any[]) => void;
         onMouseLeave: (...args: any[]) => void;
@@ -895,6 +896,8 @@ export interface IBubbleProps {
     className?: string;
     // (undocumented)
     closeOnOutsideClick?: boolean;
+    // (undocumented)
+    closeOnParentScroll?: boolean;
     ignoreClicksOn?: any[];
     // (undocumented)
     ignoreClicksOnByClass?: string[];

--- a/libs/sdk-ui-kit/src/Bubble/Bubble.tsx
+++ b/libs/sdk-ui-kit/src/Bubble/Bubble.tsx
@@ -62,6 +62,7 @@ export interface IBubbleProps {
     arrowStyle?: React.CSSProperties;
     className?: string;
     closeOnOutsideClick?: boolean;
+    closeOnParentScroll?: boolean;
 
     /**
      * Array of refs where user clicks should be ignored
@@ -100,6 +101,7 @@ export class Bubble extends React.Component<IBubbleProps, IBubbleState> {
         arrowStyle: {},
         className: "bubble-primary",
         closeOnOutsideClick: false,
+        closeOnParentScroll: true,
         onClose: noop,
         onMouseEnter: noop,
         onMouseLeave: noop,
@@ -185,7 +187,7 @@ export class Bubble extends React.Component<IBubbleProps, IBubbleState> {
                 alignTo={this.props.alignTo}
                 onAlign={this.onAlign}
                 alignPoints={this.state.alignPoints}
-                closeOnParentScroll
+                closeOnParentScroll={this.props.closeOnParentScroll}
                 closeOnMouseDrag
                 closeOnOutsideClick={this.props.closeOnOutsideClick}
                 ignoreClicksOn={this.props.ignoreClicksOn}


### PR DESCRIPTION
- add closeOnParentScroll to Bubble props sdk-ui-kit
- fix dashboard Configuration bubble component

JIRA: RAIL-4683

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
