### PR TITLE
RELATED: RAIL-4738 fix dashboard cancel with plugin reload

### DIFF
--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/common/stateInitializers.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/common/stateInitializers.ts
@@ -178,6 +178,7 @@ export function* actionsToInitializeExistingDashboard(
         metaActions.setMeta({
             dashboard: persistedDashboard ?? dashboard,
         }),
+        insightsActions.setInsights(insights),
         metaActions.setDashboardTitle(dashboard.title), // even when using persistedDashboard, use the working title of the dashboard
         uiActions.clearWidgetSelection(),
         uiActions.setWidgetsOverlay(modifiedWidgets),

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/initializeDashboardHandler/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/initializeDashboardHandler/index.ts
@@ -3,7 +3,6 @@ import { SagaIterator } from "redux-saga";
 import { all, call, put, SagaReturnType } from "redux-saga/effects";
 import { InitializeDashboard } from "../../../commands/dashboard";
 import { DashboardInitialized, dashboardInitialized } from "../../../events/dashboard";
-import { insightsActions } from "../../../store/insights";
 import { loadingActions } from "../../../store/loading";
 import { DashboardContext, PrivateDashboardContext } from "../../../types/commonTypes";
 import { IDashboardWithReferences, walkLayout } from "@gooddata/sdk-backend-spi";
@@ -201,7 +200,6 @@ function* loadExistingDashboard(
             }),
             ...initActions,
             alertsActions.setAlerts(alerts),
-            insightsActions.setInsights(insights),
             dateFilterConfigActions.setDateFilterConfig({
                 dateFilterConfig: dashboard.dateFilterConfig,
                 effectiveDateFilterConfig: effectiveDateFilterConfig.config,


### PR DESCRIPTION
Plugin reload can cause the insights collection to be missing some insights that were on the original dashboard. So when cancelling, we need to make sure that we have all the insights needed for the dashboard state we are resetting to.

The resolution uses the caches so for 99% of the cases it should be instantaneous.

JIRA: RAIL-4738

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
