### PR TITLE
BUGFIX: RAIL-4817 always expand Date dropdown list automatically

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/widget/common/configuration/useDateDatasetFilter.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/common/configuration/useDateDatasetFilter.ts
@@ -1,4 +1,4 @@
-// (C) 2022 GoodData Corporation
+// (C) 2022-2023 GoodData Corporation
 import { useCallback, useEffect } from "react";
 import { ICatalogDateDataset } from "@gooddata/sdk-model";
 import {
@@ -30,13 +30,17 @@ export function useDateDatasetFilter(dateDatasets: Readonly<ICatalogDateDataset[
      * Only open the picker if
      * 1. auto selection happened
      * 2. there was no recommended dataset
+     * 3. there are more datasets than one
      *
      * In that case we want to show the user the picker to pick one of the non-recommended datasets.
      * Otherwise the preselected recommended dataset is most likely correct so we do not bother the user
      * with the automatically opened picker.
      */
     const shouldOpenDateDatasetPicker =
-        isWidgetDateDatasetAutoSelect && dateDatasets && !getRecommendedCatalogDateDataset(dateDatasets);
+        isWidgetDateDatasetAutoSelect &&
+        dateDatasets &&
+        dateDatasets.length > 1 &&
+        !getRecommendedCatalogDateDataset(dateDatasets);
 
     return { handleDateDatasetChanged, shouldOpenDateDatasetPicker };
 }


### PR DESCRIPTION
Open configuration widget first time always expand Date dropdown list automatically

KD with new edit mode, In KD when opening configuration widget of some insight for the first time, it always expands Date dropdown list automatically. This is just a minor issue for user but currently it is causing an issue for the automation tests for toggling other attribute because this attribute is covered by the Date dropdown list.

JIRA: RAIL-4817

---

Supported PR commands:

| Command                                               | Description                                                |
| ----------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                          | Re-run standard checks                                     |
| `extended check sonar`                                | SonarQube tests                                            |
| `extended check plugins`                              | Dashboard plugins tests                                    |
| `extended test - backstop`                            | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                |                                                            |
| `extended test - tiger-cypress - isolated <testName>` | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`   | Create a new recording for isolated Tiger tests.           |
| **E2E Cypress tests commands - BEAR**                 |                                                            |
| `extended test - cypress - isolated <testName>`       | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`         | Create a new recording for isolated Bear tests.            |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
