### PR TITLE
BUGFIX: RAIL-4729 reset widgets overlay state on loading mode changed

### DIFF
--- a/libs/sdk-ui-loaders/src/dashboard/useDashboardLoaderWithPluginManipulation.ts
+++ b/libs/sdk-ui-loaders/src/dashboard/useDashboardLoaderWithPluginManipulation.ts
@@ -99,13 +99,13 @@ export function useDashboardLoaderWithPluginManipulation(options: IDashboardLoad
         const select = dashboardSelect.current;
         const dashboardObject = select(selectDashboardWorkingDefinition);
         const renderMode = select(selectRenderMode);
-        const widgetsOverlay = select(selectWidgetsOverlay);
         // force new reference in case the current dashboard object is the same as the one with which the last loading mode change occurred
         // this makes sure the dashboard is fully reloaded each time
         setDashboard({ ...dashboardObject } as any);
         setRenderMode(renderMode);
         setLoadingMode(newLoadingMode);
-        setWidgetsOverlay(widgetsOverlay);
+        // force reset overlays to not keep between modes
+        setWidgetsOverlay({});
     }, []);
 
     const setExtraPlugins = useCallback((extraPlugins: IEmbeddedPlugin | IEmbeddedPlugin[]) => {


### PR DESCRIPTION
JIRA: RAIL-4729

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
