### PR TITLE
BUGFIX: RAIL-4746 widget height isn't reevaluated after changing widget

### DIFF
--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -5962,13 +5962,7 @@ export const selectInsightsMap: OutputSelector<DashboardState, ObjRefMap<IInsigh
 export const selectInsightWidgetPlaceholder: OutputSelector<DashboardState, InsightPlaceholderWidget | undefined, (res: ICustomWidget[]) => InsightPlaceholderWidget | undefined>;
 
 // @internal (undocumented)
-export const selectInsightWidgetPlaceholderCoordinates: OutputSelector<DashboardState, {
-sectionIndex: number;
-itemIndex: number;
-} | undefined, (res1: InsightPlaceholderWidget | undefined, res2: IDashboardLayout<ExtendedDashboardWidget>) => {
-sectionIndex: number;
-itemIndex: number;
-} | undefined>;
+export const selectInsightWidgetPlaceholderCoordinates: OutputSelector<DashboardState, ILayoutCoordinates | undefined, (res1: InsightPlaceholderWidget | undefined, res2: IDashboardLayout<ExtendedDashboardWidget>) => ILayoutCoordinates | undefined>;
 
 // @internal (undocumented)
 export const selectInvalidDrillWidgetRefs: OutputSelector<DashboardState, ObjRef[], (res: UiState) => ObjRef[]>;
@@ -6091,13 +6085,7 @@ export const selectKpiDeleteDialogWidgetCoordinates: OutputSelector<DashboardSta
 export const selectKpiWidgetPlaceholder: OutputSelector<DashboardState, KpiPlaceholderWidget | undefined, (res: ICustomWidget[]) => KpiPlaceholderWidget | undefined>;
 
 // @internal (undocumented)
-export const selectKpiWidgetPlaceholderCoordinates: OutputSelector<DashboardState, {
-sectionIndex: number;
-itemIndex: number;
-} | undefined, (res1: KpiPlaceholderWidget | undefined, res2: IDashboardLayout<ExtendedDashboardWidget>) => {
-sectionIndex: number;
-itemIndex: number;
-} | undefined>;
+export const selectKpiWidgetPlaceholderCoordinates: OutputSelector<DashboardState, ILayoutCoordinates | undefined, (res1: KpiPlaceholderWidget | undefined, res2: IDashboardLayout<ExtendedDashboardWidget>) => ILayoutCoordinates | undefined>;
 
 // @alpha
 export const selectLayout: OutputSelector<DashboardState, IDashboardLayout<ExtendedDashboardWidget>, (res: LayoutState) => IDashboardLayout<ExtendedDashboardWidget>>;
@@ -6205,13 +6193,7 @@ export const selectWidgetDrills: (ref: ObjRef | undefined) => OutputSelector<Das
 export const selectWidgetPlaceholder: OutputSelector<DashboardState, PlaceholderWidget | undefined, (res: ICustomWidget[]) => PlaceholderWidget | undefined>;
 
 // @internal (undocumented)
-export const selectWidgetPlaceholderCoordinates: OutputSelector<DashboardState, {
-sectionIndex: number;
-itemIndex: number;
-} | undefined, (res1: PlaceholderWidget | undefined, res2: IDashboardLayout<ExtendedDashboardWidget>) => {
-sectionIndex: number;
-itemIndex: number;
-} | undefined>;
+export const selectWidgetPlaceholderCoordinates: OutputSelector<DashboardState, ILayoutCoordinates | undefined, (res1: PlaceholderWidget | undefined, res2: IDashboardLayout<ExtendedDashboardWidget>) => ILayoutCoordinates | undefined>;
 
 // @internal
 export const selectWidgets: OutputSelector<DashboardState, ExtendedDashboardWidget[], (res: IDashboardLayout<ExtendedDashboardWidget>) => ExtendedDashboardWidget[]>;

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/changeInsightWidgetInsightHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/changeInsightWidgetInsightHandler.ts
@@ -1,4 +1,4 @@
-// (C) 2021-2022 GoodData Corporation
+// (C) 2021-2023 GoodData Corporation
 
 import { DashboardContext } from "../../types/commonTypes";
 import { ChangeInsightWidgetInsight } from "../../commands";
@@ -16,6 +16,7 @@ import { invalidArgumentsProvided } from "../../events/general";
 import { insightsActions } from "../../store/insights";
 import { uiActions } from "../../store/ui";
 import { selectInsightByRef } from "../../store/insights/insightsSelectors";
+import { getSizeInfo } from "../../../_staging/layout/sizing";
 import { loadInsight } from "./common/loadInsight";
 
 export function* changeInsightWidgetInsightHandler(
@@ -53,6 +54,7 @@ export function* changeInsightWidgetInsightHandler(
     const isTitleDifferent = insightTitle(insight) !== originalInsightTitle;
 
     const shouldChangeTitle = !hasCustomName && isTitleDifferent;
+    const newSize = getSizeInfo({ enableKDWidgetCustomHeight: true }, "insight", insight);
 
     yield put(
         batchActions([
@@ -75,6 +77,7 @@ export function* changeInsightWidgetInsightHandler(
                           title: insightTitle(insight),
                       }
                     : undefined,
+                newSize,
                 undo: {
                     cmd,
                 },

--- a/libs/sdk-ui-dashboard/src/model/store/layout/layoutReducers.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/layout/layoutReducers.ts
@@ -1,4 +1,4 @@
-// (C) 2021-2022 GoodData Corporation
+// (C) 2021-2023 GoodData Corporation
 import { CaseReducer, PayloadAction } from "@reduxjs/toolkit";
 import { LayoutState } from "./layoutState";
 import { invariant } from "ts-invariant";
@@ -34,6 +34,8 @@ import { Draft } from "immer";
 import { ObjRefMap } from "../../../_staging/metadata/objRefMap";
 import { IdentityMapping } from "../../../_staging/dashboard/dashboardLayout";
 import { setOrDelete } from "../../../_staging/objectUtils/setOrDelete";
+import { IVisualizationSizeInfo } from "@gooddata/sdk-ui-ext";
+import { getWidgetCoordinatesAndItem, resizeInsightWidget } from "./layoutUtils";
 
 type LayoutReducer<A> = CaseReducer<LayoutState, PayloadAction<A>>;
 
@@ -463,13 +465,15 @@ type ReplaceWidgetInsight = {
     insightRef: ObjRef;
     properties: VisualizationProperties | undefined;
     header: WidgetHeader | undefined;
+    newSize?: IVisualizationSizeInfo;
 };
 
 const replaceInsightWidgetInsight: LayoutReducer<ReplaceWidgetInsight> = (state, action) => {
     invariant(state.layout);
 
-    const { insightRef, properties, ref, header } = action.payload;
+    const { insightRef, properties, ref, header, newSize } = action.payload;
     const widget = getWidgetByRef(state, ref);
+    const data = getWidgetCoordinatesAndItem(state.layout, ref);
 
     invariant(isInsightWidget(widget));
 
@@ -482,6 +486,10 @@ const replaceInsightWidgetInsight: LayoutReducer<ReplaceWidgetInsight> = (state,
     }
 
     widget.insight = insightRef;
+
+    if (newSize && data?.item) {
+        data.item.size.xl = resizeInsightWidget(data.item.size.xl, newSize);
+    }
 };
 
 //

--- a/libs/sdk-ui-dashboard/src/model/store/layout/layoutSelectors.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/layout/layoutSelectors.ts
@@ -1,4 +1,4 @@
-// (C) 2021-2022 GoodData Corporation
+// (C) 2021-2023 GoodData Corporation
 import { createSelector } from "@reduxjs/toolkit";
 import {
     ObjRef,
@@ -7,23 +7,24 @@ import {
     isKpiWidget,
     isInsightWidget,
     IDashboardLayout,
-    IDashboardLayoutItem,
-    areObjRefsEqual,
     IInsightWidget,
     IKpiWidget,
 } from "@gooddata/sdk-model";
 import invariant from "ts-invariant";
+import isEmpty from "lodash/isEmpty";
+
 import { DashboardState } from "../types";
-import { LayoutState } from "./layoutState";
 import { ExtendedDashboardWidget, isCustomWidget } from "../../types/layoutTypes";
 import { createUndoableCommandsMapping } from "../_infra/undoEnhancer";
 import { newMapForObjectWithIdentity } from "../../../_staging/metadata/objRefMap";
 import { selectFilterContextFilters } from "../filterContext/filterContextSelectors";
 import { filterContextItemsToDashboardFiltersByWidget } from "../../../converters";
 import { createMemoizedSelector } from "../_infra/selectors";
-import isEmpty from "lodash/isEmpty";
 import { ILayoutCoordinates } from "../../../types";
 import { isInsightPlaceholderWidget, isKpiPlaceholderWidget, isPlaceholderWidget } from "../../../widgets";
+
+import { LayoutState } from "./layoutState";
+import { isItemWithBaseWidget, getWidgetCoordinates } from "./layoutUtils";
 
 const selectSelf = createSelector(
     (state: DashboardState) => state,
@@ -61,14 +62,6 @@ export const selectLayout = createSelector(selectSelf, (layoutState: LayoutState
 
     return layoutState.layout;
 });
-
-function isItemWithBaseWidget(
-    obj: IDashboardLayoutItem<ExtendedDashboardWidget>,
-): obj is IDashboardLayoutItem<IWidget> {
-    const widget = obj.widget;
-
-    return isInsightWidget(widget) || isKpiWidget(widget);
-}
 
 /**
  * This selector returns the basic dashboard layout that does not contain any client-side extensions.
@@ -260,25 +253,6 @@ export const selectLayoutHasAnalyticalWidgets = createSelector(
         return allAnalyticalWidgets.length > 0;
     },
 );
-
-function getWidgetCoordinates(layout: IDashboardLayout<ExtendedDashboardWidget>, ref: ObjRef) {
-    for (let sectionIndex = 0; sectionIndex < layout.sections.length; sectionIndex++) {
-        const section = layout.sections[sectionIndex];
-
-        for (let itemIndex = 0; itemIndex < section.items.length; itemIndex++) {
-            const item = section.items[itemIndex];
-
-            if (areObjRefsEqual(item.widget?.ref, ref)) {
-                return {
-                    sectionIndex,
-                    itemIndex,
-                };
-            }
-        }
-    }
-
-    return undefined;
-}
 
 /**
  * Selects layout coordinates for a given widget.

--- a/libs/sdk-ui-dashboard/src/model/store/layout/layoutUtils.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/layout/layoutUtils.ts
@@ -1,0 +1,91 @@
+// (C) 2021-2023 GoodData Corporation
+import {
+    IDashboardLayoutSize,
+    IDashboardLayout,
+    ObjRef,
+    areObjRefsEqual,
+    IDashboardLayoutItem,
+    IWidget,
+    isInsightWidget,
+    isKpiWidget,
+} from "@gooddata/sdk-model";
+import { IVisualizationSizeInfo } from "@gooddata/sdk-ui-ext";
+
+import { ExtendedDashboardWidget } from "../../types/layoutTypes";
+import { ILayoutCoordinates } from "../../../types";
+
+export function getWidgetCoordinates(
+    layout: IDashboardLayout<ExtendedDashboardWidget>,
+    ref: ObjRef,
+): ILayoutCoordinates | undefined {
+    const itemData = getWidgetCoordinatesAndItem(layout, ref);
+
+    if (itemData) {
+        return {
+            sectionIndex: itemData.sectionIndex,
+            itemIndex: itemData.itemIndex,
+        };
+    }
+    return undefined;
+}
+
+export function getWidgetCoordinatesAndItem(layout: IDashboardLayout<ExtendedDashboardWidget>, ref: ObjRef) {
+    for (let sectionIndex = 0; sectionIndex < layout.sections.length; sectionIndex++) {
+        const section = layout.sections[sectionIndex];
+
+        for (let itemIndex = 0; itemIndex < section.items.length; itemIndex++) {
+            const item = section.items[itemIndex];
+
+            if (areObjRefsEqual(item.widget?.ref, ref)) {
+                return {
+                    sectionIndex,
+                    itemIndex,
+                    item,
+                };
+            }
+        }
+    }
+
+    return undefined;
+}
+
+export function isItemWithBaseWidget(
+    obj: IDashboardLayoutItem<ExtendedDashboardWidget>,
+): obj is IDashboardLayoutItem<IWidget> {
+    const widget = obj.widget;
+
+    return isInsightWidget(widget) || isKpiWidget(widget);
+}
+
+export function resizeInsightWidget(
+    size: IDashboardLayoutSize,
+    sizeInfo: IVisualizationSizeInfo,
+): IDashboardLayoutSize {
+    const { width, height } = sizeInfo;
+    const { heightAsRatio } = size;
+    let { gridWidth = 0, gridHeight } = size;
+
+    //width
+    if (width.max && gridWidth > width.max) {
+        gridWidth = width.max;
+    }
+    if (width.min && gridWidth < width.min) {
+        gridWidth = width.min;
+    }
+
+    //height
+    if (!heightAsRatio) {
+        if (height.max && (gridHeight || 0) > height.max) {
+            gridHeight = height.max;
+        }
+        if (height.min && (gridHeight || 0) < height.min) {
+            gridHeight = height.min;
+        }
+    }
+
+    return {
+        gridWidth,
+        gridHeight,
+        heightAsRatio,
+    };
+}

--- a/libs/sdk-ui-dashboard/src/model/store/layout/tests/layoutUtils.test.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/layout/tests/layoutUtils.test.ts
@@ -1,0 +1,82 @@
+// (C) 2021-2023 GoodData Corporation
+import { IDashboardLayoutSize } from "@gooddata/sdk-model";
+import { resizeInsightWidget } from "../layoutUtils";
+
+describe("layout utils", () => {
+    describe("resizeInsightWidget", () => {
+        function size(gridWidth: number, gridHeight?: number, heightAsRatio?: number): IDashboardLayoutSize {
+            return { gridWidth, gridHeight, heightAsRatio };
+        }
+
+        function sizeInfo(
+            wmn: number,
+            wmx: number,
+            hmn: number,
+            hmx: number,
+            wd: number = wmn,
+            hd: number = hmn,
+        ) {
+            return {
+                width: { min: wmn, max: wmx, default: wd },
+                height: { min: hmn, max: hmx, default: hd },
+            };
+        }
+
+        it("match into size info, do nothing", () => {
+            const results = resizeInsightWidget(size(2, 2), sizeInfo(2, 2, 2, 2));
+            expect(results).toEqual({
+                gridHeight: 2,
+                gridWidth: 2,
+            });
+        });
+
+        it("is smaller than min width and height", () => {
+            const results = resizeInsightWidget(size(2, 2), sizeInfo(5, 20, 5, 20));
+            expect(results).toEqual({
+                gridHeight: 5,
+                gridWidth: 5,
+            });
+        });
+
+        it("is bigger than max width and height", () => {
+            const results = resizeInsightWidget(size(25, 25), sizeInfo(5, 20, 5, 20));
+            expect(results).toEqual({
+                gridHeight: 20,
+                gridWidth: 20,
+            });
+        });
+
+        it("ratio: match into size info, do nothing", () => {
+            const results = resizeInsightWidget(size(5, undefined, 100), sizeInfo(5, 20, 5, 20));
+            expect(results).toEqual({
+                gridWidth: 5,
+                heightAsRatio: 100,
+            });
+        });
+
+        it("ratio: is smaller than min width and height", () => {
+            const results = resizeInsightWidget(size(2, undefined, 100), sizeInfo(5, 20, 5, 20));
+            expect(results).toEqual({
+                gridWidth: 5,
+                heightAsRatio: 100,
+            });
+        });
+
+        it("ratio: is bigger than max width and height", () => {
+            const results = resizeInsightWidget(size(25, undefined, 100), sizeInfo(5, 20, 5, 20));
+            expect(results).toEqual({
+                gridWidth: 20,
+                heightAsRatio: 100,
+            });
+        });
+
+        it("invalid ratio: match into size info, do nothing", () => {
+            const results = resizeInsightWidget(size(5, 5, 100), sizeInfo(5, 20, 5, 20));
+            expect(results).toEqual({
+                gridWidth: 5,
+                gridHeight: 5,
+                heightAsRatio: 100,
+            });
+        });
+    });
+});


### PR DESCRIPTION
In new KD edit mode, after changing widget type from AD overlay → the widget height in KD canvas isn’t recalculated to adapt new chart type

JIRA: RAIL-4746

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
