### PR TITLE
DO NOT MERGE: testing token

### DIFF
--- a/libs/sdk-ui-tests-e2e/cypress/support/commands/login.ts
+++ b/libs/sdk-ui-tests-e2e/cypress/support/commands/login.ts
@@ -1,6 +1,8 @@
 // (C) 2021 GoodData Corporation
 
 import { getHost, getUsername, getPassword } from "../constants";
+import { Users } from "../../tools/users";
+import { getTigerAuthToken } from "../../tools/api";
 
 declare global {
     // eslint-disable-next-line @typescript-eslint/no-namespace
@@ -15,6 +17,10 @@ declare global {
 export default {};
 
 Cypress.Commands.add("login", () => {
+    if (getTigerAuthToken()) {
+        Users.switchToDefaultUser();
+    }
+
     if (!getUsername()) {
         return;
     }

--- a/libs/sdk-ui-tests-e2e/docker-compose-isolated.yaml
+++ b/libs/sdk-ui-tests-e2e/docker-compose-isolated.yaml
@@ -36,7 +36,7 @@ services:
         image: wiremock/wiremock:2.34.0
         # Use "--print-all-network-traffic --verbose" for verbose logging
         # Note that we need --preserve-host-header for BEAR backend only and it must be missing for TIGER (see run_isolated.sh)
-        command: "${PRESERVE_HOST_HEADER_OPTION} --proxy-all=${HOST:-https://staging3.intgdc.com} --extensions org.gooddata.extensions.ResponseHeadersTransformer,org.gooddata.extensions.RequestHeadersTransformer"
+        command: "${PRESERVE_HOST_HEADER_OPTION} --print-all-network-traffic --verbose --proxy-all=${HOST:-https://staging3.intgdc.com} --extensions org.gooddata.extensions.ResponseHeadersTransformer,org.gooddata.extensions.RequestHeadersTransformer"
         user: "$USER_UID:$USER_GID"
         volumes:
             - ./recordings/wiremock_extension/jar/:/var/wiremock/extensions:ro

--- a/libs/sdk-ui-tests-e2e/scripts/lib/cypress.js
+++ b/libs/sdk-ui-tests-e2e/scripts/lib/cypress.js
@@ -109,7 +109,11 @@ export function runCypress(configParams = {}) {
         cypressProps["CYPRESS_TIGER_API_TOKEN"] = tigerApiToken;
     }
 
-    console.log("Going to run cypress with args: ", args);
+    console.log(
+        "Going to run cypress with args: ",
+        args,
+        cypressProps["CYPRESS_TIGER_API_TOKEN"].slice(0, 8),
+    );
     const cypressProcess = spawn("cypress", args, {
         env: {
             ...process.env,


### PR DESCRIPTION
<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                               | Description                                                |
| ----------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                          | Re-run standard checks                                     |
| `extended check sonar`                                | SonarQube tests                                            |
| `extended check plugins`                              | Dashboard plugins tests                                    |
| `extended test - backstop`                            | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                |                                                            |
| `extended test - tiger-cypress - isolated <testName>` | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`   | Create a new recording for isolated Tiger tests.           |
| **E2E Cypress tests commands - BEAR**                 |                                                            |
| `extended test - cypress - isolated <testName>`       | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`         | Create a new recording for isolated Bear tests.            |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)