### PR TITLE
BUGFIX: RAIL-4719 plugin toolbar is hidden behind widgets and difficult to select

### DIFF
--- a/libs/sdk-ui-dashboard/styles/scss/_zIndexes.scss
+++ b/libs/sdk-ui-dashboard/styles/scss/_zIndexes.scss
@@ -1,0 +1,35 @@
+// (C) 2023 GoodData Corporation
+
+$configuration-panel: 1000;
+$configuration-panel-sticky: 10;
+$configuration-panel-bubble: 1000;
+$configuration-panel-bubble-sticky: 5;
+
+$drag-and-drop-basic: 1;
+$drag-and-drop-draggable-wrapper: 10;
+$drag-and-drop-drop-zone: 99;
+
+$drill-dialog-basic: 1;
+$drill-dialog-loading: 3;
+$drill-dialog-error: $drill-dialog-loading + 1;
+$drill-select: 5002;
+$drill-dialog-charts: 5011;
+
+$layout-fluidlayout-item-changed: $drag-and-drop-draggable-wrapper + 1;
+
+$topbar-basic: 5001;
+
+$filterbar-old: 100;
+$filterbar-sdk-8-12: 6000;
+
+$kpi-alert-dialog: 1000;
+
+$resize-basic: 101;
+$resize-basic-overlay: $resize-basic + 4;
+$resize-basic-overlay-text: $resize-basic-overlay + 1;
+
+$scheduled-email-mask: 5001;
+$scheduled-email-mask-small: $scheduled-email-mask + 1;
+
+//toolbar need to be on top of resize and draggable wrapper
+$toolbar-basic: $resize-basic + 1;

--- a/libs/sdk-ui-dashboard/styles/scss/configurationPanel.scss
+++ b/libs/sdk-ui-dashboard/styles/scss/configurationPanel.scss
@@ -1,5 +1,6 @@
 // (C) 2007-2021 GoodData Corporation
 @use "variables";
+@use "zIndexes";
 @use "@gooddata/sdk-ui-kit/styles/scss/Button/variables" as button-variables;
 @use "@gooddata/sdk-ui-kit/styles/scss/variables" as kit-variables;
 
@@ -49,23 +50,23 @@
     $gd-configuration-bubble-arrow-offset: 35px;
     $gd-configuration-bubble-arrow-height: 14px;
 
-    z-index: 1000;
+    z-index: zIndexes.$configuration-panel;
     &.is-sticky {
-        z-index: 10;
+        z-index: zIndexes.$configuration-panel-sticky;
     }
 
     // make configuration panel visible over dashboard headers when screen size is limited
     // and alignPoints matches the custom class
     &.target-br {
-        z-index: 1000;
+        z-index: zIndexes.$configuration-panel;
     }
 
     .gd-configuration-bubble {
-        z-index: 1000;
+        z-index: zIndexes.$configuration-panel-bubble;
         width: variables.$gd-configuration-bubble-width;
 
         &.is-sticky {
-            z-index: 5;
+            z-index: zIndexes.$configuration-panel-bubble-sticky;
         }
 
         &.arrow-right-direction {

--- a/libs/sdk-ui-dashboard/styles/scss/dragAndDrop.scss
+++ b/libs/sdk-ui-dashboard/styles/scss/dragAndDrop.scss
@@ -1,6 +1,7 @@
 // (C) 2022 GoodData Corporation
 @use "sass:color";
 @use "variables";
+@use "zIndexes";
 @use "@gooddata/sdk-ui-kit/styles/scss/variables" as kit-variables;
 @use "@gooddata/sdk-ui-kit/styles/scss/Button/variables" as kit-button-variables;
 @use "@gooddata/sdk-ui-kit/styles/scss/mixins" as kit-mixins;
@@ -45,7 +46,7 @@
     .drag-handle-icon {
         content: "";
         position: absolute;
-        z-index: 1;
+        z-index: zIndexes.$drag-and-drop-basic;
         top: 8px;
         left: -4px;
         width: 7px;
@@ -57,7 +58,7 @@
 
 .attr-filter-dropzone {
     position: absolute;
-    z-index: 99;
+    z-index: zIndexes.$drag-and-drop-drop-zone;
     top: 0;
     bottom: 0;
     width: 50%;
@@ -145,7 +146,7 @@
     }
 
     .gd-dropzone-message {
-        z-index: 1;
+        z-index: zIndexes.$drag-and-drop-basic;
         flex: 1 1 auto;
         margin: 0 23px;
         color: kit-variables.$gd-color-text;
@@ -189,7 +190,7 @@
 }
 
 .dropzone {
-    z-index: 99;
+    z-index: zIndexes.$drag-and-drop-drop-zone;
     &.next,
     &.prev {
         position: absolute;
@@ -288,13 +289,13 @@
 
 .row-hotspot-container {
     position: relative;
-    z-index: 99;
+    z-index: zIndexes.$drag-and-drop-drop-zone;
     width: 100%;
     height: 0;
 
     .row-hotspot {
         position: absolute;
-        z-index: 99;
+        z-index: zIndexes.$drag-and-drop-drop-zone;
         top: 0;
         right: 0;
         bottom: 0;
@@ -617,7 +618,7 @@
     width: 100%;
     height: 100%;
     position: relative;
-    z-index: 10;
+    z-index: zIndexes.$drag-and-drop-draggable-wrapper;
 }
 
 .current-dragging-item {

--- a/libs/sdk-ui-dashboard/styles/scss/drillDialog.scss
+++ b/libs/sdk-ui-dashboard/styles/scss/drillDialog.scss
@@ -1,6 +1,7 @@
 // (C) 2007-2021 GoodData Corporation
 @use "sass:color";
 @use "variables";
+@use "zIndexes";
 @use "@gooddata/sdk-ui-kit/styles/scss/Dialog/_variables" as dialog-variables;
 @use "@gooddata/sdk-ui-kit/styles/scss/variables" as kit-variables;
 
@@ -109,8 +110,8 @@ $border-color: #dde4eb;
     }
 
     .visualization-uri-root {
+        z-index: zIndexes.$drill-dialog-basic;
         position: relative;
-        z-index: 1;
         width: 100%;
         height: 100%;
 
@@ -143,9 +144,8 @@ $border-color: #dde4eb;
         background-color: $light-color;
     }
 
-    $modal-loading-z-index: 3;
     .gd-loading-equalizer-wrap {
-        z-index: $modal-loading-z-index;
+        z-index: zIndexes.$drill-dialog-loading;
 
         .gd-loading-equalizer {
             margin: auto 0;
@@ -154,7 +154,7 @@ $border-color: #dde4eb;
 
     .gd-drill-modal-error {
         position: absolute;
-        z-index: $modal-loading-z-index + 1;
+        z-index: zIndexes.$drill-dialog-error;
         display: flex;
         justify-content: center;
         align-items: center;
@@ -170,5 +170,5 @@ $border-color: #dde4eb;
 // https://github.com/highcharts/highcharts/commit/48a82ce80ba946839e3a1280e63ca02ab1f88ec0
 /* stylelint-disable declaration-no-important */
 .highcharts-tooltip-container {
-    z-index: 5011 !important;
+    z-index: zIndexes.$drill-dialog-charts !important;
 }

--- a/libs/sdk-ui-dashboard/styles/scss/drillSelect.scss
+++ b/libs/sdk-ui-dashboard/styles/scss/drillSelect.scss
@@ -1,12 +1,13 @@
 // (C) 2020-2021 GoodData Corporation
 @use "variables";
+@use "zIndexes";
 @use "@gooddata/sdk-ui-kit/styles/scss/Bubble/variables" as bubble-variables;
 @use "@gooddata/sdk-ui-kit/styles/scss/Button/variables" as button-variables;
 @use "@gooddata/sdk-ui-kit/styles/scss/variables" as kit-variables;
 
 .gd-drill-modal-picker-overlay-mask {
     position: absolute;
-    z-index: 5002;
+    z-index: zIndexes.$drill-select;
     width: 100%;
     height: 100%;
     background-color: transparent;
@@ -103,7 +104,7 @@
         padding-top: 10px;
 
         .gd-bubble-trigger-zoom-out {
-            z-index: 1;
+            z-index: zIndexes.$drill-dialog-basic;
             top: -30px;
             right: 30px;
         }

--- a/libs/sdk-ui-dashboard/styles/scss/filterBar.scss
+++ b/libs/sdk-ui-dashboard/styles/scss/filterBar.scss
@@ -1,6 +1,7 @@
 // (C) 2019-2021 GoodData Corporation
 @use "sass:color";
 @use "variables";
+@use "zIndexes";
 @use "@gooddata/sdk-ui-kit/styles/scss/Button/variables" as button-variables;
 @use "@gooddata/sdk-ui-kit/styles/scss/variables" as kit-variables;
 
@@ -22,12 +23,12 @@ $attribute-filter-drag-handle-left: 10px;
 }
 
 .gd-dash-header-wrapper {
-    z-index: 100; // we have to leave this style unchanged because old plugins
+    z-index: zIndexes.$filterbar-old; // we have to leave this style unchanged because old plugins
     transition: left variables.$sidebar-transition-length;
 
     &.gd-dash-header-wrapper-sdk-8-12 {
         // style is added because we should keep old styles unchanged to not brake plugins
-        z-index: 6000; // overlay in Dashboard component start at index 5000
+        z-index: zIndexes.$filterbar-sdk-8-12; // overlay in Dashboard component start at index 5000
     }
 
     .is-dashboard-loading & {

--- a/libs/sdk-ui-dashboard/styles/scss/kpi_alert_dialog.scss
+++ b/libs/sdk-ui-dashboard/styles/scss/kpi_alert_dialog.scss
@@ -3,6 +3,7 @@
 @use "@gooddata/sdk-ui-kit/styles/scss/Button/_variables" as button-variables;
 @use "@gooddata/sdk-ui-kit/styles/scss/Bubble/_variables" as bubble-variables;
 @use "variables";
+@use "zIndexes";
 @use "@gooddata/sdk-ui-kit/styles/scss/variables" as kit-variables;
 
 $dialog-border: bubble-variables.$default-bubble-light-border-base;
@@ -27,7 +28,7 @@ $dialog-background: kit-variables.$is-focused-background;
 
 .kpi-alert-dialog {
     position: relative;
-    z-index: 1000;
+    z-index: zIndexes.$kpi-alert-dialog;
     min-height: 148px;
     border: 1px solid var(--gd-palette-complementary-3, color.adjust($dialog-border, $alpha: -0.5));
     border-radius: 5px;

--- a/libs/sdk-ui-dashboard/styles/scss/layout.scss
+++ b/libs/sdk-ui-dashboard/styles/scss/layout.scss
@@ -3,6 +3,7 @@
 @use "@gooddata/sdk-ui-kit/styles/scss/typo-mixins";
 @use "@gooddata/sdk-ui-kit/styles/scss/typo";
 @use "variables";
+@use "zIndexes";
 @use "@gooddata/sdk-ui-kit/styles/scss/mixins";
 
 $gd-dashboards-section-title-color: var(--gd-dashboards-section-title-color, kit-variables.$gd-color-text);
@@ -283,8 +284,7 @@ $gd-dashboards-section-description-color: var(
 
 .gd-fluidlayout-item-changed {
     position: absolute;
-    //need z-index over draggable overlay also
-    z-index: 11;
+    z-index: zIndexes.$layout-fluidlayout-item-changed;
     top: 0;
     left: 0;
     right: 0;

--- a/libs/sdk-ui-dashboard/styles/scss/resizing.scss
+++ b/libs/sdk-ui-dashboard/styles/scss/resizing.scss
@@ -1,5 +1,6 @@
 // (C) 2019-2021 GoodData Corporation
 @use "variables";
+@use "zIndexes";
 @use "@gooddata/sdk-ui-kit/styles/scss/variables" as kit-variables;
 
 $gd-width-resizer-hotpost-width: 40px;
@@ -111,7 +112,7 @@ $gd-width-resizer-hotpost-height: 40px;
     .dash-height-resizer-hotspot,
     .dash-width-resizer-hotspot,
     .height-resizer-drag-preview {
-        z-index: 101;
+        z-index: zIndexes.$resize-basic;
     }
 
     .dash-width-resizer-hotspot {
@@ -132,7 +133,7 @@ $gd-width-resizer-hotpost-height: 40px;
     }
 
     .gd-resize-overlay {
-        z-index: 105;
+        z-index: zIndexes.$resize-basic-overlay;
         border-width: 0;
         border-radius: calc(#{variables.$gd-dashboards-content-widget-borderRadius} + 5px);
         background-color: var(--gd-palette-complementary-0-t50, rgba(255, 255, 255, 0.5));
@@ -147,7 +148,7 @@ $gd-width-resizer-hotpost-height: 40px;
     }
 
     .gd-resize-overlay-text {
-        z-index: 106;
+        z-index: zIndexes.$resize-basic-overlay-text;
         display: flex;
         justify-content: center;
         align-items: center;

--- a/libs/sdk-ui-dashboard/styles/scss/scheduled_mail.scss
+++ b/libs/sdk-ui-dashboard/styles/scss/scheduled_mail.scss
@@ -1,6 +1,7 @@
 // (C) 2019-2020 GoodData Corporation
 @use "@gooddata/sdk-ui-kit/styles/scss/Button/_variables" as button-variables;
 @use "@gooddata/sdk-ui-kit/styles/scss/variables" as kit-variables;
+@use "zIndexes";
 
 $horizontal-space: 20px;
 $vertical-space: 10px;
@@ -549,12 +550,12 @@ $vertical-space: 10px;
 
 .gd-scheduled-email-delete-dialog-overlay {
     .modalityPlugin-mask {
-        z-index: 5001;
+        z-index: zIndexes.$scheduled-email-mask;
     }
 
     @media #{kit-variables.$small-only} {
         .modalityPlugin-mask {
-            z-index: 5002;
+            z-index: zIndexes.$scheduled-email-mask-small;
         }
     }
 }

--- a/libs/sdk-ui-dashboard/styles/scss/toolbar.scss
+++ b/libs/sdk-ui-dashboard/styles/scss/toolbar.scss
@@ -1,8 +1,10 @@
 // (C) 2022 GoodData Corporation
 @use "sass:map";
+@use "zIndexes";
 @use "@gooddata/sdk-ui-kit/styles/scss/variables" as kit-variables;
 
 .gd-dashboard-toolbar {
+    z-index: zIndexes.$toolbar-basic;
     position: fixed;
     right: 20px;
     bottom: 20px;

--- a/libs/sdk-ui-dashboard/styles/scss/topBar.scss
+++ b/libs/sdk-ui-dashboard/styles/scss/topBar.scss
@@ -1,4 +1,5 @@
 @use "variables";
+@use "zIndexes";
 @use "@gooddata/sdk-ui-kit/styles/scss/mixins";
 @use "@gooddata/sdk-ui-kit/styles/scss/variables" as kit-variables;
 
@@ -131,7 +132,7 @@
 }
 
 .overlay-wrapper {
-    z-index: 5001;
+    z-index: zIndexes.$topbar-basic;
 }
 
 .gd-list-item.delete-button {


### PR DESCRIPTION
When a dashboard has many widgets, it shows a vertical scroll bar → observe plugin toolbar in bottom-right side:

It is hidden behind dashboard widgets, we need to roll to the end of the dashboard to see it

When we hover on the icons of the toolbar, this is difficult to select, because height resizer of the widget is activated in this case

JIRA: RAIL-4719

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)


[RAIL-4719]: https://gooddata.atlassian.net/browse/RAIL-4719?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ