### PR TITLE
RELATED: RAIL-4702 prevent invariants in InsightRenderer

### DIFF
--- a/libs/sdk-ui-ext/src/insightView/InsightRenderer.tsx
+++ b/libs/sdk-ui-ext/src/insightView/InsightRenderer.tsx
@@ -231,8 +231,8 @@ class InsightRendererCore extends React.PureComponent<IInsightRendererProps & Wr
          * Ignore properties when comparing insights to determine if a new setup is needed: changes to properties
          * only will be handled using the updateVisualization without unnecessary new setup just fine.
          */
-        const prevInsightForCompare = insightSetProperties(prevProps.insight, {});
-        const newInsightForCompare = insightSetProperties(this.props.insight, {});
+        const prevInsightForCompare = prevProps.insight && insightSetProperties(prevProps.insight, {});
+        const newInsightForCompare = this.props.insight && insightSetProperties(this.props.insight, {});
 
         const needsNewSetup =
             !isEqual(newInsightForCompare, prevInsightForCompare) ||


### PR DESCRIPTION
When used from InsightView, the props.insight can be undefined, which then triggers an invariant in insightSetProperties.

JIRA: RAIL-4702

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
