### PR TITLE
test integrated bear

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -39,4 +39,5 @@ Supported PR commands:
 -   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
 -   [ ] `extended test - tiger-cypress - isolated` passes
 -   [ ] `extended test - cypress - isolated` passes
+-   [ ] `extended test - tiger-cypress - integrated` passes
 -   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)

--- a/common/scripts/ci/run_cypress_integrated_tests.sh
+++ b/common/scripts/ci/run_cypress_integrated_tests.sh
@@ -17,7 +17,6 @@ fi
 pushd $E2E_TEST_DIR
 cat > .env <<-EOF
 SDK_BACKEND=${SDK_BACKEND:-BEAR}
-HOST=${TEST_BACKEND:-}
 CYPRESS_TEST_TAGS=post-merge_integrated_${sdk_backend}
 FIXTURE_TYPE=goodsales
 FILTER=${FILTER:-}
@@ -40,6 +39,7 @@ else
     exit 1
 fi
 
+export HOST=$TEST_BACKEND
 $_RUSH install
 $_RUSH build -t sdk-ui-tests-e2e
 $_RUSHX libs/sdk-ui-tests-e2e create-ref-workspace

--- a/common/scripts/ci/run_cypress_integrated_tests.sh
+++ b/common/scripts/ci/run_cypress_integrated_tests.sh
@@ -8,17 +8,37 @@ E2E_TEST_DIR=$ROOT_DIR/libs/sdk-ui-tests-e2e
 _RUSH="${DIR}/docker_rush.sh"
 _RUSHX="${DIR}/docker_rushx.sh"
 
-sdk_backend=$(tr <<< $SDK_BACKEND '[:upper:]' '[:lower:]')
+sdk_backend=$(tr <<< "${SDK_BACKEND:?}" '[:upper:]' '[:lower:]')
+
+if [[ ! "${TEST_BACKEND:?}" =~ 'https://' ]]; then
+    export TEST_BACKEND="https://${TEST_BACKEND}"
+fi
 
 pushd $E2E_TEST_DIR
 cat > .env <<-EOF
 SDK_BACKEND=${SDK_BACKEND:-BEAR}
 HOST=${TEST_BACKEND:-}
 CYPRESS_TEST_TAGS=post-merge_integrated_${sdk_backend}
+FIXTURE_TYPE=goodsales
 FILTER=${FILTER:-}
-TIGER_API_TOKEN=${TIGER_API_TOKEN:-}
-TIGER_DATASOURCES_NAME=vertica_staging-goodsales
 EOF
+
+if [[ "$SDK_BACKEND" == 'BEAR' ]]; then
+    cat >> .env <<-EOF
+USER_NAME=${USER_NAME:?}
+PASSWORD=${PASSWORD:?}
+AUTH_TOKEN=${AUTH_TOKEN:?}
+EOF
+
+elif [[ "$SDK_BACKEND" == 'TIGER' ]]; then
+    cat >> .env <<-EOF
+TIGER_API_TOKEN=${TIGER_API_TOKEN:?}
+TIGER_DATASOURCES_NAME=${TIGER_DATASOURCES_NAME:?}
+EOF
+else
+    echo "Unknown SDK_BACKEND=${SDK_BACKEND}. Exiting..."
+    exit 1
+fi
 
 $_RUSH install
 $_RUSH build -t sdk-ui-tests-e2e

--- a/common/scripts/ci/run_cypress_integrated_tests.sh
+++ b/common/scripts/ci/run_cypress_integrated_tests.sh
@@ -17,6 +17,7 @@ fi
 pushd $E2E_TEST_DIR
 cat > .env <<-EOF
 SDK_BACKEND=${SDK_BACKEND:-BEAR}
+HOST=${TEST_BACKEND:-}
 CYPRESS_TEST_TAGS=post-merge_integrated_${sdk_backend}
 FIXTURE_TYPE=goodsales
 FILTER=${FILTER:-}

--- a/libs/sdk-ui-tests-e2e/cypress/integration/01-sdk-ui-dashboard/dashboard.spec.ts
+++ b/libs/sdk-ui-tests-e2e/cypress/integration/01-sdk-ui-dashboard/dashboard.spec.ts
@@ -14,7 +14,23 @@ Cypress.on("uncaught:exception", (error) => {
 
 Cypress.Cookies.debug(true);
 
-describe("Dashboard", { tags: ["pre-merge_isolated_bear", "post-merge_integrated_bear"] }, () => {
+describe("Dashboard2", { tags: ["post-merge_integrated_bear"] }, () => {
+    describe("TopBar rendering2", () => {
+        beforeEach(() => {
+            cy.login();
+
+            Navigation.visit("dashboard/dashboard");
+        });
+
+        it("should render topBar2", () => {
+            const dashboard = new Dashboard();
+
+            dashboard.topBarExist();
+        });
+    });
+});
+
+describe("Dashboard", { tags: ["pre-merge_isolated_bear"] }, () => {
     describe("TopBar rendering", () => {
         beforeEach(() => {
             cy.login();

--- a/libs/sdk-ui-tests-e2e/cypress/integration/01-sdk-ui-dashboard/dashboard.spec.ts
+++ b/libs/sdk-ui-tests-e2e/cypress/integration/01-sdk-ui-dashboard/dashboard.spec.ts
@@ -14,7 +14,7 @@ Cypress.on("uncaught:exception", (error) => {
 
 Cypress.Cookies.debug(true);
 
-describe("Dashboard", { tags: ["pre-merge_isolated_bear"] }, () => {
+describe("Dashboard", { tags: ["pre-merge_isolated_bear", "post-merge_integrated_bear"] }, () => {
     describe("TopBar rendering", () => {
         beforeEach(() => {
             cy.login();

--- a/libs/sdk-ui-tests-e2e/nginx/nginx.conf
+++ b/libs/sdk-ui-tests-e2e/nginx/nginx.conf
@@ -9,6 +9,8 @@ events {
 }
 
 http {
+  include /etc/nginx/conf.d/domain-strip.conf;
+
   server {
     listen 9500;
     root /usr/share/nginx/html;
@@ -30,6 +32,7 @@ http {
     include /etc/nginx/extra-conf.d/*.conf;
     include /etc/nginx/conf.d/proxy-*.conf;
   }
+
 
   proxy_temp_path /tmp/proxy_temp;
   client_body_temp_path /tmp/client_temp;

--- a/libs/sdk-ui-tests-e2e/nginx/templates/domain-strip.conf.template
+++ b/libs/sdk-ui-tests-e2e/nginx/templates/domain-strip.conf.template
@@ -1,0 +1,4 @@
+map "$TEST_BACKEND" $testBackendDomain {
+    default                    "";
+    "~^https?://(?<suffix>.*)$"  $suffix;
+}

--- a/libs/sdk-ui-tests-e2e/nginx/templates/proxy-integrated-tests.conf.template
+++ b/libs/sdk-ui-tests-e2e/nginx/templates/proxy-integrated-tests.conf.template
@@ -7,3 +7,15 @@ location ^~ /api {
     proxy_pass $TEST_BACKEND;
     proxy_set_header Origin $TEST_BACKEND;
 }
+
+location ^~ /gdc {
+    proxy_pass $TEST_BACKEND;
+    proxy_set_header x-forwarded-host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header Referer $TEST_BACKEND;
+    proxy_set_header Origin "";
+    # need to strip http(s) from TEST_BACKEND, see domain-strip.conf.template
+    proxy_set_header Host $testBackendDomain;
+    proxy_cookie_domain $testBackendDomain $host;
+    proxy_cookie_flags ~ nosecure samesite=lax;
+}


### PR DESCRIPTION
<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended check plugins`                                | Dashboard plugins tests                                    |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)