### PR TITLE
RELATED: RAIL-4703 switch to view mode on save and save as

### DIFF
--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/saveAsDashboardHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/saveAsDashboardHandler.ts
@@ -1,4 +1,4 @@
-// (C) 2021-2022 GoodData Corporation
+// (C) 2021-2023 GoodData Corporation
 
 import { IDashboard, IDashboardDefinition, IAccessControlAware } from "@gooddata/sdk-model";
 import { BatchAction, batchActions } from "redux-batched-actions";
@@ -32,6 +32,9 @@ import { listedDashboardsActions } from "../../store/listedDashboards";
 import { createListedDashboard } from "../../../_staging/listedDashboard/listedDashboardUtils";
 import { accessibleDashboardsActions } from "../../store/accessibleDashboards";
 import { selectCurrentUser } from "../../store/user/userSelectors";
+import { changeRenderModeHandler } from "../renderMode/changeRenderModeHandler";
+import { changeRenderMode } from "../../commands";
+import { selectIsInViewMode } from "../../store/renderMode/renderModeSelectors";
 
 type DashboardSaveAsContext = {
     cmd: SaveDashboardAs;
@@ -223,6 +226,12 @@ export function* saveAsDashboardHandler(
         const listedDashboard = createListedDashboard(dashboard);
         yield put(listedDashboardsActions.addListedDashboard(listedDashboard));
         yield put(accessibleDashboardsActions.addAccessibleDashboard(listedDashboard));
+
+        const isInViewMode: ReturnType<typeof selectIsInViewMode> = yield select(selectIsInViewMode);
+        if (!isInViewMode) {
+            yield call(changeRenderModeHandler, ctx, changeRenderMode("view", undefined, cmd.correlationId));
+        }
+
         yield put(savingActions.setSavingSuccess());
 
         return dashboardCopySaved(context, dashboard, cmd.correlationId);

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/saveDashboardHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/saveDashboardHandler.ts
@@ -1,6 +1,6 @@
-// (C) 2021-2022 GoodData Corporation
+// (C) 2021-2023 GoodData Corporation
 import { DashboardContext } from "../../types/commonTypes";
-import { SaveDashboard } from "../../commands";
+import { changeRenderMode, SaveDashboard } from "../../commands";
 import { SagaIterator } from "redux-saga";
 import { selectBasicLayout } from "../../store/layout/layoutSelectors";
 import { call, put, SagaReturnType, select, setContext } from "redux-saga/effects";
@@ -32,6 +32,8 @@ import { layoutActions } from "../../store/layout";
 import { savingActions } from "../../store/saving";
 import { selectSettings } from "../../store/config/configSelectors";
 import { selectBackendCapabilities } from "../../store/backendCapabilities/backendCapabilitiesSelectors";
+import { changeRenderModeHandler } from "../renderMode/changeRenderModeHandler";
+import { selectIsInViewMode } from "../../store/renderMode/renderModeSelectors";
 
 type DashboardSaveContext = {
     cmd: SaveDashboard;
@@ -259,6 +261,11 @@ export function* saveDashboardHandler(
                     dashboardRef: dashboard.ref,
                 },
             });
+        }
+
+        const isInViewMode: ReturnType<typeof selectIsInViewMode> = yield select(selectIsInViewMode);
+        if (!isInViewMode) {
+            yield call(changeRenderModeHandler, ctx, changeRenderMode("view", undefined, cmd.correlationId));
         }
 
         yield put(savingActions.setSavingSuccess());

--- a/libs/sdk-ui-dashboard/src/presentation/saveAs/DefaultSaveAsDialog/index.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/saveAs/DefaultSaveAsDialog/index.tsx
@@ -6,15 +6,12 @@ import { useSaveAs } from "./useSaveAs";
 import { SaveAsDialogRenderer } from "./SaveAsDialogRenderer";
 import { messages } from "../../../locales";
 import {
-    // changeRenderMode,
     selectIsSaveAsDialogOpen,
     uiActions,
-    // useDashboardCommandProcessing,
     useDashboardDispatch,
     useDashboardSelector,
 } from "../../../model";
 
-//TODO: RAIL-4750 fix redirect to view mode
 /**
  * @internal
  */
@@ -30,22 +27,9 @@ export function useSaveAsDialogProps(): ISaveAsDialogProps {
         closeSaveAsDialog();
         addError(messages.messagesDashboardSaveFailed);
     }, [closeSaveAsDialog, addError]);
-    /* TODO: RAIL-4750 fix redirect to view mode
-    const { run: changeEditMode } = useDashboardCommandProcessing({
-        commandCreator: changeRenderMode,
-        errorEvent: "GDC.DASH/EVT.COMMAND.FAILED",
-        successEvent: "GDC.DASH/EVT.RENDER_MODE.CHANGED",
-        onSuccess: () => {
-            addSuccess(messages.messagesDashboardSaveSuccess);
-        },
-    });*/
 
     const onSaveAsSuccess = useCallback(() => {
         closeSaveAsDialog();
-        // TODO: RAIL-4750 fix redirect to view mode
-        // need wait till change mode is finished
-        //changeEditMode("view", { resetDashboard: true });
-
         addSuccess(messages.messagesDashboardSaveSuccess);
     }, [closeSaveAsDialog, addSuccess]);
 

--- a/libs/sdk-ui-dashboard/src/presentation/topBar/buttonBar/button/saveButton/DefaultSaveButton.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/topBar/buttonBar/button/saveButton/DefaultSaveButton.tsx
@@ -6,7 +6,6 @@ import { Bubble, BubbleHoverTrigger, Button } from "@gooddata/sdk-ui-kit";
 import noop from "lodash/noop";
 
 import {
-    cancelEditRenderMode,
     dispatchAndWaitFor,
     saveDashboard,
     selectEnableAnalyticalDashboardPermissions,
@@ -48,7 +47,6 @@ export function useSaveButtonProps(): ISaveButtonProps {
         )
             .then(() => {
                 setOptimisticIsSaving(false);
-                dispatch(cancelEditRenderMode());
             })
             .catch(() => {
                 setOptimisticIsSaving(false);


### PR DESCRIPTION
Makes the "save dashboard" and "switch to view mode" operations atomic: we always do those two together. Doing it like this makes reacting to the saved events easier as the dashboard is in view mode by the time the event is fired.

JIRA: RAIL-4703

Related commit in gdc-dashboards: https://github.com/no23reason/gdc-dashboards/commit/5db29c50af12f8b1be5741af3b5b5e917bbb3d4b

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)


[RAIL-4703]: https://gooddata.atlassian.net/browse/RAIL-4703?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ