### PR TITLE
BUGFIX: RAIL-4661 disable drag for custom widgets

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/layout/DashboardLayoutWidget.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/layout/DashboardLayoutWidget.tsx
@@ -128,12 +128,17 @@ export const DashboardLayoutWidget: IDashboardLayoutWidgetRenderer<
 
     const handleDragEnd = useWidgetDragEndHandler();
 
+    // TODO: we should probably do something more meaningful when item has no widget; should that even
+    //  be allowed? undefined widget will make things explode down the line away so..
+    const widget = item.widget()!;
+    const isDraggableWidgetType = !(isPlaceholderWidget(widget) || isCustomWidget(widget));
+
     const [{ isDragging }, dragRef] = useDashboardDrag(
         {
             dragItem: () => {
                 return createDraggableItem(item, insights, settings);
             },
-            canDrag: isInEditMode && !isPlaceholderWidget(item.widget()),
+            canDrag: isInEditMode && isDraggableWidgetType,
             dragStart: (item) => {
                 dispatch(uiActions.setDraggingWidgetSource(item));
             },
@@ -143,9 +148,7 @@ export const DashboardLayoutWidget: IDashboardLayoutWidgetRenderer<
     );
 
     const { ErrorComponent, LoadingComponent } = useDashboardComponentsContext();
-    // TODO: we should probably do something more meaningful when item has no widget; should that even
-    //  be allowed? undefined widget will make things explode down the line away so..
-    const widget = item.widget()!;
+
     const currentSize = item.size()[screen]!;
     const minHeight = calculateWidgetMinHeight(widget, currentSize, insights, settings);
     const height =


### PR DESCRIPTION
fix: disable drag for custom widgets

JIRA: RAIL-4661

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
