### PR TITLE
RELATED: RAIL-4717 fix attributes in drill to URL

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/configuration/DrillTargets/useAttributesWithDisplayForms.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/configuration/DrillTargets/useAttributesWithDisplayForms.ts
@@ -6,13 +6,11 @@ import {
     IAttributeMetadataObject,
 } from "@gooddata/sdk-model";
 import invariant from "ts-invariant";
-import intersectionWith from "lodash/intersectionWith";
 import uniqWith from "lodash/uniqWith";
 import { AttributeDisplayFormType } from "../../../../drill/types";
 import {
     selectAllCatalogAttributesMap,
     selectAllCatalogDisplayFormsMap,
-    selectDrillTargetsByWidgetRef,
     selectSelectedWidgetRef,
     useDashboardSelector,
 } from "../../../../../model";
@@ -37,23 +35,12 @@ export function useAttributesWithDisplayForms(
     const widgetRef = useDashboardSelector(selectSelectedWidgetRef);
     invariant(widgetRef, "must have selected widget");
 
-    const drillTargets = useDashboardSelector(selectDrillTargetsByWidgetRef(widgetRef));
     const allAttributes = useDashboardSelector(selectAllCatalogAttributesMap);
     const allDisplayForms = useDashboardSelector(selectAllCatalogDisplayFormsMap);
 
-    // restrict the possible attributes be the available drill targets
-    const drillTargetDisplayFormRefs =
-        drillTargets?.availableDrillTargets?.attributes?.map((a) => a.attribute.attributeHeader.ref) ?? [];
-
     const incomingDisplayFormRefs = attributes.map((a) => a.attributeHeader.ref);
 
-    const candidateDisplayFormRefs = intersectionWith(
-        drillTargetDisplayFormRefs,
-        incomingDisplayFormRefs,
-        areObjRefsEqual,
-    );
-
-    const result = candidateDisplayFormRefs.reduce(
+    const result = incomingDisplayFormRefs.reduce(
         (result: IUseAttributesWithDisplayFormsResult, ref) => {
             const displayForm = allDisplayForms.get(ref);
             if (!displayForm) {


### PR DESCRIPTION
The additional restriction by drill targets was wrong, the incoming attributes are already limited correctly.

JIRA: RAIL-4717

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
