### PR TITLE
BUGFIX: RAIL-4758 Can't save a dashboard with D2U to a hyperlink attribute

### DIFF
--- a/libs/sdk-backend-bear/src/convertors/fromBackend/DashboardConverter/drills.ts
+++ b/libs/sdk-backend-bear/src/convertors/fromBackend/DashboardConverter/drills.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2022 GoodData Corporation
+// (C) 2019-2023 GoodData Corporation
 
 import { GdcVisualizationWidget, GdcKpi } from "@gooddata/api-model-bear";
 import {
@@ -61,7 +61,7 @@ export const convertVisualizationWidgetDrill = (
         return {
             type: "drillToInsight",
             origin: convertDrillOrigin(from),
-            target: toVisualization,
+            target: uriRef(toVisualization.uri),
             transition: target,
         };
     } else if (GdcVisualizationWidget.isDrillToCustomUrl(drill)) {
@@ -84,8 +84,8 @@ export const convertVisualizationWidgetDrill = (
             type: "drillToAttributeUrl",
             origin: convertDrillOrigin(from),
             target: {
-                displayForm: insightAttributeDisplayForm,
-                hyperlinkDisplayForm: drillToAttributeDisplayForm,
+                displayForm: uriRef(insightAttributeDisplayForm.uri),
+                hyperlinkDisplayForm: uriRef(drillToAttributeDisplayForm.uri),
             },
             transition: target,
         };

--- a/libs/sdk-backend-bear/src/convertors/fromBackend/ObjRefConverter.ts
+++ b/libs/sdk-backend-bear/src/convertors/fromBackend/ObjRefConverter.ts
@@ -1,6 +1,6 @@
-// (C) 2007-2021 GoodData Corporation
-
-import { isLocalIdRef, isUriRef, ObjectType, ObjRef, ObjRefInScope } from "@gooddata/sdk-model";
+// (C) 2007-2023 GoodData Corporation
+import { GdcVisualizationObject, GdcExecuteAFM } from "@gooddata/api-model-bear";
+import { ObjectType, ObjRef, ObjRefInScope, idRef, uriRef, localIdRef } from "@gooddata/sdk-model";
 
 /**
  * Converts reference into a format acceptable by the SPI. URI references are left as-is, while
@@ -10,12 +10,12 @@ import { isLocalIdRef, isUriRef, ObjectType, ObjRef, ObjRefInScope } from "@good
  * @param defaultType - type to use it the ref has none specified
  * @internal
  */
-export function fromBearRef(ref: ObjRef, defaultType?: ObjectType): ObjRef {
-    if (isUriRef(ref)) {
-        return ref;
+export function fromBearRef(ref: GdcVisualizationObject.ObjQualifier, defaultType: ObjectType): ObjRef {
+    if (GdcExecuteAFM.isObjectUriQualifier(ref)) {
+        return uriRef(ref.uri);
     }
 
-    return { identifier: ref.identifier, type: ref.type ?? defaultType };
+    return idRef(ref.identifier, defaultType);
 }
 
 /**
@@ -26,9 +26,9 @@ export function fromBearRef(ref: ObjRef, defaultType?: ObjectType): ObjRef {
  * @param defaultType - type to use it the ref has none specified
  * @internal
  */
-export function fromScopedBearRef(ref: ObjRefInScope, defaultType?: ObjectType): ObjRefInScope {
-    if (isLocalIdRef(ref)) {
-        return ref;
+export function fromScopedBearRef(ref: GdcExecuteAFM.Qualifier, defaultType: ObjectType): ObjRefInScope {
+    if (GdcExecuteAFM.isLocalIdentifierQualifier(ref)) {
+        return localIdRef(ref.localIdentifier);
     }
 
     return fromBearRef(ref, defaultType);

--- a/libs/sdk-backend-bear/src/convertors/toBackend/ObjRefConverter.ts
+++ b/libs/sdk-backend-bear/src/convertors/toBackend/ObjRefConverter.ts
@@ -1,6 +1,6 @@
-// (C) 2007-2020 GoodData Corporation
+// (C) 2007-2023 GoodData Corporation
 
-import { isLocalIdRef, isUriRef, ObjRef, ObjRefInScope } from "@gooddata/sdk-model";
+import { isLocalIdRef, isUriRef, ObjRef, ObjRefInScope, idRef, uriRef } from "@gooddata/sdk-model";
 
 /**
  * Converts reference into a format acceptable by the bear backend. URI references are left as-is, while
@@ -11,10 +11,10 @@ import { isLocalIdRef, isUriRef, ObjRef, ObjRefInScope } from "@gooddata/sdk-mod
  */
 export function toBearRef(ref: ObjRef): ObjRef {
     if (isUriRef(ref)) {
-        return ref;
+        return uriRef(ref.uri);
     }
 
-    return { identifier: ref.identifier };
+    return idRef(ref.identifier);
 }
 
 /**

--- a/libs/sdk-backend-tiger/src/convertors/fromBackend/ObjRefConverter.ts
+++ b/libs/sdk-backend-tiger/src/convertors/fromBackend/ObjRefConverter.ts
@@ -1,7 +1,7 @@
-// (C) 2007-2021 GoodData Corporation
+// (C) 2007-2023 GoodData Corporation
 import { AfmObjectIdentifier } from "@gooddata/api-client-tiger";
 import { NotSupported, UnexpectedError } from "@gooddata/sdk-backend-spi";
-import { isUriRef, ObjRef } from "@gooddata/sdk-model";
+import { isUriRef, idRef, ObjRef } from "@gooddata/sdk-model";
 import isEmpty from "lodash/isEmpty";
 
 import { TigerObjectType } from "../../types";
@@ -20,10 +20,7 @@ export function toObjRef(qualifier: AfmObjectIdentifier): ObjRef {
         throw new NotSupported(`Tiger backend does not allow referencing objects by URI.`);
     }
 
-    return {
-        identifier: qualifier.identifier.id,
-        type: toObjectType(qualifier.identifier.type as TigerObjectType),
-    };
+    return idRef(qualifier.identifier.id, toObjectType(qualifier.identifier.type as TigerObjectType));
 }
 
 export type JsonApiId = {
@@ -36,8 +33,5 @@ export function isJsonApiId(obj: unknown): obj is JsonApiId {
 }
 
 export function jsonApiIdToObjRef(idAndType: JsonApiId): ObjRef {
-    return {
-        identifier: idAndType.id,
-        type: toObjectType(idAndType.type as TigerObjectType),
-    };
+    return idRef(idAndType.id, toObjectType(idAndType.type as TigerObjectType));
 }

--- a/libs/sdk-ui-dashboard/src/model/store/drillTargets/drillTargetsEntityAdapter.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/drillTargets/drillTargetsEntityAdapter.ts
@@ -1,6 +1,8 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2023 GoodData Corporation
 import { createEntityAdapter } from "@reduxjs/toolkit";
 import { ObjRef, serializeObjRef } from "@gooddata/sdk-model";
+
+import { objRef } from "../../utils/objRef";
 import { IDrillTargets } from "./drillTargetsTypes";
 
 export const drillTargetsAdapter = createEntityAdapter<IDrillTargets>({
@@ -8,8 +10,5 @@ export const drillTargetsAdapter = createEntityAdapter<IDrillTargets>({
 });
 
 const getIdFromDrillTargets = (targets: IDrillTargets): ObjRef => {
-    return {
-        uri: targets.uri,
-        identifier: targets.identifier,
-    };
+    return objRef(targets.uri, targets.identifier);
 };

--- a/libs/sdk-ui-dashboard/src/model/utils/objRef.ts
+++ b/libs/sdk-ui-dashboard/src/model/utils/objRef.ts
@@ -1,0 +1,6 @@
+// (C) 2021-2023 GoodData Corporation
+import { ObjRef } from "@gooddata/sdk-model";
+
+export function objRef(uri: string, identifier: string): ObjRef {
+    return { uri, identifier };
+}

--- a/libs/sdk-ui-dashboard/src/presentation/drill/DrillConfigPanel/DrillToUrl/AttributeUrlSection.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/drill/DrillConfigPanel/DrillToUrl/AttributeUrlSection.tsx
@@ -1,4 +1,4 @@
-// (C) 2020-2022 GoodData Corporation
+// (C) 2020-2023 GoodData Corporation
 import React, { useCallback } from "react";
 import { FormattedMessage } from "react-intl";
 import { areObjRefsEqual, ObjRef, objRefToString } from "@gooddata/sdk-model";
@@ -22,7 +22,7 @@ export const AttributeUrlSection: React.FC<AttributeUrlSectionProps> = (props) =
 
     const onClickHandler = useCallback(
         (event: React.SyntheticEvent, target: IAttributeWithDisplayForm) => {
-            onSelect(target.displayForm, target.displayForm);
+            onSelect(target.displayForm.ref, target.displayForm.ref);
             closeDropdown(event);
         },
         [onSelect, closeDropdown],

--- a/libs/sdk-ui-dashboard/src/tools/InsightWidgetBuilder.ts
+++ b/libs/sdk-ui-dashboard/src/tools/InsightWidgetBuilder.ts
@@ -1,4 +1,4 @@
-// (C) 2022 GoodData Corporation
+// (C) 2022-2023 GoodData Corporation
 
 import {
     IDashboardFilterReference,
@@ -8,6 +8,7 @@ import {
     InsightDrillDefinition,
     insightRef,
     insightTitle,
+    uriRef,
     ObjRef,
     VisualizationProperties,
 } from "@gooddata/sdk-model";
@@ -45,7 +46,7 @@ export function newInsightWidget(insight: IInsight, modifications: InsightWidget
  */
 export class InsightWidgetBuilder {
     widget: { -readonly [K in keyof IInsightWidgetBase]: IInsightWidgetBase[K] } = {
-        insight: { uri: "" },
+        insight: uriRef(""),
         type: "insight",
         ignoreDashboardFilters: [],
         drills: [],

--- a/tools/reference-workspace/src/md/ext.ts
+++ b/tools/reference-workspace/src/md/ext.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2022 GoodData Corporation
+// (C) 2019-2023 GoodData Corporation
 import {
     modifyMeasure,
     newArithmeticMeasure,
@@ -8,6 +8,7 @@ import {
     modifySimpleMeasure,
     IAttribute,
     modifyAttribute,
+    idRef,
 } from "@gooddata/sdk-model";
 import * as ReferenceMd from "./full";
 
@@ -66,9 +67,7 @@ export const AmountWithRatio = modifySimpleMeasure(ReferenceMd.Amount, (m) =>
 /**
  * A reference to Stage History Attribute
  */
-export const StageHistoryAttributeRef: ObjRef = {
-    identifier: "attr.stagehistory.id",
-};
+export const StageHistoryAttributeRef: ObjRef = idRef("attr.stagehistory.id");
 /**
  * Copy of ClosedYear attribute
  */


### PR DESCRIPTION
In new KD edit mode, place an insight has at least 1 metric and 1 hyperlink attribute to KD. Try to set up D2U from a metric to the hyperlink attribute (don’t use custom url dialog), press save the dashboard

 + use factories where is it possible

JIRA: RAIL-4758

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
