### PR TITLE
RELATED: RAIL-4697 auto open dataset picker for insights

### DIFF
--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -6023,9 +6023,6 @@ export const selectIsWhiteLabeled: OutputSelector<DashboardState, boolean, (res:
 export const selectIsWidgetLoadingAdditionalDataByWidgetRef: (ref: ObjRef) => OutputSelector<DashboardState, boolean, (res: ObjRef[]) => boolean>;
 
 // @internal (undocumented)
-export const selectKpiDateDatasetAutoSelect: OutputSelector<DashboardState, boolean, (res: UiState) => boolean>;
-
-// @internal (undocumented)
 export const selectKpiDeleteDialogWidgetCoordinates: OutputSelector<DashboardState, ILayoutCoordinates | undefined, (res: UiState) => ILayoutCoordinates | undefined>;
 
 // @internal (undocumented)
@@ -6132,6 +6129,9 @@ export const selectWidgetByRef: (ref: ObjRef | undefined) => OutputSelector<Dash
 
 // @alpha
 export const selectWidgetCoordinatesByRef: (ref: ObjRef) => OutputSelector<DashboardState, ILayoutCoordinates, (res: IDashboardLayout<ExtendedDashboardWidget>) => ILayoutCoordinates>;
+
+// @internal (undocumented)
+export const selectWidgetDateDatasetAutoSelect: OutputSelector<DashboardState, boolean, (res: UiState) => boolean>;
 
 // @alpha
 export const selectWidgetDrills: (ref: ObjRef | undefined) => OutputSelector<DashboardState, IDrillToLegacyDashboard[] | InsightDrillDefinition[], (res: IKpiWidget | IInsightWidget | undefined) => IDrillToLegacyDashboard[] | InsightDrillDefinition[]>;
@@ -6340,7 +6340,7 @@ setConfigurationPanelOpened: CaseReducer<UiState, {
 payload: boolean;
 type: string;
 }>;
-setKpiDateDatasetAutoSelect: CaseReducer<UiState, {
+setWidgetDateDatasetAutoSelect: CaseReducer<UiState, {
 payload: boolean;
 type: string;
 }>;
@@ -6440,8 +6440,6 @@ export interface UiState {
         highlightedWidgetRef: ObjRef | undefined;
     };
     // (undocumented)
-    kpiDateDatasetAutoSelect: boolean;
-    // (undocumented)
     kpiDeleteDialog: {
         widgetCoordinates: ILayoutCoordinates | undefined;
     };
@@ -6472,6 +6470,8 @@ export interface UiState {
     };
     // (undocumented)
     toastMessages: IToastMessage[];
+    // (undocumented)
+    widgetDateDatasetAutoSelect: boolean;
     // (undocumented)
     widgetsLoadingAdditionalData: ObjRef[];
     // (undocumented)

--- a/libs/sdk-ui-dashboard/src/model/store/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/index.ts
@@ -231,7 +231,7 @@ export {
     selectScheduleEmailDialogDefaultAttachment,
     selectSelectedWidgetRef,
     selectConfigurationPanelOpened,
-    selectKpiDateDatasetAutoSelect,
+    selectWidgetDateDatasetAutoSelect,
     selectIsDeleteDialogOpen,
     selectIsKpiDeleteDialogOpen,
     selectKpiDeleteDialogWidgetCoordinates,

--- a/libs/sdk-ui-dashboard/src/model/store/ui/uiReducers.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/ui/uiReducers.ts
@@ -107,8 +107,8 @@ const setConfigurationPanelOpened: UiReducer<PayloadAction<boolean>> = (state, a
     state.configurationPanelOpened = action.payload;
 };
 
-const setKpiDateDatasetAutoSelect: UiReducer<PayloadAction<boolean>> = (state, action) => {
-    state.kpiDateDatasetAutoSelect = action.payload;
+const setWidgetDateDatasetAutoSelect: UiReducer<PayloadAction<boolean>> = (state, action) => {
+    state.widgetDateDatasetAutoSelect = action.payload;
 };
 
 const requestInsightListUpdate: UiReducer = (state) => {
@@ -237,7 +237,7 @@ export const uiReducers = {
     selectWidget,
     clearWidgetSelection,
     setConfigurationPanelOpened,
-    setKpiDateDatasetAutoSelect,
+    setWidgetDateDatasetAutoSelect,
     requestInsightListUpdate,
     setWidgetLoadingAdditionalDataStarted,
     setWidgetLoadingAdditionalDataStopped,

--- a/libs/sdk-ui-dashboard/src/model/store/ui/uiSelectors.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/ui/uiSelectors.ts
@@ -170,9 +170,9 @@ export const selectConfigurationPanelOpened = createSelector(
 /**
  * @internal
  */
-export const selectKpiDateDatasetAutoSelect = createSelector(
+export const selectWidgetDateDatasetAutoSelect = createSelector(
     selectSelf,
-    (state) => state.kpiDateDatasetAutoSelect,
+    (state) => state.widgetDateDatasetAutoSelect,
 );
 
 /**

--- a/libs/sdk-ui-dashboard/src/model/store/ui/uiState.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/ui/uiState.ts
@@ -46,7 +46,7 @@ export interface UiState {
     };
     selectedWidgetRef: ObjRef | undefined;
     configurationPanelOpened: boolean;
-    kpiDateDatasetAutoSelect: boolean;
+    widgetDateDatasetAutoSelect: boolean;
     insightListLastUpdateRequested: number;
     widgetsLoadingAdditionalData: ObjRef[];
     filterAttributeSelectionOpen: boolean;
@@ -93,7 +93,7 @@ export const uiInitialState: UiState = {
     },
     selectedWidgetRef: undefined,
     configurationPanelOpened: true,
-    kpiDateDatasetAutoSelect: false,
+    widgetDateDatasetAutoSelect: false,
     insightListLastUpdateRequested: 0,
     widgetsLoadingAdditionalData: [],
     filterAttributeSelectionOpen: false,

--- a/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/useInsightListItemDropHandler.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/useInsightListItemDropHandler.ts
@@ -42,6 +42,7 @@ export function useInsightListItemDropHandler(sectionIndex: number, itemIndex: n
             const ref = event.payload.items[0].widget!.ref;
             dispatch(uiActions.selectWidget(ref));
             dispatch(uiActions.setConfigurationPanelOpened(true));
+            dispatch(uiActions.setWidgetDateDatasetAutoSelect(true));
             dispatch(uiActions.setWidgetLoadingAdditionalDataStarted(ref));
             preselectDateDataset(ref, "default");
         },

--- a/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/useKpiPlaceholderDropHandler.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/useKpiPlaceholderDropHandler.ts
@@ -25,7 +25,7 @@ export function useKpiPlaceholderDropHandler(sectionIndex: number, itemIndex: nu
             const ref = event.payload.itemsAdded[0].widget!.ref;
             dispatch(uiActions.selectWidget(idRef(KPI_PLACEHOLDER_WIDGET_ID)));
             dispatch(uiActions.setConfigurationPanelOpened(true));
-            dispatch(uiActions.setKpiDateDatasetAutoSelect(true));
+            dispatch(uiActions.setWidgetDateDatasetAutoSelect(true));
             dispatch(uiActions.setWidgetLoadingAdditionalDataStarted(ref));
         },
     });

--- a/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/useNewSectionInsightListItemDropHandler.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/useNewSectionInsightListItemDropHandler.ts
@@ -42,6 +42,7 @@ export function useNewSectionInsightListItemDropHandler(sectionIndex: number) {
             const ref = event.payload.items[0].widget!.ref;
             dispatch(uiActions.selectWidget(ref));
             dispatch(uiActions.setConfigurationPanelOpened(true));
+            dispatch(uiActions.setWidgetDateDatasetAutoSelect(true));
             dispatch(uiActions.setWidgetLoadingAdditionalDataStarted(ref));
             preselectDateDataset(ref, "default");
         },

--- a/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/useNewSectionKpiPlaceholderDropHandler.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/useNewSectionKpiPlaceholderDropHandler.ts
@@ -25,7 +25,7 @@ export function useNewSectionKpiPlaceholderDropHandler(sectionIndex: number) {
             const ref = event.payload.section.items[0].widget!.ref;
             dispatch(uiActions.selectWidget(idRef(KPI_PLACEHOLDER_WIDGET_ID)));
             dispatch(uiActions.setConfigurationPanelOpened(true));
-            dispatch(uiActions.setKpiDateDatasetAutoSelect(true));
+            dispatch(uiActions.setWidgetDateDatasetAutoSelect(true));
             dispatch(uiActions.setWidgetLoadingAdditionalDataStarted(ref));
         },
     });

--- a/libs/sdk-ui-dashboard/src/presentation/widget/common/configuration/useDateDatasetFilter.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/common/configuration/useDateDatasetFilter.ts
@@ -1,0 +1,42 @@
+// (C) 2022 GoodData Corporation
+import { useCallback, useEffect } from "react";
+import { ICatalogDateDataset } from "@gooddata/sdk-model";
+import {
+    selectWidgetDateDatasetAutoSelect,
+    uiActions,
+    useDashboardDispatch,
+    useDashboardSelector,
+} from "../../../../model";
+import { getRecommendedCatalogDateDataset } from "../../../../_staging/dateDatasets/getRecommendedCatalogDateDataset";
+
+export function useDateDatasetFilter(dateDatasets: Readonly<ICatalogDateDataset[]> | undefined) {
+    const dispatch = useDashboardDispatch();
+
+    const isWidgetDateDatasetAutoSelect = useDashboardSelector(selectWidgetDateDatasetAutoSelect);
+
+    useEffect(() => {
+        return () => {
+            // once the config panel disappears set the auto-select flag to false so that editing existing KPIs
+            // does not have it set to true
+            dispatch(uiActions.setWidgetDateDatasetAutoSelect(false));
+        };
+    }, [dispatch]);
+
+    const handleDateDatasetChanged = useCallback(() => {
+        dispatch(uiActions.setWidgetDateDatasetAutoSelect(false));
+    }, [dispatch]);
+
+    /**
+     * Only open the picker if
+     * 1. auto selection happened
+     * 2. there was no recommended dataset
+     *
+     * In that case we want to show the user the picker to pick one of the non-recommended datasets.
+     * Otherwise the preselected recommended dataset is most likely correct so we do not bother the user
+     * with the automatically opened picker.
+     */
+    const shouldOpenDateDatasetPicker =
+        isWidgetDateDatasetAutoSelect && dateDatasets && !getRecommendedCatalogDateDataset(dateDatasets);
+
+    return { handleDateDatasetChanged, shouldOpenDateDatasetPicker };
+}

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/configuration/InsightDateDataSetFilter.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/configuration/InsightDateDataSetFilter.tsx
@@ -1,5 +1,5 @@
 // (C) 2007-2022 GoodData Corporation
-import React, { useEffect } from "react";
+import React, { useCallback, useEffect } from "react";
 import { DateDatasetFilter } from "../../common";
 import { IInsightWidget, isInsightWidget, widgetRef } from "@gooddata/sdk-model";
 import invariant from "ts-invariant";
@@ -9,9 +9,13 @@ import {
     QueryInsightDateDatasets,
     selectInsightByRef,
     selectIsWidgetLoadingAdditionalDataByWidgetRef,
+    selectWidgetDateDatasetAutoSelect,
+    uiActions,
+    useDashboardDispatch,
     useDashboardQueryProcessing,
     useDashboardSelector,
 } from "../../../../model";
+import { getRecommendedCatalogDateDataset } from "../../../../_staging/dateDatasets/getRecommendedCatalogDateDataset";
 
 export interface IConfigurationPanelProps {
     widget: IInsightWidget;
@@ -30,6 +34,9 @@ export default function InsightDateDataSetFilter({ widget }: IConfigurationPanel
         queryCreator: queryDateDatasetsForInsight,
     });
 
+    const dispatch = useDashboardDispatch();
+
+    const isWidgetDateDatasetAutoSelect = useDashboardSelector(selectWidgetDateDatasetAutoSelect);
     const isLoadingAdditionalData = useDashboardSelector(
         selectIsWidgetLoadingAdditionalDataByWidgetRef(widgetRef(widget)),
     );
@@ -37,10 +44,36 @@ export default function InsightDateDataSetFilter({ widget }: IConfigurationPanel
     const insight = useDashboardSelector(selectInsightByRef(widget.insight));
     invariant(insight, "inconsistent state in InsightDateDataSetFilter");
 
+    const handleDateDatasetChanged = useCallback(() => {
+        dispatch(uiActions.setWidgetDateDatasetAutoSelect(false));
+    }, [dispatch]);
+
     useEffect(() => {
         // use the whole insight to improve cache hits: other calls to this query also use whole insights
         queryDateDatasets(insight);
     }, [queryDateDatasets, insight]);
+
+    useEffect(() => {
+        return () => {
+            // once the config panel disappears set the auto-select flag to false so that editing existing KPIs
+            // does not have it set to true
+            dispatch(uiActions.setWidgetDateDatasetAutoSelect(false));
+        };
+    }, [dispatch]);
+
+    /**
+     * Only open the picker if
+     * 1. auto selection happened
+     * 2. there was no recommended dataset
+     *
+     * In that case we want to show the user the picker to pick one of the non-recommended datasets.
+     * Otherwise the preselected recommended dataset is most likely correct so we do not bother the user
+     * with the automatically opened picker.
+     */
+    const shouldOpenDateDatasetPicker =
+        isWidgetDateDatasetAutoSelect &&
+        result?.dateDatasets &&
+        !getRecommendedCatalogDateDataset(result.dateDatasets);
 
     if (isInsightWidget(widget)) {
         return (
@@ -50,6 +83,8 @@ export default function InsightDateDataSetFilter({ widget }: IConfigurationPanel
                 isDatasetsLoading={status === "running" || status === "pending" || isLoadingAdditionalData}
                 relatedDateDatasets={result?.dateDatasetsOrdered}
                 isLoadingAdditionalData={isLoadingAdditionalData}
+                shouldOpenDateDatasetPicker={shouldOpenDateDatasetPicker}
+                onDateDatasetChanged={handleDateDatasetChanged}
             />
         );
     }

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/configuration/InsightDateDataSetFilter.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/configuration/InsightDateDataSetFilter.tsx
@@ -1,5 +1,5 @@
 // (C) 2007-2022 GoodData Corporation
-import React, { useCallback, useEffect } from "react";
+import React, { useEffect } from "react";
 import { DateDatasetFilter } from "../../common";
 import { IInsightWidget, isInsightWidget, widgetRef } from "@gooddata/sdk-model";
 import invariant from "ts-invariant";
@@ -9,13 +9,10 @@ import {
     QueryInsightDateDatasets,
     selectInsightByRef,
     selectIsWidgetLoadingAdditionalDataByWidgetRef,
-    selectWidgetDateDatasetAutoSelect,
-    uiActions,
-    useDashboardDispatch,
     useDashboardQueryProcessing,
     useDashboardSelector,
 } from "../../../../model";
-import { getRecommendedCatalogDateDataset } from "../../../../_staging/dateDatasets/getRecommendedCatalogDateDataset";
+import { useDateDatasetFilter } from "../../common/configuration/useDateDatasetFilter";
 
 export interface IConfigurationPanelProps {
     widget: IInsightWidget;
@@ -34,9 +31,6 @@ export default function InsightDateDataSetFilter({ widget }: IConfigurationPanel
         queryCreator: queryDateDatasetsForInsight,
     });
 
-    const dispatch = useDashboardDispatch();
-
-    const isWidgetDateDatasetAutoSelect = useDashboardSelector(selectWidgetDateDatasetAutoSelect);
     const isLoadingAdditionalData = useDashboardSelector(
         selectIsWidgetLoadingAdditionalDataByWidgetRef(widgetRef(widget)),
     );
@@ -44,36 +38,14 @@ export default function InsightDateDataSetFilter({ widget }: IConfigurationPanel
     const insight = useDashboardSelector(selectInsightByRef(widget.insight));
     invariant(insight, "inconsistent state in InsightDateDataSetFilter");
 
-    const handleDateDatasetChanged = useCallback(() => {
-        dispatch(uiActions.setWidgetDateDatasetAutoSelect(false));
-    }, [dispatch]);
-
     useEffect(() => {
         // use the whole insight to improve cache hits: other calls to this query also use whole insights
         queryDateDatasets(insight);
     }, [queryDateDatasets, insight]);
 
-    useEffect(() => {
-        return () => {
-            // once the config panel disappears set the auto-select flag to false so that editing existing KPIs
-            // does not have it set to true
-            dispatch(uiActions.setWidgetDateDatasetAutoSelect(false));
-        };
-    }, [dispatch]);
-
-    /**
-     * Only open the picker if
-     * 1. auto selection happened
-     * 2. there was no recommended dataset
-     *
-     * In that case we want to show the user the picker to pick one of the non-recommended datasets.
-     * Otherwise the preselected recommended dataset is most likely correct so we do not bother the user
-     * with the automatically opened picker.
-     */
-    const shouldOpenDateDatasetPicker =
-        isWidgetDateDatasetAutoSelect &&
-        result?.dateDatasets &&
-        !getRecommendedCatalogDateDataset(result.dateDatasets);
+    const { handleDateDatasetChanged, shouldOpenDateDatasetPicker } = useDateDatasetFilter(
+        result?.dateDatasets,
+    );
 
     if (isInsightWidget(widget)) {
         return (

--- a/libs/sdk-ui-dashboard/src/presentation/widget/kpi/DefaultKpiConfigurationPanel/KpiWidgetDateDatasetFilter.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/kpi/DefaultKpiConfigurationPanel/KpiWidgetDateDatasetFilter.tsx
@@ -9,7 +9,7 @@ import {
     queryDateDatasetsForMeasure,
     QueryMeasureDateDatasets,
     selectIsWidgetLoadingAdditionalDataByWidgetRef,
-    selectKpiDateDatasetAutoSelect,
+    selectWidgetDateDatasetAutoSelect,
     uiActions,
     useDashboardCommandProcessing,
     useDashboardDispatch,
@@ -40,7 +40,7 @@ export const KpiWidgetDateDatasetFilter: React.FC<{
         queryDateDatasets(widget.kpi.metric);
     }, [queryDateDatasets, widget.kpi.metric]);
 
-    const isKpiDateDatasetAutoSelect = useDashboardSelector(selectKpiDateDatasetAutoSelect);
+    const isWidgetDateDatasetAutoSelect = useDashboardSelector(selectWidgetDateDatasetAutoSelect);
     const isLoadingAdditionalData = useDashboardSelector(selectIsWidgetLoadingAdditionalDataByWidgetRef(ref));
 
     const dispatch = useDashboardDispatch();
@@ -50,7 +50,7 @@ export const KpiWidgetDateDatasetFilter: React.FC<{
         errorEvent: "GDC.DASH/EVT.COMMAND.FAILED",
         onError: () => {
             dispatch(uiActions.setWidgetLoadingAdditionalDataStopped(ref));
-            dispatch(uiActions.setKpiDateDatasetAutoSelect(false));
+            dispatch(uiActions.setWidgetDateDatasetAutoSelect(false));
         },
         onSuccess: () => {
             dispatch(uiActions.setWidgetLoadingAdditionalDataStopped(ref));
@@ -59,13 +59,13 @@ export const KpiWidgetDateDatasetFilter: React.FC<{
 
     // preselect the first dataset upon loading if the auto select was true
     useEffect(() => {
-        if (isKpiDateDatasetAutoSelect) {
+        if (isWidgetDateDatasetAutoSelect) {
             preselectDateDataset(ref, "default");
         }
-    }, [isKpiDateDatasetAutoSelect, dispatch, ref, preselectDateDataset]);
+    }, [isWidgetDateDatasetAutoSelect, dispatch, ref, preselectDateDataset]);
 
     const handleDateDatasetChanged = useCallback(() => {
-        dispatch(uiActions.setKpiDateDatasetAutoSelect(false));
+        dispatch(uiActions.setWidgetDateDatasetAutoSelect(false));
     }, [dispatch]);
 
     /**
@@ -78,7 +78,7 @@ export const KpiWidgetDateDatasetFilter: React.FC<{
      * with the automatically opened picker.
      */
     const shouldOpenDateDatasetPicker =
-        isKpiDateDatasetAutoSelect &&
+        isWidgetDateDatasetAutoSelect &&
         result?.dateDatasets &&
         !getRecommendedCatalogDateDataset(result.dateDatasets);
 
@@ -86,7 +86,7 @@ export const KpiWidgetDateDatasetFilter: React.FC<{
         return () => {
             // once the config panel disappears set the auto-select flag to false so that editing existing KPIs
             // does not have it set to true
-            dispatch(uiActions.setKpiDateDatasetAutoSelect(false));
+            dispatch(uiActions.setWidgetDateDatasetAutoSelect(false));
         };
     }, [dispatch]);
 
@@ -97,7 +97,7 @@ export const KpiWidgetDateDatasetFilter: React.FC<{
                 dateFilterCheckboxDisabled={false} // for KPI date checkbox is always enabled
                 isDatasetsLoading={status === "running" || status === "pending" || isLoadingAdditionalData}
                 relatedDateDatasets={result?.dateDatasetsOrdered}
-                shouldPickDateDataset={isKpiDateDatasetAutoSelect}
+                shouldPickDateDataset={isWidgetDateDatasetAutoSelect}
                 shouldOpenDateDatasetPicker={shouldOpenDateDatasetPicker}
                 isLoadingAdditionalData={isLoadingAdditionalData}
                 onDateDatasetChanged={handleDateDatasetChanged}

--- a/libs/sdk-ui-dashboard/src/presentation/widget/kpi/DefaultKpiConfigurationPanel/KpiWidgetDateDatasetFilter.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/kpi/DefaultKpiConfigurationPanel/KpiWidgetDateDatasetFilter.tsx
@@ -1,5 +1,5 @@
 // (C) 2022 GoodData Corporation
-import React, { useCallback, useEffect } from "react";
+import React, { useEffect } from "react";
 import { IKpiWidget, widgetRef } from "@gooddata/sdk-model";
 
 import { DateDatasetFilter } from "../../common";
@@ -16,7 +16,7 @@ import {
     useDashboardQueryProcessing,
     useDashboardSelector,
 } from "../../../../model";
-import { getRecommendedCatalogDateDataset } from "../../../../_staging/dateDatasets/getRecommendedCatalogDateDataset";
+import { useDateDatasetFilter } from "../../common/configuration/useDateDatasetFilter";
 
 export const KpiWidgetDateDatasetFilter: React.FC<{
     widget: IKpiWidget;
@@ -64,31 +64,9 @@ export const KpiWidgetDateDatasetFilter: React.FC<{
         }
     }, [isWidgetDateDatasetAutoSelect, dispatch, ref, preselectDateDataset]);
 
-    const handleDateDatasetChanged = useCallback(() => {
-        dispatch(uiActions.setWidgetDateDatasetAutoSelect(false));
-    }, [dispatch]);
-
-    /**
-     * Only open the picker if
-     * 1. auto selection happened
-     * 2. there was no recommended dataset
-     *
-     * In that case we want to show the user the picker to pick one of the non-recommended datasets.
-     * Otherwise the preselected recommended dataset is most likely correct so we do not bother the user
-     * with the automatically opened picker.
-     */
-    const shouldOpenDateDatasetPicker =
-        isWidgetDateDatasetAutoSelect &&
-        result?.dateDatasets &&
-        !getRecommendedCatalogDateDataset(result.dateDatasets);
-
-    useEffect(() => {
-        return () => {
-            // once the config panel disappears set the auto-select flag to false so that editing existing KPIs
-            // does not have it set to true
-            dispatch(uiActions.setWidgetDateDatasetAutoSelect(false));
-        };
-    }, [dispatch]);
+    const { handleDateDatasetChanged, shouldOpenDateDatasetPicker } = useDateDatasetFilter(
+        result?.dateDatasets,
+    );
 
     return (
         <div className="gd-kpi-date-dataset-dropdown">


### PR DESCRIPTION
Insights should also automatically open the dataset picker if there is no recommended dataset preselected.
Also extract common logic into a hook.

JIRA: RAIL-4697

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
