### PR TITLE
BUGFIX: TNT-1298 Support attribute color mapping by identifier

### DIFF
--- a/libs/sdk-ui-ext/src/internal/utils/colors.ts
+++ b/libs/sdk-ui-ext/src/internal/utils/colors.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2022 GoodData Corporation
+// (C) 2019-2023 GoodData Corporation
 import set from "lodash/set";
 import isEqual from "lodash/isEqual";
 import uniqBy from "lodash/uniqBy";
@@ -17,6 +17,7 @@ import {
     isAttributeDescriptor,
     isMeasureDescriptor,
     isResultAttributeHeader,
+    isUriRef,
 } from "@gooddata/sdk-model";
 import { getMappingHeaderName, IColorAssignment, IMappingHeader } from "@gooddata/sdk-ui";
 import { ColorUtils } from "@gooddata/sdk-ui-charts";
@@ -91,7 +92,10 @@ export function getProperties(
     } else if (isResultAttributeHeader(item)) {
         return mergeColorMappingToProperties(properties, item.attributeHeaderItem.uri, color);
     } else if (isAttributeDescriptor(item)) {
-        return mergeColorMappingToProperties(properties, item.attributeHeader.uri, color);
+        const id = isUriRef(item.attributeHeader.ref)
+            ? item.attributeHeader.uri
+            : item.attributeHeader.identifier;
+        return mergeColorMappingToProperties(properties, id, color);
     }
 
     return {};
@@ -118,7 +122,9 @@ export function getValidProperties(
             } else if (isResultAttributeHeader(colorAssignment.headerItem)) {
                 return colorAssignment.headerItem.attributeHeaderItem.uri === id;
             } else if (isAttributeDescriptor(colorAssignment.headerItem)) {
-                return colorAssignment.headerItem.attributeHeader.uri === id;
+                return isUriRef(colorAssignment.headerItem.attributeHeader.ref)
+                    ? colorAssignment.headerItem.attributeHeader.uri === id
+                    : colorAssignment.headerItem.attributeHeader.identifier === id;
             }
 
             return false;

--- a/libs/sdk-ui-ext/src/internal/utils/tests/colors.test.ts
+++ b/libs/sdk-ui-ext/src/internal/utils/tests/colors.test.ts
@@ -1,8 +1,8 @@
-// (C) 2019-2020 GoodData Corporation
+// (C) 2019-2023 GoodData Corporation
 import { DefaultColorPalette, IMappingHeader } from "@gooddata/sdk-ui";
 import { IColorConfiguration, IColoredItem } from "../../interfaces/Colors";
 import { getColoredInputItems, getProperties, getSearchedItems, getValidProperties } from "../colors";
-import { GuidType, IColor, uriRef } from "@gooddata/sdk-model";
+import { GuidType, IColor, idRef, uriRef } from "@gooddata/sdk-model";
 
 describe("color utils", () => {
     const color1: IColor = {
@@ -44,6 +44,27 @@ describe("color utils", () => {
                     localIdentifier: "a1",
                     name: "attribute header",
                     ref: uriRef("a1"),
+                    formOf: {
+                        uri: "a1",
+                        identifier: "label.a1",
+                        name: "attribute header",
+                        ref: uriRef("a1"),
+                    },
+                },
+            },
+            color: color1,
+        },
+    ];
+
+    const tigerAttributeHeaderColorAssignments = [
+        {
+            headerItem: {
+                attributeHeader: {
+                    uri: "",
+                    identifier: "label.a1",
+                    localIdentifier: "a1",
+                    name: "attribute header",
+                    ref: idRef("label.a1"),
                     formOf: {
                         uri: "a1",
                         identifier: "label.a1",
@@ -133,6 +154,28 @@ describe("color utils", () => {
             const result = getValidProperties(properties, attributeHeaderColorAssignments);
             expect(result.controls.colorMapping).toEqual(colorMapping);
         });
+
+        it("should keep attribute header color mapping defined by identifier (Tiger) for items which are in color assignment", () => {
+            const colorMapping = [
+                {
+                    id: "label.a1",
+                    color: color1,
+                },
+            ];
+
+            const richColorMapping = [
+                ...colorMapping,
+                {
+                    id: "label.a2",
+                    color: color1,
+                },
+            ];
+
+            const properties = getProperties(richColorMapping);
+
+            const result = getValidProperties(properties, tigerAttributeHeaderColorAssignments);
+            expect(result.controls.colorMapping).toEqual(colorMapping);
+        });
     });
 
     describe("getProperties", () => {
@@ -157,6 +200,38 @@ describe("color utils", () => {
             attributeHeaderItem: {
                 uri: "/a1",
                 name: "",
+            },
+        };
+
+        const attributeHeader: IMappingHeader = {
+            attributeHeader: {
+                uri: "/a1",
+                identifier: "label.a1",
+                localIdentifier: "a1",
+                name: "attribute header",
+                ref: uriRef("/a1"),
+                formOf: {
+                    uri: "a1",
+                    identifier: "label.a1",
+                    name: "attribute header",
+                    ref: uriRef("a1"),
+                },
+            },
+        };
+
+        const tigerAttributeHeader = {
+            attributeHeader: {
+                uri: "",
+                identifier: "label.a1",
+                localIdentifier: "a1",
+                name: "attribute header",
+                ref: idRef("label.a1"),
+                formOf: {
+                    uri: "a1",
+                    identifier: "label.a1",
+                    name: "attribute header",
+                    ref: uriRef("a1"),
+                },
             },
         };
 
@@ -203,6 +278,44 @@ describe("color utils", () => {
                 controls: {
                     colorMapping: [
                         createIdColorMappingItemByGuid("/a1", guid),
+                        createIdColorMappingItemByGuid("m1", "guid1"),
+                    ],
+                },
+            });
+        });
+
+        it("should assign attribute by uri to properties", () => {
+            const properties = {
+                controls: {
+                    colorMapping: [createIdColorMappingItemByGuid("m1", "guid1")],
+                },
+            };
+
+            const result = getProperties(properties, attributeHeader, guidColor);
+
+            expect(result).toEqual({
+                controls: {
+                    colorMapping: [
+                        createIdColorMappingItemByGuid("/a1", guid),
+                        createIdColorMappingItemByGuid("m1", "guid1"),
+                    ],
+                },
+            });
+        });
+
+        it("should assign attribute by identifier to properties", () => {
+            const properties = {
+                controls: {
+                    colorMapping: [createIdColorMappingItemByGuid("m1", "guid1")],
+                },
+            };
+
+            const result = getProperties(properties, tigerAttributeHeader, guidColor);
+
+            expect(result).toEqual({
+                controls: {
+                    colorMapping: [
+                        createIdColorMappingItemByGuid("label.a1", guid),
                         createIdColorMappingItemByGuid("m1", "guid1"),
                     ],
                 },

--- a/libs/sdk-ui-vis-commons/src/coloring/color.ts
+++ b/libs/sdk-ui-vis-commons/src/coloring/color.ts
@@ -1,4 +1,4 @@
-// (C) 2007-2022 GoodData Corporation
+// (C) 2007-2023 GoodData Corporation
 import {
     IColor,
     IColorPalette,
@@ -206,7 +206,10 @@ export function getColorMappingPredicate(testValue: string): IHeaderPredicate {
         }
 
         if (isAttributeDescriptor(header)) {
-            return testValue ? testValue === header.attributeHeader.uri : false;
+            // check both to support ref by uri and ref by identifier
+            return testValue
+                ? testValue === header.attributeHeader.uri || testValue === header.attributeHeader.identifier
+                : false;
         }
 
         const headerLocalIdentifier = getMappingHeaderLocalIdentifier(header);


### PR DESCRIPTION
To support color mapping on location attribute
of Geo chart on Tiger add comparison
with identifier too
JIRA: TNT-1298

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                               | Description                                                |
| ----------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                          | Re-run standard checks                                     |
| `extended check sonar`                                | SonarQube tests                                            |
| `extended check plugins`                              | Dashboard plugins tests                                    |
| `extended test - backstop`                            | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                |                                                            |
| `extended test - tiger-cypress - isolated <testName>` | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`   | Create a new recording for isolated Tiger tests.           |
| **E2E Cypress tests commands - BEAR**                 |                                                            |
| `extended test - cypress - isolated <testName>`       | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`         | Create a new recording for isolated Bear tests.            |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
