### PR TITLE
BUGFIX: RAIL-4732 Sections editing

### DIFF
--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -6072,6 +6072,9 @@ export const selectIsScheduleEmailDialogOpen: OutputSelector<DashboardState, boo
 // @alpha (undocumented)
 export const selectIsScheduleEmailManagementDialogOpen: OutputSelector<DashboardState, boolean, (res: UiState) => boolean>;
 
+// @internal (undocumented)
+export const selectIsSectionInsertedByPlugin: (refs: (ObjRef | undefined)[]) => OutputSelector<DashboardState, boolean, (res: ("insertedByPlugin" | "modifiedByPlugin")[]) => boolean>;
+
 // @internal
 export const selectIsShareButtonHidden: OutputSelector<DashboardState, boolean, (res: ResolvedDashboardConfig) => boolean>;
 

--- a/libs/sdk-ui-dashboard/src/model/store/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/index.ts
@@ -1,4 +1,4 @@
-// (C) 2021-2022 GoodData Corporation
+// (C) 2021-2023 GoodData Corporation
 export { DashboardDispatch, DashboardState, DashboardSelector, DashboardSelectorEvaluator } from "./types";
 
 export { selectDashboardLoading, selectIsDashboardLoading } from "./loading/loadingSelectors";
@@ -249,6 +249,7 @@ export {
     selectWidgetsOverlayState,
     selectWidgetsModification,
     selectSectionModification,
+    selectIsSectionInsertedByPlugin,
     selectInvalidDrillWidgetRefs,
     selectInvalidUrlDrillParameterDrillLocalIdsByWidgetRef,
     selectInvalidUrlDrillParameterWidgetRefs,

--- a/libs/sdk-ui-dashboard/src/model/store/ui/uiSelectors.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/ui/uiSelectors.ts
@@ -1,4 +1,4 @@
-// (C) 2021-2022 GoodData Corporation
+// (C) 2021-2023 GoodData Corporation
 
 import { createSelector } from "@reduxjs/toolkit";
 import { areObjRefsEqual, ObjRef, objRefToString } from "@gooddata/sdk-model";
@@ -327,4 +327,16 @@ export const selectSectionModification = createMemoizedSelector((refs: (ObjRef |
             ...(modified.length === refs.length ? ["modifiedByPlugin"] : []),
         ] as Required<IDashboardWidgetOverlay>["modification"][];
     }),
+);
+
+/**
+ * @internal
+ */
+export const selectIsSectionInsertedByPlugin = createMemoizedSelector((refs: (ObjRef | undefined)[]) =>
+    createSelector(
+        selectSectionModification(refs),
+        // When all the widgets in the section were inserted by the plugin,
+        // the section was added by the plugin as well (empty section(s) cannot be added)
+        (modifications) => modifications.length > 0 && modifications.every((m) => m === "insertedByPlugin"),
+    ),
 );

--- a/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayoutRenderer/DashboardLayoutEditSectionHeaderRenderer.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayoutRenderer/DashboardLayoutEditSectionHeaderRenderer.tsx
@@ -1,4 +1,4 @@
-// (C) 2019-2022 GoodData Corporation
+// (C) 2019-2023 GoodData Corporation
 import * as React from "react";
 import { DashboardLayoutSectionHeader } from "./DashboardLayoutSectionHeader";
 import { IDashboardLayoutSectionHeaderRenderProps } from "./interfaces";
@@ -8,7 +8,7 @@ import { SectionHotspot } from "../../dragAndDrop";
 import { isInitialPlaceholderWidget } from "../../../widgets";
 import { DashboardLayoutItemViewRenderer } from "./DashboardLayoutItemViewRenderer";
 import { getRefsForSection } from "../refs";
-import { selectSectionModification, useDashboardSelector } from "../../../model";
+import { selectIsSectionInsertedByPlugin, useDashboardSelector } from "../../../model";
 
 export function DashboardLayoutEditSectionHeaderRenderer(
     props: IDashboardLayoutSectionHeaderRenderProps<any>,
@@ -20,8 +20,7 @@ export function DashboardLayoutEditSectionHeaderRenderer(
         section.index() === 0 && section.items().every((i) => isInitialPlaceholderWidget(i.widget()));
 
     const refs = getRefsForSection(section);
-    const sectionPluginModifications = useDashboardSelector(selectSectionModification(refs));
-    const isEditingDisabled = sectionPluginModifications.length > 0;
+    const isEditingDisabled = useDashboardSelector(selectIsSectionInsertedByPlugin(refs));
 
     return (
         <DashboardLayoutItemViewRenderer


### PR DESCRIPTION
In edit mode, disable editing title/description of the sections, that were inserted by the plugin.

JIRA: RAIL-4732

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
