### PR TITLE
BUGFIX: RAIL-4840 date picker dropdown is ugly when opening first time

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/widget/common/configuration/DateDatasetDropdown.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/common/configuration/DateDatasetDropdown.tsx
@@ -1,5 +1,5 @@
-// (C) 2007-2022 GoodData Corporation
-import React from "react";
+// (C) 2007-2023 GoodData Corporation
+import React, { useState, useEffect } from "react";
 import { ICatalogDateDataset, ObjRef, objRefToString } from "@gooddata/sdk-model";
 import { defineMessages, useIntl } from "react-intl";
 import cx from "classnames";
@@ -107,6 +107,7 @@ export const DateDatasetDropdown: React.FC<IDateDatasetDropdownProps> = (props) 
     } = props;
 
     const intl = useIntl();
+    const setScrollElement = useAutoscroll(autoOpen);
 
     const unrelatedDateDataSetId = unrelatedDateDataset ? unrelatedDateDataset.dataSet.id : null;
     let activeDateDataSetId: string;
@@ -153,13 +154,15 @@ export const DateDatasetDropdown: React.FC<IDateDatasetDropdownProps> = (props) 
                     : removeDateFromTitle(activeDateDataSetTitle);
 
                 return (
-                    <DropdownButton
-                        className={buttonClassName}
-                        value={buttonValue}
-                        isOpen={isOpen}
-                        onClick={toggleDropdown}
-                        disabled={isLoading}
-                    />
+                    <span ref={setScrollElement}>
+                        <DropdownButton
+                            className={buttonClassName}
+                            value={buttonValue}
+                            isOpen={isOpen}
+                            onClick={toggleDropdown}
+                            disabled={isLoading}
+                        />
+                    </span>
                 );
             }}
             className={className}
@@ -209,3 +212,14 @@ export const DateDatasetDropdown: React.FC<IDateDatasetDropdownProps> = (props) 
         />
     );
 };
+
+function useAutoscroll(autoscroll: boolean) {
+    const [ref, setRef] = useState<HTMLElement | null>(null);
+
+    useEffect(() => {
+        if (ref && autoscroll) {
+            ref.scrollIntoView();
+        }
+    }, [ref, autoscroll]);
+    return setRef;
+}


### PR DESCRIPTION
In new KD edit mode, after drop an insight to KD canvas,
 then open insight configuration

=Actual: in the first time, date dropdown list is
automatically opened, but the insight configuration panel isn’t rolled to the date dropdown button,
therefore the date dropdown list is separated from the panel. The issue just happens in the first time after opening the insight configuration

JIRA: RAIL-4840

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended check plugins`                                | Dashboard plugins tests                                    |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
