### PR TITLE
BUGFIX: TNT-1249 Swap default value to cover undefined config

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/widget/description/InsightWidgetDescriptionTrigger.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/description/InsightWidgetDescriptionTrigger.tsx
@@ -21,7 +21,7 @@ export const InsightWidgetDescriptionTrigger: React.FC<IInsightWidgetDescription
 
     const eventPayload: DescriptionTooltipOpenedData = {
         from: "widget",
-        type: widget.configuration?.description?.source === "insight" ? "inherit" : "custom",
+        type: widget.configuration?.description?.source === "widget" ? "custom" : "inherit",
         description: trimmedDescription,
     };
 

--- a/libs/sdk-ui-dashboard/src/presentation/widget/kpi/ViewModeDashboardKpi/KpiAlerts/KpiDescriptionTrigger.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/kpi/ViewModeDashboardKpi/KpiAlerts/KpiDescriptionTrigger.tsx
@@ -34,7 +34,7 @@ export const KpiDescriptionTrigger: React.FC<IKpiDescriptionTriggerProps> = (pro
 
     const eventPayload: DescriptionTooltipOpenedData = {
         from: "kpi",
-        type: kpi.configuration?.description?.source === "metric" ? "inherit" : "custom",
+        type: kpi.configuration?.description?.source === "kpi" ? "custom" : "inherit",
         description: trimmedDescription,
     };
 


### PR DESCRIPTION
Change default value of telemetry payload to match it with default behavior when description config is missing.
JIRA: TNT-1249

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
