### PR TITLE
BUGFIX: RAIL-4837 Allow export handling in the dashboard plugins

### DIFF
--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -6113,7 +6113,7 @@ export const selectIsExecutionResultExportableToXlsxByRef: (ref: ObjRef) => Outp
 // @alpha (undocumented)
 export const selectIsExecutionResultReadyForExportByRef: (ref: ObjRef) => OutputSelector<DashboardState, boolean, (res1: IExecutionResultEnvelope | undefined, res2: IKpiWidget | IInsightWidget | undefined) => boolean>;
 
-// @internal
+// @public
 export const selectIsExport: OutputSelector<DashboardState, boolean, (res: ResolvedDashboardConfig) => boolean>;
 
 // @alpha (undocumented)

--- a/libs/sdk-ui-dashboard/src/model/store/config/configSelectors.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/config/configSelectors.ts
@@ -122,7 +122,7 @@ export const selectIsEmbedded = createSelector(selectConfig, (state) => {
  * Returns whether the Dashboard is rendered in the export mode.
  * In export mode, some components can be hidden, or rendered differently.
  *
- * @internal
+ * @public
  */
 export const selectIsExport = createSelector(selectConfig, (state) => {
     return state.isExport ?? false;

--- a/tools/dashboard-plugin-template/package.json
+++ b/tools/dashboard-plugin-template/package.json
@@ -135,5 +135,8 @@
         "webpack-bundle-analyzer": "^4.5.0",
         "webpack-cli": "^4.9.2",
         "webpack-dev-server": "^4.9.1"
+    },
+    "overrides": {
+        "reselect": "4.1.5"
     }
 }

--- a/tools/plugin-toolkit/src/initCmd/index.ts
+++ b/tools/plugin-toolkit/src/initCmd/index.ts
@@ -1,4 +1,4 @@
-// (C) 2021-2022 GoodData Corporation
+// (C) 2021-2023 GoodData Corporation
 import { ActionOptions, TargetAppLanguage } from "../_base/types";
 import { logError, logInfo, logSuccess, logWarn } from "../_base/terminal/loggers";
 import * as path from "path";
@@ -43,15 +43,20 @@ const BearBackendPackage = "@gooddata/sdk-backend-bear";
  * @param config - config for the initialization action
  */
 function modifyPackageJson(target: string, config: InitCmdActionConfig) {
-    const { name, backend } = config;
+    const { name, backend, packageManager } = config;
     const packageJsonFile = path.resolve(target, "package.json");
     const packageJson = readJsonSync(packageJsonFile);
-    const { peerDependencies, devDependencies } = packageJson;
+    const { peerDependencies, devDependencies, overrides } = packageJson;
     const unnecessaryBackendPkg = backend === "bear" ? TigerBackendPackage : BearBackendPackage;
 
     packageJson.name = name;
     delete peerDependencies[unnecessaryBackendPkg];
     delete devDependencies[unnecessaryBackendPkg];
+
+    if (overrides && packageManager === "yarn") {
+        delete packageJson.overrides;
+        packageJson.resolutions = overrides;
+    }
 
     writeAsJsonSync(packageJsonFile, packageJson);
 }


### PR DESCRIPTION
- Make selectIsExport selector public
- Add override for reselect version in the plugin template to fix selector typing errors

JIRA: RAIL-4837


<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                               | Description                                                |
| ----------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                          | Re-run standard checks                                     |
| `extended check sonar`                                | SonarQube tests                                            |
| `extended check plugins`                              | Dashboard plugins tests                                    |
| `extended test - backstop`                            | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                |                                                            |
| `extended test - tiger-cypress - isolated <testName>` | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`   | Create a new recording for isolated Tiger tests.           |
| **E2E Cypress tests commands - BEAR**                 |                                                            |
| `extended test - cypress - isolated <testName>`       | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`         | Create a new recording for isolated Bear tests.            |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
