### PR TITLE
RELATED: RAIL-4708 fix width resizing behavior

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/dashboard/components/DashboardInner.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/dashboard/components/DashboardInner.tsx
@@ -22,13 +22,13 @@ export const DashboardInner: React.FC<IDashboardProps> = () => {
     return (
         <IntlWrapper locale={locale}>
             {/* we need wrapping element for drag layer and dashboard for proper rendering in flex layout */}
-            <div className="component-root">
+            <div
+                className={cx("component-root", {
+                    "sdk-edit-mode-on": isEditMode,
+                })}
+            >
                 <DragLayerComponent />
-                <div
-                    className={cx("gd-dashboards-root", "gd-flex-container", {
-                        "sdk-edit-mode-on": isEditMode,
-                    })}
-                >
+                <div className="gd-dashboards-root gd-flex-container">
                     <DashboardSidebar DefaultSidebar={RenderModeAwareDashboardSidebar} />
                     <div className="gd-dash-content">
                         {/* gd-dash-header-wrapper-sdk-8-12 style is added because we should keep old styles unchanged to not brake plugins */}

--- a/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/Resize/WidthResizerHotspot.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/Resize/WidthResizerHotspot.tsx
@@ -89,7 +89,7 @@ export function WidthResizerHotspot({
 
     const isThisResizing = isWidthResizing && isActive;
 
-    const showHotspot = !isDragging || isWidthResizing;
+    const showHotspot = !isDragging || isWidthResizing || isResizerVisible;
     const showResizer = isResizerVisible || isThisResizing;
     const status = isDragging ? "muted" : "active";
 


### PR DESCRIPTION
fix: width resizing behavior

- prevent resizer rerender, which changes DND behavior
- move class sdk-edit-mode-on to root (now is usable in drag layer)

JIRA: RAIL-4708

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
