### PR TITLE
RELATED: RAIL-4672 handle df switching loading

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/AttributeFilterParentFilteringContext.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/AttributeFilterParentFilteringContext.tsx
@@ -70,6 +70,7 @@ export const AttributeFilterParentFilteringProvider: React.FC<
         displayFormChanged,
         onDisplayFormChange,
         onConfigurationClose: onDisplayFormClose,
+        displayFormChangeStatus,
     } = useDisplayFormConfiguration(currentFilter);
 
     const onConfigurationSave = useCallback(() => {
@@ -99,6 +100,7 @@ export const AttributeFilterParentFilteringProvider: React.FC<
                 onConfigurationClose,
                 showDisplayFormPicker,
                 configurationChanged,
+                displayFormChangeStatus,
             }}
         >
             {children}

--- a/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/DefaultDashboardAttributeFilter.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/DefaultDashboardAttributeFilter.tsx
@@ -35,6 +35,7 @@ import {
     AttributeFilterParentFilteringProvider,
     useAttributeFilterParentFiltering,
 } from "./AttributeFilterParentFilteringContext";
+import { LoadingMask, LOADING_HEIGHT } from "@gooddata/sdk-ui-kit";
 
 /**
  * Default implementation of the attribute filter to use on the dashboard's filter bar.
@@ -131,16 +132,22 @@ export const DefaultDashboardAttributeFilter = (props: IDashboardAttributeFilter
 
     const CustomElementsSelect = useMemo(() => {
         return function ElementsSelect(props: IAttributeFilterElementsSelectProps) {
+            const { displayFormChangeStatus } = useAttributeFilterParentFiltering();
+
             const closeHandler = useCallback(() => {
                 setIsConfigurationOpen(false);
             }, []);
+
+            if (displayFormChangeStatus === "running") {
+                return <LoadingMask height={LOADING_HEIGHT} />;
+            }
+
             return (
                 <>
                     {isConfigurationOpen ? (
                         <AttributeFilterConfiguration
                             closeHandler={closeHandler}
                             filterRef={filterRef}
-                            onChange={() => {}}
                             filterByText={filterByText}
                             displayValuesAsText={displayValuesAsText}
                         />

--- a/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/dashboardDropdownBody/configuration/AttributeFilterConfiguration.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/dashboardDropdownBody/configuration/AttributeFilterConfiguration.tsx
@@ -22,7 +22,6 @@ import { useAttributes } from "./hooks/useAttributes";
 
 interface IAttributeFilterConfigurationProps {
     closeHandler: () => void;
-    onChange: () => void;
     filterRef?: ObjRef;
     filterByText: string;
     displayValuesAsText: string;

--- a/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/dashboardDropdownBody/configuration/hooks/useDisplayFormConfiguration.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/dashboardDropdownBody/configuration/hooks/useDisplayFormConfiguration.ts
@@ -3,16 +3,20 @@ import { areObjRefsEqual, IDashboardAttributeFilter, ObjRef } from "@gooddata/sd
 import { useState, useCallback } from "react";
 import {
     useDashboardSelector,
-    useDispatchDashboardCommand,
     selectCatalogAttributes,
     IDashboardAttributeFilterDisplayForms,
     setAttributeFilterDisplayForm,
+    useDashboardCommandProcessing,
 } from "../../../../../../model";
 
 export function useDisplayFormConfiguration(currentFilter: IDashboardAttributeFilter) {
     const catalogAttributes = useDashboardSelector(selectCatalogAttributes);
 
-    const changeDisplayFormCommand = useDispatchDashboardCommand(setAttributeFilterDisplayForm);
+    const { run: changeDisplayForm, status: displayFormChangeStatus } = useDashboardCommandProcessing({
+        commandCreator: setAttributeFilterDisplayForm,
+        successEvent: "GDC.DASH/EVT.FILTER_CONTEXT.ATTRIBUTE_FILTER.DISPLAY_FORM_CHANGED",
+        errorEvent: "GDC.DASH/EVT.COMMAND.FAILED",
+    });
 
     const originalDisplayForm = currentFilter.attributeFilter.displayForm;
 
@@ -46,12 +50,12 @@ export function useDisplayFormConfiguration(currentFilter: IDashboardAttributeFi
 
     const onDisplayFormChange = useCallback(() => {
         if (!areObjRefsEqual(originalDisplayForm, filterDisplayForms.selectedDisplayForm)) {
-            changeDisplayFormCommand(
+            changeDisplayForm(
                 currentFilter.attributeFilter.localIdentifier!,
                 filterDisplayForms.selectedDisplayForm,
             );
         }
-    }, [filterDisplayForms, originalDisplayForm, currentFilter, changeDisplayFormCommand]);
+    }, [filterDisplayForms, originalDisplayForm, currentFilter, changeDisplayForm]);
 
     const onConfigurationClose = useCallback(() => {
         setFilterDisplayForms((old) => ({
@@ -66,5 +70,6 @@ export function useDisplayFormConfiguration(currentFilter: IDashboardAttributeFi
         displayFormChanged,
         onDisplayFormChange,
         onConfigurationClose,
+        displayFormChangeStatus,
     };
 }


### PR DESCRIPTION
Show a loading spinner while switching display form, before it used to show old display form elements while switching.

JIRA: RAIL-4672

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
