### PR TITLE
RELATED: RAIL-4774 fix filter-related ObjRef matching

### DIFF
--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/filterContext/attributeFilter/validation/filterDisplayFormValidation.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/filterContext/attributeFilter/validation/filterDisplayFormValidation.ts
@@ -1,6 +1,5 @@
-// (C) 2022 GoodData Corporation
-
-import { areObjRefsEqual, ObjRef } from "@gooddata/sdk-model";
+// (C) 2022-2023 GoodData Corporation
+import { areObjRefsEqual, idRef, ObjRef, uriRef } from "@gooddata/sdk-model";
 import { DashboardContext } from "../../../../types/commonTypes";
 
 export type AttributeFilterDisplayFormValidationResult =
@@ -25,7 +24,14 @@ export async function validateFilterDisplayForm(
     ).displayForms;
 
     // validate if the display form is between attributes available display forms.
-    if (attributeDisplayForms.some((df) => areObjRefsEqual(df.ref, displayForm))) {
+    // try matching both uri and id in case the type of ref is different from what is in the ref field
+    if (
+        attributeDisplayForms.some(
+            (df) =>
+                areObjRefsEqual(idRef(df.id, "displayForm"), displayForm) ||
+                areObjRefsEqual(uriRef(df.uri), displayForm),
+        )
+    ) {
         return "VALID";
     }
 

--- a/libs/sdk-ui-dashboard/src/model/store/filterContext/filterContextSelectors.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/filterContext/filterContextSelectors.ts
@@ -1,4 +1,4 @@
-// (C) 2021-2022 GoodData Corporation
+// (C) 2021-2023 GoodData Corporation
 import { createSelector } from "@reduxjs/toolkit";
 import { DashboardState } from "../types";
 import invariant from "ts-invariant";
@@ -10,6 +10,8 @@ import {
     IDashboardDateFilter,
     isDashboardAttributeFilter,
     isDashboardDateFilter,
+    uriRef,
+    idRef,
 } from "@gooddata/sdk-model";
 import { newDisplayFormMap } from "../../../_staging/metadata/objRefMap";
 import { createMemoizedSelector } from "../_infra/selectors";
@@ -201,8 +203,14 @@ export const selectFilterContextAttributeFilterByDisplayForm = createMemoizedSel
         selectFilterContextAttributeFilters,
         (attributeDisplayFormsMap, attributeFilters) => {
             const df = attributeDisplayFormsMap.get(displayForm);
-            return attributeFilters.find((filter) =>
-                areObjRefsEqual(filter.attributeFilter.displayForm, df?.ref),
+            if (!df) {
+                return undefined;
+            }
+            // try matching both uri and id in case the type of ref is different from what is in the ref field
+            return attributeFilters.find(
+                (filter) =>
+                    areObjRefsEqual(filter.attributeFilter.displayForm, idRef(df.id, "displayForm")) ||
+                    areObjRefsEqual(filter.attributeFilter.displayForm, uriRef(df.uri)),
             );
         },
     ),


### PR DESCRIPTION
Handle both types of ObjRefs in case the user uses idRef and backend uses uriRef or vice versa.

JIRA: RAIL-4774

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
