### PR TITLE
BUGFIX: RAIL-4691 show 2 scroll bars in configuration of insight panel

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/configuration/InsightConfiguration.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/configuration/InsightConfiguration.tsx
@@ -35,11 +35,7 @@ export const InsightConfiguration: React.FC<IInsightConfigurationProps> = ({ wid
     const settings = useDashboardSelector(selectSettings);
     const dispatch = useDashboardDispatch();
 
-    const classes = cx(
-        "configuration-panel",
-        "configuration-scrollable-panel",
-        `s-visualization-${widgetRefSuffix}`,
-    );
+    const classes = cx("configuration-scrollable-panel", `s-visualization-${widgetRefSuffix}`);
 
     const defaultDescriptionConfig: IInsightWidgetDescriptionConfiguration = {
         source: "insight",


### PR DESCRIPTION
In new KD edit mode, open configuration of insight panel, when its content is long (e.g there are many attribute filters), will have 2 vertical scroll bar there

JIRA: RAIL-4691

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
