### PR TITLE
RELATED: RAIL-4762 fix useDashboardLoaderWithPluginManipulation

### DIFF
--- a/libs/sdk-ui-loaders/src/dashboard/useDashboardLoaderWithPluginManipulation.ts
+++ b/libs/sdk-ui-loaders/src/dashboard/useDashboardLoaderWithPluginManipulation.ts
@@ -1,4 +1,4 @@
-// (C) 2022 GoodData Corporation
+// (C) 2022-2023 GoodData Corporation
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import invariant from "ts-invariant";
 import compact from "lodash/compact";
@@ -79,7 +79,9 @@ export function useDashboardLoaderWithPluginManipulation(options: IDashboardLoad
         const select = dashboardSelect.current;
         const dashboardObject = select(selectDashboardWorkingDefinition);
         const renderMode = select(selectRenderMode);
-        setDashboard(dashboardObject as any);
+        // force new reference in case the current dashboard object is the same as the one with which the last reload occurred
+        // this makes sure the dashboard is fully reloaded each time
+        setDashboard({ ...dashboardObject } as any);
         setRenderMode(renderMode);
     }, []);
 
@@ -93,7 +95,9 @@ export function useDashboardLoaderWithPluginManipulation(options: IDashboardLoad
         const select = dashboardSelect.current;
         const dashboardObject = select(selectDashboardWorkingDefinition);
         const renderMode = select(selectRenderMode);
-        setDashboard(dashboardObject as any);
+        // force new reference in case the current dashboard object is the same as the one with which the last loading mode change occurred
+        // this makes sure the dashboard is fully reloaded each time
+        setDashboard({ ...dashboardObject } as any);
         setRenderMode(renderMode);
         setLoadingMode(newLoadingMode);
     }, []);
@@ -103,7 +107,9 @@ export function useDashboardLoaderWithPluginManipulation(options: IDashboardLoad
         const select = dashboardSelect.current;
         const dashboardObject = select(selectDashboardWorkingDefinition);
         const renderMode = select(selectRenderMode);
-        setDashboard(dashboardObject as any);
+        // force new reference in case the current dashboard object is the same as the one with which the last setting of extra plugins occurred
+        // this makes sure the dashboard is fully reloaded each time
+        setDashboard({ ...dashboardObject } as any);
         setRenderMode(renderMode);
         setCurrentExtraPlugins(isArray(extraPlugins) ? extraPlugins : [extraPlugins]);
     }, []);


### PR DESCRIPTION
Make sure the reload/loading mode switch/extra plugins setting happens even when there are no changes to the dashboard since the last of these actions happened previously.

JIRA: RAIL-4762

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
