### PR TITLE
RELATED: RAIL-4772 fix saga context updating

### DIFF
--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/saveDashboardHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/saveDashboardHandler.ts
@@ -3,7 +3,7 @@ import { DashboardContext } from "../../types/commonTypes";
 import { changeRenderMode, SaveDashboard } from "../../commands";
 import { SagaIterator } from "redux-saga";
 import { selectBasicLayout } from "../../store/layout/layoutSelectors";
-import { call, put, SagaReturnType, select, setContext } from "redux-saga/effects";
+import { call, put, SagaReturnType, select } from "redux-saga/effects";
 import {
     selectFilterContextDefinition,
     selectFilterContextIdentity,
@@ -255,12 +255,11 @@ export function* saveDashboardHandler(
         yield put(batch);
 
         if (isNewDashboard) {
-            yield setContext({
-                dashboardContext: {
-                    ...ctx,
-                    dashboardRef: dashboard.ref,
-                },
-            });
+            /*
+             * We must do this by mutating the context object, the setContext effect changes the context only
+             * for the current saga and its children. See https://github.com/redux-saga/redux-saga/issues/1798#issuecomment-468054586
+             */
+            ctx.dashboardRef = dashboard.ref;
         }
 
         const isInViewMode: ReturnType<typeof selectIsInViewMode> = yield select(selectIsInViewMode);

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/tests/saveAsDashboardHandler.test.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/tests/saveAsDashboardHandler.test.ts
@@ -1,4 +1,4 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2023 GoodData Corporation
 import { DashboardTester, preloadedTesterFactory } from "../../../tests/DashboardTester";
 import { addLayoutSection, saveDashboard, saveDashboardAs } from "../../../commands";
 import { TestInsightItem } from "../../../tests/fixtures/Layout.fixtures";
@@ -58,7 +58,7 @@ describe("save as dashboard handler", () => {
 
             expect(event.payload.dashboard.ref).not.toEqual(initialSaveEvent.payload.dashboard.ref);
             expect(event.payload.dashboard.title).toEqual(TestDashboardTitle);
-            expect(event.ctx.dashboardRef).not.toEqual(initialSaveEvent.ctx.dashboardRef);
+            expect(event.ctx.dashboardRef).toEqual(event.payload.dashboard.ref);
             const newState = Tester.state();
 
             const originalLayout = selectBasicLayout(originalState);


### PR DESCRIPTION
Turns out the setContext effect does not overwrite the value globally, instead, it sets it only for the given saga and its children. The only way to change the value globally is to mutate the context object itself.

JIRA: RAIL-4772

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
