### PR TITLE
BUGFIX: RAIL-4832 dependent filter isn't refreshed to original state

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/DefaultDashboardAttributeFilter.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/DefaultDashboardAttributeFilter.tsx
@@ -1,4 +1,4 @@
-// (C) 2021-2022 GoodData Corporation
+// (C) 2021-2023 GoodData Corporation
 import React, { useCallback, useMemo, useState } from "react";
 import { useIntl } from "react-intl";
 import {
@@ -162,6 +162,7 @@ export const DefaultDashboardAttributeFilter = (props: IDashboardAttributeFilter
     return (
         <AttributeFilterParentFilteringProvider filter={filter}>
             <AttributeFilterButton
+                resetOnParentFilterChange={false}
                 filter={attributeFilter}
                 onApply={(newFilter) => {
                     onFilterChanged(

--- a/libs/sdk-ui-filters/api/sdk-ui-filters.api.md
+++ b/libs/sdk-ui-filters/api/sdk-ui-filters.api.md
@@ -482,6 +482,8 @@ export interface IAttributeFilterCoreProps {
     onError?: (error: GoodDataSdkError) => void;
     parentFilterOverAttribute?: ParentFilterOverAttributeType;
     parentFilters?: AttributeFiltersOrPlaceholders;
+    // @internal (undocumented)
+    resetOnParentFilterChange?: boolean;
     staticElements?: IAttributeElement[];
     title?: string;
     workspace?: string;
@@ -1051,6 +1053,7 @@ export type IUseAttributeFilterControllerProps = Omit<IAttributeFilterCoreProps,
     elementsOptions?: {
         limit: number;
     };
+    resetOnParentFilterChange?: boolean;
 };
 
 // @beta

--- a/libs/sdk-ui-filters/src/AttributeFilter/AttributeFilterProviders.tsx
+++ b/libs/sdk-ui-filters/src/AttributeFilter/AttributeFilterProviders.tsx
@@ -1,4 +1,4 @@
-// (C) 2021-2022 GoodData Corporation
+// (C) 2021-2023 GoodData Corporation
 import React from "react";
 import { IntlWrapper } from "@gooddata/sdk-ui";
 import { AttributeFilterComponentsProvider } from "./Context/AttributeFilterComponentsContext";
@@ -13,6 +13,7 @@ export const AttributeFilterProviders: React.FC<IAttributeFilterBaseProps & { ch
     props,
 ) => {
     const {
+        resetOnParentFilterChange = true,
         children,
         locale,
         backend,
@@ -79,6 +80,7 @@ export const AttributeFilterProviders: React.FC<IAttributeFilterBaseProps & { ch
                     filter={filter}
                     connectToPlaceholder={connectToPlaceholder}
                     identifier={identifier}
+                    resetOnParentFilterChange={resetOnParentFilterChange}
                     parentFilters={parentFilters}
                     parentFilterOverAttribute={parentFilterOverAttribute}
                     onApply={onApply}

--- a/libs/sdk-ui-filters/src/AttributeFilter/types.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilter/types.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2022 GoodData Corporation
+// (C) 2019-2023 GoodData Corporation
 
 import { IAttributeElement, IAttributeFilter, Identifier, ObjRef } from "@gooddata/sdk-model";
 import { IAnalyticalBackend } from "@gooddata/sdk-backend-spi";
@@ -42,6 +42,15 @@ export interface IAttributeFilterBaseProps
  * @public
  */
 export interface IAttributeFilterCoreProps {
+    /**
+     * @internal
+     *
+     * @remarks
+     * Internal purpose that is used for marking if filter reset children filters after changed
+     * Default value is "true"
+"     */
+    resetOnParentFilterChange?: boolean;
+
     /**
      * Specify an instance of analytical backend instance to work with.
      *


### PR DESCRIPTION
In view mode, change filter of A (select/unselect) → now B and C are refreshed to All value (correct behavior). Then switch to edit mode → observe attribute filters

=Actual: A, B and C are loaded All value

=Expected: Attribute filters should be refreshed to original state which persisted in MD: A is all value. B and C have value different than All

JIRA: RAIL-4832

---

Supported PR commands:

| Command                                               | Description                                                |
| ----------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                          | Re-run standard checks                                     |
| `extended check sonar`                                | SonarQube tests                                            |
| `extended check plugins`                              | Dashboard plugins tests                                    |
| `extended test - backstop`                            | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                |                                                            |
| `extended test - tiger-cypress - isolated <testName>` | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`   | Create a new recording for isolated Tiger tests.           |
| **E2E Cypress tests commands - BEAR**                 |                                                            |
| `extended test - cypress - isolated <testName>`       | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`         | Create a new recording for isolated Bear tests.            |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
