### PR TITLE
RELATED: RAIL-4695 improve insight date dataset picker

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/configuration/InsightDateDataSetFilter.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/configuration/InsightDateDataSetFilter.tsx
@@ -2,10 +2,12 @@
 import React, { useEffect } from "react";
 import { DateDatasetFilter } from "../../common";
 import { IInsightWidget, isInsightWidget, widgetRef } from "@gooddata/sdk-model";
+import invariant from "ts-invariant";
 import {
     MeasureDateDatasets,
     queryDateDatasetsForInsight,
     QueryInsightDateDatasets,
+    selectInsightByRef,
     selectIsWidgetLoadingAdditionalDataByWidgetRef,
     useDashboardQueryProcessing,
     useDashboardSelector,
@@ -32,9 +34,13 @@ export default function InsightDateDataSetFilter({ widget }: IConfigurationPanel
         selectIsWidgetLoadingAdditionalDataByWidgetRef(widgetRef(widget)),
     );
 
+    const insight = useDashboardSelector(selectInsightByRef(widget.insight));
+    invariant(insight, "inconsistent state in InsightDateDataSetFilter");
+
     useEffect(() => {
-        queryDateDatasets(widget.insight);
-    }, [queryDateDatasets, widget.insight]);
+        // use the whole insight to improve cache hits: other calls to this query also use whole insights
+        queryDateDatasets(insight);
+    }, [queryDateDatasets, insight]);
 
     if (isInsightWidget(widget)) {
         return (


### PR DESCRIPTION
Improve cache hits so that date datasets are not reloaded unnecessarily.

JIRA: RAIL-4695

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
