### PR TITLE
RELATED: RAIL-4713, RAIL-4714 validate drills in edit mode

### DIFF
--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/common/validateDrills.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/common/validateDrills.ts
@@ -10,7 +10,7 @@ import {
     widgetRef,
 } from "@gooddata/sdk-model";
 import { SagaIterator } from "redux-saga";
-import { all, call, put, SagaReturnType, select } from "redux-saga/effects";
+import { all, call, put, SagaReturnType } from "redux-saga/effects";
 import { v4 as uuid } from "uuid";
 import flatMap from "lodash/flatMap";
 import { IDashboardCommand } from "../../commands";
@@ -24,7 +24,6 @@ import {
     validateDrillDefinition,
 } from "../widgets/validation/insightDrillDefinitionValidation";
 import { validateKpiDrill } from "../widgets/validation/kpiDrillValidation";
-import { selectAllAnalyticalWidgets } from "../../store/layout/layoutSelectors";
 import { uiActions } from "../../store/ui";
 
 interface IInvalidDrillInfo {
@@ -32,8 +31,11 @@ interface IInvalidDrillInfo {
     widget: IWidget;
 }
 
-export function* validateDrills(ctx: DashboardContext, cmd: IDashboardCommand) {
-    const widgets: ReturnType<typeof selectAllAnalyticalWidgets> = yield select(selectAllAnalyticalWidgets);
+export function* validateDrills(
+    ctx: DashboardContext,
+    cmd: IDashboardCommand,
+    widgets: (IKpiWidget | IInsightWidget)[],
+) {
     const widgetsWithDrills = widgets.filter((widget) => widget.drills.length > 0);
     if (!widgetsWithDrills.length) {
         return;

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/drillTargets/addDrillTargetsHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/drillTargets/addDrillTargetsHandler.ts
@@ -1,6 +1,6 @@
 // (C) 2021-2022 GoodData Corporation
 import { SagaIterator } from "redux-saga";
-import { put, select } from "redux-saga/effects";
+import { call, put, select } from "redux-saga/effects";
 import { AddDrillTargets } from "../../commands/drillTargets";
 import { DrillTargetsAdded, drillTargetsAdded } from "../../events/drillTargets";
 import { drillTargetsActions } from "../../store/drillTargets";
@@ -9,6 +9,8 @@ import { selectWidgetsMap } from "../../store/layout/layoutSelectors";
 import { validateExistingInsightWidget } from "../widgets/validation/widgetValidations";
 import { selectEnableKPIDashboardDrillFromAttribute } from "../../store/config/configSelectors";
 import { availableDrillTargetsValidation } from "./validation/availableDrillTargetsValidation";
+import { validateDrills } from "../common/validateDrills";
+import { selectIsInEditMode } from "../../store/renderMode/renderModeSelectors";
 
 export function* addDrillTargetsHandler(
     ctx: DashboardContext,
@@ -42,6 +44,12 @@ export function* addDrillTargetsHandler(
             availableDrillTargets: drillTarget,
         }),
     );
+
+    // in edit mode, we need to remove invalid drills in case the insight in the widget changes its drill targets
+    const isInEditMode: ReturnType<typeof selectIsInEditMode> = yield select(selectIsInEditMode);
+    if (isInEditMode) {
+        yield call(validateDrills, ctx, cmd, [insightWidget]);
+    }
 
     return drillTargetsAdded(ctx, ref, availableDrillTargets, correlationId);
 }

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/renderMode/changeRenderModeHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/renderMode/changeRenderModeHandler.ts
@@ -10,6 +10,7 @@ import { selectDashboardEditModeDevRollout } from "../../store/config/configSele
 import { resetDashboardHandler } from "../dashboard/resetDashboardHandler";
 import { validateDrills } from "../common/validateDrills";
 import { uiActions } from "../../store/ui";
+import { selectAllAnalyticalWidgets } from "../../store/layout/layoutSelectors";
 
 export function* changeRenderModeHandler(
     ctx: DashboardContext,
@@ -32,7 +33,10 @@ export function* changeRenderModeHandler(
         }
 
         if (renderMode === "edit") {
-            yield call(validateDrills, ctx, cmd);
+            const widgets: ReturnType<typeof selectAllAnalyticalWidgets> = yield select(
+                selectAllAnalyticalWidgets,
+            );
+            yield call(validateDrills, ctx, cmd, widgets);
         }
 
         return renderModeChanged(ctx, renderMode, correlationId);


### PR DESCRIPTION
In edit mode, when a widget changes its drill targets, we need to run the drill validation again in case some of the drills set on the widget are no longer valid and remove them.

JIRA: RAIL-4713, RAIL-4714

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
