### PR TITLE
FEATURE: RAIL-4803 missing warning when Drill to custom URL

### DIFF
--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -4032,6 +4032,8 @@ export interface InvalidCustomUrlDrillParameterInfo {
     // (undocumented)
     drillsWithInvalidParametersLocalIds: string[];
     // (undocumented)
+    showMessage: boolean;
+    // (undocumented)
     widgetId: Identifier;
     // (undocumented)
     widgetRef: ObjRef;
@@ -6033,6 +6035,9 @@ export const selectInvalidUrlDrillParameterDrillLocalIdsByWidgetRef: (ref: ObjRe
 // @internal (undocumented)
 export const selectInvalidUrlDrillParameterWidgetRefs: OutputSelector<DashboardState, ObjRef[], (res: InvalidCustomUrlDrillParameterInfo[]) => ObjRef[]>;
 
+// @internal (undocumented)
+export const selectInvalidUrlDrillParameterWidgetWarnings: OutputSelector<DashboardState, ObjRef[], (res: InvalidCustomUrlDrillParameterInfo[]) => ObjRef[]>;
+
 // @internal
 export const selectIsAlternativeDisplayFormSelectionEnabled: OutputSelector<DashboardState, boolean, (res: ResolvedDashboardConfig) => boolean>;
 
@@ -6481,6 +6486,7 @@ openCancelEditModeDialog: CaseReducer<UiState, AnyAction>;
 closeCancelEditModeDialog: CaseReducer<UiState, AnyAction>;
 resetInvalidDrillWidgetRefs: CaseReducer<UiState, AnyAction>;
 resetAllInvalidCustomUrlDrillParameterWidgets: CaseReducer<UiState, AnyAction>;
+resetAllInvalidCustomUrlDrillParameterWidgetsWarnings: CaseReducer<UiState, AnyAction>;
 addInvalidDrillWidgetRefs: CaseReducer<UiState, {
 payload: ObjRef[];
 type: string;

--- a/libs/sdk-ui-dashboard/src/model/store/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/index.ts
@@ -264,6 +264,7 @@ export {
     selectInvalidDrillWidgetRefs,
     selectInvalidUrlDrillParameterDrillLocalIdsByWidgetRef,
     selectInvalidUrlDrillParameterWidgetRefs,
+    selectInvalidUrlDrillParameterWidgetWarnings,
 } from "./ui/uiSelectors";
 export { uiActions } from "./ui";
 export { RenderModeState } from "./renderMode/renderModeState";

--- a/libs/sdk-ui-dashboard/src/model/store/ui/uiReducers.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/ui/uiReducers.ts
@@ -1,4 +1,4 @@
-// (C) 2021-2022 GoodData Corporation
+// (C) 2021-2023 GoodData Corporation
 import { Action, AnyAction, CaseReducer, PayloadAction } from "@reduxjs/toolkit";
 import {
     areObjRefsEqual,
@@ -163,6 +163,13 @@ const resetAllInvalidCustomUrlDrillParameterWidgets: UiReducer = (state) => {
     state.drillValidationMessages.invalidCustomUrlDrillParameterWidgets = [];
 };
 
+const resetAllInvalidCustomUrlDrillParameterWidgetsWarnings: UiReducer = (state) => {
+    state.drillValidationMessages.invalidCustomUrlDrillParameterWidgets =
+        state.drillValidationMessages.invalidCustomUrlDrillParameterWidgets.map((item) => {
+            return { ...item, showMessage: false };
+        });
+};
+
 const addInvalidDrillWidgetRefs: UiReducer<PayloadAction<ObjRef[]>> = (state, action) => {
     action.payload.forEach((toAdd) => {
         if (
@@ -188,6 +195,7 @@ const setInvalidCustomUrlDrillParameterWidgets: UiReducer<
             widgetId: widgetId(item.widget),
             widgetRef: widgetRef(item.widget),
             widgetUri: widgetUri(item.widget),
+            showMessage: true,
         };
 
         if (existingIndex >= 0) {
@@ -313,6 +321,7 @@ export const uiReducers = {
     closeCancelEditModeDialog,
     resetInvalidDrillWidgetRefs,
     resetAllInvalidCustomUrlDrillParameterWidgets,
+    resetAllInvalidCustomUrlDrillParameterWidgetsWarnings,
     addInvalidDrillWidgetRefs,
     setInvalidCustomUrlDrillParameterWidgets,
     removeInvalidDrillWidgetRefs,

--- a/libs/sdk-ui-dashboard/src/model/store/ui/uiSelectors.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/ui/uiSelectors.ts
@@ -246,6 +246,15 @@ export const selectInvalidUrlDrillParameterWidgetRefs = createSelector(
     (invalidCustomUrlDrillParameterWidgets) => invalidCustomUrlDrillParameterWidgets.map((i) => i.widgetRef),
 );
 
+/**
+ * @internal
+ */
+export const selectInvalidUrlDrillParameterWidgetWarnings = createSelector(
+    selectInvalidCustomUrlDrillParameterWidgets,
+    (invalidCustomUrlDrillParameterWidgets) =>
+        invalidCustomUrlDrillParameterWidgets.filter((item) => item.showMessage).map((i) => i.widgetRef),
+);
+
 const selectInvalidUrlDrillParameterWidgetsMap = createSelector(
     selectInvalidCustomUrlDrillParameterWidgets,
     (invalidCustomUrlDrillParameterWidgets) =>

--- a/libs/sdk-ui-dashboard/src/model/store/ui/uiState.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/ui/uiState.ts
@@ -13,6 +13,7 @@ export interface InvalidCustomUrlDrillParameterInfo {
     widgetUri: Uri;
     widgetRef: ObjRef;
     drillsWithInvalidParametersLocalIds: string[];
+    showMessage: boolean;
 }
 
 /**

--- a/libs/sdk-ui-dashboard/src/presentation/dashboard/components/useDrillValidationMessages.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/dashboard/components/useDrillValidationMessages.tsx
@@ -5,7 +5,7 @@ import { IMessage } from "@gooddata/sdk-ui-kit";
 import compact from "lodash/compact";
 import {
     selectInvalidDrillWidgetRefs,
-    selectInvalidUrlDrillParameterWidgetRefs,
+    selectInvalidUrlDrillParameterWidgetWarnings,
     selectIsInEditMode,
     selectWidgetsMap,
     uiActions,
@@ -37,7 +37,7 @@ export function useDrillValidationMessages() {
 
     const allWidgets = useDashboardSelector(selectWidgetsMap);
     const invalidDrillWidgetRefs = useDashboardSelector(selectInvalidDrillWidgetRefs);
-    const invalidUrlDrillWidgetRefs = useDashboardSelector(selectInvalidUrlDrillParameterWidgetRefs);
+    const invalidUrlDrillWidgetRefs = useDashboardSelector(selectInvalidUrlDrillParameterWidgetWarnings);
     const isInEditMode = useDashboardSelector(selectIsInEditMode);
 
     const messages = useMemo(() => {
@@ -84,7 +84,7 @@ export function useDrillValidationMessages() {
                 dispatch(uiActions.resetInvalidDrillWidgetRefs());
             }
             if (id === URL_DRILL_MESSAGE_ID) {
-                dispatch(uiActions.resetAllInvalidCustomUrlDrillParameterWidgets());
+                dispatch(uiActions.resetAllInvalidCustomUrlDrillParameterWidgetsWarnings());
             }
         },
         [dispatch],
@@ -92,7 +92,7 @@ export function useDrillValidationMessages() {
 
     const removeAllMessages = useCallback(() => {
         dispatch(uiActions.resetInvalidDrillWidgetRefs());
-        dispatch(uiActions.resetAllInvalidCustomUrlDrillParameterWidgets());
+        dispatch(uiActions.resetAllInvalidCustomUrlDrillParameterWidgetsWarnings());
     }, [dispatch]);
 
     return {


### PR DESCRIPTION
This issue come from e2e test "fails to dill and shows error message, shows warning in edit mode" in drillToCustomUrl.spec

JIRA: RAIL-4803

---

Supported PR commands:

| Command                                               | Description                                                |
| ----------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                          | Re-run standard checks                                     |
| `extended check sonar`                                | SonarQube tests                                            |
| `extended check plugins`                              | Dashboard plugins tests                                    |
| `extended test - backstop`                            | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                |                                                            |
| `extended test - tiger-cypress - isolated <testName>` | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`   | Create a new recording for isolated Tiger tests.           |
| **E2E Cypress tests commands - BEAR**                 |                                                            |
| `extended test - cypress - isolated <testName>`       | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`         | Create a new recording for isolated Bear tests.            |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
