### PR TITLE
RELATED: RAIL-4734 fix custom URL drill validation

### DIFF
--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -148,6 +148,7 @@ import { ScreenSize } from '@gooddata/sdk-model';
 import { Selector } from '@reduxjs/toolkit';
 import { ShareStatus } from '@gooddata/sdk-model';
 import { TypedUseSelectorHook } from 'react-redux';
+import { Uri } from '@gooddata/sdk-model';
 import { UriRef } from '@gooddata/sdk-model';
 import { UseCancelablePromiseCallbacks } from '@gooddata/sdk-ui';
 import { UseCancelablePromiseState } from '@gooddata/sdk-ui';
@@ -3990,6 +3991,18 @@ export type InsightWidgetComponentSet = CustomComponentBase<IDashboardInsightPro
 // @internal (undocumented)
 export type InsightWidgetModifications = (builder: InsightWidgetBuilder) => InsightWidgetBuilder;
 
+// @alpha (undocumented)
+export interface InvalidCustomUrlDrillParameterInfo {
+    // (undocumented)
+    drillsWithInvalidParametersLocalIds: string[];
+    // (undocumented)
+    widgetId: Identifier;
+    // (undocumented)
+    widgetRef: ObjRef;
+    // (undocumented)
+    widgetUri: Uri;
+}
+
 // @internal (undocumented)
 export interface IParentWithConnectingAttributes {
     connectingAttributes: IConnectingAttribute[];
@@ -5914,7 +5927,10 @@ itemIndex: number;
 export const selectInvalidDrillWidgetRefs: OutputSelector<DashboardState, ObjRef[], (res: UiState) => ObjRef[]>;
 
 // @internal (undocumented)
-export const selectInvalidUrlDrillWidgetRefs: OutputSelector<DashboardState, ObjRef[], (res: UiState) => ObjRef[]>;
+export const selectInvalidUrlDrillParameterDrillLocalIdsByWidgetRef: (ref: ObjRef) => OutputSelector<DashboardState, string[], (res: ObjRefMap<InvalidCustomUrlDrillParameterInfo>) => string[]>;
+
+// @internal (undocumented)
+export const selectInvalidUrlDrillParameterWidgetRefs: OutputSelector<DashboardState, ObjRef[], (res: InvalidCustomUrlDrillParameterInfo[]) => ObjRef[]>;
 
 // @internal
 export const selectIsAlternativeDisplayFormSelectionEnabled: OutputSelector<DashboardState, boolean, (res: ResolvedDashboardConfig) => boolean>;
@@ -6366,21 +6382,24 @@ clearActiveSectionIndex: CaseReducer<UiState, AnyAction>;
 openCancelEditModeDialog: CaseReducer<UiState, AnyAction>;
 closeCancelEditModeDialog: CaseReducer<UiState, AnyAction>;
 resetInvalidDrillWidgetRefs: CaseReducer<UiState, AnyAction>;
-resetInvalidUrlDrillWidgetRefs: CaseReducer<UiState, AnyAction>;
+resetAllInvalidCustomUrlDrillParameterWidgets: CaseReducer<UiState, AnyAction>;
 addInvalidDrillWidgetRefs: CaseReducer<UiState, {
 payload: ObjRef[];
 type: string;
 }>;
-addInvalidUrlDrillWidgetRefs: CaseReducer<UiState, {
-payload: ObjRef[];
+setInvalidCustomUrlDrillParameterWidgets: CaseReducer<UiState, {
+payload: {
+widget: IInsightWidget;
+invalidDrills: IDrillToCustomUrl[];
+}[];
 type: string;
 }>;
 removeInvalidDrillWidgetRefs: CaseReducer<UiState, {
 payload: ObjRef[];
 type: string;
 }>;
-removeInvalidUrlDrillWidgetRefs: CaseReducer<UiState, {
-payload: ObjRef[];
+resetInvalidCustomUrlDrillParameterWidget: CaseReducer<UiState, {
+payload: IInsightWidget[];
 type: string;
 }>;
 setDraggingWidgetSource: CaseReducer<UiState, {
@@ -6434,7 +6453,7 @@ export interface UiState {
     // (undocumented)
     drillValidationMessages: {
         invalidDrillWidgetRefs: ObjRef[];
-        invalidUrlDrillWidgetRefs: ObjRef[];
+        invalidCustomUrlDrillParameterWidgets: InvalidCustomUrlDrillParameterInfo[];
     };
     // (undocumented)
     filterAttributeSelectionOpen: boolean;

--- a/libs/sdk-ui-dashboard/src/_staging/drills/drillingUtils.ts
+++ b/libs/sdk-ui-dashboard/src/_staging/drills/drillingUtils.ts
@@ -16,6 +16,7 @@ import {
     ICatalogAttribute,
     ICatalogDateAttribute,
     isMeasureDescriptor,
+    IAttributeDescriptor,
 } from "@gooddata/sdk-model";
 import {
     HeaderPredicates,
@@ -23,6 +24,7 @@ import {
     IHeaderPredicate,
     getMappingHeaderLocalIdentifier,
     IDrillEvent,
+    IAvailableDrillTargets,
 } from "@gooddata/sdk-ui";
 import first from "lodash/first";
 import last from "lodash/last";
@@ -205,4 +207,25 @@ export function isDrillConfigured(
 
         return isEqual(drill, configDrill);
     });
+}
+
+export function getValidDrillOriginAttributes(
+    supportedItemsForWidget: IAvailableDrillTargets,
+    localIdentifier: string,
+): IAttributeDescriptor[] {
+    const measureItems = supportedItemsForWidget.measures ?? [];
+    const measureSupportedItems = measureItems.find(
+        (item) => item.measure.measureHeaderItem.localIdentifier === localIdentifier,
+    );
+
+    if (measureSupportedItems) {
+        return measureSupportedItems.attributes;
+    }
+
+    const attributeItems = supportedItemsForWidget.attributes ?? [];
+    const attributeSupportedItems = attributeItems.find(
+        (attrItem) => attrItem.attribute.attributeHeader.localIdentifier === localIdentifier,
+    );
+
+    return attributeSupportedItems?.intersectionAttributes ?? [];
 }

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/common/validateDrillToCustomUrlParams.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/common/validateDrillToCustomUrlParams.ts
@@ -1,0 +1,99 @@
+// (C) 2022 GoodData Corporation
+import {
+    areObjRefsEqual,
+    IDrillToCustomUrl,
+    IInsightWidget,
+    isDrillFromAttribute,
+    isDrillToCustomUrl,
+    widgetRef,
+} from "@gooddata/sdk-model";
+import { SagaIterator } from "redux-saga";
+import { all, call, put, SagaReturnType, select } from "redux-saga/effects";
+import { extractDisplayFormIdentifiers } from "../widgets/validation/insightDrillDefinitionUtils";
+import { uiActions } from "../../store/ui";
+import {
+    getLocalIdentifierOrDie,
+    getValidDrillOriginAttributes,
+} from "../../../_staging/drills/drillingUtils";
+import { selectDrillTargetsByWidgetRef } from "../../store/drillTargets/drillTargetsSelectors";
+import { selectAllCatalogDisplayFormsMap } from "../../store/catalog/catalogSelectors";
+
+interface IInvalidParamsInfo {
+    widget: IInsightWidget;
+    invalidDrills: IDrillToCustomUrl[];
+}
+
+export function* validateDrillToCustomUrlParams(widgets: IInsightWidget[]) {
+    const widgetsWithDrills = widgets.filter((widget) => widget.drills.length > 0);
+    if (!widgetsWithDrills.length) {
+        return;
+    }
+
+    const possibleInvalidDrills: SagaReturnType<typeof validateWidgetDrillToCustomUrlParams>[] = yield all(
+        widgetsWithDrills.map((widget) => call(validateWidgetDrillToCustomUrlParams, widget)),
+    );
+
+    const invalidDrills = possibleInvalidDrills.filter(({ invalidDrills }) => invalidDrills.length > 0);
+
+    if (invalidDrills.length === 0) {
+        yield put(uiActions.removeInvalidUrlDrillWidgetRefs(widgetsWithDrills.map(widgetRef)));
+    } else {
+        // TODO be more specific about which drills have the problem, this is useful in the warning
+        yield put(uiActions.addInvalidUrlDrillWidgetRefs(invalidDrills.map((drill) => drill.widget.ref)));
+    }
+}
+
+function* validateWidgetDrillToCustomUrlParams(widget: IInsightWidget): SagaIterator<IInvalidParamsInfo> {
+    const selectDrillTargetsByWidgetRefSelector = selectDrillTargetsByWidgetRef(widgetRef(widget));
+    const drillTargets: ReturnType<typeof selectDrillTargetsByWidgetRefSelector> = yield select(
+        selectDrillTargetsByWidgetRefSelector,
+    );
+
+    if (!drillTargets?.availableDrillTargets) {
+        // skip this part of the validation in case the drill targets are not available yet
+        return {
+            widget,
+            invalidDrills: [],
+        };
+    }
+
+    const displayForms = yield select(selectAllCatalogDisplayFormsMap);
+
+    return widget.drills.filter(isDrillToCustomUrl).reduce(
+        (acc: IInvalidParamsInfo, drillDefinition) => {
+            const ids = extractDisplayFormIdentifiers([drillDefinition]);
+
+            const hasInvalidParam = ids.some((identifier) => {
+                const displayForm = displayForms.get(identifier);
+                if (!displayForm) {
+                    // the drill as a whole is invalid, no reason to validate the parameters
+                    return false;
+                }
+
+                const attributeRef = isDrillFromAttribute(drillDefinition.origin)
+                    ? drillDefinition.origin?.attribute
+                    : drillDefinition.origin?.measure;
+
+                const localId = getLocalIdentifierOrDie(attributeRef);
+
+                const relevantAttributes = getValidDrillOriginAttributes(
+                    drillTargets.availableDrillTargets!,
+                    localId,
+                );
+
+                const isValidDrillParameter = relevantAttributes.some((attribute) =>
+                    areObjRefsEqual(displayForm.attribute, attribute.attributeHeader.formOf),
+                );
+
+                return !isValidDrillParameter;
+            });
+
+            if (hasInvalidParam) {
+                acc.invalidDrills.push(drillDefinition);
+            }
+
+            return acc;
+        },
+        { widget, invalidDrills: [] },
+    );
+}

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/common/validateDrillToCustomUrlParams.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/common/validateDrillToCustomUrlParams.ts
@@ -24,22 +24,16 @@ interface IInvalidParamsInfo {
 }
 
 export function* validateDrillToCustomUrlParams(widgets: IInsightWidget[]) {
-    const widgetsWithDrills = widgets.filter((widget) => widget.drills.length > 0);
-    if (!widgetsWithDrills.length) {
-        return;
-    }
-
     const possibleInvalidDrills: SagaReturnType<typeof validateWidgetDrillToCustomUrlParams>[] = yield all(
-        widgetsWithDrills.map((widget) => call(validateWidgetDrillToCustomUrlParams, widget)),
+        widgets.map((widget) => call(validateWidgetDrillToCustomUrlParams, widget)),
     );
 
     const invalidDrills = possibleInvalidDrills.filter(({ invalidDrills }) => invalidDrills.length > 0);
 
     if (invalidDrills.length === 0) {
-        yield put(uiActions.removeInvalidUrlDrillWidgetRefs(widgetsWithDrills.map(widgetRef)));
+        yield put(uiActions.resetInvalidCustomUrlDrillParameterWidget(widgets));
     } else {
-        // TODO be more specific about which drills have the problem, this is useful in the warning
-        yield put(uiActions.addInvalidUrlDrillWidgetRefs(invalidDrills.map((drill) => drill.widget.ref)));
+        yield put(uiActions.setInvalidCustomUrlDrillParameterWidgets(invalidDrills));
     }
 }
 

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/common/validateDrills.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/common/validateDrills.ts
@@ -34,19 +34,14 @@ export function* validateDrills(
     cmd: IDashboardCommand,
     widgets: (IKpiWidget | IInsightWidget)[],
 ) {
-    const widgetsWithDrills = widgets.filter((widget) => widget.drills.length > 0);
-    if (!widgetsWithDrills.length) {
-        return;
-    }
-
     const possibleInvalidDrills: SagaReturnType<typeof validateWidgetDrills>[] = yield all(
-        widgetsWithDrills.map((widget) => call(validateWidgetDrills, ctx, cmd, widget)),
+        widgets.map((widget) => call(validateWidgetDrills, ctx, cmd, widget)),
     );
 
     const invalidDrills = possibleInvalidDrills.filter(({ invalidDrills }) => invalidDrills.length > 0);
 
     if (invalidDrills.length === 0) {
-        yield put(uiActions.removeInvalidDrillWidgetRefs(widgetsWithDrills.map(widgetRef)));
+        yield put(uiActions.removeInvalidDrillWidgetRefs(widgets.map(widgetRef)));
     } else {
         yield all(
             invalidDrills.map((drillInfo) =>

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/common/validateDrills.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/common/validateDrills.ts
@@ -4,7 +4,6 @@ import {
     IInsightWidget,
     IKpiWidget,
     InsightDrillDefinition,
-    isDrillToCustomUrl,
     isInsightWidget,
     IWidget,
     widgetRef,
@@ -48,31 +47,16 @@ export function* validateDrills(
 
     if (invalidDrills.length === 0) {
         yield put(uiActions.removeInvalidDrillWidgetRefs(widgetsWithDrills.map(widgetRef)));
-        yield put(uiActions.removeInvalidUrlDrillWidgetRefs(widgetsWithDrills.map(widgetRef)));
-        return;
-    }
-
-    yield all(
-        invalidDrills.map((drillInfo) =>
-            isInsightWidget(drillInfo.widget)
-                ? call(removeInsightWidgetDrills, ctx, cmd, drillInfo.widget, drillInfo.invalidDrills)
-                : call(removeKpiWidgetDrill, ctx, cmd, drillInfo.widget),
-        ),
-    );
-
-    yield put(uiActions.addInvalidDrillWidgetRefs(invalidDrills.map((drill) => drill.widget.ref)));
-
-    // custom URL drills have their own extra message
-    const invalidCustomUrlDrills = invalidDrills.filter((drillInfo) =>
-        drillInfo.invalidDrills.some((drill) => isDrillToCustomUrl(drill)),
-    );
-
-    if (invalidCustomUrlDrills.length > 0) {
-        yield put(
-            uiActions.addInvalidUrlDrillWidgetRefs(invalidCustomUrlDrills.map((drill) => drill.widget.ref)),
-        );
     } else {
-        yield put(uiActions.removeInvalidUrlDrillWidgetRefs(widgetsWithDrills.map(widgetRef)));
+        yield all(
+            invalidDrills.map((drillInfo) =>
+                isInsightWidget(drillInfo.widget)
+                    ? call(removeInsightWidgetDrills, ctx, cmd, drillInfo.widget, drillInfo.invalidDrills)
+                    : call(removeKpiWidgetDrill, ctx, cmd, drillInfo.widget),
+            ),
+        );
+
+        yield put(uiActions.addInvalidDrillWidgetRefs(invalidDrills.map((drill) => drill.widget.ref)));
     }
 }
 

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/drillTargets/addDrillTargetsHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/drillTargets/addDrillTargetsHandler.ts
@@ -11,6 +11,7 @@ import { selectEnableKPIDashboardDrillFromAttribute } from "../../store/config/c
 import { availableDrillTargetsValidation } from "./validation/availableDrillTargetsValidation";
 import { validateDrills } from "../common/validateDrills";
 import { selectIsInEditMode } from "../../store/renderMode/renderModeSelectors";
+import { validateDrillToCustomUrlParams } from "../common/validateDrillToCustomUrlParams";
 
 export function* addDrillTargetsHandler(
     ctx: DashboardContext,
@@ -38,17 +39,19 @@ export function* addDrillTargetsHandler(
 
     yield put(
         drillTargetsActions.addDrillTargets({
-            identifier: identifier,
-            uri: uri,
+            identifier,
+            uri,
             ref,
             availableDrillTargets: drillTarget,
         }),
     );
 
     // in edit mode, we need to remove invalid drills in case the insight in the widget changes its drill targets
+    // and also validate drill to custom URL parameters
     const isInEditMode: ReturnType<typeof selectIsInEditMode> = yield select(selectIsInEditMode);
     if (isInEditMode) {
         yield call(validateDrills, ctx, cmd, [insightWidget]);
+        yield call(validateDrillToCustomUrlParams, [insightWidget]);
     }
 
     return drillTargetsAdded(ctx, ref, availableDrillTargets, correlationId);

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/renderMode/changeRenderModeHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/renderMode/changeRenderModeHandler.ts
@@ -10,6 +10,8 @@ import { selectDashboardEditModeDevRollout } from "../../store/config/configSele
 import { resetDashboardHandler } from "../dashboard/resetDashboardHandler";
 import { validateDrills } from "../common/validateDrills";
 import { selectAllAnalyticalWidgets } from "../../store/layout/layoutSelectors";
+import { validateDrillToCustomUrlParams } from "../common/validateDrillToCustomUrlParams";
+import { isInsightWidget } from "@gooddata/sdk-model";
 
 export function* changeRenderModeHandler(
     ctx: DashboardContext,
@@ -34,6 +36,7 @@ export function* changeRenderModeHandler(
                 selectAllAnalyticalWidgets,
             );
             yield call(validateDrills, ctx, cmd, widgets);
+            yield call(validateDrillToCustomUrlParams, widgets.filter(isInsightWidget));
         }
 
         return renderModeChanged(ctx, renderMode, correlationId);

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/removeDrillsForInsightWidgetHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/removeDrillsForInsightWidgetHandler.ts
@@ -3,13 +3,15 @@
 import { DashboardContext } from "../../types/commonTypes";
 import { RemoveDrillsForInsightWidget } from "../../commands";
 import { SagaIterator } from "redux-saga";
-import { put, select } from "redux-saga/effects";
+import { call, put, select } from "redux-saga/effects";
 import { DashboardInsightWidgetDrillsRemoved, insightWidgetDrillsRemoved } from "../../events/insight";
-import { selectWidgetsMap } from "../../store/layout/layoutSelectors";
+import { selectWidgetByRef, selectWidgetsMap } from "../../store/layout/layoutSelectors";
 import { validateExistingInsightWidget } from "./validation/widgetValidations";
 import { validateRemoveDrillsByOrigins } from "./validation/removeDrillsSelectorValidation";
 import { layoutActions } from "../../store/layout";
 import { existsDrillDefinitionInArray } from "./validation/insightDrillDefinitionUtils";
+import { validateDrillToCustomUrlParams } from "../common/validateDrillToCustomUrlParams";
+import { validateDrills } from "../common/validateDrills";
 
 export function* removeDrillsForInsightWidgetHandler(
     ctx: DashboardContext,
@@ -39,6 +41,11 @@ export function* removeDrillsForInsightWidgetHandler(
             },
         }),
     );
+
+    // need to select the update widget to validate it by its new value
+    const updatedWidget = yield select(selectWidgetByRef(widgetRef));
+    yield call(validateDrills, ctx, cmd, [updatedWidget]);
+    yield call(validateDrillToCustomUrlParams, [updatedWidget]);
 
     return insightWidgetDrillsRemoved(ctx, widgetRef, drillsToRemove, correlationId);
 }

--- a/libs/sdk-ui-dashboard/src/model/store/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/index.ts
@@ -219,7 +219,7 @@ export {
     selectIsExecutionResultReadyForExportByRef,
 } from "./executionResults/executionResultsSelectors";
 export { IExecutionResultEnvelope } from "./executionResults/types";
-export { UiState } from "./ui/uiState";
+export { UiState, InvalidCustomUrlDrillParameterInfo } from "./ui/uiState";
 export {
     selectIsScheduleEmailDialogOpen,
     selectIsScheduleEmailManagementDialogOpen,
@@ -249,7 +249,8 @@ export {
     selectWidgetsModification,
     selectSectionModification,
     selectInvalidDrillWidgetRefs,
-    selectInvalidUrlDrillWidgetRefs,
+    selectInvalidUrlDrillParameterDrillLocalIdsByWidgetRef,
+    selectInvalidUrlDrillParameterWidgetRefs,
 } from "./ui/uiSelectors";
 export { uiActions } from "./ui";
 export { RenderModeState } from "./renderMode/renderModeState";

--- a/libs/sdk-ui-dashboard/src/model/store/ui/uiSelectors.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/ui/uiSelectors.ts
@@ -8,6 +8,8 @@ import { selectWidgetsMap } from "../layout/layoutSelectors";
 import { DashboardState } from "../types";
 import { createMemoizedSelector } from "../_infra/selectors";
 import { IDashboardWidgetOverlay } from "../../types/commonTypes";
+import { ObjRefMap } from "../../../_staging/metadata/objRefMap";
+import { InvalidCustomUrlDrillParameterInfo } from "./uiState";
 
 const selectSelf = createSelector(
     (state: DashboardState) => state,
@@ -231,12 +233,39 @@ export const selectInvalidDrillWidgetRefs = createSelector(
     (state) => state.drillValidationMessages.invalidDrillWidgetRefs,
 );
 
+const selectInvalidCustomUrlDrillParameterWidgets = createSelector(
+    selectSelf,
+    (state) => state.drillValidationMessages.invalidCustomUrlDrillParameterWidgets,
+);
+
 /**
  * @internal
  */
-export const selectInvalidUrlDrillWidgetRefs = createSelector(
-    selectSelf,
-    (state) => state.drillValidationMessages.invalidUrlDrillWidgetRefs,
+export const selectInvalidUrlDrillParameterWidgetRefs = createSelector(
+    selectInvalidCustomUrlDrillParameterWidgets,
+    (invalidCustomUrlDrillParameterWidgets) => invalidCustomUrlDrillParameterWidgets.map((i) => i.widgetRef),
+);
+
+const selectInvalidUrlDrillParameterWidgetsMap = createSelector(
+    selectInvalidCustomUrlDrillParameterWidgets,
+    (invalidCustomUrlDrillParameterWidgets) =>
+        new ObjRefMap<InvalidCustomUrlDrillParameterInfo>({
+            idExtract: (i) => i.widgetId,
+            refExtract: (i) => i.widgetRef,
+            uriExtract: (i) => i.widgetUri,
+            strictTypeCheck: false,
+        }).fromItems(invalidCustomUrlDrillParameterWidgets),
+);
+
+/**
+ * @internal
+ */
+export const selectInvalidUrlDrillParameterDrillLocalIdsByWidgetRef = createMemoizedSelector((ref: ObjRef) =>
+    createSelector(
+        selectInvalidUrlDrillParameterWidgetsMap,
+        (invalidParameterWidgetsMap) =>
+            invalidParameterWidgetsMap.get(ref)?.drillsWithInvalidParametersLocalIds ?? [],
+    ),
 );
 
 /**

--- a/libs/sdk-ui-dashboard/src/model/store/ui/uiState.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/ui/uiState.ts
@@ -1,9 +1,19 @@
 // (C) 2021-2022 GoodData Corporation
-import { ObjRef } from "@gooddata/sdk-model";
+import { ObjRef, Identifier, Uri } from "@gooddata/sdk-model";
 
 import { ILayoutCoordinates, IMenuButtonItemsVisibility } from "../../../types";
 import { DraggableLayoutItem } from "../../../presentation/dragAndDrop/types";
 import { IDashboardWidgetOverlay } from "../../types/commonTypes";
+
+/**
+ * @alpha
+ */
+export interface InvalidCustomUrlDrillParameterInfo {
+    widgetId: Identifier;
+    widgetUri: Uri;
+    widgetRef: ObjRef;
+    drillsWithInvalidParametersLocalIds: string[];
+}
 
 /**
  * @alpha
@@ -54,7 +64,7 @@ export interface UiState {
     activeSectionIndex: number | undefined;
     drillValidationMessages: {
         invalidDrillWidgetRefs: ObjRef[];
-        invalidUrlDrillWidgetRefs: ObjRef[];
+        invalidCustomUrlDrillParameterWidgets: InvalidCustomUrlDrillParameterInfo[];
     };
     draggingWidgetSource: DraggableLayoutItem | undefined;
     draggingWidgetTarget: ILayoutCoordinates | undefined;
@@ -104,7 +114,7 @@ export const uiInitialState: UiState = {
     activeSectionIndex: undefined,
     drillValidationMessages: {
         invalidDrillWidgetRefs: [],
-        invalidUrlDrillWidgetRefs: [],
+        invalidCustomUrlDrillParameterWidgets: [],
     },
     draggingWidgetSource: undefined,
     draggingWidgetTarget: undefined,

--- a/libs/sdk-ui-dashboard/src/presentation/dashboard/components/DrillValidationToastMessages.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/dashboard/components/DrillValidationToastMessages.tsx
@@ -5,7 +5,7 @@ import { Messages, IMessage } from "@gooddata/sdk-ui-kit";
 import compact from "lodash/compact";
 import {
     selectInvalidDrillWidgetRefs,
-    selectInvalidUrlDrillWidgetRefs,
+    selectInvalidUrlDrillParameterWidgetRefs,
     selectIsInEditMode,
     selectWidgetsMap,
     uiActions,
@@ -37,7 +37,7 @@ function useDrillValidationMessages(): { messages: IMessage[]; onMessageClose: (
 
     const allWidgets = useDashboardSelector(selectWidgetsMap);
     const invalidDrillWidgetRefs = useDashboardSelector(selectInvalidDrillWidgetRefs);
-    const invalidUrlDrillWidgetRefs = useDashboardSelector(selectInvalidUrlDrillWidgetRefs);
+    const invalidUrlDrillWidgetRefs = useDashboardSelector(selectInvalidUrlDrillParameterWidgetRefs);
 
     const invalidDrillWidgets = compact(
         invalidDrillWidgetRefs.map((ref) => allWidgets.get(ref)).filter(isWidget),
@@ -77,7 +77,7 @@ function useDrillValidationMessages(): { messages: IMessage[]; onMessageClose: (
                 dispatch(uiActions.resetInvalidDrillWidgetRefs());
             }
             if (id === URL_DRILL_MESSAGE_ID) {
-                dispatch(uiActions.resetInvalidUrlDrillWidgetRefs());
+                dispatch(uiActions.resetAllInvalidCustomUrlDrillParameterWidgets());
             }
         },
         [dispatch],

--- a/libs/sdk-ui-dashboard/src/presentation/localization/bundles/de-DE.json
+++ b/libs/sdk-ui-dashboard/src/presentation/localization/bundles/de-DE.json
@@ -292,6 +292,7 @@
     "configurationPanel.drillConfig.drillIntoDashboard": "Dashboard verfeinern",
     "configurationPanel.drillConfig.drillIntoInsight": "Betrachtung verfeinern",
     "configurationPanel.drillConfig.drillIntoUrl": "URL-Ansicht verfeinern",
+    "configurationPanel.drillConfig.drillIntoUrl.invalidCustomUrl": "Ungültige URL-Parameter",
     "configurationPanel.drillConfig.select": "Befehl auswählen…",
     "configurationPanel.drillConfig.drillIntoDashboard.dateFilterWarning": "Der Datumsattributwert aus der Betrachtung wird nicht übertragen, um das Ziel-Dashboard zu filtern.",
     "configurationPanel.unlistedDashboardTab": "Nicht aufgeführtes Dashboard",

--- a/libs/sdk-ui-dashboard/src/presentation/localization/bundles/en-US.json
+++ b/libs/sdk-ui-dashboard/src/presentation/localization/bundles/en-US.json
@@ -1620,6 +1620,11 @@
         "comment": "Name of an option in dropdown that is used to select type of dashboard drill.",
         "limit": 0
     },
+    "configurationPanel.drillConfig.drillIntoUrl.invalidCustomUrl": {
+        "value": "Invalid URL parameters",
+        "comment": "Warning displayed in drill config when drill into URL has invalid parameters of custom URL.",
+        "limit": 0
+    },
     "configurationPanel.drillConfig.select": {
         "value": "Choose action…",
         "comment": "Hint guiding users that drill actions in select box has to be selected. Use '…' as one character, not 3 dots ('...').",

--- a/libs/sdk-ui-dashboard/src/presentation/localization/bundles/es-ES.json
+++ b/libs/sdk-ui-dashboard/src/presentation/localization/bundles/es-ES.json
@@ -292,6 +292,7 @@
     "configurationPanel.drillConfig.drillIntoDashboard": "Explorar hasta el panel",
     "configurationPanel.drillConfig.drillIntoInsight": "Explorar hasta la perspectiva",
     "configurationPanel.drillConfig.drillIntoUrl": "Explorar hasta la URL",
+    "configurationPanel.drillConfig.drillIntoUrl.invalidCustomUrl": "Parámetros de URL no válidos",
     "configurationPanel.drillConfig.select": "Elija una acción…",
     "configurationPanel.drillConfig.drillIntoDashboard.dateFilterWarning": "El valor del atributo de fecha de la perspectiva no se transferirá para filtrar el panel de destino.",
     "configurationPanel.unlistedDashboardTab": "Panel no listado",

--- a/libs/sdk-ui-dashboard/src/presentation/localization/bundles/fr-FR.json
+++ b/libs/sdk-ui-dashboard/src/presentation/localization/bundles/fr-FR.json
@@ -292,6 +292,7 @@
     "configurationPanel.drillConfig.drillIntoDashboard": "Explorer le tableau de bord",
     "configurationPanel.drillConfig.drillIntoInsight": "Explorer la perception",
     "configurationPanel.drillConfig.drillIntoUrl": "Explorer l'URL",
+    "configurationPanel.drillConfig.drillIntoUrl.invalidCustomUrl": "Paramètres URL non valides",
     "configurationPanel.drillConfig.select": "Choisir une action…",
     "configurationPanel.drillConfig.drillIntoDashboard.dateFilterWarning": "La valeur de l'attribut date de la perception ne sera pas transférée pour filtrer le tableau de bord cible.",
     "configurationPanel.unlistedDashboardTab": "Tableau de bord non répertorié",

--- a/libs/sdk-ui-dashboard/src/presentation/localization/bundles/ja-JP.json
+++ b/libs/sdk-ui-dashboard/src/presentation/localization/bundles/ja-JP.json
@@ -292,6 +292,7 @@
     "configurationPanel.drillConfig.drillIntoDashboard": "ダッシュボードにドリル",
     "configurationPanel.drillConfig.drillIntoInsight": "インサイトにドリル",
     "configurationPanel.drillConfig.drillIntoUrl": "URL にドリル",
+    "configurationPanel.drillConfig.drillIntoUrl.invalidCustomUrl": "無効な URL パラメーター",
     "configurationPanel.drillConfig.select": "アクションを選択…",
     "configurationPanel.drillConfig.drillIntoDashboard.dateFilterWarning": "インサイトの日付アトリビュート値は、ターゲットダッシュボードをフィルタリングするために転送されません。",
     "configurationPanel.unlistedDashboardTab": "リストにないダッシュボード",

--- a/libs/sdk-ui-dashboard/src/presentation/localization/bundles/nl-NL.json
+++ b/libs/sdk-ui-dashboard/src/presentation/localization/bundles/nl-NL.json
@@ -292,6 +292,7 @@
     "configurationPanel.drillConfig.drillIntoDashboard": "Drill in dashboard",
     "configurationPanel.drillConfig.drillIntoInsight": "Inzoomen op inzicht",
     "configurationPanel.drillConfig.drillIntoUrl": "Inzoomen op URL",
+    "configurationPanel.drillConfig.drillIntoUrl.invalidCustomUrl": "Ongeldige URL-parameters",
     "configurationPanel.drillConfig.select": "Actie kiezen…",
     "configurationPanel.drillConfig.drillIntoDashboard.dateFilterWarning": "De datum-attribuutwaarde van het inzicht wordt niet overgedragen om het doel-dashboard te filteren.",
     "configurationPanel.unlistedDashboardTab": "Niet-vermeld dashboard",

--- a/libs/sdk-ui-dashboard/src/presentation/localization/bundles/pt-BR.json
+++ b/libs/sdk-ui-dashboard/src/presentation/localization/bundles/pt-BR.json
@@ -292,6 +292,7 @@
     "configurationPanel.drillConfig.drillIntoDashboard": "Detalhar painel",
     "configurationPanel.drillConfig.drillIntoInsight": "Detalhar insight",
     "configurationPanel.drillConfig.drillIntoUrl": "Detalhar URL",
+    "configurationPanel.drillConfig.drillIntoUrl.invalidCustomUrl": "Parâmetros inválidos da URL",
     "configurationPanel.drillConfig.select": "Escolher ação…",
     "configurationPanel.drillConfig.drillIntoDashboard.dateFilterWarning": "O valor do atributo de data do insight não será transferido para filtrar o painel de destino.",
     "configurationPanel.unlistedDashboardTab": "Painel não listado",

--- a/libs/sdk-ui-dashboard/src/presentation/localization/bundles/pt-PT.json
+++ b/libs/sdk-ui-dashboard/src/presentation/localization/bundles/pt-PT.json
@@ -292,6 +292,7 @@
     "configurationPanel.drillConfig.drillIntoDashboard": "Exploração aprofundada do dashboard",
     "configurationPanel.drillConfig.drillIntoInsight": "Aprofundar insight",
     "configurationPanel.drillConfig.drillIntoUrl": "Aprofundar URL",
+    "configurationPanel.drillConfig.drillIntoUrl.invalidCustomUrl": "Parâmetros de URL inválidos",
     "configurationPanel.drillConfig.select": "Escolher ação…",
     "configurationPanel.drillConfig.drillIntoDashboard.dateFilterWarning": "O valor do atributo de data do insight não será transferido para filtrar o dashboard de destino.",
     "configurationPanel.unlistedDashboardTab": "Dashboard não listado",

--- a/libs/sdk-ui-dashboard/src/presentation/localization/bundles/ru-RU.json
+++ b/libs/sdk-ui-dashboard/src/presentation/localization/bundles/ru-RU.json
@@ -292,6 +292,7 @@
     "configurationPanel.drillConfig.drillIntoDashboard": "Углубиться в дашборд",
     "configurationPanel.drillConfig.drillIntoInsight": "Углубиться в анализ",
     "configurationPanel.drillConfig.drillIntoUrl": "Углубиться в URL",
+    "configurationPanel.drillConfig.drillIntoUrl.invalidCustomUrl": "Неверные параметры URL",
     "configurationPanel.drillConfig.select": "Выбрать действие…",
     "configurationPanel.drillConfig.drillIntoDashboard.dateFilterWarning": "Значение атрибута даты из анализа не будет передано для фильтрации целевого дашборда.",
     "configurationPanel.unlistedDashboardTab": "Дашборд вне списка",

--- a/libs/sdk-ui-dashboard/src/presentation/localization/bundles/zh-Hans.json
+++ b/libs/sdk-ui-dashboard/src/presentation/localization/bundles/zh-Hans.json
@@ -292,6 +292,7 @@
     "configurationPanel.drillConfig.drillIntoDashboard": "深入控制面板",
     "configurationPanel.drillConfig.drillIntoInsight": "深入了解",
     "configurationPanel.drillConfig.drillIntoUrl": "深入查看 URL",
+    "configurationPanel.drillConfig.drillIntoUrl.invalidCustomUrl": "URL 参数无效",
     "configurationPanel.drillConfig.select": "选择操作…",
     "configurationPanel.drillConfig.drillIntoDashboard.dateFilterWarning": "筛选目标控制面板时，洞察中的日期属性值不会被传输。",
     "configurationPanel.unlistedDashboardTab": "未列出的控制面板",

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/configuration/InsightDrillConfigItem.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/configuration/InsightDrillConfigItem.tsx
@@ -97,7 +97,7 @@ const DrillConfigItem: React.FunctionComponent<IDrillConfigItemProps> = ({
                     <DrillTargets item={item} onSetup={onSetup} />
                     {!!item.warning && (
                         <div className="drill-config-target-warning s-drill-config-target-warning">
-                            <span className="icon-warning" />
+                            <span className="gd-icon-warning" />
                             <span>
                                 <FormattedMessage id={item.warning} />
                             </span>

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/configuration/InsightDrillConfigPanel.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/configuration/InsightDrillConfigPanel.tsx
@@ -8,6 +8,7 @@ import {
     modifyDrillsForInsightWidget,
     removeDrillsForInsightWidget,
     selectDrillTargetsByWidgetRef,
+    selectInvalidUrlDrillParameterDrillLocalIdsByWidgetRef,
     selectSettings,
     selectWidgetByRef,
     useDashboardDispatch,
@@ -139,11 +140,18 @@ export const InsightDrillConfigPanel: React.FunctionComponent<IDrillConfigPanelP
 
     const configItems = useDashboardSelector(selectDrillTargetsByWidgetRef(widgetRef));
     const widget = useDashboardSelector(selectWidgetByRef(widgetRef));
-
     invariant(isInsightWidget(widget), "must be insight widget");
 
+    const invalidCustomUrlDrillLocalIds = useDashboardSelector(
+        selectInvalidUrlDrillParameterDrillLocalIdsByWidgetRef(widgetRef),
+    );
+
     const drillItems = configItems?.availableDrillTargets
-        ? getMappedConfigForWidget(widget.drills, configItems?.availableDrillTargets)
+        ? getMappedConfigForWidget(
+              widget.drills,
+              configItems?.availableDrillTargets,
+              invalidCustomUrlDrillLocalIds,
+          )
         : [];
 
     const dispatch = useDashboardDispatch();


### PR DESCRIPTION
Validation of Custom URL parameters needs to happen differently: invalid parameters is not grounds for removing the drill.

Also:
* indicate the wrong interaction on the UI
* re-validate the drills when drills change or are removed to hide the warnings once the are no longer relevant

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
