### PR TITLE
 FEATURE: TNT-1268 Allow showing all attribute values in execution and persisting in MD

### DIFF
--- a/libs/api-model-bear/api/api-model-bear.api.md
+++ b/libs/api-model-bear/api/api-model-bear.api.md
@@ -2992,6 +2992,8 @@ export namespace GdcVisualizationObject {
         displayForm: ObjQualifier;
         // (undocumented)
         localIdentifier: Identifier;
+        // (undocumented)
+        showAllValues?: boolean;
     }
     // (undocumented)
     export interface IVisualizationObject {

--- a/libs/api-model-bear/src/visualizationObject/GdcVisualizationObject.ts
+++ b/libs/api-model-bear/src/visualizationObject/GdcVisualizationObject.ts
@@ -1,4 +1,4 @@
-// (C) 2007-2021 GoodData Corporation
+// (C) 2007-2023 GoodData Corporation
 import { GdcMetadata } from "../meta/GdcMetadata";
 import isEmpty from "lodash/isEmpty";
 
@@ -183,6 +183,7 @@ export namespace GdcVisualizationObject {
         localIdentifier: Identifier;
         displayForm: ObjQualifier;
         alias?: string;
+        showAllValues?: boolean;
     }
 
     export interface IMeasureDefinition {

--- a/libs/sdk-backend-tiger/src/backend/features/feature.ts
+++ b/libs/sdk-backend-tiger/src/backend/features/feature.ts
@@ -100,6 +100,13 @@ export function mapFeatures(features: FeaturesMap): Partial<ITigerFeatureFlags> 
             "BOOLEAN",
             FeatureFlagsValues.enablePushpinGeoChart,
         ),
+        ...loadFeature(
+            features,
+            TigerFeaturesNames.EnableAttributeAllValues,
+            "enableAttributeAllValues",
+            "BOOLEAN",
+            FeatureFlagsValues.enableAttributeAllValues,
+        ),
     };
 }
 

--- a/libs/sdk-backend-tiger/src/backend/uiFeatures.ts
+++ b/libs/sdk-backend-tiger/src/backend/uiFeatures.ts
@@ -30,6 +30,8 @@ export enum TigerFeaturesNames {
     EnableAnalyticalDashboardPermissions = "enableAnalyticalDashboardPermissions",
     //boolean + possible values: enabled, disabled
     EnablePushpinGeoChart = "enablePushpinGeoChart",
+    //boolean + possible values: enabled, disabled
+    EnableAttributeAllValues = "enableAttributeAllValues",
 }
 
 export type ITigerFeatureFlags = {
@@ -45,6 +47,7 @@ export type ITigerFeatureFlags = {
     enableDescriptions: typeof FeatureFlagsValues["enableDescriptions"][number];
     enableAnalyticalDashboardPermissions: typeof FeatureFlagsValues["enableAnalyticalDashboardPermissions"][number];
     enablePushpinGeoChart: typeof FeatureFlagsValues["enablePushpinGeoChart"][number];
+    enableAttributeAllValues: typeof FeatureFlagsValues["enableAttributeAllValues"][number];
 };
 
 export const DefaultFeatureFlags: ITigerFeatureFlags = {
@@ -61,6 +64,7 @@ export const DefaultFeatureFlags: ITigerFeatureFlags = {
     enableDescriptions: false,
     enableAnalyticalDashboardPermissions: false,
     enablePushpinGeoChart: false,
+    enableAttributeAllValues: false,
 };
 
 export const FeatureFlagsValues = {
@@ -80,4 +84,5 @@ export const FeatureFlagsValues = {
     enableDescriptions: [true, false] as const,
     enableAnalyticalDashboardPermissions: [true, false] as const,
     enablePushpinGeoChart: [true, false] as const,
+    enableAttributeAllValues: [true, false] as const,
 };

--- a/libs/sdk-backend-tiger/src/convertors/toBackend/afm/AttributeConverter.ts
+++ b/libs/sdk-backend-tiger/src/convertors/toBackend/afm/AttributeConverter.ts
@@ -1,4 +1,4 @@
-// (C) 2020-2021 GoodData Corporation
+// (C) 2020-2023 GoodData Corporation
 
 import { IAttribute } from "@gooddata/sdk-model";
 import { AttributeItem } from "@gooddata/api-client-tiger";
@@ -6,13 +6,14 @@ import { AttributeItem } from "@gooddata/api-client-tiger";
 import { toLabelQualifier } from "../ObjRefConverter";
 
 export function convertAttribute(attribute: IAttribute, idx: number): AttributeItem {
-    const alias = attribute.attribute.alias;
+    const { displayForm, alias, showAllValues } = attribute.attribute;
     const aliasProp = alias ? { alias } : {};
-    const labelRef = attribute.attribute.displayForm;
+    const showAllValuesProp = showAllValues ? { showAllValues } : {};
 
     return {
-        label: toLabelQualifier(labelRef),
+        label: toLabelQualifier(displayForm),
         localIdentifier: attribute.attribute.localIdentifier || `a${idx + 1}`,
         ...aliasProp,
+        ...showAllValuesProp,
     };
 }

--- a/libs/sdk-backend-tiger/src/convertors/toBackend/afm/tests/AttributeConverter.test.ts
+++ b/libs/sdk-backend-tiger/src/convertors/toBackend/afm/tests/AttributeConverter.test.ts
@@ -1,4 +1,4 @@
-// (C) 2020-2021 GoodData Corporation
+// (C) 2020-2023 GoodData Corporation
 import { ReferenceMd } from "@gooddata/reference-workspace";
 import { newAttribute } from "@gooddata/sdk-model";
 
@@ -10,6 +10,7 @@ describe("attribute converter", () => {
         ["simple attribute", newAttribute(displayFormRef)],
         ["attribute with empty localId", newAttribute(displayFormRef, (a) => a.localId(""))],
         ["attribute with alias", newAttribute(displayFormRef, (m) => m.alias("alias"))],
+        ["attribute with show all values", newAttribute(displayFormRef, (m) => m.showAllValues(true))],
     ];
 
     it.each(Scenarios)("should return %s", (_desc, input) => {

--- a/libs/sdk-backend-tiger/src/convertors/toBackend/afm/tests/__snapshots__/AttributeConverter.test.ts.snap
+++ b/libs/sdk-backend-tiger/src/convertors/toBackend/afm/tests/__snapshots__/AttributeConverter.test.ts.snap
@@ -13,6 +13,19 @@ Object {
 }
 `;
 
+exports[`attribute converter should return attribute with show all values 1`] = `
+Object {
+  "label": Object {
+    "identifier": Object {
+      "id": "label.account.id.name",
+      "type": "label",
+    },
+  },
+  "localIdentifier": "a_label.account.id.name",
+  "showAllValues": true,
+}
+`;
+
 exports[`attribute converter should return attribute with empty localId 1`] = `
 Object {
   "label": Object {

--- a/libs/sdk-model/api/sdk-model.api.md
+++ b/libs/sdk-model/api/sdk-model.api.md
@@ -65,6 +65,7 @@ export class AttributeBuilder {
     displayForm: (ref: ObjRef) => this;
     localId: (localId?: Identifier | undefined) => this;
     noAlias: () => this;
+    showAllValues: (showAllValues?: boolean | undefined) => this;
 }
 
 // @public
@@ -121,6 +122,9 @@ export type AttributePredicate = (attribute: IAttribute) => boolean;
 
 // @public
 export function attributesFind(attributes: IAttribute[], idOrFun?: string | AttributePredicate): IAttribute | undefined;
+
+// @public
+export function attributeShowAllValues(attribute: IAttribute): boolean | undefined;
 
 // @public
 export function attributeUri(attribute: IAttribute): string | undefined;
@@ -472,6 +476,7 @@ export interface IAttributeBody {
     alias?: string;
     displayForm: ObjRef;
     localIdentifier: Identifier;
+    showAllValues?: boolean;
 }
 
 // @public

--- a/libs/sdk-model/src/execution/attribute/factory.ts
+++ b/libs/sdk-model/src/execution/attribute/factory.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2022 GoodData Corporation
+// (C) 2019-2023 GoodData Corporation
 import identity from "lodash/identity";
 import cloneDeep from "lodash/cloneDeep";
 import isEmpty from "lodash/isEmpty";
@@ -69,6 +69,26 @@ export class AttributeBuilder {
      */
     public noAlias = (): this => {
         delete this.attribute.alias;
+
+        return this;
+    };
+
+    /**
+     * Sets show all values property.
+     *
+     * @remarks
+     * The flag showAllValues translates to a property of the same name on the attribute in execution definition.
+     * If truthy, the backend will return all values of the particular attribute in the execution response
+     * even if there are no data available for it.
+     *
+     * @param showAllValues - flag defining whether to return all attribute values for given attribute; undefined to use backend default behavior(false)
+     */
+    public showAllValues = (showAllValues?: boolean | undefined): this => {
+        if (showAllValues === undefined) {
+            delete this.attribute.showAllValues;
+        } else {
+            this.attribute.showAllValues = showAllValues;
+        }
 
         return this;
     };

--- a/libs/sdk-model/src/execution/attribute/index.ts
+++ b/libs/sdk-model/src/execution/attribute/index.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2022 GoodData Corporation
+// (C) 2019-2023 GoodData Corporation
 import { Identifier, isUriRef, ObjRef, isIdentifierRef } from "../../objRef";
 import isEmpty from "lodash/isEmpty";
 import invariant from "ts-invariant";
@@ -45,6 +45,12 @@ export interface IAttributeBody {
      * metadata about execution results, it WILL include this user-assigned alias in the metadata.
      */
     alias?: string;
+
+    /**
+     * Indicates whether to show all values of given attribute even if the data bound to those values
+     * are not available
+     */
+    showAllValues?: boolean;
 }
 
 /**
@@ -152,6 +158,19 @@ export function attributeAlias(attribute: IAttribute): string | undefined {
     invariant(attribute, "attribute must be specified");
 
     return attribute.attribute.alias;
+}
+
+/**
+ * Gets an attribute show all values property.
+ *
+ * @param attribute - attribute to work with
+ * @returns value of attribute show all values property
+ * @public
+ */
+export function attributeShowAllValues(attribute: IAttribute): boolean | undefined {
+    invariant(attribute, "attribute must be specified");
+
+    return attribute.attribute.showAllValues;
 }
 
 /**

--- a/libs/sdk-model/src/index.ts
+++ b/libs/sdk-model/src/index.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2022 GoodData Corporation
+// (C) 2019-2023 GoodData Corporation
 /**
  * This package provides domain models for GoodData.UI.
  *
@@ -26,6 +26,7 @@ export {
     attributeUri,
     attributeIdentifier,
     attributeAlias,
+    attributeShowAllValues,
     attributeDisplayFormRef,
 } from "./execution/attribute";
 


### PR DESCRIPTION
Jira: TNT-1268

There is a new feature being developed on Tiger backend - showing all attribute values (elements) in the execution result even if there are no (fact) data bound to that particular value. 

This change is to allow the AD user to choose "show all values" on an attribute, persist it on Tiger backend, and to construct the execution request as defined in TNT-1268.

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
