### PR TITLE
RELATED: RAIL-4735 do not show Save as button in readonly mode

### DIFF
--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -6020,7 +6020,7 @@ export const selectIsSaveAsDialogOpen: OutputSelector<DashboardState, boolean, (
 export const selectIsSaveAsNewButtonHidden: OutputSelector<DashboardState, boolean, (res: ResolvedDashboardConfig) => boolean>;
 
 // @internal (undocumented)
-export const selectIsSaveAsNewButtonVisible: OutputSelector<DashboardState, boolean, (res1: boolean, res2: boolean, res3: boolean, res4: boolean, res5: boolean, res6: boolean) => boolean>;
+export const selectIsSaveAsNewButtonVisible: OutputSelector<DashboardState, boolean, (res1: boolean, res2: boolean, res3: boolean, res4: boolean, res5: boolean, res6: boolean, res7: boolean) => boolean>;
 
 // @alpha (undocumented)
 export const selectIsScheduleEmailDialogOpen: OutputSelector<DashboardState, boolean, (res: UiState) => boolean>;

--- a/libs/sdk-ui-dashboard/src/presentation/topBar/buttonBar/button/saveAsButton/DefaultSaveAsNewButton.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/topBar/buttonBar/button/saveAsButton/DefaultSaveAsNewButton.tsx
@@ -12,6 +12,7 @@ import {
     uiActions,
     useDashboardDispatch,
     useDashboardSelector,
+    selectIsReadOnly,
 } from "../../../../../model";
 import { ISaveAsNewButtonProps } from "./types";
 import { selectCanEnterEditModeAndIsLoaded } from "../selectors";
@@ -27,6 +28,7 @@ export const selectIsSaveAsNewButtonVisible = createSelector(
     selectCanEnterEditModeAndIsLoaded,
     selectCanCreateAnalyticalDashboard,
     selectIsExport,
+    selectIsReadOnly,
     (
         isEditModeDevRollout,
         isSaveAsNewEnabled,
@@ -34,6 +36,7 @@ export const selectIsSaveAsNewButtonVisible = createSelector(
         isDashboardEditable,
         canCreateDashboard,
         isExport,
+        isReadOnly,
     ) => {
         /*
          * The reasoning behind this condition is as follows. Do not show separate Save As button if:
@@ -46,6 +49,7 @@ export const selectIsSaveAsNewButtonVisible = createSelector(
          *     it is somewhat more hidden
          * 4.  dashboard is not in export mode
          * 5.  If the user cannot create dashboards - e.g. does not have permissions to do so (is viewer for example).
+         * 6.  If the dashboard is in read-only mode.
          */
         return (
             isEditModeDevRollout &&
@@ -53,7 +57,8 @@ export const selectIsSaveAsNewButtonVisible = createSelector(
             !isSaveAsButtonHidden &&
             !isDashboardEditable &&
             !isExport &&
-            canCreateDashboard
+            canCreateDashboard &&
+            !isReadOnly
         );
     },
 );

--- a/libs/sdk-ui-dashboard/src/presentation/topBar/menuButton/useDefaultMenuItems.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/topBar/menuButton/useDefaultMenuItems.tsx
@@ -132,7 +132,9 @@ export function useDefaultMenuItems(): IMenuButtonItem[] {
             {
                 type: "separator",
                 itemId: "save-as-separator",
-                visible: isSaveAsVisible,
+                // show the separator if at least one item of the two groups is visible as well
+                visible:
+                    isSaveAsVisible && (isPdfExportVisible || isScheduledEmailingVisible || isDeleteVisible),
             },
             {
                 type: "button",


### PR DESCRIPTION
Also prevent redundant separator in the menuButton menu (on tiger view mode neither of the export, schedule email and delete buttons is visible).

JIRA: RAIL-4735

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
