### PR TITLE
RELATED: RAIL-4734 fix drill validation on tiger

### DIFF
--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/validation/insightDrillDefinitionUtils.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/validation/insightDrillDefinitionUtils.ts
@@ -102,9 +102,7 @@ export function extractDisplayFormIdentifiers(drillDefinitions: InsightDrillDefi
             .map((drillItem) => {
                 if (isDrillToCustomUrl(drillItem)) {
                     const params = getAttributeIdentifiersPlaceholdersFromUrl(drillItem.target.url);
-                    return params.map((param) => {
-                        return idRef(param.identifier);
-                    });
+                    return params.map((param) => idRef(param.identifier, "displayForm"));
                 } else {
                     return [drillItem.target.displayForm, drillItem.target.hyperlinkDisplayForm];
                 }


### PR DESCRIPTION
We need to explicitly pass the id type so that even when strict ids are in effect, we can use the objRefMaps correctly.

JIRA: RAIL-4734

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
