### PR TITLE
RELATED: RAIL-4726 z-Index of dashboard header for old plugins

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/dashboard/components/DashboardInner.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/dashboard/components/DashboardInner.tsx
@@ -31,7 +31,8 @@ export const DashboardInner: React.FC<IDashboardProps> = () => {
                 >
                     <DashboardSidebar DefaultSidebar={RenderModeAwareDashboardSidebar} />
                     <div className="gd-dash-content">
-                        <div className="gd-dash-header-wrapper">
+                        {/* gd-dash-header-wrapper-sdk-8-12 style is added because we should keep old styles unchanged to not brake plugins */}
+                        <div className="gd-dash-header-wrapper gd-dash-header-wrapper-sdk-8-12">
                             {/* Header z-index start at  6000 so we need force all overlays z-indexes start at 6000 to be under header */}
                             <OverlayControllerProvider overlayController={overlayController}>
                                 <DashboardHeader />

--- a/libs/sdk-ui-dashboard/styles/scss/filterBar.scss
+++ b/libs/sdk-ui-dashboard/styles/scss/filterBar.scss
@@ -22,8 +22,13 @@ $attribute-filter-drag-handle-left: 10px;
 }
 
 .gd-dash-header-wrapper {
-    z-index: 6000; // overlay in Dashboard component start at index 5000
+    z-index: 100; // we have to leave this style unchanged because old plugins
     transition: left variables.$sidebar-transition-length;
+
+    &.gd-dash-header-wrapper-sdk-8-12 {
+        // style is added because we should keep old styles unchanged to not brake plugins
+        z-index: 6000; // overlay in Dashboard component start at index 5000
+    }
 
     .is-dashboard-loading & {
         z-index: 0;


### PR DESCRIPTION
JIRA: RAIL-4726

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
