### PR TITLE
BUGFIX: RAIL-4798 frontend apps is stuck in loading

### DIFF
--- a/libs/sdk-backend-tiger/src/backend/features/hub.ts
+++ b/libs/sdk-backend-tiger/src/backend/features/hub.ts
@@ -1,4 +1,4 @@
-// (C) 2020-2022 GoodData Corporation
+// (C) 2020-2023 GoodData Corporation
 import { ILiveFeatures, FeatureContext } from "@gooddata/api-client-tiger";
 import axios, { AxiosResponse } from "axios";
 
@@ -14,6 +14,7 @@ type HubServiceState = Record<
 >;
 
 const state: HubServiceState = {};
+const FH_TIMEOUT = 30000; //wait max 30s to FeatureHub
 
 export async function getFeatureHubFeatures(
     features: ILiveFeatures["live"],
@@ -93,6 +94,7 @@ async function getFeatureHubData(
         params: {
             sdkUrl: key,
         },
+        timeout: FH_TIMEOUT,
         headers: {
             "Content-type": "application/json",
             "X-FeatureHub": Object.keys(context)

--- a/libs/sdk-backend-tiger/src/backend/features/test/hub.test.ts
+++ b/libs/sdk-backend-tiger/src/backend/features/test/hub.test.ts
@@ -1,4 +1,4 @@
-// (C) 2020-2022 GoodData Corporation
+// (C) 2020-2023 GoodData Corporation
 
 import axios, { AxiosResponse } from "axios";
 import { ILiveFeatures } from "@gooddata/api-client-tiger";
@@ -51,6 +51,7 @@ describe("live features", () => {
             method: "GET",
             params: { sdkUrl: "" },
             validateStatus: expect.anything(),
+            timeout: 30000,
         });
     });
 
@@ -68,6 +69,7 @@ describe("live features", () => {
             method: "GET",
             params: { sdkUrl: "" },
             validateStatus: expect.anything(),
+            timeout: 30000,
         });
     });
 
@@ -85,6 +87,7 @@ describe("live features", () => {
             method: "GET",
             params: { sdkUrl: "" },
             validateStatus: expect.anything(),
+            timeout: 30000,
         });
     });
 
@@ -102,6 +105,7 @@ describe("live features", () => {
             method: "GET",
             params: { sdkUrl: "" },
             validateStatus: expect.anything(),
+            timeout: 30000,
         });
     });
 


### PR DESCRIPTION
FE apps is stuck in loading when connection to FeatureHub
 got timeout

JIRA: RAIL-4798

---

Supported PR commands:

| Command                                               | Description                                                |
| ----------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                          | Re-run standard checks                                     |
| `extended check sonar`                                | SonarQube tests                                            |
| `extended check plugins`                              | Dashboard plugins tests                                    |
| `extended test - backstop`                            | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                |                                                            |
| `extended test - tiger-cypress - isolated <testName>` | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`   | Create a new recording for isolated Tiger tests.           |
| **E2E Cypress tests commands - BEAR**                 |                                                            |
| `extended test - cypress - isolated <testName>`       | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`         | Create a new recording for isolated Bear tests.            |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
