### PR TITLE
RELATED: RAIL-4676 fix date filter config warnings

### DIFF
--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/initializeDashboardHandler/mergeDateFilterConfigs.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/initializeDashboardHandler/mergeDateFilterConfigs.ts
@@ -1,13 +1,13 @@
 // (C) 2021-2022 GoodData Corporation
 import { SagaIterator } from "redux-saga";
+import { call } from "redux-saga/effects";
 import { IDateFilterConfig, IDashboardDateFilterConfig } from "@gooddata/sdk-model";
 
 import { mergeDateFilterConfigs } from "../../../../_staging/dateFilterConfig/merge";
 import { validateDateFilterConfig } from "../../../../_staging/dateFilterConfig/validation";
 import { InitializeDashboard } from "../../../commands/dashboard";
-import { dispatchDashboardEvent } from "../../../store/_infra/eventDispatcher";
-import { dateFilterValidationFailed } from "../../../events/dashboard";
 import { DashboardContext } from "../../../types/commonTypes";
+import { onDateFilterConfigValidationError } from "./onDateFilterConfigValidationError";
 
 export interface DateFilterMergeResult {
     config: IDateFilterConfig;
@@ -38,9 +38,7 @@ export function* mergeDateFilterConfigWithOverrides(
     const mergedConfigValidation = validateDateFilterConfig(mergedConfig, false);
 
     if (mergedConfigValidation !== "Valid") {
-        yield dispatchDashboardEvent(
-            dateFilterValidationFailed(ctx, mergedConfigValidation, cmd.correlationId),
-        );
+        yield call(onDateFilterConfigValidationError, ctx, mergedConfigValidation, cmd.correlationId);
 
         return {
             config,

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/initializeDashboardHandler/onDateFilterConfigValidationError.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/initializeDashboardHandler/onDateFilterConfigValidationError.ts
@@ -1,0 +1,17 @@
+// (C) 2022 GoodData Corporation
+import { put } from "redux-saga/effects";
+
+import { dateFilterValidationFailed } from "../../../events/dashboard";
+import { dispatchDashboardEvent } from "../../../store/_infra/eventDispatcher";
+import { dateFilterConfigActions } from "../../../store/dateFilterConfig";
+import { DateFilterValidationResult } from "../../../../types";
+import { DashboardContext } from "../../../types/commonTypes";
+
+export function* onDateFilterConfigValidationError(
+    ctx: DashboardContext,
+    validationResult: DateFilterValidationResult,
+    correlationId?: string,
+) {
+    yield dispatchDashboardEvent(dateFilterValidationFailed(ctx, validationResult, correlationId));
+    yield put(dateFilterConfigActions.addDateFilterConfigValidationWarning(validationResult));
+}

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/initializeDashboardHandler/resolveDashboardConfig.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/initializeDashboardHandler/resolveDashboardConfig.ts
@@ -9,10 +9,7 @@ import { defaultDateFilterConfig } from "../../../../_staging/dateFilterConfig/d
 import { getValidDateFilterConfig } from "../../../../_staging/dateFilterConfig/validation";
 import { stripUserAndWorkspaceProps } from "../../../../_staging/settings/conversion";
 import { InitializeDashboard } from "../../../commands";
-import { dateFilterValidationFailed } from "../../../events/dashboard";
-import { dispatchDashboardEvent } from "../../../store/_infra/eventDispatcher";
 import { dateFilterConfigActions } from "../../../store/dateFilterConfig";
-import { DateFilterValidationResult } from "../../../../types";
 import {
     DashboardConfig,
     DashboardContext,
@@ -21,6 +18,7 @@ import {
 } from "../../../types/commonTypes";
 import { PromiseFnReturnType } from "../../../types/sagas";
 import { sanitizeUnfinishedFeatureSettings } from "./sanitizeUnfinishedFeatureSettings";
+import { onDateFilterConfigValidationError } from "./onDateFilterConfigValidationError";
 
 function loadDateFilterConfig(ctx: DashboardContext): Promise<IDateFilterConfigsQueryResult | undefined> {
     const { backend, workspace } = ctx;
@@ -51,15 +49,6 @@ function loadColorPalette(ctx: DashboardContext): Promise<IColorPalette> {
     const { backend, workspace } = ctx;
 
     return backend.workspace(workspace).styling().getColorPalette();
-}
-
-function* onDateFilterConfigValidationError(
-    ctx: DashboardContext,
-    validationResult: DateFilterValidationResult,
-    correlationId?: string,
-) {
-    yield dispatchDashboardEvent(dateFilterValidationFailed(ctx, validationResult, correlationId));
-    yield put(dateFilterConfigActions.addDateFilterConfigValidationWarning(validationResult));
 }
 
 function* resolveDateFilterConfig(ctx: DashboardContext, config: DashboardConfig, cmd: InitializeDashboard) {


### PR DESCRIPTION
Some of the warnings are only useful when creating a new dashboard. Also fix propagation of the warnings from merging of workspace and dashboard configs (previously the store was not updated properly).

JIRA: RAIL-4676

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
