### PR TITLE
RELATED: RAIL-4750 temporarily revert redirect to edit mode when saveAs

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/saveAs/DefaultSaveAsDialog/index.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/saveAs/DefaultSaveAsDialog/index.tsx
@@ -1,4 +1,4 @@
-// (C) 2019-2022 GoodData Corporation
+// (C) 2019-2023 GoodData Corporation
 import React, { useCallback } from "react";
 import { useToastMessage } from "@gooddata/sdk-ui-kit";
 import { ISaveAsDialogProps } from "../types";
@@ -6,14 +6,15 @@ import { useSaveAs } from "./useSaveAs";
 import { SaveAsDialogRenderer } from "./SaveAsDialogRenderer";
 import { messages } from "../../../locales";
 import {
-    changeRenderMode,
+    // changeRenderMode,
     selectIsSaveAsDialogOpen,
     uiActions,
-    useDashboardCommandProcessing,
+    // useDashboardCommandProcessing,
     useDashboardDispatch,
     useDashboardSelector,
 } from "../../../model";
 
+//TODO: RAIL-4750 fix redirect to view mode
 /**
  * @internal
  */
@@ -29,7 +30,7 @@ export function useSaveAsDialogProps(): ISaveAsDialogProps {
         closeSaveAsDialog();
         addError(messages.messagesDashboardSaveFailed);
     }, [closeSaveAsDialog, addError]);
-
+    /* TODO: RAIL-4750 fix redirect to view mode
     const { run: changeEditMode } = useDashboardCommandProcessing({
         commandCreator: changeRenderMode,
         errorEvent: "GDC.DASH/EVT.COMMAND.FAILED",
@@ -37,13 +38,16 @@ export function useSaveAsDialogProps(): ISaveAsDialogProps {
         onSuccess: () => {
             addSuccess(messages.messagesDashboardSaveSuccess);
         },
-    });
+    });*/
 
     const onSaveAsSuccess = useCallback(() => {
         closeSaveAsDialog();
+        // TODO: RAIL-4750 fix redirect to view mode
         // need wait till change mode is finished
-        changeEditMode("view", { resetDashboard: false });
-    }, [closeSaveAsDialog, changeEditMode]);
+        //changeEditMode("view", { resetDashboard: true });
+
+        addSuccess(messages.messagesDashboardSaveSuccess);
+    }, [closeSaveAsDialog, addSuccess]);
 
     const onSaveAsCancel = useCallback(() => {
         closeSaveAsDialog();


### PR DESCRIPTION
JIRA: RAIL-4750

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
