### PR TITLE
RELATED: RAIL-4636 fix drill to URL config panel

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/configuration/DrillTargets/useAttributesWithDisplayForms.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/configuration/DrillTargets/useAttributesWithDisplayForms.ts
@@ -7,6 +7,7 @@ import {
 } from "@gooddata/sdk-model";
 import invariant from "ts-invariant";
 import intersectionWith from "lodash/intersectionWith";
+import uniqWith from "lodash/uniqWith";
 import { AttributeDisplayFormType } from "../../../../drill/types";
 import {
     selectAllCatalogAttributesMap,
@@ -24,6 +25,10 @@ interface IAttributeWithDisplayForm {
 interface IUseAttributesWithDisplayFormsResult {
     linkDisplayForms: IAttributeWithDisplayForm[];
     allDisplayForms: IAttributeWithDisplayForm[];
+}
+
+function areAttributesWithDisplayFormsEqual(a: IAttributeWithDisplayForm, b: IAttributeWithDisplayForm) {
+    return areObjRefsEqual(a.displayForm.ref, b.displayForm.ref);
 }
 
 export function useAttributesWithDisplayForms(
@@ -48,7 +53,7 @@ export function useAttributesWithDisplayForms(
         areObjRefsEqual,
     );
 
-    return candidateDisplayFormRefs.reduce(
+    const result = candidateDisplayFormRefs.reduce(
         (result: IUseAttributesWithDisplayFormsResult, ref) => {
             const displayForm = allDisplayForms.get(ref);
             if (!displayForm) {
@@ -84,4 +89,9 @@ export function useAttributesWithDisplayForms(
             allDisplayForms: [],
         },
     );
+
+    return {
+        allDisplayForms: uniqWith(result.allDisplayForms, areAttributesWithDisplayFormsEqual),
+        linkDisplayForms: uniqWith(result.linkDisplayForms, areAttributesWithDisplayFormsEqual),
+    };
 }


### PR DESCRIPTION
* prevent duplicities in the picker in case the insight uses the same display form more than once
* fix the dropdown button text

JIRA: RAIL-4636

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
