### PR TITLE
BUGFIX: RAIL-4765 Custom widgets export

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/layout/DashboardLayoutWidget.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/layout/DashboardLayoutWidget.tsx
@@ -1,4 +1,4 @@
-// (C) 2020-2022 GoodData Corporation
+// (C) 2020-2023 GoodData Corporation
 import {
     AnalyticalWidgetType,
     IDashboardLayoutSize,
@@ -13,6 +13,7 @@ import {
 } from "@gooddata/sdk-model";
 import { IVisualizationSizeInfo, WIDGET_DROPZONE_SIZE_INFO_DEFAULT } from "@gooddata/sdk-ui-ext";
 import React, { useRef } from "react";
+import cx from "classnames";
 import {
     ExtendedDashboardWidget,
     isCustomWidget,
@@ -26,6 +27,7 @@ import {
     selectWidgetsOverlayState,
     selectWidgetsModification,
     selectSectionModification,
+    selectIsExport,
 } from "../../model";
 import { isAnyPlaceholderWidget, isPlaceholderWidget } from "../../widgets";
 import { getDashboardLayoutWidgetDefaultHeight, getSizeInfo } from "../../_staging/layout/sizing";
@@ -124,6 +126,7 @@ export const DashboardLayoutWidget: IDashboardLayoutWidgetRenderer<
     const insights = useDashboardSelector(selectInsightsMap);
     const settings = useDashboardSelector(selectSettings);
     const isInEditMode = useDashboardSelector(selectIsInEditMode);
+    const isExport = useDashboardSelector(selectIsExport);
     const enableWidgetCustomHeight = useDashboardSelector(selectEnableWidgetCustomHeight);
 
     const handleDragEnd = useWidgetDragEndHandler();
@@ -131,7 +134,8 @@ export const DashboardLayoutWidget: IDashboardLayoutWidgetRenderer<
     // TODO: we should probably do something more meaningful when item has no widget; should that even
     //  be allowed? undefined widget will make things explode down the line away so..
     const widget = item.widget()!;
-    const isDraggableWidgetType = !(isPlaceholderWidget(widget) || isCustomWidget(widget));
+    const isCustom = isCustomWidget(widget);
+    const isDraggableWidgetType = !(isPlaceholderWidget(widget) || isCustom);
 
     const [{ isDragging }, dragRef] = useDashboardDrag(
         {
@@ -204,7 +208,13 @@ export const DashboardLayoutWidget: IDashboardLayoutWidgetRenderer<
             contentRef={contentRef}
             getLayoutDimensions={getLayoutDimensions}
         >
-            <div ref={dragRef} className="dashboard-widget-draggable-wrapper">
+            <div
+                ref={dragRef}
+                className={cx([
+                    "dashboard-widget-draggable-wrapper",
+                    { "gd-custom-widget-export": isCustom && isExport },
+                ])}
+            >
                 <DashboardWidget
                     // @ts-expect-error Don't expose index prop on public interface (we need it only for css class for KD tests)
                     index={index}

--- a/libs/sdk-ui-dashboard/styles/scss/export.scss
+++ b/libs/sdk-ui-dashboard/styles/scss/export.scss
@@ -27,4 +27,15 @@
     .gd-row-header-view .description .more-link.active {
         display: none;
     }
+
+    // For some reason, custom widgets in export mode are rendered with wrong height,
+    // or with height 0. height: 100% does not solve it, but we can rely on fact, that
+    // gd-fluild-layout-column has position: relative, so we can stretch the container to a full size.
+    .gd-custom-widget-export {
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+    }
 }


### PR DESCRIPTION
Ensure that custom widgets height in export mode
is equal to the grid height and the custom widgets are properly stretched,
otherwise, they may be rendered with the wrong height, or not at all.

JIRA: RAIL-4765

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
