### PR TITLE
BUGFIX: RAIL-4729 Hide overlay should be kept its state

### DIFF
--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -1108,12 +1108,16 @@ export interface DashboardConfig {
     objectAvailability?: ObjectAvailabilityConfig;
     separators?: ISeparators;
     settings?: ISettings;
+    // @internal
+    widgetsOverlay?: Record<string, IDashboardWidgetOverlay>;
 }
 
 // @public (undocumented)
 export interface DashboardContext {
     backend: IAnalyticalBackend;
     clientId?: string;
+    // @internal
+    config?: DashboardConfig;
     dashboardRef?: ObjRef;
     dataProductId?: string;
     filterContextRef?: ObjRef;
@@ -6206,6 +6210,9 @@ export const selectWidgetsMap: OutputSelector<DashboardState, ObjRefMap<Extended
 
 // @internal (undocumented)
 export const selectWidgetsModification: (refs: (ObjRef | undefined)[]) => OutputSelector<DashboardState, ("insertedByPlugin" | "modifiedByPlugin")[], (res: Record<string, IDashboardWidgetOverlay>) => ("insertedByPlugin" | "modifiedByPlugin")[]>;
+
+// @internal (undocumented)
+export const selectWidgetsOverlay: OutputSelector<DashboardState, Record<string, IDashboardWidgetOverlay>, (res: UiState) => Record<string, IDashboardWidgetOverlay>>;
 
 // @internal (undocumented)
 export const selectWidgetsOverlayState: (refs: (ObjRef | undefined)[]) => OutputSelector<DashboardState, boolean, (res: Record<string, IDashboardWidgetOverlay>) => boolean>;

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/initializeDashboardHandler/resolveDashboardConfig.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/initializeDashboardHandler/resolveDashboardConfig.ts
@@ -1,4 +1,4 @@
-// (C) 2021-2022 GoodData Corporation
+// (C) 2021-2023 GoodData Corporation
 import { SagaIterator } from "redux-saga";
 import { all, call, put } from "redux-saga/effects";
 import { IDateFilterConfigsQueryResult, IUserWorkspaceSettings } from "@gooddata/sdk-backend-spi";
@@ -186,5 +186,6 @@ function applyConfigDefaults<T extends DashboardConfig>(config: T) {
         initialRenderMode: config.initialRenderMode ?? "view",
         hideSaveAsNewButton: config.hideSaveAsNewButton ?? false,
         hideShareButton: config.hideShareButton ?? false,
+        widgetsOverlay: config.widgetsOverlay ?? {},
     };
 }

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/initializeDashboardHandler/tests/__snapshots__/handler.test.ts.snap
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/initializeDashboardHandler/tests/__snapshots__/handler.test.ts.snap
@@ -197,6 +197,7 @@ Object {
   "settings": Object {
     "enableKPIDashboardDrillFromAttribute": true,
   },
+  "widgetsOverlay": Object {},
 }
 `;
 

--- a/libs/sdk-ui-dashboard/src/model/commands/layout.ts
+++ b/libs/sdk-ui-dashboard/src/model/commands/layout.ts
@@ -1,4 +1,4 @@
-// (C) 2021-2022 GoodData Corporation
+// (C) 2021-2023 GoodData Corporation
 
 import { IDashboardCommand } from "./base";
 import { DashboardItemDefinition, RelativeIndex, StashedDashboardItemsId } from "../types/layoutTypes";
@@ -652,7 +652,6 @@ export interface MoveSectionItemToNewSection extends IDashboardCommand {
  * @param sectionIndex - source section index
  * @param itemIndex - index of item to move
  * @param toSectionIndex - target section index; you may specify -1 to move to last section
- * @param removeOriginalSectionIfEmpty - specify if original section will be removed if it stays empty after move
  * @param correlationId - specify correlation id to use for this command. this will be included in all
  *  events that will be emitted during the command processing
  *
@@ -686,7 +685,6 @@ export function moveSectionItemToNewSection(
  * @param sectionIndex - source section index
  * @param itemIndex - index of item to move
  * @param toSectionIndex - target section index; you may specify -1 to move to last section
- * @param removeOriginalSectionIfEmpty - specify if original section will be removed if it stays empty after move
  * @param correlationId - specify correlation id to use for this command. this will be included in all
  *  events that will be emitted during the command processing
  *

--- a/libs/sdk-ui-dashboard/src/model/store/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/index.ts
@@ -246,6 +246,7 @@ export {
     selectIsCancelEditModeDialogOpen,
     selectDraggingWidgetSource,
     selectDraggingWidgetTarget,
+    selectWidgetsOverlay,
     selectWidgetsOverlayState,
     selectWidgetsModification,
     selectSectionModification,

--- a/libs/sdk-ui-dashboard/src/model/types/commonTypes.ts
+++ b/libs/sdk-ui-dashboard/src/model/types/commonTypes.ts
@@ -1,4 +1,4 @@
-// (C) 2021-2022 GoodData Corporation
+// (C) 2021-2023 GoodData Corporation
 import { IAnalyticalBackend } from "@gooddata/sdk-backend-spi";
 import {
     IColorPalette,
@@ -182,6 +182,12 @@ export interface DashboardConfig {
      * Hide "Share" button in TopBar
      */
     hideShareButton?: boolean;
+
+    /**
+     * @internal
+     * Provide widgets overlays for dashboard
+     */
+    widgetsOverlay?: Record<string, IDashboardWidgetOverlay>;
 }
 
 /**
@@ -235,6 +241,16 @@ export interface DashboardContext {
      * Analytical Backend where the dashboard exists.
      */
     workspace: string;
+
+    /**
+     * Dashboard config
+     * @internal
+     *
+     * @remarks
+     * Do not use this, can be changed in future or removed at all
+     *
+     */
+    config?: DashboardConfig;
 
     /**
      * Reference to dashboard that should be loaded into the store.

--- a/libs/sdk-ui-dashboard/src/plugins/engine.ts
+++ b/libs/sdk-ui-dashboard/src/plugins/engine.ts
@@ -1,4 +1,4 @@
-// (C) 2021-2022 GoodData Corporation
+// (C) 2021-2023 GoodData Corporation
 
 import { IDashboardPluginContract_V1 } from "./plugin";
 import { Dashboard, IDashboardExtensionProps, IDashboardProps } from "../presentation";
@@ -71,6 +71,8 @@ export function newDashboardEngine(): IDashboardEngine {
                     .map(pluginDebugStr)
                     .join(", ")}`,
             );
+
+            customizationBuilder.setWidgetOverlays(ctx.config?.widgetsOverlay);
 
             for (const plugin of plugins) {
                 customizationBuilder.onBeforePluginRegister(plugin);

--- a/libs/sdk-ui-dashboard/src/presentation/layout/DashboardItemOverlay/DashboardItemOverlayController.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/layout/DashboardItemOverlay/DashboardItemOverlayController.tsx
@@ -1,4 +1,4 @@
-// (C) 2022 GoodData Corporation
+// (C) 2022-2023 GoodData Corporation
 import React from "react";
 import {
     useDashboardSelector,
@@ -30,8 +30,8 @@ export const DashboardLayoutSectionOverlayController: React.FC<
             onHide={() =>
                 dispatch(
                     uiActions.toggleWidgetsOverlay({
-                        visible: false,
                         refs: section.items().map((item) => item.ref()),
+                        visible: false,
                     }),
                 )
             }

--- a/libs/sdk-ui-dashboard/src/presentation/layout/DashboardLayoutWidget.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/layout/DashboardLayoutWidget.tsx
@@ -1,4 +1,4 @@
-// (C) 2020-2022 GoodData Corporation
+// (C) 2020-2023 GoodData Corporation
 import {
     AnalyticalWidgetType,
     IDashboardLayoutSize,
@@ -253,8 +253,8 @@ export const DashboardLayoutWidget: IDashboardLayoutWidgetRenderer<
                 onHide={() =>
                     dispatch(
                         uiActions.toggleWidgetsOverlay({
-                            visible: false,
                             refs: [item.ref()],
+                            visible: false,
                         }),
                     )
                 }

--- a/libs/sdk-ui-loaders/src/dashboard/dashboardLoader.tsx
+++ b/libs/sdk-ui-loaders/src/dashboard/dashboardLoader.tsx
@@ -1,4 +1,4 @@
-// (C) 2021-2022 GoodData Corporation
+// (C) 2021-2023 GoodData Corporation
 
 import { DashboardLoadResult, IDashboardLoader } from "./loader";
 import {
@@ -282,8 +282,12 @@ export class DashboardLoader implements IDashboardLoader {
                     "dashboardPlugin",
                 ]));
 
+        const { config } = this.baseProps;
+        let dashboardConfig = config;
+
         const ctx: DashboardContext = {
             backend,
+            config,
             workspace,
             dashboardRef,
             filterContextRef,
@@ -316,15 +320,18 @@ export class DashboardLoader implements IDashboardLoader {
             !pluginsAreValid ? StaticLoadStrategies : this.config,
             beforeExternalPluginLoaded,
         );
-        const extensionProps: IDashboardExtensionProps = engine.initializePlugins(ctx, plugins);
-        const { config } = this.baseProps;
-        let dashboardConfig = config;
+
         if (options?.allowUnfinishedFeatures === "staticOnly" && externalPluginLoaded) {
             dashboardConfig = {
                 ...config,
                 allowUnfinishedFeatures: false,
             };
         }
+
+        const extensionProps: IDashboardExtensionProps = engine.initializePlugins(
+            { ...ctx, config: dashboardConfig },
+            plugins,
+        );
         const props: IDashboardProps = {
             ...this.baseProps,
             config: dashboardConfig,

--- a/libs/sdk-ui-loaders/src/dashboard/useDashboardLoaderWithPluginManipulation.ts
+++ b/libs/sdk-ui-loaders/src/dashboard/useDashboardLoaderWithPluginManipulation.ts
@@ -12,6 +12,7 @@ import {
     RenderMode,
     selectRenderMode,
     selectDashboardWorkingDefinition,
+    selectWidgetsOverlay,
     uiActions,
 } from "@gooddata/sdk-ui-dashboard";
 import { DashboardLoadingMode, IDashboardLoadOptions, IEmbeddedPlugin } from "./types";
@@ -40,14 +41,15 @@ export function useDashboardLoaderWithPluginManipulation(options: IDashboardLoad
 } {
     const [dashboard, setDashboard] = useState(() => sanitizedDashboardRef(options.dashboard));
     const [renderMode, setRenderMode] = useState<RenderMode>(options.dashboard ? "view" : "edit");
+    const [widgetsOverlay, setWidgetsOverlay] = useState(options.config?.widgetsOverlay);
     const [loadingMode, setLoadingMode] = useState<DashboardLoadingMode>(options.loadingMode ?? "adaptive");
     const [currentExtraPlugins, setCurrentExtraPlugins] = useState<IEmbeddedPlugin[]>(() =>
         isArray(options.extraPlugins) ? options.extraPlugins : compact([options.extraPlugins]),
     );
 
     const augmentedConfig = useMemo<DashboardConfig>(
-        () => ({ ...options.config, initialRenderMode: renderMode }),
-        [options.config, renderMode],
+        () => ({ ...options.config, initialRenderMode: renderMode, widgetsOverlay }),
+        [options.config, renderMode, widgetsOverlay],
     );
 
     useEffect(() => {
@@ -79,10 +81,12 @@ export function useDashboardLoaderWithPluginManipulation(options: IDashboardLoad
         const select = dashboardSelect.current;
         const dashboardObject = select(selectDashboardWorkingDefinition);
         const renderMode = select(selectRenderMode);
+        const widgetsOverlay = select(selectWidgetsOverlay);
         // force new reference in case the current dashboard object is the same as the one with which the last reload occurred
         // this makes sure the dashboard is fully reloaded each time
         setDashboard({ ...dashboardObject } as any);
         setRenderMode(renderMode);
+        setWidgetsOverlay(widgetsOverlay);
     }, []);
 
     const hidePluginOverlays = useCallback(() => {
@@ -95,11 +99,13 @@ export function useDashboardLoaderWithPluginManipulation(options: IDashboardLoad
         const select = dashboardSelect.current;
         const dashboardObject = select(selectDashboardWorkingDefinition);
         const renderMode = select(selectRenderMode);
+        const widgetsOverlay = select(selectWidgetsOverlay);
         // force new reference in case the current dashboard object is the same as the one with which the last loading mode change occurred
         // this makes sure the dashboard is fully reloaded each time
         setDashboard({ ...dashboardObject } as any);
         setRenderMode(renderMode);
         setLoadingMode(newLoadingMode);
+        setWidgetsOverlay(widgetsOverlay);
     }, []);
 
     const setExtraPlugins = useCallback((extraPlugins: IEmbeddedPlugin | IEmbeddedPlugin[]) => {
@@ -107,10 +113,12 @@ export function useDashboardLoaderWithPluginManipulation(options: IDashboardLoad
         const select = dashboardSelect.current;
         const dashboardObject = select(selectDashboardWorkingDefinition);
         const renderMode = select(selectRenderMode);
+        const widgetsOverlay = select(selectWidgetsOverlay);
         // force new reference in case the current dashboard object is the same as the one with which the last setting of extra plugins occurred
         // this makes sure the dashboard is fully reloaded each time
         setDashboard({ ...dashboardObject } as any);
         setRenderMode(renderMode);
+        setWidgetsOverlay(widgetsOverlay);
         setCurrentExtraPlugins(isArray(extraPlugins) ? extraPlugins : [extraPlugins]);
     }, []);
 


### PR DESCRIPTION
In plugin harness, click “hide overlay” in each custom widget “hide overlays” button in plugin toolbar, now widgets added customized by the plugin will shown without overlay. Change anythings in the dashboard and press “reload” button in the plugin toolbar

Actual: The custom widgets are backed to overlay state 
Expected: They should keep selected state

JIRA: RAIL-4729

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
