### PR TITLE
RELATED: QA-17366 support bear BE in cypress integrated tests

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,6 +21,7 @@ Supported PR commands:
 | **E2E Cypress tests commands - BEAR**                   |                                                            |
 | `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
 | `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
+| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |
 
 `<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend
 

--- a/common/scripts/ci/run_cypress_integrated_tests.sh
+++ b/common/scripts/ci/run_cypress_integrated_tests.sh
@@ -8,17 +8,37 @@ E2E_TEST_DIR=$ROOT_DIR/libs/sdk-ui-tests-e2e
 _RUSH="${DIR}/docker_rush.sh"
 _RUSHX="${DIR}/docker_rushx.sh"
 
-sdk_backend=$(tr <<< $SDK_BACKEND '[:upper:]' '[:lower:]')
+sdk_backend=$(tr <<< "${SDK_BACKEND:?}" '[:upper:]' '[:lower:]')
+
+if [[ ! "${TEST_BACKEND:?}" =~ 'https://' ]]; then
+    export TEST_BACKEND="https://${TEST_BACKEND}"
+fi
 
 pushd $E2E_TEST_DIR
 cat > .env <<-EOF
 SDK_BACKEND=${SDK_BACKEND:-BEAR}
 HOST=${TEST_BACKEND:-}
 CYPRESS_TEST_TAGS=post-merge_integrated_${sdk_backend}
+FIXTURE_TYPE=goodsales
 FILTER=${FILTER:-}
-TIGER_API_TOKEN=${TIGER_API_TOKEN:-}
-TIGER_DATASOURCES_NAME=vertica_staging-goodsales
 EOF
+
+if [[ "$SDK_BACKEND" == 'BEAR' ]]; then
+    cat >> .env <<-EOF
+USER_NAME=${USER_NAME:?}
+PASSWORD=${PASSWORD:?}
+AUTH_TOKEN=${AUTH_TOKEN:?}
+EOF
+
+elif [[ "$SDK_BACKEND" == 'TIGER' ]]; then
+    cat >> .env <<-EOF
+TIGER_API_TOKEN=${TIGER_API_TOKEN:?}
+TIGER_DATASOURCES_NAME=${TIGER_DATASOURCES_NAME:?}
+EOF
+else
+    echo "Unknown SDK_BACKEND=${SDK_BACKEND}. Exiting..."
+    exit 1
+fi
 
 $_RUSH install
 $_RUSH build -t sdk-ui-tests-e2e


### PR DESCRIPTION
<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended check plugins`                                | Dashboard plugins tests                                    |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
