### PR TITLE
BUGFIX: RAIL-4739 React contexts in plugins

### DIFF
--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -716,7 +716,7 @@ export type ConfigurableWidget<TWidget> = {
 };
 
 // @internal (undocumented)
-export function CreatableAttributeFilter(): JSX.Element;
+export function CreatableAttributeFilter(props: ICreatePanelItemComponentProps): JSX.Element;
 
 // @internal
 export type CreatableByDragComponent = DraggableComponent & {
@@ -2471,17 +2471,6 @@ export type DraggableContentItemType = "attributeFilter" | "attributeFilter-plac
 export const DraggableCreatePanelItem: React_2.FC<IDraggableCreatePanelItemProps>;
 
 // @internal (undocumented)
-export type DraggableCreatePanelItemInnerProps = {
-    Component: CustomCreatePanelItemComponent;
-    dragItem: DraggableItem;
-    hideDefaultPreview?: boolean;
-    disabled?: boolean;
-    canDrag: boolean;
-    onDragStart?: (item: DraggableItem) => void;
-    onDragEnd?: (didDrop: boolean) => void;
-};
-
-// @internal (undocumented)
 export type DraggableInternalItem = HeightResizerDragItem | WidthResizerDragItem;
 
 // @internal (undocumented)
@@ -3031,6 +3020,8 @@ export interface IConnectingAttribute {
 export interface ICreatePanelItemComponentProps {
     // (undocumented)
     disabled?: boolean;
+    // (undocumented)
+    WrapCreatePanelItemWithDragComponent?: IWrapCreatePanelItemWithDragComponent;
 }
 
 // @alpha (undocumented)
@@ -3551,7 +3542,13 @@ export interface IDefaultDashboardToolbarGroupProps {
 }
 
 // @internal (undocumented)
-export type IDraggableCreatePanelItemProps = Pick<DraggableCreatePanelItemInnerProps, "Component" | "dragItem" | "disabled" | "hideDefaultPreview">;
+export type IDraggableCreatePanelItemProps = {
+    Component: CustomCreatePanelItemComponent;
+    WrapCreatePanelItemWithDragComponent?: IWrapCreatePanelItemWithDragComponent;
+    dragItem: DraggableItem;
+    hideDefaultPreview?: boolean;
+    disabled?: boolean;
+};
 
 // @alpha
 export interface IDrillDownContext {
@@ -3697,6 +3694,8 @@ export interface IInsightListProps {
     selectedRef?: ObjRef;
     // (undocumented)
     width?: number;
+    // (undocumented)
+    WrapInsightListItemWithDragComponent?: IWrapInsightListItemWithDragComponent;
 }
 
 // @alpha (undocumented)
@@ -4435,8 +4434,20 @@ export interface ISharingProperties {
 
 // @alpha (undocumented)
 export interface ISidebarProps {
+    // @internal
+    AttributeFilterComponentSet?: AttributeFilterComponentSet;
     configurationPanelClassName?: string;
     DefaultSidebar: ComponentType<ISidebarProps>;
+    // @internal
+    DeleteDropZoneComponent?: React.ComponentType;
+    // @internal
+    InsightWidgetComponentSet?: InsightWidgetComponentSet;
+    // @internal
+    KpiWidgetComponentSet?: KpiWidgetComponentSet;
+    // @internal
+    WrapCreatePanelItemWithDragComponent?: IWrapCreatePanelItemWithDragComponent;
+    // @internal
+    WrapInsightListItemWithDragComponent?: IWrapInsightListItemWithDragComponent;
 }
 
 // @internal
@@ -4525,6 +4536,39 @@ export interface IUseWidgetSelectionResult {
     isSelectable: boolean;
     isSelected: boolean;
     onSelected: (e?: MouseEvent_2) => void;
+}
+
+// @internal (undocumented)
+export type IWrapCreatePanelItemWithDragComponent = React.ComponentType<IWrapCreatePanelItemWithDragProps>;
+
+// @internal (undocumented)
+export type IWrapCreatePanelItemWithDragInnerProps = {
+    children: JSX.Element;
+    dragItem: DraggableItem;
+    hideDefaultPreview?: boolean;
+    disabled?: boolean;
+    canDrag: boolean;
+    onDragStart?: (item: DraggableItem) => void;
+    onDragEnd?: (didDrop: boolean) => void;
+};
+
+// @internal (undocumented)
+export type IWrapCreatePanelItemWithDragProps = {
+    children: JSX.Element;
+    dragItem: DraggableItem;
+    hideDefaultPreview?: boolean;
+    disabled?: boolean;
+};
+
+// @internal (undocumented)
+export type IWrapInsightListItemWithDragComponent = React.ComponentType<IWrapInsightListItemWithDragProps>;
+
+// @internal (undocumented)
+export interface IWrapInsightListItemWithDragProps {
+    // (undocumented)
+    children: JSX.Element;
+    // (undocumented)
+    insight: IInsight;
 }
 
 // @alpha (undocumented)
@@ -7016,9 +7060,6 @@ export function useDefaultMenuItems(): IMenuButtonItem[];
 
 // @public
 export const useDispatchDashboardCommand: <TCommand extends DashboardCommands, TArgs extends any[]>(commandCreator: (...args: TArgs) => TCommand) => (...args: TArgs) => void;
-
-// @internal (undocumented)
-export function useDraggableCreatePanelItemProps(props: IDraggableCreatePanelItemProps): DraggableCreatePanelItemInnerProps;
 
 // @internal (undocumented)
 export const useDrill: ({ onSuccess, onError, onBeforeRun }?: UseDrillProps) => {

--- a/libs/sdk-ui-dashboard/src/presentation/componentDefinition/types.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/componentDefinition/types.ts
@@ -9,6 +9,7 @@ import {
     AttributeFilterDraggableItem,
     CustomDraggableItem,
     DraggableContentItemType,
+    IWrapCreatePanelItemWithDragComponent,
     InsightDraggableItem,
     KpiDraggableItem,
 } from "../dragAndDrop/types";
@@ -158,6 +159,8 @@ export type DropTarget = {
  * @internal
  */
 export interface ICreatePanelItemComponentProps {
+    WrapCreatePanelItemWithDragComponent?: IWrapCreatePanelItemWithDragComponent;
+
     disabled?: boolean;
 }
 

--- a/libs/sdk-ui-dashboard/src/presentation/dashboard/DashboardSidebar/CreationPanel.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/dashboard/DashboardSidebar/CreationPanel.tsx
@@ -13,20 +13,35 @@ import {
     selectIsNewDashboard,
     selectSettings,
 } from "../../../model";
-import { useDashboardComponentsContext } from "../../dashboardContexts";
 import cx from "classnames";
+import {
+    IWrapCreatePanelItemWithDragComponent,
+    IWrapInsightListItemWithDragComponent,
+} from "../../dragAndDrop/types";
+import {
+    AttributeFilterComponentSet,
+    InsightWidgetComponentSet,
+    KpiWidgetComponentSet,
+} from "../../componentDefinition";
+
 interface ICreationPanelProps {
     className?: string;
+    WrapCreatePanelItemWithDragComponent?: IWrapCreatePanelItemWithDragComponent;
+    WrapInsightListItemWithDragComponent?: IWrapInsightListItemWithDragComponent;
+    KpiWidgetComponentSet?: KpiWidgetComponentSet;
+    AttributeFilterComponentSet?: AttributeFilterComponentSet;
+    InsightWidgetComponentSet?: InsightWidgetComponentSet;
 }
 
-export const CreationPanel: React.FC<ICreationPanelProps> = ({ className }) => {
+export const CreationPanel: React.FC<ICreationPanelProps> = (props) => {
+    const { className, WrapCreatePanelItemWithDragComponent, WrapInsightListItemWithDragComponent } = props;
     const supportsKpis = useDashboardSelector(selectSupportsKpiWidgetCapability);
     const isAnalyticalDesignerEnabled = useDashboardSelector(selectIsAnalyticalDesignerEnabled);
     const isNewDashboard = useDashboardSelector(selectIsNewDashboard);
     const settings = useDashboardSelector(selectSettings);
-
-    const { KpiWidgetComponentSet, AttributeFilterComponentSet, InsightWidgetComponentSet } =
-        useDashboardComponentsContext();
+    const KpiWidgetComponentSet = props.KpiWidgetComponentSet!;
+    const AttributeFilterComponentSet = props.AttributeFilterComponentSet!;
+    const InsightWidgetComponentSet = props.InsightWidgetComponentSet!;
 
     const addItemPanelItems = useMemo(() => {
         const items = compact([
@@ -35,9 +50,14 @@ export const CreationPanel: React.FC<ICreationPanelProps> = ({ className }) => {
             InsightWidgetComponentSet.creating,
         ]);
 
-        return sortBy(items, (item) => item.priority ?? 0).map(({ CreatePanelListItemComponent, type }) => (
-            <CreatePanelListItemComponent key={type} />
-        ));
+        return sortBy(items, (item) => item.priority ?? 0).map(({ CreatePanelListItemComponent, type }) => {
+            return (
+                <CreatePanelListItemComponent
+                    key={type}
+                    WrapCreatePanelItemWithDragComponent={WrapCreatePanelItemWithDragComponent}
+                />
+            );
+        });
     }, [AttributeFilterComponentSet, KpiWidgetComponentSet, InsightWidgetComponentSet, supportsKpis]);
 
     return (
@@ -58,6 +78,7 @@ export const CreationPanel: React.FC<ICreationPanelProps> = ({ className }) => {
                             <FormattedMessage id="visualizationsList.savedVisualizations" />
                         </Typography>
                         <DraggableInsightList
+                            WrapInsightListItemWithDragComponent={WrapInsightListItemWithDragComponent}
                             recalculateSizeReference={className}
                             searchAutofocus={!isNewDashboard}
                             enableDescriptions={settings?.enableDescriptions}

--- a/libs/sdk-ui-dashboard/src/presentation/dashboard/DashboardSidebar/DashboardSidebar.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/dashboard/DashboardSidebar/DashboardSidebar.tsx
@@ -1,10 +1,31 @@
 // (C) 2022 GoodData Corporation
 import React from "react";
 import { useDashboardComponentsContext } from "../../dashboardContexts";
+
 import { ISidebarProps } from "./types";
 
 export const DashboardSidebar = (props: ISidebarProps): JSX.Element => {
-    const { SidebarComponent } = useDashboardComponentsContext();
+    const {
+        WrapCreatePanelItemWithDragComponent,
+        WrapInsightListItemWithDragComponent,
+        DeleteDropZoneComponent,
+    } = props;
+    const {
+        SidebarComponent,
+        KpiWidgetComponentSet,
+        AttributeFilterComponentSet,
+        InsightWidgetComponentSet,
+    } = useDashboardComponentsContext();
 
-    return <SidebarComponent {...props} />;
+    return (
+        <SidebarComponent
+            {...props}
+            KpiWidgetComponentSet={KpiWidgetComponentSet}
+            AttributeFilterComponentSet={AttributeFilterComponentSet}
+            InsightWidgetComponentSet={InsightWidgetComponentSet}
+            WrapCreatePanelItemWithDragComponent={WrapCreatePanelItemWithDragComponent}
+            WrapInsightListItemWithDragComponent={WrapInsightListItemWithDragComponent}
+            DeleteDropZoneComponent={DeleteDropZoneComponent}
+        />
+    );
 };

--- a/libs/sdk-ui-dashboard/src/presentation/dashboard/DashboardSidebar/DraggableInsightList/DraggableInsightList.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/dashboard/DashboardSidebar/DraggableInsightList/DraggableInsightList.tsx
@@ -3,15 +3,22 @@ import React, { useEffect, useRef } from "react";
 import { FlexDimensions } from "@gooddata/sdk-ui-kit";
 
 import { DraggableInsightListCore } from "./DraggableInsightListCore";
+import { IWrapInsightListItemWithDragComponent } from "../../../dragAndDrop/types";
 
 interface IDraggableInsightListProps {
+    WrapInsightListItemWithDragComponent?: IWrapInsightListItemWithDragComponent;
     recalculateSizeReference?: string;
     searchAutofocus?: boolean;
     enableDescriptions?: boolean;
 }
 
 export const DraggableInsightList: React.FC<IDraggableInsightListProps> = (props) => {
-    const { recalculateSizeReference, searchAutofocus, enableDescriptions } = props;
+    const {
+        recalculateSizeReference,
+        searchAutofocus,
+        enableDescriptions,
+        WrapInsightListItemWithDragComponent,
+    } = props;
 
     const flexRef = useRef<FlexDimensions>(null);
 
@@ -28,6 +35,7 @@ export const DraggableInsightList: React.FC<IDraggableInsightListProps> = (props
                 className="visualizations-flex-dimensions"
             >
                 <DraggableInsightListCore
+                    WrapInsightListItemWithDragComponent={WrapInsightListItemWithDragComponent}
                     searchAutofocus={searchAutofocus}
                     enableDescriptions={enableDescriptions}
                 />

--- a/libs/sdk-ui-dashboard/src/presentation/dashboard/DashboardSidebar/DraggableInsightList/DraggableInsightListCore.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/dashboard/DashboardSidebar/DraggableInsightList/DraggableInsightListCore.tsx
@@ -15,7 +15,7 @@ import { VisType } from "@gooddata/sdk-ui";
 import { useDashboardUserInteraction, DescriptionTooltipOpenedData } from "./../../../../model";
 
 export const DraggableInsightListCore: React.FC<IInsightListProps> = (props) => {
-    const { enableDescriptions, ...remainingProps } = props;
+    const { enableDescriptions, WrapInsightListItemWithDragComponent, ...remainingProps } = props;
     const userInteraction = useDashboardUserInteraction();
 
     return (
@@ -44,6 +44,7 @@ export const DraggableInsightListCore: React.FC<IInsightListProps> = (props) => 
 
                 return (
                     <DraggableInsightListItemWrapper
+                        WrapInsightListItemWithDragComponent={WrapInsightListItemWithDragComponent}
                         title={insightTitle(insight)}
                         description={description}
                         showDescriptionPanel={enableDescriptions}

--- a/libs/sdk-ui-dashboard/src/presentation/dashboard/DashboardSidebar/DraggableInsightList/DraggableInsightListItemWrapper.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/dashboard/DashboardSidebar/DraggableInsightList/DraggableInsightListItemWrapper.tsx
@@ -3,9 +3,13 @@ import React from "react";
 import { IInsightListItemProps, InsightListItem } from "@gooddata/sdk-ui-kit";
 import { IInsight } from "@gooddata/sdk-model";
 import { DraggableInsightListItem } from "../../../dragAndDrop/draggableWidget/DraggableInsightListItem";
-import { CustomDashboardInsightListItemComponent } from "../../../dragAndDrop/types";
+import {
+    CustomDashboardInsightListItemComponent,
+    IWrapInsightListItemWithDragComponent,
+} from "../../../dragAndDrop/types";
 
 interface IDraggableInsightListItemWrapperProps extends IInsightListItemProps {
+    WrapInsightListItemWithDragComponent?: IWrapInsightListItemWithDragComponent;
     className?: string;
     insight: IInsight;
 }
@@ -21,6 +25,7 @@ export const DraggableInsightListItemBody: CustomDashboardInsightListItemCompone
 
 export const DraggableInsightListItemWrapper: React.FC<IDraggableInsightListItemWrapperProps> = (props) => {
     const {
+        WrapInsightListItemWithDragComponent,
         className,
         isLocked,
         title,
@@ -33,6 +38,7 @@ export const DraggableInsightListItemWrapper: React.FC<IDraggableInsightListItem
     } = props;
     return (
         <DraggableInsightListItem
+            WrapInsightListItemWithDragComponent={WrapInsightListItemWithDragComponent}
             ListItemComponent={DraggableInsightListItemBody}
             listItemComponentProps={{
                 className,

--- a/libs/sdk-ui-dashboard/src/presentation/dashboard/DashboardSidebar/SidebarConfigurationPanel.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/dashboard/DashboardSidebar/SidebarConfigurationPanel.tsx
@@ -1,6 +1,5 @@
 // (C) 2022 GoodData Corporation
 import React from "react";
-import { DeleteDropZone } from "../../dragAndDrop";
 import { useWidgetSelection } from "../../../model";
 import { CreationPanel } from "./CreationPanel";
 import { ISidebarProps } from "./types";
@@ -8,16 +7,33 @@ import { ISidebarProps } from "./types";
 /**
  * @internal
  */
-export const SidebarConfigurationPanel: React.FC<Omit<ISidebarProps, "DefaultSidebar">> = ({
-    configurationPanelClassName,
-}): JSX.Element => {
+export const SidebarConfigurationPanel: React.FC<Omit<ISidebarProps, "DefaultSidebar">> = (
+    props,
+): JSX.Element => {
+    const {
+        configurationPanelClassName,
+        WrapCreatePanelItemWithDragComponent,
+        WrapInsightListItemWithDragComponent,
+        KpiWidgetComponentSet,
+        AttributeFilterComponentSet,
+        InsightWidgetComponentSet,
+    } = props;
     const { deselectWidgets } = useWidgetSelection();
+    const DeleteDropZoneComponent = props.DeleteDropZoneComponent!;
+
     return (
         <div className="col gd-flex-item gd-sidebar-container" onClick={deselectWidgets}>
             <div className="flex-panel-full-height">
-                <CreationPanel className={configurationPanelClassName} />
+                <CreationPanel
+                    className={configurationPanelClassName}
+                    WrapCreatePanelItemWithDragComponent={WrapCreatePanelItemWithDragComponent}
+                    WrapInsightListItemWithDragComponent={WrapInsightListItemWithDragComponent}
+                    KpiWidgetComponentSet={KpiWidgetComponentSet}
+                    AttributeFilterComponentSet={AttributeFilterComponentSet}
+                    InsightWidgetComponentSet={InsightWidgetComponentSet}
+                />
             </div>
-            <DeleteDropZone />
+            <DeleteDropZoneComponent />
         </div>
     );
 };

--- a/libs/sdk-ui-dashboard/src/presentation/dashboard/DashboardSidebar/types.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/dashboard/DashboardSidebar/types.ts
@@ -1,5 +1,14 @@
 // (C) 2021-2022 GoodData Corporation
 import { ComponentType } from "react";
+import {
+    AttributeFilterComponentSet,
+    InsightWidgetComponentSet,
+    KpiWidgetComponentSet,
+} from "../../componentDefinition";
+import {
+    IWrapCreatePanelItemWithDragComponent,
+    IWrapInsightListItemWithDragComponent,
+} from "../../dragAndDrop/types";
 
 /**
  * @alpha
@@ -15,6 +24,54 @@ export interface ISidebarProps {
      * Specify className for configurationPanel.
      */
     configurationPanelClassName?: string;
+
+    /**
+     * Component, that adds dnd functionality to a create panel item.
+     * Do not set or override this property, it's injected by the Dashboard.
+     *
+     * @internal
+     */
+    WrapCreatePanelItemWithDragComponent?: IWrapCreatePanelItemWithDragComponent;
+
+    /**
+     * Component, that adds dnd functionality to a insight list item.
+     * Do not set or override this property, it's injected by the Dashboard.
+     *
+     * @internal
+     */
+    WrapInsightListItemWithDragComponent?: IWrapInsightListItemWithDragComponent;
+
+    /**
+     * Kpi widget component set.
+     * Do not set or override this property, it's injected by the Dashboard.
+     *
+     * @internal
+     */
+    KpiWidgetComponentSet?: KpiWidgetComponentSet;
+
+    /**
+     * Attribute filter component set.
+     * Do not set or override this property, it's injected by the Dashboard.
+     *
+     * @internal
+     */
+    AttributeFilterComponentSet?: AttributeFilterComponentSet;
+
+    /**
+     * Insight widget component set.
+     * Do not set or override this property, it's injected by the Dashboard.
+     *
+     * @internal
+     */
+    InsightWidgetComponentSet?: InsightWidgetComponentSet;
+
+    /**
+     * Component, that renders delete drop zone.
+     * Do not set or override this property, it's injected by the Dashboard.
+     *
+     * @internal
+     */
+    DeleteDropZoneComponent?: React.ComponentType;
 }
 
 /**

--- a/libs/sdk-ui-dashboard/src/presentation/dashboard/components/DashboardInner.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/dashboard/components/DashboardInner.tsx
@@ -8,7 +8,13 @@ import { IDashboardProps } from "../types";
 import { DashboardMainContent } from "./DashboardMainContent";
 import { DashboardSidebar } from "../DashboardSidebar/DashboardSidebar";
 import { RenderModeAwareDashboardSidebar } from "../DashboardSidebar/RenderModeAwareDashboardSidebar";
-import { DragLayerComponent, useDashboardDragScroll } from "../../dragAndDrop";
+import {
+    DragLayerComponent,
+    useDashboardDragScroll,
+    DeleteDropZone,
+    WrapCreatePanelItemWithDrag,
+    WrapInsightListItemWithDrag,
+} from "../../dragAndDrop";
 import { Toolbar } from "../../toolbar";
 import { OverlayController, OverlayControllerProvider } from "@gooddata/sdk-ui-kit";
 import { DASHBOARD_HEADER_OVERLAYS_Z_INDEX } from "../../constants";
@@ -35,7 +41,12 @@ export const DashboardInner: React.FC<IDashboardProps> = () => {
             >
                 <DragLayerComponent />
                 <div className="gd-dashboards-root gd-flex-container">
-                    <DashboardSidebar DefaultSidebar={RenderModeAwareDashboardSidebar} />
+                    <DashboardSidebar
+                        DefaultSidebar={RenderModeAwareDashboardSidebar}
+                        DeleteDropZoneComponent={DeleteDropZone}
+                        WrapCreatePanelItemWithDragComponent={WrapCreatePanelItemWithDrag}
+                        WrapInsightListItemWithDragComponent={WrapInsightListItemWithDrag}
+                    />
                     <div className="gd-dash-content">
                         {/* gd-dash-header-wrapper-sdk-8-12 style is added because we should keep old styles unchanged to not brake plugins */}
                         <div

--- a/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/DraggableCreatePanelItem.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/DraggableCreatePanelItem.tsx
@@ -1,90 +1,29 @@
 // (C) 2022 GoodData Corporation
 import React from "react";
-import cx from "classnames";
-
-import { useDashboardDrag } from "./useDashboardDrag";
-import { DraggableItem } from "./types";
 import { CustomCreatePanelItemComponent } from "../componentDefinition";
-import { selectIsInEditMode, useDashboardSelector } from "../../model";
-import { useWidgetDragEndHandler } from "./draggableWidget/useWidgetDragEndHandler";
+import { DraggableItem, IWrapCreatePanelItemWithDragComponent } from "./types";
 
 /**
  * @internal
  */
-export type DraggableCreatePanelItemInnerProps = {
+export type IDraggableCreatePanelItemProps = {
     Component: CustomCreatePanelItemComponent;
+    WrapCreatePanelItemWithDragComponent?: IWrapCreatePanelItemWithDragComponent;
     dragItem: DraggableItem;
     hideDefaultPreview?: boolean;
     disabled?: boolean;
-    canDrag: boolean;
-    onDragStart?: (item: DraggableItem) => void;
-    onDragEnd?: (didDrop: boolean) => void;
 };
-
-/**
- * @internal
- */
-export type IDraggableCreatePanelItemProps = Pick<
-    DraggableCreatePanelItemInnerProps,
-    "Component" | "dragItem" | "disabled" | "hideDefaultPreview"
->;
-
-/**
- * @internal
- */
-export function useDraggableCreatePanelItemProps(
-    props: IDraggableCreatePanelItemProps,
-): DraggableCreatePanelItemInnerProps {
-    const isInEditMode = useDashboardSelector(selectIsInEditMode);
-
-    const onDragEnd = useWidgetDragEndHandler();
-
-    const canDrag = isInEditMode && !props.disabled;
-
-    return {
-        ...props,
-        canDrag,
-        onDragEnd,
-    };
-}
 
 /**
  * @internal
  */
 export const DraggableCreatePanelItem: React.FC<IDraggableCreatePanelItemProps> = (props) => {
-    const draggableCreatePanelItemProps = useDraggableCreatePanelItemProps(props);
-
-    return <DraggableCreatePanelItemInner {...draggableCreatePanelItemProps} />;
-};
-
-/**
- * @internal
- */
-export const DraggableCreatePanelItemInner: React.FC<DraggableCreatePanelItemInnerProps> = ({
-    Component,
-    dragItem,
-    disabled,
-    hideDefaultPreview,
-    canDrag,
-    onDragStart,
-    onDragEnd,
-}) => {
-    const [{ isDragging }, dragRef] = useDashboardDrag(
-        {
-            dragItem,
-            canDrag,
-            hideDefaultPreview,
-            dragEnd: (_, monitor) => {
-                onDragEnd?.(monitor.didDrop());
-            },
-            dragStart: onDragStart,
-        },
-        [canDrag, onDragEnd, hideDefaultPreview, dragItem],
-    );
+    const { Component, disabled } = props;
+    const WrapCreatePanelItemWithDragComponent = props.WrapCreatePanelItemWithDragComponent!;
 
     return (
-        <div ref={dragRef} className={cx({ "is-dragging": isDragging })}>
+        <WrapCreatePanelItemWithDragComponent {...props}>
             <Component disabled={disabled} />
-        </div>
+        </WrapCreatePanelItemWithDragComponent>
     );
 };

--- a/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/WrapCreatePanelItemWithDrag.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/WrapCreatePanelItemWithDrag.tsx
@@ -1,0 +1,53 @@
+// (C) 2022 GoodData Corporation
+import React from "react";
+import cx from "classnames";
+
+import { useDashboardDrag } from "./useDashboardDrag";
+import { useWidgetDragEndHandler } from "./draggableWidget";
+import { selectIsInEditMode, useDashboardSelector } from "../../model";
+import { IWrapCreatePanelItemWithDragInnerProps, IWrapCreatePanelItemWithDragProps } from "./types";
+
+/**
+ * @internal
+ */
+export const WrapCreatePanelItemWithDrag: React.FC<IWrapCreatePanelItemWithDragProps> = (props) => {
+    const { canDrag, dragItem, hideDefaultPreview, onDragEnd, onDragStart, children } =
+        useWrapCreatePanelItemWithDrag(props);
+
+    const [{ isDragging }, dragRef] = useDashboardDrag(
+        {
+            dragItem,
+            canDrag,
+            hideDefaultPreview,
+            dragEnd: (_, monitor) => {
+                onDragEnd?.(monitor.didDrop());
+            },
+            dragStart: onDragStart,
+        },
+        [canDrag, onDragEnd, hideDefaultPreview, dragItem],
+    );
+
+    return (
+        <div ref={dragRef} className={cx({ "is-dragging": isDragging })}>
+            {children}
+        </div>
+    );
+};
+
+/**
+ * @internal
+ */
+export function useWrapCreatePanelItemWithDrag(
+    props: IWrapCreatePanelItemWithDragProps,
+): IWrapCreatePanelItemWithDragInnerProps {
+    const isInEditMode = useDashboardSelector(selectIsInEditMode);
+    const onDragEnd = useWidgetDragEndHandler();
+
+    const canDrag = isInEditMode && !props.disabled;
+
+    return {
+        ...props,
+        canDrag,
+        onDragEnd,
+    };
+}

--- a/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/WrapInsightListItemWithDrag.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/WrapInsightListItemWithDrag.tsx
@@ -1,0 +1,47 @@
+// (C) 2022 GoodData Corporation
+import React from "react";
+import classNames from "classnames";
+
+import { useDashboardSelector, selectIsInEditMode, selectSettings } from "../../model";
+import { useDashboardDrag } from "./useDashboardDrag";
+import { useWidgetDragEndHandler } from "./draggableWidget/useWidgetDragEndHandler";
+import { getSizeInfo } from "../../_staging/layout/sizing";
+import { INSIGHT_WIDGET_SIZE_INFO_DEFAULT } from "@gooddata/sdk-ui-ext";
+import { IWrapInsightListItemWithDragProps } from "./types";
+
+/**
+ * @internal
+ */
+export function WrapInsightListItemWithDrag({ children, insight }: IWrapInsightListItemWithDragProps) {
+    const isInEditMode = useDashboardSelector(selectIsInEditMode);
+    const settings = useDashboardSelector(selectSettings);
+
+    const handleDragEnd = useWidgetDragEndHandler();
+
+    const [{ isDragging }, dragRef] = useDashboardDrag(
+        {
+            dragItem: () => {
+                const sizeInfo = getSizeInfo(settings, "insight", insight);
+                return {
+                    type: "insightListItem",
+                    insight,
+                    size: {
+                        gridHeight:
+                            sizeInfo.height.default || INSIGHT_WIDGET_SIZE_INFO_DEFAULT.height.default,
+                        gridWidth: sizeInfo.width.default || INSIGHT_WIDGET_SIZE_INFO_DEFAULT.width.default,
+                    },
+                };
+            },
+            canDrag: isInEditMode,
+            hideDefaultPreview: false,
+            dragEnd: handleDragEnd,
+        },
+        [isInEditMode, insight, handleDragEnd],
+    );
+
+    return (
+        <div className={classNames({ "is-dragging": isDragging })} ref={dragRef}>
+            {children}
+        </div>
+    );
+}

--- a/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableAttributeFilter/DraggableAttributeFilterCreatePanelItem.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableAttributeFilter/DraggableAttributeFilterCreatePanelItem.tsx
@@ -1,7 +1,7 @@
 // (C) 2022 GoodData Corporation
 import React from "react";
 
-import { DraggableItem } from "../types";
+import { IWrapCreatePanelItemWithDragComponent, DraggableItem } from "../types";
 import { DraggableCreatePanelItem } from "../DraggableCreatePanelItem";
 import { CustomCreatePanelItemComponent } from "../../componentDefinition";
 
@@ -10,6 +10,7 @@ import { CustomCreatePanelItemComponent } from "../../componentDefinition";
  */
 export interface IDraggableAttributeFilterCreatePanelItemProps {
     CreatePanelItemComponent: CustomCreatePanelItemComponent;
+    WrapCreatePanelItemWithDragComponent?: IWrapCreatePanelItemWithDragComponent;
     disabled?: boolean;
 }
 
@@ -22,10 +23,11 @@ const dragItem: DraggableItem = {
  */
 export const DraggableAttributeFilterCreatePanelItem: React.FC<
     IDraggableAttributeFilterCreatePanelItemProps
-> = ({ CreatePanelItemComponent, disabled }) => {
+> = ({ CreatePanelItemComponent, WrapCreatePanelItemWithDragComponent, disabled }) => {
     return (
         <DraggableCreatePanelItem
             Component={CreatePanelItemComponent}
+            WrapCreatePanelItemWithDragComponent={WrapCreatePanelItemWithDragComponent}
             dragItem={dragItem}
             disabled={disabled}
             hideDefaultPreview={false}

--- a/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/DraggableInsightListItem.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/DraggableInsightListItem.tsx
@@ -1,22 +1,18 @@
 // (C) 2022 GoodData Corporation
 import React from "react";
-import classNames from "classnames";
 import { IInsight } from "@gooddata/sdk-model";
 
-import { useDashboardSelector, selectIsInEditMode, selectSettings } from "../../../model";
-import { useDashboardDrag } from "../useDashboardDrag";
 import {
     CustomDashboardInsightListItemComponent,
     CustomDashboardInsightListItemComponentProps,
+    IWrapInsightListItemWithDragComponent,
 } from "../types";
-import { useWidgetDragEndHandler } from "./useWidgetDragEndHandler";
-import { getSizeInfo } from "../../../_staging/layout/sizing";
-import { INSIGHT_WIDGET_SIZE_INFO_DEFAULT } from "@gooddata/sdk-ui-ext";
 
 /**
  * @internal
  */
 export interface IDraggableInsightListItemProps {
+    WrapInsightListItemWithDragComponent?: IWrapInsightListItemWithDragComponent;
     ListItemComponent: CustomDashboardInsightListItemComponent;
     listItemComponentProps: CustomDashboardInsightListItemComponentProps;
     insight: IInsight;
@@ -25,40 +21,13 @@ export interface IDraggableInsightListItemProps {
 /**
  * @internal
  */
-export function DraggableInsightListItem({
-    ListItemComponent,
-    listItemComponentProps,
-    insight,
-}: IDraggableInsightListItemProps) {
-    const isInEditMode = useDashboardSelector(selectIsInEditMode);
-    const settings = useDashboardSelector(selectSettings);
-
-    const handleDragEnd = useWidgetDragEndHandler();
-
-    const [{ isDragging }, dragRef] = useDashboardDrag(
-        {
-            dragItem: () => {
-                const sizeInfo = getSizeInfo(settings, "insight", insight);
-                return {
-                    type: "insightListItem",
-                    insight,
-                    size: {
-                        gridHeight:
-                            sizeInfo.height.default || INSIGHT_WIDGET_SIZE_INFO_DEFAULT.height.default,
-                        gridWidth: sizeInfo.width.default || INSIGHT_WIDGET_SIZE_INFO_DEFAULT.width.default,
-                    },
-                };
-            },
-            canDrag: isInEditMode,
-            hideDefaultPreview: false,
-            dragEnd: handleDragEnd,
-        },
-        [isInEditMode, insight, handleDragEnd],
-    );
+export function DraggableInsightListItem(props: IDraggableInsightListItemProps) {
+    const { ListItemComponent, listItemComponentProps, insight } = props;
+    const WrapInsightListItemWithDragComponent = props.WrapInsightListItemWithDragComponent!;
 
     return (
-        <div className={classNames({ "is-dragging": isDragging })} ref={dragRef}>
+        <WrapInsightListItemWithDragComponent insight={insight}>
             <ListItemComponent {...listItemComponentProps} />
-        </div>
+        </WrapInsightListItemWithDragComponent>
     );
 }

--- a/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/DraggableKpiCreatePanelItem.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/DraggableKpiCreatePanelItem.tsx
@@ -4,10 +4,14 @@ import React from "react";
 import { KPI_WIDGET_SIZE_INFO_DEFAULT } from "@gooddata/sdk-ui-ext";
 import { CustomCreatePanelItemComponent } from "../../componentDefinition";
 import { DraggableCreatePanelItem } from "../DraggableCreatePanelItem";
-import { DraggableItem } from "../types";
+import { DraggableItem, IWrapCreatePanelItemWithDragComponent } from "../types";
 
+/**
+ * @internal
+ */
 interface IDraggableKpiCreatePanelItemProps {
     CreatePanelItemComponent: CustomCreatePanelItemComponent;
+    WrapCreatePanelItemWithDragComponent?: IWrapCreatePanelItemWithDragComponent;
     disabled?: boolean;
 }
 
@@ -19,13 +23,18 @@ const dragItem: DraggableItem = {
     },
 };
 
+/**
+ * @internal
+ */
 export const DraggableKpiCreatePanelItem: React.FC<IDraggableKpiCreatePanelItemProps> = ({
     CreatePanelItemComponent,
+    WrapCreatePanelItemWithDragComponent,
     disabled,
 }) => {
     return (
         <DraggableCreatePanelItem
             Component={CreatePanelItemComponent}
+            WrapCreatePanelItemWithDragComponent={WrapCreatePanelItemWithDragComponent}
             disabled={disabled}
             dragItem={dragItem}
             hideDefaultPreview={false}

--- a/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/index.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/index.ts
@@ -14,3 +14,5 @@ export * from "./Resize/HeightResizerHotspot";
 export * from "./Resize/WidthResizerHotspot";
 export * from "./Resize/ResizeOverlay";
 export * from "./Resize/BulletsBar/BulletsBar";
+export * from "./WrapCreatePanelItemWithDrag";
+export * from "./WrapInsightListItemWithDrag";

--- a/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/types.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/types.ts
@@ -294,3 +294,44 @@ export type CustomDashboardInsightListItemComponentProps = {
  */
 export type CustomDashboardInsightListItemComponent =
     React.ComponentType<CustomDashboardInsightListItemComponentProps>;
+
+/**
+ * @internal
+ */
+export type IWrapCreatePanelItemWithDragProps = {
+    children: JSX.Element;
+    dragItem: DraggableItem;
+    hideDefaultPreview?: boolean;
+    disabled?: boolean;
+};
+
+/**
+ * @internal
+ */
+export type IWrapCreatePanelItemWithDragInnerProps = {
+    children: JSX.Element;
+    dragItem: DraggableItem;
+    hideDefaultPreview?: boolean;
+    disabled?: boolean;
+    canDrag: boolean;
+    onDragStart?: (item: DraggableItem) => void;
+    onDragEnd?: (didDrop: boolean) => void;
+};
+
+/**
+ * @internal
+ */
+export type IWrapCreatePanelItemWithDragComponent = React.ComponentType<IWrapCreatePanelItemWithDragProps>;
+
+/**
+ * @internal
+ */
+export interface IWrapInsightListItemWithDragProps {
+    children: JSX.Element;
+    insight: IInsight;
+}
+
+/**
+ * @internal
+ */
+export type IWrapInsightListItemWithDragComponent = React.ComponentType<IWrapInsightListItemWithDragProps>;

--- a/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/CreatableAttributeFilter.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/CreatableAttributeFilter.tsx
@@ -10,11 +10,13 @@ import {
     selectIsWhiteLabeled,
     selectCanAddMoreAttributeFilters,
 } from "../../../model";
+import { ICreatePanelItemComponentProps } from "../../componentDefinition";
 
 /**
  * @internal
  */
-export function CreatableAttributeFilter() {
+export function CreatableAttributeFilter(props: ICreatePanelItemComponentProps) {
+    const { WrapCreatePanelItemWithDragComponent } = props;
     const hasAttributes = useDashboardSelector(selectHasCatalogAttributes);
     const canAddMoreAttributeFilters = useDashboardSelector(selectCanAddMoreAttributeFilters);
     const isWhiteLabeled = useDashboardSelector(selectIsWhiteLabeled);
@@ -43,6 +45,7 @@ export function CreatableAttributeFilter() {
         <BubbleHoverTrigger eventsOnBubble={true} className="s-add-attribute-filter-bubble-trigger">
             <DraggableAttributeFilterCreatePanelItem
                 CreatePanelItemComponent={AddAttributeFilterPlaceholder}
+                WrapCreatePanelItemWithDragComponent={WrapCreatePanelItemWithDragComponent}
                 disabled={disabled}
             />
 

--- a/libs/sdk-ui-dashboard/src/presentation/index.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/index.ts
@@ -8,8 +8,6 @@ export * from "./dragAndDrop/types";
 export {
     DraggableCreatePanelItem,
     IDraggableCreatePanelItemProps,
-    DraggableCreatePanelItemInnerProps,
-    useDraggableCreatePanelItemProps,
     useWidgetDragEndHandler,
 } from "./dragAndDrop";
 export * from "./drill";

--- a/libs/sdk-ui-dashboard/src/presentation/insightList/types.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/insightList/types.ts
@@ -1,11 +1,13 @@
 // (C) 2022 GoodData Corporation
 import { IInsight, ObjRef } from "@gooddata/sdk-model";
 import { IRenderListItemProps } from "@gooddata/sdk-ui-kit";
+import { IWrapInsightListItemWithDragComponent } from "../dragAndDrop/types";
 
 /**
  * @internal
  */
 export interface IInsightListProps {
+    WrapInsightListItemWithDragComponent?: IWrapInsightListItemWithDragComponent;
     height?: number;
     width?: number;
     searchAutofocus?: boolean;

--- a/libs/sdk-ui-dashboard/src/presentation/widget/kpi/CreatableKpi.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/kpi/CreatableKpi.tsx
@@ -4,13 +4,15 @@ import { Bubble, BubbleHoverTrigger, IAlignPoint } from "@gooddata/sdk-ui-kit";
 import { FormattedMessage } from "react-intl";
 import { useDashboardSelector, selectHasCatalogMeasures, selectIsWhiteLabeled } from "../../../model";
 import { AddKpiWidgetButton, DraggableKpiCreatePanelItem } from "../../dragAndDrop";
+import { ICreatePanelItemComponentProps } from "../../componentDefinition";
 
 const bubbleAlignPoints: IAlignPoint[] = [{ align: "cr cl", offset: { x: -20, y: 0 } }];
 
 /**
  * @internal
  */
-export const CreatableKpi: React.FC = () => {
+export const CreatableKpi: React.FC<ICreatePanelItemComponentProps> = (props) => {
+    const { WrapCreatePanelItemWithDragComponent } = props;
     const hasMeasures = useDashboardSelector(selectHasCatalogMeasures);
     const isWhiteLabeled = useDashboardSelector(selectIsWhiteLabeled);
 
@@ -34,7 +36,11 @@ export const CreatableKpi: React.FC = () => {
 
     return (
         <BubbleHoverTrigger eventsOnBubble={true} className="s-add-kpi-bubble-trigger">
-            <DraggableKpiCreatePanelItem CreatePanelItemComponent={AddKpiWidgetButton} disabled={disabled} />
+            <DraggableKpiCreatePanelItem
+                CreatePanelItemComponent={AddKpiWidgetButton}
+                WrapCreatePanelItemWithDragComponent={WrapCreatePanelItemWithDragComponent}
+                disabled={disabled}
+            />
             {tooltip ? <Bubble alignPoints={bubbleAlignPoints}>{tooltip}</Bubble> : null}
         </BubbleHoverTrigger>
     );


### PR DESCRIPTION
- There is a dashboard package, that is bundled with KD.
- There is a dashboard package, that is bundled with plugins.
- In KD, it's necessary to customize/override particular default dashboard components and it's importing the default components from the package, that is bundled with KD.
- This was causing issues with React contexts, because components, imported in KD have an access to the React context bundled with KD only, but they need an access to the React context bundled with plugin.
- Now all components that access the React context are passed through props so they all come from the same package. Either from the one that comes with the KD or the one that comes with the plugin.
- Problematic were react-dnd and dashboard components context.

JIRA: RAIL-4739

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
