### PR TITLE
RELATED: RAIL-4737 prevent saving dashboard with only custom widgets

### DIFF
--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -6059,6 +6059,9 @@ itemIndex: number;
 export const selectLayout: OutputSelector<DashboardState, IDashboardLayout<ExtendedDashboardWidget>, (res: LayoutState) => IDashboardLayout<ExtendedDashboardWidget>>;
 
 // @alpha
+export const selectLayoutHasAnalyticalWidgets: OutputSelector<DashboardState, boolean, (res: IWidget[]) => boolean>;
+
+// @alpha
 export const selectLegacyDashboards: OutputSelector<DashboardState, ILegacyDashboard[], (res: LegacyDashboardsState) => ILegacyDashboard[]>;
 
 // @alpha
@@ -7009,7 +7012,7 @@ export const useDashboardUserInteraction: () => {
 };
 
 // @internal (undocumented)
-export const useDefaultMenuItems: () => IMenuButtonItem[];
+export function useDefaultMenuItems(): IMenuButtonItem[];
 
 // @public
 export const useDispatchDashboardCommand: <TCommand extends DashboardCommands, TArgs extends any[]>(commandCreator: (...args: TArgs) => TCommand) => (...args: TArgs) => void;

--- a/libs/sdk-ui-dashboard/src/model/store/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/index.ts
@@ -129,6 +129,7 @@ export {
     selectAllKpiWidgets,
     selectAllAnalyticalWidgets,
     selectIsLayoutEmpty,
+    selectLayoutHasAnalyticalWidgets,
     selectWidgetDrills,
     selectWidgetCoordinatesByRef,
     selectWidgetPlaceholder,

--- a/libs/sdk-ui-dashboard/src/model/store/layout/layoutSelectors.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/layout/layoutSelectors.ts
@@ -249,6 +249,18 @@ export const selectAllAnalyticalWidgets = createSelector(selectAllWidgets, (allW
     return allWidgets.filter((w): w is IKpiWidget | IInsightWidget => !isCustomWidget(w));
 });
 
+/**
+ * Selects a boolean indicating if the dashboard contains at least one non-custom widget.
+ *
+ * @alpha
+ */
+export const selectLayoutHasAnalyticalWidgets = createSelector(
+    selectAllAnalyticalWidgets,
+    (allAnalyticalWidgets) => {
+        return allAnalyticalWidgets.length > 0;
+    },
+);
+
 function getWidgetCoordinates(layout: IDashboardLayout<ExtendedDashboardWidget>, ref: ObjRef) {
     for (let sectionIndex = 0; sectionIndex < layout.sections.length; sectionIndex++) {
         const section = layout.sections[sectionIndex];

--- a/libs/sdk-ui-dashboard/src/presentation/topBar/buttonBar/button/saveButton/DefaultSaveButton.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/topBar/buttonBar/button/saveButton/DefaultSaveButton.tsx
@@ -12,11 +12,11 @@ import {
     selectEnableAnalyticalDashboardPermissions,
     selectIsDashboardDirty,
     selectIsDashboardSaving,
-    selectIsLayoutEmpty,
     selectIsInEditMode,
     useDashboardDispatch,
     useDashboardSelector,
     selectDashboardTitle,
+    selectLayoutHasAnalyticalWidgets,
 } from "../../../../../model";
 import { messages } from "../../../../../locales";
 import { selectCanSaveDashboard, selectIsPrivateDashboard } from "../selectors";
@@ -48,7 +48,7 @@ export function useSaveButtonProps(): ISaveButtonProps {
     const isSaving = useDashboardSelector(selectIsDashboardSaving);
     const arePermissionsEnabled = useDashboardSelector(selectEnableAnalyticalDashboardPermissions);
     const isPrivateDashboard = useDashboardSelector(selectIsPrivateDashboard);
-    const isEmptyDashboard = useDashboardSelector(selectIsLayoutEmpty);
+    const isEmptyDashboard = !useDashboardSelector(selectLayoutHasAnalyticalWidgets); // we need at least one non-custom widget there
     const canSaveDashboard = useDashboardSelector(selectCanSaveDashboard);
     const isDashboardDirty = useDashboardSelector(selectIsDashboardDirty);
 

--- a/libs/sdk-ui-dashboard/src/presentation/topBar/menuButton/useDefaultMenuItems.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/topBar/menuButton/useDefaultMenuItems.tsx
@@ -11,10 +11,10 @@ import {
     selectEnableKPIDashboardExportPDF,
     selectIsInEditMode,
     selectIsInViewMode,
-    selectIsLayoutEmpty,
     selectIsNewDashboard,
     selectIsReadOnly,
     selectIsSaveAsNewButtonHidden,
+    selectLayoutHasAnalyticalWidgets,
     selectMenuButtonItemsVisibility,
     uiActions,
     useDashboardCommandProcessing,
@@ -29,16 +29,16 @@ import { messages } from "../../../locales";
 /**
  * @internal
  */
-export const useDefaultMenuItems = function (): IMenuButtonItem[] {
+export function useDefaultMenuItems(): IMenuButtonItem[] {
     const intl = useIntl();
     const isNewDashboard = useDashboardSelector(selectIsNewDashboard);
-    const isEmptyLayout = useDashboardSelector(selectIsLayoutEmpty);
+    const isEmptyLayout = !useDashboardSelector(selectLayoutHasAnalyticalWidgets); // we need at least one non-custom widget there
     const { addSuccess, addError, addProgress, removeMessage } = useToastMessage();
     const { isScheduledEmailingVisible, defaultOnScheduleEmailing } = useDashboardScheduledEmails();
 
     const dispatch = useDashboardDispatch();
-    const openSaveAsDialog = () => dispatch(uiActions.openSaveAsDialog());
-    const openDeleteDialog = () => dispatch(uiActions.openDeleteDialog());
+    const openSaveAsDialog = useCallback(() => dispatch(uiActions.openSaveAsDialog()), [dispatch]);
+    const openDeleteDialog = useCallback(() => dispatch(uiActions.openDeleteDialog()), [dispatch]);
 
     const lastExportMessageId = useRef("");
     const { run: exportDashboard } = useDashboardCommandProcessing({
@@ -78,7 +78,7 @@ export const useDefaultMenuItems = function (): IMenuButtonItem[] {
         }
 
         openSaveAsDialog();
-    }, [isNewDashboard]);
+    }, [isNewDashboard, openSaveAsDialog]);
 
     const defaultOnExportToPdf = useCallback(() => {
         if (isNewDashboard) {
@@ -158,14 +158,23 @@ export const useDefaultMenuItems = function (): IMenuButtonItem[] {
             },
         ];
     }, [
-        defaultOnScheduleEmailing,
+        canCreateDashboard,
+        canExport,
         defaultOnExportToPdf,
+        defaultOnSaveAs,
+        defaultOnScheduleEmailing,
+        intl,
         isEmptyLayout,
+        isInEditMode,
+        isInViewMode,
+        isKPIDashboardExportPDFEnabled,
         isNewDashboard,
         isReadOnly,
-        menuButtonItemsVisibility,
-        canExport,
-        isKPIDashboardExportPDFEnabled,
+        isSaveAsNewHidden,
         isScheduledEmailingVisible,
+        menuButtonItemsVisibility.deleteButton,
+        menuButtonItemsVisibility.pdfExportButton,
+        menuButtonItemsVisibility.saveAsNewButton,
+        openDeleteDialog,
     ]);
-};
+}


### PR DESCRIPTION
This would open a loophole allowing users to save dashboards with empty layout which we do not allow for dashboards without plugins.

Both Save and Save as buttons were handled by the change.

Also fixed the useMemo dependencies in `useDefaultMenuItems` and improved the memoization there.

JIRA: RAIL-4737

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
