### PR TITLE
RELATED: TNT-1354 Cleanup docker network on exit in tests

### DIFF
--- a/common/scripts/ci/run_unit_tests.sh
+++ b/common/scripts/ci/run_unit_tests.sh
@@ -33,6 +33,19 @@ fi
 # ---------------------------------------------------------------------
 
 #
+# Stop wiremock server(s) & destroy the network
+#
+stop_wiremocks() {
+  echo "Stopping wiremock server for bear integrated tests."
+  $_WIREMOCK_STOP
+
+  echo "Stopping wiremock server for tiger integrated tests."
+  $_TIGER_WIREMOCK_STOP
+
+  docker network rm -f ${WIREMOCK_NET}
+}
+
+#
 # Start wiremock server(s) needed by the integrated tests. This will create a dedicated docker bridge network
 # that will be used by the containers.
 #
@@ -46,24 +59,12 @@ start_wiremocks() {
   _TIGER_WIREMOCK_STOP="${TIGER_WIREMOCK_DIR}/stop_wiremock.sh"
 
   docker network create ${WIREMOCK_NET} || { echo "Network creation failed" && exit 1; }
+  trap stop_wiremocks EXIT
 
   echo "Starting wiremock server for bear integrated tests"
   $_WIREMOCK_START detached
   echo "Starting wiremock server for tiger integrated tests"
   $_TIGER_WIREMOCK_START detached
-}
-
-#
-# Stop wiremock server(s) & destroy the network
-#
-stop_wiremocks() {
-  echo "Stopping wiremock server for bear integrated tests."
-  $_WIREMOCK_STOP
-
-  echo "Stopping wiremock server for tiger integrated tests."
-  $_TIGER_WIREMOCK_STOP
-
-  docker network rm ${WIREMOCK_NET}
 }
 
 # ---------------------------------------------------------------------

--- a/libs/sdk-ui-tests/backstop/run-backstop.sh
+++ b/libs/sdk-ui-tests/backstop/run-backstop.sh
@@ -40,6 +40,7 @@ wait-for-url() {
 echo "Creating docker network for the storybook & backstop to share: ${BACKSTOP_NET}"
 
 docker network create "${BACKSTOP_NET}" || { echo "Network creation failed" && exit 1 ; }
+trap "docker network rm -f ${BACKSTOP_NET}" EXIT
 
 {
     echo "Starting nginx container serving storybooks from ${STORYBOOK_ASSETS}"
@@ -84,7 +85,7 @@ docker network create "${BACKSTOP_NET}" || { echo "Network creation failed" && e
 
     echo "Cleaning up docker network ${BACKSTOP_NET}"
 
-    docker network rm "${BACKSTOP_NET}"
+    docker network rm -f "${BACKSTOP_NET}"
 
     # Check if the test report exists - if not, it means that the test
     # failed with "cannot open the browser" error.


### PR DESCRIPTION
<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                               | Description                                                |
| ----------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                          | Re-run standard checks                                     |
| `extended check sonar`                                | SonarQube tests                                            |
| `extended check plugins`                              | Dashboard plugins tests                                    |
| `extended test - backstop`                            | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                |                                                            |
| `extended test - tiger-cypress - isolated <testName>` | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`   | Create a new recording for isolated Tiger tests.           |
| **E2E Cypress tests commands - BEAR**                 |                                                            |
| `extended test - cypress - isolated <testName>`       | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`         | Create a new recording for isolated Bear tests.            |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)