### PR TITLE
RELATED: QA-17917 build docker for isolated/integrated with --no-cache

### DIFF
--- a/common/scripts/ci/run_cypress_integrated_tests.sh
+++ b/common/scripts/ci/run_cypress_integrated_tests.sh
@@ -30,7 +30,7 @@ export IMAGE_ID=${sdk_backend}-gooddata-ui-sdk-scenarios-${EXECUTOR_NUMBER}
 trap "$_RUSHX libs/sdk-ui-tests-e2e delete-ref-workspace; rm -f $E2E_TEST_DIR/.env; docker rmi --force $IMAGE_ID || true" EXIT
 
 # Use Dockerfile_local as scenarios have been build in previous steps
-docker build --file Dockerfile_local -t $IMAGE_ID . || exit 1
+docker build --no-cache --file Dockerfile_local -t $IMAGE_ID . || exit 1
 
 NO_COLOR=1 docker-compose -f docker-compose-integrated.yaml up \
   --abort-on-container-exit --exit-code-from integrated-tests \

--- a/common/scripts/ci/run_cypress_isolated_tests.sh
+++ b/common/scripts/ci/run_cypress_isolated_tests.sh
@@ -29,7 +29,7 @@ $_RUSHX libs/sdk-ui-tests-e2e build-scenarios
 export IMAGE_ID=${sdk_backend}-gooddata-ui-sdk-scenarios-${EXECUTOR_NUMBER}
 trap "rm -f $E2E_TEST_DIR/.env; docker rmi --force $IMAGE_ID || true" EXIT
 
-docker build --file Dockerfile_local -t $IMAGE_ID . || exit 1
+docker build --no-cache --file Dockerfile_local -t $IMAGE_ID . || exit 1
 
 NO_COLOR=1 docker-compose -f docker-compose-isolated.yaml up \
   --abort-on-container-exit --exit-code-from isolated-tests \

--- a/common/scripts/ci/run_cypress_recording.sh
+++ b/common/scripts/ci/run_cypress_recording.sh
@@ -75,7 +75,7 @@ trap "docker rmi --force $IMAGE_ID || true" EXIT
 pushd $E2E_TEST_DIR
 rm -rf ./recordings/mappings
 mkdir -p ./recordings/mappings/$SDK_BACKEND
-docker build --file Dockerfile_local -t $IMAGE_ID . || exit 1
+docker build --no-cache --file Dockerfile_local -t $IMAGE_ID . || exit 1
 
 echo "⭐️ 6/8 Run isolated recording against TEST_BACKEND=$TEST_BACKEND."
 MODE=record NO_COLOR=1 docker-compose -f docker-compose-isolated.yaml up \


### PR DESCRIPTION
JIRA: QA-17917

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended check plugins`                                | Dashboard plugins tests                                    |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
