### PR TITLE
BUGFIX: TNT-1327 Color configuration for attribute empty values in outer join

### DIFF
--- a/libs/sdk-ui-charts/src/highcharts/chartTypes/_util/test/color.test.ts
+++ b/libs/sdk-ui-charts/src/highcharts/chartTypes/_util/test/color.test.ts
@@ -1,4 +1,4 @@
-// (C) 2007-2022 GoodData Corporation
+// (C) 2007-2023 GoodData Corporation
 import { DefaultColorPalette, DataViewFacade } from "@gooddata/sdk-ui";
 import {
     getColorMappingPredicate,
@@ -121,6 +121,13 @@ describe("getColorMappingPredicate", () => {
         },
     };
 
+    const falsyAttributeHeaderItem = (value: any) => ({
+        attributeHeaderItem: {
+            uri: value,
+            name: value,
+        },
+    });
+
     const context = { dv: DataViewFacade.for(dummyDataView(emptyDef("testWorkspace"))) };
 
     describe("no references provided", () => {
@@ -146,6 +153,24 @@ describe("getColorMappingPredicate", () => {
             const predicate = getColorMappingPredicate("/attributeItemUri");
 
             expect(predicate(attributeHeaderItem, {} as any)).toEqual(true);
+        });
+
+        it("should match predicate when referenced null uri matches", () => {
+            const predicate = getColorMappingPredicate(null);
+
+            expect(predicate(falsyAttributeHeaderItem(null), {} as any)).toEqual(true);
+        });
+
+        it("should match predicate when referenced empty string uri matches", () => {
+            const predicate = getColorMappingPredicate("");
+
+            expect(predicate(falsyAttributeHeaderItem(""), {} as any)).toEqual(true);
+        });
+
+        it("should not match predicate when referenced undefined uri matches", () => {
+            const predicate = getColorMappingPredicate(undefined);
+
+            expect(predicate(falsyAttributeHeaderItem(undefined), {} as any)).toEqual(false);
         });
     });
 });

--- a/libs/sdk-ui-ext/src/internal/components/configurationControls/colors/coloredItemsList/ColoredItem.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/configurationControls/colors/coloredItemsList/ColoredItem.tsx
@@ -1,4 +1,4 @@
-// (C) 2019-2022 GoodData Corporation
+// (C) 2019-2023 GoodData Corporation
 import React from "react";
 import { WrappedComponentProps, injectIntl } from "react-intl";
 import { IColor, IColorPalette } from "@gooddata/sdk-model";
@@ -6,6 +6,7 @@ import ColoredItemContent from "./ColoredItemContent";
 import ColorDropdown from "../colorDropdown/ColorDropdown";
 import { IColoredItem } from "../../../../interfaces/Colors";
 import { getMappingHeaderFormattedName, IMappingHeader } from "@gooddata/sdk-ui";
+import { getTranslation } from "../../../../utils/translations";
 
 export interface IColoredItemProps {
     colorPalette: IColorPalette;
@@ -24,21 +25,24 @@ class ColoredItem extends React.PureComponent<IColoredItemProps & WrappedCompone
     };
 
     public render() {
-        const coloredItem: IColoredItem = this.props.item ? this.props.item : null;
+        const { item, intl, colorPalette, showCustomPicker } = this.props;
+        const coloredItem: IColoredItem = item ? item : null;
 
         if (!coloredItem) {
             return this.renderLoadingItem();
         }
 
         const headerItem: IMappingHeader = coloredItem.mappingHeader;
-        const text = this.getText(headerItem);
+        const headerText = this.getText(headerItem);
+        const emptyText = `(${getTranslation("empty_value", intl)})`;
+        const text = headerText === null || headerText === "" ? emptyText : headerText;
 
         return (
             <ColorDropdown
                 selectedColorItem={coloredItem.colorItem}
-                colorPalette={this.props.colorPalette}
+                colorPalette={colorPalette}
                 onColorSelected={this.onColorSelected}
-                showCustomPicker={this.props.showCustomPicker}
+                showCustomPicker={showCustomPicker}
             >
                 <ColoredItemContent text={text} color={coloredItem.color} />
             </ColorDropdown>

--- a/libs/sdk-ui-ext/src/internal/components/configurationControls/colors/tests/ColorsSection.test.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/configurationControls/colors/tests/ColorsSection.test.tsx
@@ -1,4 +1,4 @@
-// (C) 2019-2022 GoodData Corporation
+// (C) 2019-2023 GoodData Corporation
 import React from "react";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -46,6 +46,23 @@ const defaultProps: IColorsSectionProps = {
     colors,
     isLoading: false,
 };
+
+const propsWithFalsyColor = (value: any): IColorsSectionProps => ({
+    ...defaultProps,
+    colors: {
+        colorPalette: DefaultColorPalette,
+        colorAssignments: [
+            ...colors.colorAssignments,
+            {
+                headerItem: { attributeHeaderItem: { uri: value, name: value } },
+                color: {
+                    type: "guid",
+                    value: "6",
+                },
+            },
+        ],
+    },
+});
 
 function createComponent(customProps: Partial<IColorsSectionProps> = {}) {
     const props: IColorsSectionProps = { ...cloneDeep(defaultProps), ...customProps };
@@ -133,5 +150,17 @@ describe("ColorsSection", () => {
             isLoading: true,
         });
         expect(screen.getByLabelText("loading")).toBeInTheDocument();
+    });
+
+    it("should render ColoredItem for null text value", () => {
+        createComponent(propsWithFalsyColor(null));
+
+        expect(screen.getByText("(empty value)")).toBeInTheDocument();
+    });
+
+    it("should render ColoredItem for empty string text value", () => {
+        createComponent(propsWithFalsyColor(""));
+
+        expect(screen.getByText("(empty value)")).toBeInTheDocument();
     });
 });

--- a/libs/sdk-ui-vis-commons/src/coloring/color.ts
+++ b/libs/sdk-ui-vis-commons/src/coloring/color.ts
@@ -202,7 +202,9 @@ export function parseRGBString(color: string): IRgbColorValue | null {
 export function getColorMappingPredicate(testValue: string): IHeaderPredicate {
     return (header) => {
         if (isResultAttributeHeader(header)) {
-            return testValue ? testValue === header.attributeHeaderItem.uri : false;
+            return testValue || testValue === null || testValue === ""
+                ? testValue === header.attributeHeaderItem.uri
+                : false;
         }
 
         if (isAttributeDescriptor(header)) {


### PR DESCRIPTION
JIRA: TNT-1327

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                               | Description                                                |
| ----------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                          | Re-run standard checks                                     |
| `extended check sonar`                                | SonarQube tests                                            |
| `extended check plugins`                              | Dashboard plugins tests                                    |
| `extended test - backstop`                            | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                |                                                            |
| `extended test - tiger-cypress - isolated <testName>` | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`   | Create a new recording for isolated Tiger tests.           |
| **E2E Cypress tests commands - BEAR**                 |                                                            |
| `extended test - cypress - isolated <testName>`       | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`         | Create a new recording for isolated Bear tests.            |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
