### PR TITLE
BUGFIX: TNT-1351 Hide save as new button in menu

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/topBar/menuButton/useDefaultMenuItems.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/topBar/menuButton/useDefaultMenuItems.tsx
@@ -26,6 +26,7 @@ import {
 import { downloadFile } from "../../../_staging/fileUtils/downloadFile";
 import { IMenuButtonItem } from "../../topBar/types";
 import { messages } from "../../../locales";
+import { selectIsSaveAsNewButtonVisible } from "../buttonBar/button";
 
 /**
  * @internal
@@ -94,6 +95,7 @@ export function useDefaultMenuItems(): IMenuButtonItem[] {
     const isInEditMode = useDashboardSelector(selectIsInEditMode);
     const canCreateDashboard = useDashboardSelector(selectCanCreateAnalyticalDashboard);
     const isSaveAsNewHidden = useDashboardSelector(selectIsSaveAsNewButtonHidden);
+    const isStandaloneSaveAsNewButtonVisible = useDashboardSelector(selectIsSaveAsNewButtonVisible);
 
     const canExport = useDashboardSelector(selectCanExportPdf);
     const isKPIDashboardExportPDFEnabled = !!useDashboardSelector(selectEnableKPIDashboardExportPDF);
@@ -107,8 +109,16 @@ export function useDefaultMenuItems(): IMenuButtonItem[] {
         }
 
         const isDeleteVisible = isInEditMode && (menuButtonItemsVisibility.deleteButton ?? true);
+
+        /**
+         * Do not show save as new button in menu item when it is already shown
+         * as a standalone top bar button.
+         */
         const isSaveAsVisible =
-            canCreateDashboard && !isSaveAsNewHidden && (menuButtonItemsVisibility.saveAsNewButton ?? true);
+            !isStandaloneSaveAsNewButtonVisible &&
+            canCreateDashboard &&
+            !isSaveAsNewHidden &&
+            (menuButtonItemsVisibility.saveAsNewButton ?? true);
         const isSaveAsDisabled = isEmptyLayout || isNewDashboard || isReadOnly;
 
         const isPdfExportVisible =
@@ -170,6 +180,7 @@ export function useDefaultMenuItems(): IMenuButtonItem[] {
         defaultOnScheduleEmailing,
         intl,
         isEmptyLayout,
+        isExportPdfEntitlementPresent,
         isInEditMode,
         isInViewMode,
         isKPIDashboardExportPDFEnabled,
@@ -177,6 +188,7 @@ export function useDefaultMenuItems(): IMenuButtonItem[] {
         isReadOnly,
         isSaveAsNewHidden,
         isScheduledEmailingVisible,
+        isStandaloneSaveAsNewButtonVisible,
         menuButtonItemsVisibility.deleteButton,
         menuButtonItemsVisibility.pdfExportButton,
         menuButtonItemsVisibility.saveAsNewButton,


### PR DESCRIPTION
When save as new is shown as a standalone button
in top bar, we need to hide the one which might
be shown in dropdown menu.

JIRA: TNT-1351

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                               | Description                                                |
| ----------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                          | Re-run standard checks                                     |
| `extended check sonar`                                | SonarQube tests                                            |
| `extended check plugins`                              | Dashboard plugins tests                                    |
| `extended test - backstop`                            | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                |                                                            |
| `extended test - tiger-cypress - isolated <testName>` | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`   | Create a new recording for isolated Tiger tests.           |
| **E2E Cypress tests commands - BEAR**                 |                                                            |
| `extended test - cypress - isolated <testName>`       | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`         | Create a new recording for isolated Bear tests.            |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
