### PR TITLE
RELATED: RAIL-4698 fix save as behavior

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/saveAs/DefaultSaveAsDialog/SaveAsDialogRenderer.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/saveAs/DefaultSaveAsDialog/SaveAsDialogRenderer.tsx
@@ -19,6 +19,7 @@ export interface ISaveAsDialogRendererOwnProps {
     isDashboardLoaded: boolean;
     isKpiWidgetEnabled: boolean;
     isScheduleEmailsEnabled: boolean;
+    isInEditMode: boolean;
     locale?: string;
 
     onSubmit: (title: string, switchToCopy?: boolean, useOriginalFilterContext?: boolean) => void;
@@ -79,7 +80,9 @@ export class SaveAsNewDashboardDialog extends React.PureComponent<
             this.props.onSubmit(
                 title,
                 true, // switch to the new dashboard
-                false, // do not reuse the filter context, create a new one with the current filter state
+                // do not reuse the filter context in edit mode, create a new one with the current filter state
+                // otherwise use the original filter context values when creating a copy
+                !this.props.isInEditMode,
             );
         }
     };

--- a/libs/sdk-ui-dashboard/src/presentation/saveAs/DefaultSaveAsDialog/index.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/saveAs/DefaultSaveAsDialog/index.tsx
@@ -59,6 +59,7 @@ export const DefaultSaveAsDialog = (props: ISaveAsDialogProps): JSX.Element | nu
         isDashboardSaving,
         isDashboardLoaded,
         handleSaveAs,
+        isInEditMode,
     } = useSaveAs({ onSubmit, onSubmitSuccess: onSuccess, onSubmitError: onError });
 
     if (!isVisible) {
@@ -73,6 +74,7 @@ export const DefaultSaveAsDialog = (props: ISaveAsDialogProps): JSX.Element | nu
             isDashboardLoaded={isDashboardLoaded}
             isDashboardSaving={isDashboardSaving}
             isScheduleEmailsEnabled={isScheduleEmailsEnabled}
+            isInEditMode={isInEditMode}
             onSubmit={handleSaveAs}
             onCancel={onCancel}
         />

--- a/libs/sdk-ui-dashboard/src/presentation/saveAs/DefaultSaveAsDialog/test/SaveAsDialogRenderer.test.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/saveAs/DefaultSaveAsDialog/test/SaveAsDialogRenderer.test.tsx
@@ -16,6 +16,7 @@ describe("Test SaveAsNewDashboardDialog: ", () => {
         locale: "en-US",
         onCancel: noop,
         onSubmit: noop,
+        isInEditMode: false,
     };
 
     function renderComponent(props = defaultProps) {

--- a/libs/sdk-ui-dashboard/src/presentation/saveAs/DefaultSaveAsDialog/useSaveAs.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/saveAs/DefaultSaveAsDialog/useSaveAs.ts
@@ -8,6 +8,7 @@ import {
     selectDashboardTitle,
     selectEnableKPIDashboardSchedule,
     selectIsDashboardSaving,
+    selectIsInEditMode,
     selectLocale,
     useDashboardCommandProcessing,
     useDashboardSelector,
@@ -21,6 +22,7 @@ interface UseSaveAsResult {
     isDashboardLoaded: boolean;
     isKpiWidgetEnabled: boolean;
     isScheduleEmailsEnabled: boolean;
+    isInEditMode: boolean;
 
     /**
      * Function that triggers the SaveAs functionality. Optionally specify new title for
@@ -64,6 +66,7 @@ export const useSaveAs = (props: UseSaveAsProps): UseSaveAsResult => {
     const isScheduleEmailsEnabled = useDashboardSelector(selectEnableKPIDashboardSchedule);
     const capabilities = useDashboardSelector(selectBackendCapabilities);
     const isDashboardSaving = useDashboardSelector(selectIsDashboardSaving);
+    const isInEditMode = useDashboardSelector(selectIsInEditMode);
 
     const saveAsCommandProcessing = useDashboardCommandProcessing({
         commandCreator: saveDashboardAs,
@@ -94,6 +97,7 @@ export const useSaveAs = (props: UseSaveAsProps): UseSaveAsResult => {
         isKpiWidgetEnabled: capabilities.supportsKpiWidget ?? false,
         isDashboardLoaded: true,
         isDashboardSaving,
+        isInEditMode,
         handleSaveAs,
         saveAsStatus: saveAsCommandProcessing.status,
     };


### PR DESCRIPTION
In View mode, the original filter values need to be used when saving as, in Edit mode, the current filter values need to be used instead.

JIRA: RAIL-4698

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
