### PR TITLE
RELATED: RAIL-4699 propagate isInEditMode to plug vis config

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/ViewModeDashboardInsight/Insight/DashboardInsight.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/ViewModeDashboardInsight/Insight/DashboardInsight.tsx
@@ -53,12 +53,13 @@ const selectCommonDashboardInsightProps = createSelector(
 );
 
 const selectChartConfig = createSelector(
-    [selectMapboxToken, selectSeparators, selectDrillableItems, selectIsExport],
-    (mapboxToken, separators, drillableItems, isExport) => ({
+    [selectMapboxToken, selectSeparators, selectDrillableItems, selectIsExport, selectIsInEditMode],
+    (mapboxToken, separators, drillableItems, isExportMode, isInEditMode) => ({
         mapboxToken,
         separators,
         forceDisableDrillOnAxes: !drillableItems?.length, // to keep in line with KD, enable axes drilling only if using explicit drills
-        isExportMode: isExport,
+        isExportMode,
+        isInEditMode,
     }),
 );
 

--- a/libs/sdk-ui-ext/src/insightView/InsightRenderer.tsx
+++ b/libs/sdk-ui-ext/src/insightView/InsightRenderer.tsx
@@ -113,7 +113,7 @@ class InsightRendererCore extends React.PureComponent<IInsightRendererProps & Wr
                 colorPalette: this.props.colorPalette,
                 mapboxToken: config.mapboxToken,
                 forceDisableDrillOnAxes: config.forceDisableDrillOnAxes,
-                isInEditMode: false,
+                isInEditMode: config.isInEditMode,
                 isExportMode: config.isExportMode,
             },
             executionConfig: this.props.execConfig,


### PR DESCRIPTION
This is important for GeoChart that freezes its viewport in edit mode.

JIRA: RAIL-4699

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
