### PR TITLE
BUGFIX: TNT-1322 Granular permissions share dialog logic

### DIFF
--- a/libs/sdk-ui-kit/src/Dialog/ShareDialog/ShareDialogBase/test/GranteeMock.ts
+++ b/libs/sdk-ui-kit/src/Dialog/ShareDialog/ShareDialogBase/test/GranteeMock.ts
@@ -9,6 +9,7 @@ import {
     IAvailableUserGroupAccessGrantee,
     IGranularUserAccess,
     IGranularUserGroupAccess,
+    AccessGranteeDetail,
 } from "@gooddata/sdk-model";
 import {
     GranteeItem,
@@ -49,26 +50,10 @@ export const current: IGranteeUser = {
     status: "Active",
 };
 
-export const currentAndOwen: IGranteeUser = {
-    type: "user",
-    id: uriRef("userID4"),
-    name: "Owner Current Name",
-    email: "owner.current.name@gooddata.com",
-    isOwner: true,
-    isCurrentUser: true,
-    status: "Active",
-};
-
 export const group: IGranteeGroup = {
     type: "group",
     id: uriRef("groupId"),
     memberCount: 11,
-    name: "TNT team",
-};
-
-export const groupNoCount: IGranteeGroup = {
-    type: "group",
-    id: uriRef("groupId"),
     name: "TNT team",
 };
 
@@ -140,6 +125,40 @@ export const granularGroup: IGranularGranteeGroup = {
 
 export const granularGrantees: GranteeItem[] = [granularUser, granularGroup];
 
+export const granularGranteeUser: IGranularGranteeUser = {
+    id: userProps.ref,
+    email: userProps.email,
+    name: userProps.name,
+    type: "granularUser",
+    isOwner: false,
+    isCurrentUser: false,
+    status: "Active",
+    permissions: ["VIEW"],
+    inheritedPermissions: ["SHARE"],
+};
+
+export const granularGranteeUser2: IGranularGranteeUser = {
+    id: uriRef("john-id"),
+    email: "john.doe2@d.com",
+    name: "John Doe2",
+    type: "granularUser",
+    isOwner: false,
+    isCurrentUser: false,
+    status: "Active",
+    permissions: ["VIEW"],
+    inheritedPermissions: [],
+};
+
+export const granularGranteeGroup: IGranularGranteeGroup = {
+    id: groupProps.ref,
+    name: groupProps.name,
+    type: "granularGroup",
+    permissions: ["EDIT"],
+    inheritedPermissions: [],
+};
+
+export const granularGranteeItems = [granularGranteeUser, granularGranteeGroup];
+
 export const granularUserAccess: IGranularUserAccess = {
     ...userAccessGrantee,
     type: "granularUser",
@@ -153,3 +172,5 @@ export const granularUserGroupAccess: IGranularUserGroupAccess = {
     permissions: ["EDIT"],
     inheritedPermissions: [],
 };
+
+export const granularGranteesAccess: AccessGranteeDetail[] = [granularUserAccess, granularUserGroupAccess];

--- a/libs/sdk-ui-kit/src/Dialog/ShareDialog/ShareDialogBase/test/useShareDialogBase.test.ts
+++ b/libs/sdk-ui-kit/src/Dialog/ShareDialog/ShareDialogBase/test/useShareDialogBase.test.ts
@@ -1,0 +1,178 @@
+// (C) 2023 GoodData Corporation
+
+import { act, renderHook } from "@testing-library/react-hooks";
+import { idRef } from "@gooddata/sdk-model";
+import noop from "lodash/noop";
+
+import {
+    granularGranteeGroup,
+    granularGranteeItems,
+    granularGranteesAccess,
+    granularGranteeUser,
+    granularGranteeUser2,
+} from "./GranteeMock";
+
+import { useShareDialogBase } from "../useShareDialogBase";
+import { IGranularGranteeUser, IShareDialogBaseProps } from "../types";
+import { recordedBackend, RecordedBackendConfig } from "@gooddata/sdk-backend-mockingbird";
+import { ReferenceRecordings } from "@gooddata/reference-workspace";
+
+const recordedBackendConfig: RecordedBackendConfig = {
+    userManagement: {
+        accessControl: {
+            accessList: granularGranteesAccess,
+            availableGrantees: [],
+        },
+    },
+};
+const mockBackend = recordedBackend(ReferenceRecordings.Recordings, recordedBackendConfig);
+
+jest.mock("@gooddata/sdk-ui", () => ({
+    ...jest.requireActual("@gooddata/sdk-ui"),
+    useBackendStrict: () => mockBackend,
+    useWorkspaceStrict: () => "workspace",
+}));
+
+const defaultProps: IShareDialogBaseProps = {
+    sharedObject: {
+        ref: idRef("sharedObject"),
+        shareStatus: "shared",
+        owner: undefined,
+        isLeniencyControlSupported: false,
+        isLocked: false,
+        isUnderLenientControl: false,
+        isLockingSupported: false,
+        isMetadataObjectLockingSupported: false,
+        areGranularPermissionsSupported: true,
+    },
+    currentUserRef: idRef("user-id"),
+    currentUserPermissions: { canViewDashboard: true, canShareDashboard: true, canEditDashboard: true },
+    onCancel: noop,
+    onSubmit: noop,
+    onError: noop,
+};
+
+const renderTestedHook = (props?: Partial<IShareDialogBaseProps>) => {
+    return renderHook(() => useShareDialogBase({ ...defaultProps, ...props }));
+};
+
+describe("useShareDialogBase", () => {
+    afterEach(() => {
+        jest.resetAllMocks();
+    });
+
+    describe("granular permissions", () => {
+        it("isShareDialogDirty should be true when granular permission is changed and onSubmitShareGrantee should be called with correct parameters", async () => {
+            const onSubmit = jest.fn();
+            const { result, waitForNextUpdate } = renderTestedHook({ onSubmit });
+            await waitForNextUpdate();
+
+            const updatedGrantee: IGranularGranteeUser = {
+                ...granularGranteeUser,
+                permissions: ["EDIT"],
+            };
+
+            expect(result.current.isShareDialogDirty).toEqual(false);
+
+            act(() => result.current.onGranularGranteeShareChange(updatedGrantee));
+            expect(result.current.isShareDialogDirty).toEqual(true);
+
+            result.current.onSubmitShareGrantee();
+            expect(onSubmit).toHaveBeenCalledWith(
+                [updatedGrantee, granularGranteeGroup],
+                [updatedGrantee],
+                [],
+                false,
+                false,
+            );
+        });
+
+        it("isShareDialogDirty should be true when grantee is removed and onSubmitShareGrantee should be called with correct parameters", async () => {
+            const onSubmit = jest.fn();
+            const { result, waitForNextUpdate } = renderTestedHook({ onSubmit });
+            await waitForNextUpdate();
+
+            expect(result.current.isShareDialogDirty).toEqual(false);
+
+            act(() => result.current.onSharedGranteeDelete(granularGranteeUser));
+            expect(result.current.isShareDialogDirty).toEqual(true);
+
+            result.current.onSubmitShareGrantee();
+            expect(onSubmit).toHaveBeenCalledWith(
+                granularGranteeItems,
+                [],
+                [granularGranteeUser],
+                false,
+                false,
+            );
+        });
+
+        it("isAddDialogDirty should be true when grantee is added and onSubmitAddGrantee should be called with correct parameters", async () => {
+            const onSubmit = jest.fn();
+            const { result, waitForNextUpdate } = renderTestedHook({ onSubmit });
+            await waitForNextUpdate();
+
+            expect(result.current.granteesToAdd).toEqual([]);
+
+            act(() => result.current.onAddGranteeButtonClick());
+            expect(result.current.isAddDialogDirty).toEqual(false);
+
+            act(() => result.current.onGranteeAdd(granularGranteeUser2));
+            expect(result.current.isAddDialogDirty).toEqual(true);
+            expect(result.current.granteesToAdd).toEqual([granularGranteeUser2]);
+
+            result.current.onSubmitAddGrantee();
+            expect(onSubmit).toHaveBeenCalledWith(
+                granularGranteeItems,
+                [granularGranteeUser2],
+                [],
+                false,
+                false,
+            );
+        });
+
+        it("isShareDialogDirty should be true when granular permission is changed, grantee is added and back button action is used", async () => {
+            const onSubmit = jest.fn();
+            const { result, waitForNextUpdate } = renderTestedHook({ onSubmit });
+            await waitForNextUpdate();
+
+            const updatedGrantee: IGranularGranteeUser = {
+                ...granularGranteeUser,
+                permissions: ["EDIT"],
+            };
+
+            expect(result.current.granteesToAdd).toEqual([]);
+            expect(result.current.isShareDialogDirty).toEqual(false);
+            expect(result.current.isAddDialogDirty).toEqual(false);
+
+            act(() => result.current.onGranularGranteeShareChange(updatedGrantee));
+            expect(result.current.granteesToAdd).toEqual([]);
+            expect(result.current.isShareDialogDirty).toEqual(true);
+            expect(result.current.isAddDialogDirty).toEqual(false);
+
+            act(() => result.current.onAddGranteeButtonClick());
+            expect(result.current.granteesToAdd).toEqual([]);
+            expect(result.current.isShareDialogDirty).toEqual(true);
+            expect(result.current.isAddDialogDirty).toEqual(false);
+
+            act(() => result.current.onGranteeAdd(granularGranteeUser2));
+            expect(result.current.granteesToAdd).toEqual([granularGranteeUser2]);
+            expect(result.current.isShareDialogDirty).toEqual(true);
+            expect(result.current.isAddDialogDirty).toEqual(true);
+
+            act(() => result.current.onAddGranteeBackClick());
+            expect(result.current.granteesToAdd).toEqual([]);
+            expect(result.current.isShareDialogDirty).toEqual(true);
+            expect(result.current.isAddDialogDirty).toEqual(false);
+
+            result.current.onSubmitShareGrantee();
+            expect(onSubmit).toHaveBeenCalledWith(
+                [updatedGrantee, granularGranteeGroup],
+                [updatedGrantee],
+                [],
+                false,
+                false,
+            );
+        });
+    });
+});


### PR DESCRIPTION
When user does some permissions changes and navigates to add dialog, we need to store the previous changes and apply them if he navigates back.

JIRA: TNT-1322

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                               | Description                                                |
| ----------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                          | Re-run standard checks                                     |
| `extended check sonar`                                | SonarQube tests                                            |
| `extended check plugins`                              | Dashboard plugins tests                                    |
| `extended test - backstop`                            | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                |                                                            |
| `extended test - tiger-cypress - isolated <testName>` | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`   | Create a new recording for isolated Tiger tests.           |
| **E2E Cypress tests commands - BEAR**                 |                                                            |
| `extended test - cypress - isolated <testName>`       | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`         | Create a new recording for isolated Bear tests.            |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
