### PR TITLE
RELATED: RAIL-4736 minor style fixes

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/dashboardDropdownBody/configuration/AttributeFilterConfiguration.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/dashboardDropdownBody/configuration/AttributeFilterConfiguration.tsx
@@ -87,7 +87,7 @@ export const AttributeFilterConfiguration: React.FC<IAttributeFilterConfiguratio
     }
 
     return (
-        <div className="s-attribute-filter-dropdown-configuration attribute-filter-dropdown-configuration">
+        <div className="s-attribute-filter-dropdown-configuration attribute-filter-dropdown-configuration sdk-edit-mode-on">
             <ConfigurationPanelHeader />
             {isDependentFiltersEnabled && parents.length > 0 ? (
                 <ConfigurationCategory categoryTitle={filterByText} />

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insightMenu/DefaultDashboardInsightMenu/DefaultDashboardInsightMenuTitle.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insightMenu/DefaultDashboardInsightMenu/DefaultDashboardInsightMenuTitle.tsx
@@ -2,15 +2,29 @@
 import React from "react";
 import { Typography } from "@gooddata/sdk-ui-kit";
 import { CustomDashboardInsightMenuTitleComponent } from "../types";
-import { widgetTitle } from "@gooddata/sdk-model";
+import { insightTitle, widgetTitle } from "@gooddata/sdk-model";
+
+const OriginalInsightTitle: React.FC<{ title: string }> = (props) => {
+    const { title } = props;
+    return (
+        <Typography tagName="p" className="insight-title s-insight-title ">
+            <span title={title} className="original-insight-title">
+                {title}
+            </span>
+        </Typography>
+    );
+};
 
 /**
  * @internal
  */
 export const DefaultDashboardInsightMenuTitle: CustomDashboardInsightMenuTitleComponent = (props) => {
-    const { widget } = props;
+    const { widget, insight, renderMode } = props;
 
     const title = widgetTitle(widget);
+    const originalTitle = insightTitle(insight);
+
+    const titlesDiffer = title !== originalTitle;
 
     const renderedTitle = title ? (
         <span title={props.widget.title} className="insight-title s-insight-title s-insight-title-simple">
@@ -19,8 +33,11 @@ export const DefaultDashboardInsightMenuTitle: CustomDashboardInsightMenuTitleCo
     ) : null;
 
     return (
-        <Typography tagName="h3" className="widget-title s-widget-title">
-            {renderedTitle}
-        </Typography>
+        <>
+            <Typography tagName="h3" className="widget-title s-widget-title">
+                {renderedTitle}
+            </Typography>
+            {renderMode === "edit" && titlesDiffer ? <OriginalInsightTitle title={originalTitle} /> : null}
+        </>
     );
 };

--- a/libs/sdk-ui-dashboard/styles/scss/configurationPanel.scss
+++ b/libs/sdk-ui-dashboard/styles/scss/configurationPanel.scss
@@ -46,7 +46,7 @@
 // sdk-edit-mode-on is in selector to override same classes in KD.
 // Can be removed when old implementation in KD removed
 .gd-configuration-bubble-wrapper.overlay-wrapper.sdk-edit-mode-on {
-    $gd-configuration-bubble-arrow-offset: 9px;
+    $gd-configuration-bubble-arrow-offset: 35px;
     $gd-configuration-bubble-arrow-height: 14px;
 
     z-index: 1000;
@@ -138,9 +138,7 @@
             top: auto;
             bottom: $gd-configuration-bubble-arrow-offset;
         }
-    }
 
-    .gd-configuration-bubble.edit-insight-config {
         .arrow-position {
             top: $gd-configuration-bubble-arrow-offset;
         }
@@ -150,7 +148,7 @@
             justify-content: space-between;
             align-items: center;
             width: 100%;
-            padding: 8px 15px;
+            padding: 3px 10px 3px 15px;
             background: kit-variables.$is-focused-background;
         }
     }

--- a/libs/sdk-ui-dashboard/styles/scss/dashboard.scss
+++ b/libs/sdk-ui-dashboard/styles/scss/dashboard.scss
@@ -16,6 +16,12 @@
     flex-wrap: nowrap;
     background: variables.$gd-dashboards-content-backgroundColor;
     @include mixins.default-styles();
+
+    // needed so that font in textarea stays the same when editing
+    textarea {
+        color: inherit;
+        font: inherit;
+    }
 }
 
 .gd-dash-content {

--- a/libs/sdk-ui-dashboard/styles/scss/insightConfiguration.scss
+++ b/libs/sdk-ui-dashboard/styles/scss/insightConfiguration.scss
@@ -41,7 +41,6 @@ $delete-hover-status-bg: var(--gd-palette-error-lightest, #fff2f1);
                 line-height: normal;
                 color: kit-variables.$gd-color-link;
                 font-size: 11px;
-                cursor: pointer;
             }
 
             .gd-icon-locked {
@@ -63,17 +62,6 @@ $delete-hover-status-bg: var(--gd-palette-error-lightest, #fff2f1);
 
         p.insight-title {
             width: fit-content;
-        }
-
-        p.insight-title:hover {
-            .original-insight-title {
-                padding-right: 5px;
-                text-decoration: underline;
-            }
-
-            .gd-icon-link {
-                opacity: 1;
-            }
         }
 
         .widget-title .insight-title {


### PR DESCRIPTION
* fix CSS issues with filter config, KPI config and textareas
* add original insight title to the insight menu header in edit mode (and remove irrelevant styles for it)

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
