### PR TITLE
BUGFIX: TNT-1175 Fix KPI height in PDF exports

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayout.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayout.tsx
@@ -157,7 +157,7 @@ export const DefaultDashboardLayout = (props: IDashboardLayoutProps): JSX.Elemen
     return (
         <>
             <DashboardLayout
-                className={isExport ? "export-mode" : ""}
+                className={isExport ? "export-mode export-mode-flex" : ""}
                 layout={transformedLayout}
                 itemKeyGetter={itemKeyGetter}
                 widgetRenderer={widgetRenderer}

--- a/libs/sdk-ui-dashboard/styles/scss/export.scss
+++ b/libs/sdk-ui-dashboard/styles/scss/export.scss
@@ -39,3 +39,14 @@
         bottom: 0;
     }
 }
+
+// Display 'block' behaves weird in exports in case of small KPI in their default height. Overriding block
+// by flex seems to solve the issue. The new class is added for backwards compatibility with plugins.
+// When no new issues arise, we may delete this class and remove the 'display: block !important;'
+// from the original '.export-mode' class. Then the export mode would inherit the 'display: flex;'.
+.export-mode-flex {
+    div.gd-fluidlayout-row {
+        display: flex !important; /* stylelint-disable-line declaration-no-important */
+        flex-direction: column;
+    }
+}


### PR DESCRIPTION
When a KPI without comparison is in one row in dashboard only with other KPIs and all have their default heights, PDF export with theming is corrupted as the height of the smaller KPI is not 100%. Overriding display block by flex fixes this case.

JIRA TNT-1175

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
