### PR TITLE
BUGFIX: TNT-1262 Add hostname to export when provided

### DIFF
--- a/examples/playground/src/App.tsx
+++ b/examples/playground/src/App.tsx
@@ -1,4 +1,4 @@
-// (C) 2019-2022 GoodData Corporation
+// (C) 2019-2023 GoodData Corporation
 import React, { useMemo } from "react";
 import { BackendProvider, WorkspaceProvider } from "@gooddata/sdk-ui";
 import { createBackend } from "./createBackend";

--- a/libs/api-client-bear/src/report/report.ts
+++ b/libs/api-client-bear/src/report/report.ts
@@ -1,4 +1,4 @@
-// (C) 2007-2022 GoodData Corporation
+// (C) 2007-2023 GoodData Corporation
 import { GdcExecuteAFM, GdcExport } from "@gooddata/api-model-bear";
 import compact from "lodash/compact";
 import isEmpty from "lodash/isEmpty";
@@ -58,7 +58,13 @@ export class ReportModule {
 
         return this.xhr
             .post(`/gdc/internal/projects/${projectId}/exportResult`, { body: requestPayload })
-            .then((response: ApiResponse) => response.getData())
+            .then((response: ApiResponse) => {
+                const hostname = this.xhr.getHostname() ?? "";
+                const uri = response.getData()?.uri ?? "";
+                return {
+                    uri: `${hostname}${uri}`,
+                };
+            })
             .then((data: GdcExport.IExportResponse) =>
                 handleHeadPolling(this.xhr.get.bind(this.xhr), data.uri, isExportFinished, pollingOptions),
             )

--- a/libs/api-client-bear/src/xhr.ts
+++ b/libs/api-client-bear/src/xhr.ts
@@ -1,4 +1,4 @@
-// (C) 2007-2022 GoodData Corporation
+// (C) 2007-2023 GoodData Corporation
 import isPlainObject from "lodash/isPlainObject";
 import isFunction from "lodash/isFunction";
 import set from "lodash/set";
@@ -246,6 +246,10 @@ export class XhrModule {
 
         // throws on 400, 500, etc.
         throw new ApiResponseError(response.statusText, response, responseBody);
+    }
+
+    public getHostname() {
+        return this.configStorage?.hostname;
     }
 
     /**

--- a/libs/api-client-tiger/api/api-client-tiger.api.md
+++ b/libs/api-client-tiger/api/api-client-tiger.api.md
@@ -3789,6 +3789,8 @@ export interface ITigerClient {
     // (undocumented)
     axios: AxiosInstance;
     // (undocumented)
+    config: ITigerClientConfig;
+    // (undocumented)
     declarativeLayout: ReturnType<typeof tigerLayoutClientFactory>;
     // (undocumented)
     entities: ReturnType<typeof tigerEntitiesObjectsClientFactory>;
@@ -3809,6 +3811,12 @@ export interface ITigerClient {
     setApiToken: (token: string | undefined) => void;
     // (undocumented)
     validObjects: ReturnType<typeof tigerValidObjectsClientFactory>;
+}
+
+// @public (undocumented)
+export interface ITigerClientConfig {
+    // (undocumented)
+    hostname?: string;
 }
 
 // @public (undocumented)
@@ -7857,7 +7865,7 @@ export const tigerAfmExplainClientFactory: (axios: AxiosInstance) => Pick<AfmAct
 export const tigerAuthActionsClientFactory: (axios: AxiosInstance) => AuthActionsApiInterface;
 
 // @public
-export const tigerClientFactory: (axios: AxiosInstance) => ITigerClient;
+export const tigerClientFactory: (axios: AxiosInstance, config?: ITigerClientConfig) => ITigerClient;
 
 // @public (undocumented)
 export const tigerEntitiesObjectsClientFactory: (axios: AxiosInstance) => EntitiesApiInterface;

--- a/libs/api-client-tiger/src/client.ts
+++ b/libs/api-client-tiger/src/client.ts
@@ -85,8 +85,13 @@ export {
     ActionsApiGetTabularExportRequest,
 };
 
+export interface ITigerClientConfig {
+    hostname?: string;
+}
+
 export interface ITigerClient {
     axios: AxiosInstance;
+    config: ITigerClientConfig;
     execution: ReturnType<typeof tigerExecutionClientFactory>;
     executionResult: ReturnType<typeof tigerExecutionResultClientFactory>;
     labelElements: ReturnType<typeof tigerLabelElementsClientFactory>;
@@ -114,7 +119,7 @@ export interface ITigerClient {
  * Tiger execution client
  *
  */
-export const tigerClientFactory = (axios: AxiosInstance): ITigerClient => {
+export const tigerClientFactory = (axios: AxiosInstance, config: ITigerClientConfig = {}): ITigerClient => {
     const execution = tigerExecutionClientFactory(axios);
     const executionResult = tigerExecutionResultClientFactory(axios);
     const labelElements = tigerLabelElementsClientFactory(axios);
@@ -130,6 +135,7 @@ export const tigerClientFactory = (axios: AxiosInstance): ITigerClient => {
 
     return {
         axios,
+        config,
         execution,
         executionResult,
         labelElements,

--- a/libs/sdk-backend-tiger/src/backend/index.ts
+++ b/libs/sdk-backend-tiger/src/backend/index.ts
@@ -146,7 +146,7 @@ export class TigerBackend implements IAnalyticalBackend {
         const axios = createAxios(this.config, this.implConfig, this.telemetry);
         interceptBackendErrorsToConsole(axios);
 
-        this.client = tigerClientFactory(axios);
+        this.client = tigerClientFactory(axios, this.config);
 
         this.authProvider.initializeClient?.(this.client);
 

--- a/libs/sdk-backend-tiger/src/backend/workspace/execution/executionResult.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/execution/executionResult.ts
@@ -170,8 +170,10 @@ export class TigerExecutionResult implements IExecutionResult {
             });
 
             if (result?.status === 200) {
+                const hostname = client?.config?.hostname ?? "";
+                const url = result?.config?.url ?? "";
                 return {
-                    uri: result?.config?.url || "",
+                    uri: `${hostname}${url}`,
                 };
             }
 


### PR DESCRIPTION
JIRA: TNT-1262

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                               | Description                                                |
| ----------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                          | Re-run standard checks                                     |
| `extended check sonar`                                | SonarQube tests                                            |
| `extended check plugins`                              | Dashboard plugins tests                                    |
| `extended test - backstop`                            | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                |                                                            |
| `extended test - tiger-cypress - isolated <testName>` | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`   | Create a new recording for isolated Tiger tests.           |
| **E2E Cypress tests commands - BEAR**                 |                                                            |
| `extended test - cypress - isolated <testName>`       | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`         | Create a new recording for isolated Bear tests.            |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
