### PR TITLE
FEATURE: TNT-1185 Extend capabilities and FF for dashboard permissions

### DIFF
--- a/libs/sdk-backend-bear/src/backend/index.ts
+++ b/libs/sdk-backend-bear/src/backend/index.ts
@@ -76,6 +76,9 @@ const CAPABILITIES: IBackendCapabilities = {
     supportsOrganizationSettings: false,
     supportsInlineMeasures: false,
     supportsBootstrapResource: true,
+    supportsMetadataObjectLocking: true,
+    supportsGranularAccessControl: false,
+    supportsEveryoneUserGroupForAccessControl: true,
 };
 
 /**

--- a/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
+++ b/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
@@ -376,12 +376,15 @@ export interface IBackendCapabilities {
     supportsCustomColorPalettes?: boolean;
     supportsElementsQueryParentFiltering?: boolean;
     supportsElementUris?: boolean;
+    supportsEveryoneUserGroupForAccessControl?: boolean;
     supportsExplain?: boolean;
     supportsGenericDateAttributeElements?: boolean;
+    supportsGranularAccessControl?: boolean;
     supportsHierarchicalWorkspaces?: boolean;
     supportsHyperlinkAttributeLabels?: boolean;
     supportsInlineMeasures?: boolean;
     supportsKpiWidget?: boolean;
+    supportsMetadataObjectLocking?: boolean;
     supportsObjectUris?: boolean;
     supportsOrganizationSettings?: boolean;
     supportsOwners?: boolean;

--- a/libs/sdk-backend-spi/src/backend/capabilities.ts
+++ b/libs/sdk-backend-spi/src/backend/capabilities.ts
@@ -178,6 +178,24 @@ export interface IBackendCapabilities {
     supportsBootstrapResource?: boolean;
 
     /**
+     * Indicates whether backends supports locking of metadata objects that prevents their edit by other
+     * users than admins.
+     */
+    supportsMetadataObjectLocking?: boolean;
+
+    /**
+     * Indicates whether backend supports granular access controls of metadata objects or if permissions
+     * are tied to the user role.
+     */
+    supportsGranularAccessControl?: boolean;
+
+    /**
+     * Indicates whether backend supports virtual "Everyone" group that is used when we want
+     * to assign permissions for all current and future users of the platform.
+     */
+    supportsEveryoneUserGroupForAccessControl?: boolean;
+
+    /**
      * Catchall for additional capabilities
      */
     [key: string]: undefined | boolean | number | string;

--- a/libs/sdk-backend-tiger/src/backend/features/feature.ts
+++ b/libs/sdk-backend-tiger/src/backend/features/feature.ts
@@ -93,6 +93,13 @@ export function mapFeatures(features: FeaturesMap): Partial<ITigerFeatureFlags> 
             "BOOLEAN",
             FeatureFlagsValues.enableDescriptions,
         ),
+        ...loadFeature(
+            features,
+            TigerFeaturesNames.EnableAnalyticalDashboardPermissions,
+            "enableAnalyticalDashboardPermissions",
+            "BOOLEAN",
+            FeatureFlagsValues.enableAnalyticalDashboardPermissions,
+        ),
     };
 }
 

--- a/libs/sdk-backend-tiger/src/backend/index.ts
+++ b/libs/sdk-backend-tiger/src/backend/index.ts
@@ -77,6 +77,9 @@ const CAPABILITIES: IBackendCapabilities = {
     supportsOrganizationSettings: true,
     supportsInlineMeasures: true,
     supportsBootstrapResource: false,
+    supportsMetadataObjectLocking: false,
+    supportsGranularAccessControl: true,
+    supportsEveryoneUserGroupForAccessControl: false,
 };
 
 /**

--- a/libs/sdk-backend-tiger/src/backend/uiFeatures.ts
+++ b/libs/sdk-backend-tiger/src/backend/uiFeatures.ts
@@ -28,6 +28,8 @@ export enum TigerFeaturesNames {
     EnableMSSQLDataSource = "enableMSSQLDataSource",
     //boolean + possible values: enabled, disabled
     EnableDescriptions = "enableDescriptions",
+    //boolean + possible values: enabled, disabled
+    EnableAnalyticalDashboardPermissions = "enableAnalyticalDashboardPermissions",
 }
 
 export type ITigerFeatureFlags = {
@@ -42,6 +44,7 @@ export type ITigerFeatureFlags = {
     enableLongitudeAndLatitudeLabels: typeof FeatureFlagsValues["enableLongitudeAndLatitudeLabels"][number];
     enableMSSQLDataSource: typeof FeatureFlagsValues["enableMSSQLDataSource"][number];
     enableDescriptions: typeof FeatureFlagsValues["enableDescriptions"][number];
+    enableAnalyticalDashboardPermissions: typeof FeatureFlagsValues["enableAnalyticalDashboardPermissions"][number];
 };
 
 export const DefaultFeatureFlags: ITigerFeatureFlags = {
@@ -57,6 +60,7 @@ export const DefaultFeatureFlags: ITigerFeatureFlags = {
     enableLongitudeAndLatitudeLabels: false,
     enableMSSQLDataSource: false,
     enableDescriptions: false,
+    enableAnalyticalDashboardPermissions: false,
 };
 
 export const FeatureFlagsValues = {
@@ -75,4 +79,5 @@ export const FeatureFlagsValues = {
     enableLongitudeAndLatitudeLabels: [true, false] as const,
     enableMSSQLDataSource: [true, false] as const,
     enableDescriptions: [true, false] as const,
+    enableAnalyticalDashboardPermissions: [true, false] as const,
 };

--- a/libs/sdk-backend-tiger/src/backend/uiSettings.ts
+++ b/libs/sdk-backend-tiger/src/backend/uiSettings.ts
@@ -64,7 +64,6 @@ export const DefaultUiSettings: ISettings = {
     enableAdAdditionalDateAttributes: true,
     enableAlternativeDisplayFormSelection: true,
     enableNewAnalyticalDashboardsNavigation: true,
-    enableAnalyticalDashboardPermissions: false,
 
     // enable the plugin-ready Dashboard component in gdc-dashboards
     dashboardComponentDevRollout: true,


### PR DESCRIPTION
Extend backend capabilities related to dashboard permissions. Move dashboard permissions FF to feature hub logic.

JIRA: TNT-1185

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
