### PR TITLE
RELATED: RAIL-4680 fix available attributes in Drill to URL

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/configuration/DrillTargets/DrillTargetUrlItem.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/configuration/DrillTargets/DrillTargetUrlItem.tsx
@@ -59,13 +59,13 @@ export interface DrillUrlItemProps {
 }
 
 export const DrillTargetUrlItem: React.FunctionComponent<DrillUrlItemProps> = (props) => {
-    const { onSelect, urlDrillTarget } = props;
+    const { onSelect, urlDrillTarget, attributes } = props;
 
     const capabilities = useDashboardSelector(selectBackendCapabilities);
     const settings = useDashboardSelector(selectSettings);
 
     const { allDisplayForms: targetAttributesFormsAll, linkDisplayForms: targetAttributesFormsWithLinks } =
-        useAttributesWithDisplayForms();
+        useAttributesWithDisplayForms(attributes);
 
     const invalidAttributeDisplayFormIdentifiers = useInvalidAttributeDisplayFormIdentifiers(urlDrillTarget);
 


### PR DESCRIPTION
We need to only allow the attributes that can show in the drill intersection to configure the drill, not all the attributes.

JIRA: RAIL-4680

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
