### PR TITLE
RELATED: TNT-1344 Download exported report/dash via ObjectURL

### DIFF
--- a/common/changes/@gooddata/sdk-ui-all/pdo-tnt-1344-blob-export-download_2023-03-02-08-38.json
+++ b/common/changes/@gooddata/sdk-ui-all/pdo-tnt-1344-blob-export-download_2023-03-02-08-38.json
@@ -1,0 +1,10 @@
+{
+    "changes": [
+        {
+            "packageName": "@gooddata/sdk-ui-all",
+            "comment": "The new SPI export methods for downloading of insight and dashboard export data were added. The methods attach exported data as a blob to current browser window instance and return Object URL pointing to the blob and name of the downloaded file. There is no need to export data manually via URI. The dashboard component uses these new methods now. This means that export from dashboard component works even when provided backend uses Tiger token authentication.",
+            "type": "none"
+        }
+    ],
+    "packageName": "@gooddata/sdk-ui-all"
+}

--- a/common/config/rush/browser-approved-packages.json
+++ b/common/config/rush/browser-approved-packages.json
@@ -531,6 +531,10 @@
       "allowedCategories": [ "tools" ]
     },
     {
+      "name": "blob-polyfill",
+      "allowedCategories": [ "production" ]
+    },
+    {
       "name": "case-sensitive-paths-webpack-plugin",
       "allowedCategories": [ "tools" ]
     },

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -7318,6 +7318,10 @@ packages:
     hasBin: true
     dev: false
 
+  /blob-polyfill/7.0.20220408:
+    resolution: {integrity: sha512-oD8Ydw+5lNoqq+en24iuPt1QixdPpe/nUF8azTHnviCZYu9zUC+TwdzIp5orpblJosNlgNbVmmAb//c6d6ImUQ==}
+    dev: false
+
   /blob-util/2.0.2:
     resolution: {integrity: sha512-T7JQa+zsXXEa6/8ZhHcQEW1UFfVM49Ts65uBkFL6fz2QmrElqmbajIDJvuA0tEhRe5eIjpV9ZF+0RfZR9voJFQ==}
     dev: false
@@ -8521,7 +8525,7 @@ packages:
     dev: false
 
   /core-util-is/1.0.2:
-    resolution: {integrity: sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==}
+    resolution: {integrity: sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=}
     dev: false
 
   /core-util-is/1.0.3:
@@ -21261,7 +21265,7 @@ packages:
     dev: false
 
   file:projects/api-client-bear.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-u+ej7g+m0z3kdvPll3TMJPkdRBNOn5hTrMqstH5lbO/aYgzd0dZNj+MJx2VzJltK/81Y7O1Kodopz2hHrWplHw==, tarball: file:projects/api-client-bear.tgz}
+    resolution: {integrity: sha512-KEzAtaReVaJJVJmGsdOHHjVyi/TGsa+cQxIrF4wKhfxt3aXTth46LfB2fq92N1HoEf2fWm5RvCtYwI7vIGhuKw==, tarball: file:projects/api-client-bear.tgz}
     id: file:projects/api-client-bear.tgz
     name: '@rush-temp/api-client-bear'
     version: 0.0.0
@@ -21277,6 +21281,7 @@ packages:
       '@typescript-eslint/eslint-plugin': 5.45.0_e30006dd713619262e58476c57150ca3
       '@typescript-eslint/parser': 5.45.0_eslint@8.25.0+typescript@4.0.2
       async: 2.6.4
+      blob-polyfill: 7.0.20220408
       concurrently: 6.5.1
       dependency-cruiser: 10.9.0
       eslint: 8.25.0
@@ -21329,7 +21334,7 @@ packages:
     dev: false
 
   file:projects/api-client-tiger.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-12IcyTpXFc76lBMKDzIMRIHMFMVbbRvfUMCqAiAr5uVRtuCemGScEwRcuGlfzzjNEsrGcMqmaZxAmSotYVM9lg==, tarball: file:projects/api-client-tiger.tgz}
+    resolution: {integrity: sha512-zbu0vyntB26qUxtpxxCatBGTArWmZPboOnapqERP9S66QBRw8btiTo+stYrFSprvX0quR2HqKNAKMymrmM/Biw==, tarball: file:projects/api-client-tiger.tgz}
     id: file:projects/api-client-tiger.tgz
     name: '@rush-temp/api-client-tiger'
     version: 0.0.0
@@ -21482,7 +21487,7 @@ packages:
     dev: false
 
   file:projects/catalog-export.tgz:
-    resolution: {integrity: sha512-LX18ufeM0SZlDld05M2FeKuVHhDWaliJ+nLPHjTKvQVpzMAq+m0e5c7PmC1dAWjpVJup07pc4ODy0XNIAKNFlg==, tarball: file:projects/catalog-export.tgz}
+    resolution: {integrity: sha512-cBVkXs4NOuRm6n1GozsMSCovsK1aUN/nNM4bMctM+a+2GnikgsyPFpoXvv3C3vO4zsZkLJGR7pSVn2/BBMS8vg==, tarball: file:projects/catalog-export.tgz}
     name: '@rush-temp/catalog-export'
     version: 0.0.0
     dependencies:
@@ -21537,7 +21542,7 @@ packages:
     dev: false
 
   file:projects/dashboard-plugin-template.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-wlfxUzbbZNmdsv8gZvLD0FNzg+sQWx5bx0hZQhqb5TThlSnWOU/RYzKAD62ZcHpZ7SBM2iebsB/uB2xsr3BJyA==, tarball: file:projects/dashboard-plugin-template.tgz}
+    resolution: {integrity: sha512-9k8PRsFzINMg4eLviYG5an44/Guw4jWGSZxfBfGH8wcNSRBgv4QBbThytQeNAMvCHgkUPra9m686QgQ0GbZXPQ==, tarball: file:projects/dashboard-plugin-template.tgz}
     id: file:projects/dashboard-plugin-template.tgz
     name: '@rush-temp/dashboard-plugin-template'
     version: 0.0.0
@@ -21616,7 +21621,7 @@ packages:
     dev: false
 
   file:projects/dashboard-plugin-tests.tgz:
-    resolution: {integrity: sha512-I5/ymIJzp/zCl5U3b3jwIb42ZN3iPK1qFXiOYGGLOLZRRbH8TCi6d2R3x8ZqkS+T+Ri13SNrvSU0URAjfEkzcQ==, tarball: file:projects/dashboard-plugin-tests.tgz}
+    resolution: {integrity: sha512-OqH5M4MipK3qOXynMyJg4aaW2ovWj0q9A2n9TtkEPlV9IDxddpzUhZcRdaAhSanE2JMEj/c9jrDwsNe6GRFtKw==, tarball: file:projects/dashboard-plugin-tests.tgz}
     name: '@rush-temp/dashboard-plugin-tests'
     version: 0.0.0
     dependencies:
@@ -21707,7 +21712,7 @@ packages:
     dev: false
 
   file:projects/experimental-workspace.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-5CEbP5jyB+DjtUzqJ35kHdCsLLbfBEGAbYfu1tj0sa4LyDtIhZ+pTgzChTdH4U3i8VWqJWOfGYU/jW7IHtfs9w==, tarball: file:projects/experimental-workspace.tgz}
+    resolution: {integrity: sha512-iZVW/fLRB2a+oHEu384OMSjrSMm7U1yZheYl2o7sYkINlMwL+GAB01ndA7ltGiCRHMrEsazLnLKdkNRKI12LNQ==, tarball: file:projects/experimental-workspace.tgz}
     id: file:projects/experimental-workspace.tgz
     name: '@rush-temp/experimental-workspace'
     version: 0.0.0
@@ -21806,7 +21811,7 @@ packages:
     dev: false
 
   file:projects/live-examples-workspace.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-mFwStcA/uJH4dkNhxgr1qALo2R0SVdL0o2DO6bkRgIwMsQ4sDZ3XW4izna+FMkJZMMs0WhNRqZnQktUEdNN9vA==, tarball: file:projects/live-examples-workspace.tgz}
+    resolution: {integrity: sha512-7D0N1HLPJ7T0hAyNBwxQYRoaV8dHSCIChdvkFeG2bQsRhmznFp0JTZ3GhwWb4YLaQlEFVuWUFxqgE6eb+oCCkQ==, tarball: file:projects/live-examples-workspace.tgz}
     id: file:projects/live-examples-workspace.tgz
     name: '@rush-temp/live-examples-workspace'
     version: 0.0.0
@@ -21848,7 +21853,7 @@ packages:
     dev: false
 
   file:projects/mock-handling.tgz:
-    resolution: {integrity: sha512-RdCotY3Y0q99LzDaOsNdDyptFR3Z3+bXO9FtHgJth1xasXPiAOVIvuToLwdx9uQ+iCw2uKajkhl/t7DZJ/exFQ==, tarball: file:projects/mock-handling.tgz}
+    resolution: {integrity: sha512-Z/qjAbsl6k+ZsPtI+uEOJkcmYyvJEeBDBeiguTLJkPRslbOc8CVvNkLzwhbP+S5SapJhatXARNbedP1Xkqvbtg==, tarball: file:projects/mock-handling.tgz}
     name: '@rush-temp/mock-handling'
     version: 0.0.0
     dependencies:
@@ -21903,7 +21908,7 @@ packages:
     dev: false
 
   file:projects/playground.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-jYun7PeT8WKmdYdT1eU2fn2f/dnYTztR+wDuXZPFoDNyHCGVwIXzJ78RXGHkw3iudzDku0RgwOzr1ShuSgkIJQ==, tarball: file:projects/playground.tgz}
+    resolution: {integrity: sha512-ydbQa95vv/ZiFdzkMdAl5EnuZh5Uwp680pAtBONrkrcNjy1HA2rwYd0bbysb1+Wv633K6J8He/k2KQwpYhEs/A==, tarball: file:projects/playground.tgz}
     id: file:projects/playground.tgz
     name: '@rush-temp/playground'
     version: 0.0.0
@@ -21985,7 +21990,7 @@ packages:
     dev: false
 
   file:projects/plugin-toolkit.tgz:
-    resolution: {integrity: sha512-QvfDdHeGrqrV3hhvhbu/e/Ha7VwjoCAUbYYdBHlz6XRdsy+mBlL6RFZ80XAeGJj8bhxVoMCJJ+gOmzqVqjTlvA==, tarball: file:projects/plugin-toolkit.tgz}
+    resolution: {integrity: sha512-nrjrdgV8XskT2MNhiZf2gTTwUvggLhDNvU41RO16xssPOu4tU9bvIyTzzDrMgcPNoVg+BG2Wi9NzetE/eatj/Q==, tarball: file:projects/plugin-toolkit.tgz}
     name: '@rush-temp/plugin-toolkit'
     version: 0.0.0
     dependencies:
@@ -22050,7 +22055,7 @@ packages:
     dev: false
 
   file:projects/reference-workspace-mgmt.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-RE71vu9U0sbhM1RQr/wINOSfcLzNIXxm/1HTpFlQTmUgEFafVWy6EzbnqRv8Dfxow0/GP7nYHYY1n7eNeiEwyg==, tarball: file:projects/reference-workspace-mgmt.tgz}
+    resolution: {integrity: sha512-jhEDIIm5Ekm0LJfYZiqqFkEBwJsIWtgbLfRJd2/6LsFR0Y87PYXKVscMoYepVeXvaJePNZyyCsJTcAkQqPY9ng==, tarball: file:projects/reference-workspace-mgmt.tgz}
     id: file:projects/reference-workspace-mgmt.tgz
     name: '@rush-temp/reference-workspace-mgmt'
     version: 0.0.0
@@ -22091,7 +22096,7 @@ packages:
     dev: false
 
   file:projects/reference-workspace.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-sHlM7ZG36WxCmjveX1SPAn9WTYgi1ogrrd44wPyPNVkqoxZWTUKNbAVwkdk7mGT345qF1st0LOVrDCr0gcS0Qw==, tarball: file:projects/reference-workspace.tgz}
+    resolution: {integrity: sha512-r5k8fkknjRHo9Vt3KpbUxyJIJbt0WNV3yjOBKEZb0JL8y/mLqvgUEjZgZjMHCoC/Yq1U6mHPF3dPvoRxgM10PQ==, tarball: file:projects/reference-workspace.tgz}
     id: file:projects/reference-workspace.tgz
     name: '@rush-temp/reference-workspace'
     version: 0.0.0
@@ -22133,7 +22138,7 @@ packages:
     dev: false
 
   file:projects/sdk-backend-base.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-1LvnBaGNmJFyHP5uKb/dnMqNA3pkORy12XL1Qg7dRQjpyb3IRlWlA/NmTEFjCXLlcEOrT9QQU9Npp3CijG8iVA==, tarball: file:projects/sdk-backend-base.tgz}
+    resolution: {integrity: sha512-GrfPF85mMTel7IFys/MXqilZkiZmv12FrJj+NneY1yEbGRODvL/GMeWbFrICs3h34nX+1plytsooRlXTt93wKg==, tarball: file:projects/sdk-backend-base.tgz}
     id: file:projects/sdk-backend-base.tgz
     name: '@rush-temp/sdk-backend-base'
     version: 0.0.0
@@ -22185,7 +22190,7 @@ packages:
     dev: false
 
   file:projects/sdk-backend-bear.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-H/VCk8uKPnbFhHJ0svkZmWBHCF68Y9Jndkf1225HzBaqCg8TKSpiARxNZ6KQ2RP+WPmRtVj2HqQot/X9hxaAFg==, tarball: file:projects/sdk-backend-bear.tgz}
+    resolution: {integrity: sha512-fUlPAbLkmgaETe0Zr/1qmpU+TcNDzto4mZN2a5imcC3RjdiZ97lq8o85OrSut+7fnVG1SnqS6bRQH+XU27M4UQ==, tarball: file:projects/sdk-backend-bear.tgz}
     id: file:projects/sdk-backend-bear.tgz
     name: '@rush-temp/sdk-backend-bear'
     version: 0.0.0
@@ -22239,7 +22244,7 @@ packages:
     dev: false
 
   file:projects/sdk-backend-mockingbird.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-ZBc/dzG93UUrDjGZn2zfMpsJjn52nMH6mvW2dIx1dRLghTWigRnElxHbY3DCUZeMVGHYDP9S02k7bJ8VsNWSzA==, tarball: file:projects/sdk-backend-mockingbird.tgz}
+    resolution: {integrity: sha512-3zsmWX0KEMhm4DRsRzC4yCZ/0k6j6OqGnvthpBsS4aN7Xnu+/UIEV59sjMtFFeMJ/VGc9Gnx+vW7jYVGtlKpvA==, tarball: file:projects/sdk-backend-mockingbird.tgz}
     id: file:projects/sdk-backend-mockingbird.tgz
     name: '@rush-temp/sdk-backend-mockingbird'
     version: 0.0.0
@@ -22286,7 +22291,7 @@ packages:
     dev: false
 
   file:projects/sdk-backend-spi.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-lTrFtKBmjGS9TLaWGfQb60dmdojvy552rGx45B5UdvRl5LkbwRZ+j/Ah4lkhQuotiV29JV7YLnw9ZF5zxKgmYg==, tarball: file:projects/sdk-backend-spi.tgz}
+    resolution: {integrity: sha512-cplThIu4X6zfHCfsEeWaHWJPRRBDlax1tz/ftwlrv7cXsKDXKGaHfawNMwb5NQzApPq5AvWgxcqKjCihfYF+Iw==, tarball: file:projects/sdk-backend-spi.tgz}
     id: file:projects/sdk-backend-spi.tgz
     name: '@rush-temp/sdk-backend-spi'
     version: 0.0.0
@@ -22331,7 +22336,7 @@ packages:
     dev: false
 
   file:projects/sdk-backend-tiger.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-MsSteTfMV7UvkExr5cd99FIXOeSkpKV8A8GDmW+KWg47Em9b9qnupgyCPfGRLiwwDMw+aLiShH4zF00PLeRWPw==, tarball: file:projects/sdk-backend-tiger.tgz}
+    resolution: {integrity: sha512-q++Xt+sMtNlF2mj/d76ZKSfei6LelcsIQbFS9RrFOu3uuzdd1j9wv36bjrVjxME8E/KicQZbso32qoS4XfjEfA==, tarball: file:projects/sdk-backend-tiger.tgz}
     id: file:projects/sdk-backend-tiger.tgz
     name: '@rush-temp/sdk-backend-tiger'
     version: 0.0.0
@@ -22384,7 +22389,7 @@ packages:
     dev: false
 
   file:projects/sdk-embedding.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-LzYBuvGn6+nutnMj0tVwudDjhKk2FpmKVsVCZzAr7xzJdqkuoYFIU8yHiyQ7/P5Sd58XYF496enkQdxJNTQN6g==, tarball: file:projects/sdk-embedding.tgz}
+    resolution: {integrity: sha512-BZzEhtzTxcTOZ4mFXQqupmHsV7rgc6aPfpqZb2+8DhEbZRYkF8lu8Pgi5uMXAy491egi0mJQ8Lt+zciH/+YaWw==, tarball: file:projects/sdk-embedding.tgz}
     id: file:projects/sdk-embedding.tgz
     name: '@rush-temp/sdk-embedding'
     version: 0.0.0
@@ -22429,7 +22434,7 @@ packages:
     dev: false
 
   file:projects/sdk-examples.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-cWSNMfs3HbG5aCL1j2i9hkV6u+/YIciVwQzV40LHY+64LTQR807KzY/voQXAbAacNbtwCUTdYbCD0fkvqi2shw==, tarball: file:projects/sdk-examples.tgz}
+    resolution: {integrity: sha512-QwGsRMPatMSD2sSoRP3ihScnju1qXu91mdPK5zoy3sZBNS6jwL4Y9LB6cJBdCzP5dqzRW+k/1p4NSWufSyIJDw==, tarball: file:projects/sdk-examples.tgz}
     id: file:projects/sdk-examples.tgz
     name: '@rush-temp/sdk-examples'
     version: 0.0.0
@@ -22695,7 +22700,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-all.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-/HaIgHrZafT/Rn1jEXFV2KHC/TXq3M+KO1caSLbkS1Njzv9FJFr5sYMTI48CI2HovjQqrBU2/A9eUA9x7ElJwg==, tarball: file:projects/sdk-ui-all.tgz}
+    resolution: {integrity: sha512-AM4LIYjd1iwF0kVJi1Um64Vj6iwzjUxF21gA9xNF9TCbSgVrDBSc31t8K/k86Qfp/WXnoYrMCcB9FyiyC/FlPQ==, tarball: file:projects/sdk-ui-all.tgz}
     id: file:projects/sdk-ui-all.tgz
     name: '@rush-temp/sdk-ui-all'
     version: 0.0.0
@@ -22737,7 +22742,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-charts.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-ilo7eNRcZvuCpITcG4eTBdqm1g5sj7sSN1FYlomKE3nM3YFtRl17ZcOJpcUjlQIozJ7cW+2MB6aR2x7qMleAXQ==, tarball: file:projects/sdk-ui-charts.tgz}
+    resolution: {integrity: sha512-JioqlcHLsU9uSOnlK0ZiPRCB9qorbebG6bZVhh+38twnA2zp5c7Nvq4sHLczgtSRX6jDe+Kd/DtG8tTz8wxdZg==, tarball: file:projects/sdk-ui-charts.tgz}
     id: file:projects/sdk-ui-charts.tgz
     name: '@rush-temp/sdk-ui-charts'
     version: 0.0.0
@@ -22814,7 +22819,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-dashboard.tgz_a7e570fd5a4985262571d64f4bc94b86:
-    resolution: {integrity: sha512-m8u8w/9/C8L9k21HLVfTuaowyYrPYLF2AS+wL630sfQpNK7Jz207aHuWezowlEOMKNnpuN+GmKVPniNNpe5/dQ==, tarball: file:projects/sdk-ui-dashboard.tgz}
+    resolution: {integrity: sha512-F3vRw0+JRCC5ObFIrHUvezXFpx/SsDJkJR6i724g9vass6H3VIELFA/6S9sN9Ttz6E+Vnz0k7VeM0y6e/VOG6Q==, tarball: file:projects/sdk-ui-dashboard.tgz}
     id: file:projects/sdk-ui-dashboard.tgz
     name: '@rush-temp/sdk-ui-dashboard'
     version: 0.0.0
@@ -22910,7 +22915,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-ext.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-KNVdY9IV8G+A/LLOizHdOwHwChZEiNf2Ks5ZYQRNpkjFvi2qdt0NVmAJQhK/KVVP3uSx3WpXF8+ibW/NMQGAdQ==, tarball: file:projects/sdk-ui-ext.tgz}
+    resolution: {integrity: sha512-hFKFwkpEnraqXZqPLx56rFEAkPA5aPxIep6ibRmLKm+GCCMp2MbW/klqUlKxyfHHg2dRazCVrP8ZpzG/RY71ng==, tarball: file:projects/sdk-ui-ext.tgz}
     id: file:projects/sdk-ui-ext.tgz
     name: '@rush-temp/sdk-ui-ext'
     version: 0.0.0
@@ -22997,7 +23002,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-filters.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-nEOSWNyfLYLsjf5B+2YSFybOboUcFOOCkLYMscLjQhRvUj3ZJSNf6O0uO4XpLRHpElGpKmArToxxxaTU9Kk0UQ==, tarball: file:projects/sdk-ui-filters.tgz}
+    resolution: {integrity: sha512-sNPFRmKGrLLvgMw9/SlHjnyUin9ap/phslqxC5SKMgcIkkD+aNqrRggeSjQ6oeZ47JF/s9EuRGKBopTL6pCa8g==, tarball: file:projects/sdk-ui-filters.tgz}
     id: file:projects/sdk-ui-filters.tgz
     name: '@rush-temp/sdk-ui-filters'
     version: 0.0.0
@@ -23081,7 +23086,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-geo.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-RGKTe/akE6fUEzl1rm3/sGp942Fpo4kRVKhTg/qjklJnM/yvEAPGjnM6EA1XfZnImEV0/laIhTz1efrtCN3EAw==, tarball: file:projects/sdk-ui-geo.tgz}
+    resolution: {integrity: sha512-VZs/cBf64BAEw3uqtlnMUUG6kbbvoKgpGIv5TS2ESkQNepm78DEva5203c5ZUPR33QK0WMeAdEQOX3Dv/TFhug==, tarball: file:projects/sdk-ui-geo.tgz}
     id: file:projects/sdk-ui-geo.tgz
     name: '@rush-temp/sdk-ui-geo'
     version: 0.0.0
@@ -23152,7 +23157,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-kit.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-u5UxTU1UNXWr8CcBWcje0cvTWFLdQkiIHOrJDxn0f9Obtu8f+WE6XPYAEbDFTFtsusFbo6K1ypxV9MmVDcbBqg==, tarball: file:projects/sdk-ui-kit.tgz}
+    resolution: {integrity: sha512-c5wCFsxME9BI8d/+aCVlf+l6dm4Ft7tAp566ePrEi3OamNWD31NRMATPYXrVuYmFdLZYAGRTFDMrJmrgZvJB5w==, tarball: file:projects/sdk-ui-kit.tgz}
     id: file:projects/sdk-ui-kit.tgz
     name: '@rush-temp/sdk-ui-kit'
     version: 0.0.0
@@ -23266,7 +23271,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-loaders.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-2OJaAUZKeIFGW6dZFTKRVSTfg0NjsRONbv5KglBhn6HNauW7dRGpwS6yfl5zzYBofEAH8/W2kJZIU10W1hhamQ==, tarball: file:projects/sdk-ui-loaders.tgz}
+    resolution: {integrity: sha512-IsyJCRIxYaGRKlM2e0+47H2LxzR4KhgmhMNkGE8oeSpj3HEvDS2SejRxLY6vMOKKEGR8PCZJoe5AhcpXTJ6WNg==, tarball: file:projects/sdk-ui-loaders.tgz}
     id: file:projects/sdk-ui-loaders.tgz
     name: '@rush-temp/sdk-ui-loaders'
     version: 0.0.0
@@ -23328,7 +23333,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-pivot.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-IDfsQ65lDOusoh/6hDMMx9b6cu73wGOoe0t7bzX92TyC+yclKqlURyWbFEhJkykrrJJCiCFCd1MK81qhlVlEeA==, tarball: file:projects/sdk-ui-pivot.tgz}
+    resolution: {integrity: sha512-9sVYxcz0SZYq2ZV3F0G7+v5gMNS0XN0z3euUDEfdX48J2pnXCkmDSO+/kLmwp0sAC1iWpTnT3fU/CfChIVchgQ==, tarball: file:projects/sdk-ui-pivot.tgz}
     id: file:projects/sdk-ui-pivot.tgz
     name: '@rush-temp/sdk-ui-pivot'
     version: 0.0.0
@@ -23402,7 +23407,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-tests-e2e.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-bXUN35617hIJ171dbA9IMpI7QCNhkN15Cg0oesK7wgRKIie4CwC1gR8lz01tb6+ofj4tyeXfKYZgKln4zMZR3g==, tarball: file:projects/sdk-ui-tests-e2e.tgz}
+    resolution: {integrity: sha512-cSYWATYIe7jGJTmW98qsqsyZOGg/ik4qDVrht4hFepBE3E0JMI2ChSJh+LaJSk2N+jWIh/zBMzfqYSxjO9caVg==, tarball: file:projects/sdk-ui-tests-e2e.tgz}
     id: file:projects/sdk-ui-tests-e2e.tgz
     name: '@rush-temp/sdk-ui-tests-e2e'
     version: 0.0.0
@@ -23507,7 +23512,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-tests.tgz:
-    resolution: {integrity: sha512-cvUgq03H4iSIqRYX5EskwHindkm+ozYOD8sAgkI+zJB0vpwVnelIfCTUwmFVCdkMGwYQBwmNCA4tZS2gRPg2jQ==, tarball: file:projects/sdk-ui-tests.tgz}
+    resolution: {integrity: sha512-FHdxXkPozgZYF8lAuGRJSUBaSWBuichaICdkUrjnrWO39Y7upAoJqSKZZe5ORCd/xHZGhg2xw0w4LVIl1XrVfg==, tarball: file:projects/sdk-ui-tests.tgz}
     name: '@rush-temp/sdk-ui-tests'
     version: 0.0.0
     dependencies:
@@ -23618,7 +23623,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-theme-provider.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-W4Tbm23OugQJyWpzFljtVu+UgMPhO1FcYEabD18H9gMAePz2x7IDkmWo6PfHNsorPqlosjmrapCoXMKef22K0Q==, tarball: file:projects/sdk-ui-theme-provider.tgz}
+    resolution: {integrity: sha512-lRfZoiF4WR97XPYGWYZ1534KlX0J6fFUbTJCeGczBH0NqXqKeHQSLUka63Hxu8NSShC9YsIel1FPiSTxoFCK2w==, tarball: file:projects/sdk-ui-theme-provider.tgz}
     id: file:projects/sdk-ui-theme-provider.tgz
     name: '@rush-temp/sdk-ui-theme-provider'
     version: 0.0.0
@@ -23676,7 +23681,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-vis-commons.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-8MUxPFWKZd3itSsbvsyzK9y+ai7ANqZigeS4jMktts6e13wZeucqtGhLiTLAeAGGbPToFbl7wYnMK0Ur6sNi1A==, tarball: file:projects/sdk-ui-vis-commons.tgz}
+    resolution: {integrity: sha512-jU8/BOKqWtvdEq+7pA1FyeERm4T81IUsQCPzcdijoPTGY71umBXkPQEEp1dye2Anj3CIurmtplO6i49YCJqIhQ==, tarball: file:projects/sdk-ui-vis-commons.tgz}
     id: file:projects/sdk-ui-vis-commons.tgz
     name: '@rush-temp/sdk-ui-vis-commons'
     version: 0.0.0
@@ -23741,7 +23746,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-web-components.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-dHpDcuq377nxW+0+9bl6IP22eu/LWgcTBTiRYu8Xbs6HlQhgWRj6kVcXul5wvoBdo8+obfmFdmf4HEx23a1Nag==, tarball: file:projects/sdk-ui-web-components.tgz}
+    resolution: {integrity: sha512-+hiQ7/XkHKSopLTI8YHihVvKBNYLaOWkGO0Nsjg3BIyuZ4PrA6Nfn4MWNxqQh3Rd+sp229qBq0vK0AwvAvY45Q==, tarball: file:projects/sdk-ui-web-components.tgz}
     id: file:projects/sdk-ui-web-components.tgz
     name: '@rush-temp/sdk-ui-web-components'
     version: 0.0.0
@@ -23815,7 +23820,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-Lw0hyvo+LKOz8AckbbIwY4iIQFopr0D9ZirYdiehqBQTHjJ7tHI3yD2AvWDPvjWX9UQes6AN+fSqd6SjYzLmpA==, tarball: file:projects/sdk-ui.tgz}
+    resolution: {integrity: sha512-duiiti+rGxKoie6ktUlnTOeHlBm1LS5aw25sJd/2P5zRyQ6tCfVvOUHLkKcJoB26QDfuEMVTW6eEDXEZ29Q6Bg==, tarball: file:projects/sdk-ui.tgz}
     id: file:projects/sdk-ui.tgz
     name: '@rush-temp/sdk-ui'
     version: 0.0.0

--- a/libs/api-client-bear/jest.setup.js
+++ b/libs/api-client-bear/jest.setup.js
@@ -1,3 +1,8 @@
+// (C) 2018-2023 GoodData Corporation
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+global.Blob = require("blob-polyfill").Blob;
+
 // Fail test on console error (react proptypes validation etc.)
 const consoleError = console.error;
 console.error = (err, ...args) => {

--- a/libs/api-client-bear/package.json
+++ b/libs/api-client-bear/package.json
@@ -94,6 +94,7 @@
         "ts-loader": "^8.3.0",
         "typescript": "4.0.2",
         "webpack": "^5.58.0",
-        "webpack-cli": "^4.9.2"
+        "webpack-cli": "^4.9.2",
+        "blob-polyfill": "^7.0.20220408"
     }
 }

--- a/libs/api-client-bear/src/utils/export.ts
+++ b/libs/api-client-bear/src/utils/export.ts
@@ -1,7 +1,29 @@
-// (C) 2007-2019 GoodData Corporation
+// (C) 2007-2023 GoodData Corporation
 import { SUCCESS_REQUEST_STATUS, BAD_REQUEST_STATUS } from "../constants/errors";
+import { GdcExport } from "@gooddata/api-model-bear";
+import IBaseExportConfig = GdcExport.IBaseExportConfig;
 
-export function isExportFinished(responseHeaders: Response): boolean {
-    const taskState = responseHeaders.status;
+export function isExportFinished(response: Response): boolean {
+    const taskState = response.status;
     return taskState === SUCCESS_REQUEST_STATUS || taskState >= BAD_REQUEST_STATUS; // OK || ERROR
 }
+
+export const parseFileNameFromContentDisposition = (response: Response): string | undefined => {
+    const contentDispositionHeader = response.headers.get("Content-Disposition") || "";
+    // eslint-disable-next-line regexp/no-unused-capturing-group
+    const matches = /filename\*?=([^']*'')?([^;]*)/.exec(contentDispositionHeader);
+    const urlEncodedFileName = matches ? matches[2] : undefined;
+    return urlEncodedFileName ? decodeURIComponent(urlEncodedFileName) : undefined;
+};
+
+export const getFormatContentType = (format: IBaseExportConfig["format"]): string => {
+    switch (format) {
+        case "csv":
+            return "text/csv";
+        case "xlsx":
+            return "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+        case "raw":
+        default:
+            return "application/octet-stream";
+    }
+};

--- a/libs/api-model-bear/api/api-model-bear.api.md
+++ b/libs/api-model-bear/api/api-model-bear.api.md
@@ -1037,6 +1037,11 @@ export namespace GdcExport {
         mergeHeaders?: boolean;
         title?: string;
     }
+    export interface IExportBlobResponse {
+        fileName?: string;
+        objectUrl: string;
+        uri: string;
+    }
     // (undocumented)
     export interface IExportConfig extends IBaseExportConfig {
         afm?: GdcExecuteAFM.IAfm;

--- a/libs/api-model-bear/src/export/GdcExport.ts
+++ b/libs/api-model-bear/src/export/GdcExport.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2022 GoodData Corporation
+// (C) 2019-2023 GoodData Corporation
 import { GdcExecuteAFM } from "../executeAfm/GdcExecuteAFM";
 
 /**
@@ -48,5 +48,24 @@ export namespace GdcExport {
      */
     export interface IExportResponse {
         uri: string;
+    }
+
+    /**
+     * Result of export is an object URL pointing to a Blob of downloaded data attached to the current
+     * window instance. The result also contains name of the downloaded file provided by the backend export
+     * service.
+     *
+     * {@link URL#revokeObjectURL} method must be used when object URL is no longer needed to release
+     * the blob memory.
+     *
+     * @public
+     */
+    export interface IExportBlobResponse {
+        /** URI from which can the export be fetched again */
+        uri: string;
+        /** Object URL pointing to the downloaded blob of exported data */
+        objectUrl: string;
+        /** Name of the exported file provided by the export service */
+        fileName?: string;
     }
 }

--- a/libs/sdk-backend-base/api/sdk-backend-base.api.md
+++ b/libs/sdk-backend-base/api/sdk-backend-base.api.md
@@ -48,6 +48,7 @@ import { IExecutionFactory } from '@gooddata/sdk-backend-spi';
 import { IExecutionResult } from '@gooddata/sdk-backend-spi';
 import { IExistingDashboard } from '@gooddata/sdk-model';
 import { IExplainProvider } from '@gooddata/sdk-backend-spi';
+import { IExportBlobResult } from '@gooddata/sdk-backend-spi';
 import { IExportConfig } from '@gooddata/sdk-backend-spi';
 import { IExportResult } from '@gooddata/sdk-backend-spi';
 import { IFactMetadataObject } from '@gooddata/sdk-model';
@@ -389,6 +390,8 @@ export abstract class DecoratedExecutionResult implements IExecutionResult {
     // (undocumented)
     export(options: IExportConfig): Promise<IExportResult>;
     // (undocumented)
+    exportToBlob(options: IExportConfig): Promise<IExportBlobResult>;
+    // (undocumented)
     fingerprint(): string;
     // (undocumented)
     readAll(): Promise<IDataView>;
@@ -505,6 +508,8 @@ export abstract class DecoratedWorkspaceDashboardsService implements IWorkspaceD
     deleteWidgetAlerts(refs: ObjRef[]): Promise<void>;
     // (undocumented)
     exportDashboardToPdf(ref: ObjRef, filters?: FilterContextItem[]): Promise<string>;
+    // (undocumented)
+    exportDashboardToPdfBlob(ref: ObjRef, filters?: FilterContextItem[]): Promise<IExportBlobResult>;
     // (undocumented)
     getAllWidgetAlertsForCurrentUser(): Promise<IWidgetAlert[]>;
     // (undocumented)

--- a/libs/sdk-backend-base/src/customBackend/execution.ts
+++ b/libs/sdk-backend-base/src/customBackend/execution.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2022 GoodData Corporation
+// (C) 2019-2023 GoodData Corporation
 
 import { AbstractExecutionFactory } from "../toolkit/execution";
 import {
@@ -25,6 +25,7 @@ import {
     NotImplemented,
     IExplainProvider,
     ExplainType,
+    IExportBlobResult,
 } from "@gooddata/sdk-backend-spi";
 import isEqual from "lodash/isEqual";
 import {
@@ -188,6 +189,10 @@ class CustomExecutionResult implements IExecutionResult {
     };
 
     public export = (_options: IExportConfig): Promise<IExportResult> => {
+        throw new NotSupported("exports from custom backend are not supported");
+    };
+
+    public exportToBlob = (_options: IExportConfig): Promise<IExportBlobResult> => {
         throw new NotSupported("exports from custom backend are not supported");
     };
 }

--- a/libs/sdk-backend-base/src/decoratedBackend/dashboards.ts
+++ b/libs/sdk-backend-base/src/decoratedBackend/dashboards.ts
@@ -9,6 +9,7 @@ import {
     IWidgetAlertCount,
     SupportedWidgetReferenceTypes,
     IWidgetReferences,
+    IExportBlobResult,
 } from "@gooddata/sdk-backend-spi";
 import {
     IFilter,
@@ -77,6 +78,10 @@ export abstract class DecoratedWorkspaceDashboardsService implements IWorkspaceD
 
     exportDashboardToPdf(ref: ObjRef, filters?: FilterContextItem[]): Promise<string> {
         return this.decorated.exportDashboardToPdf(ref, filters);
+    }
+
+    exportDashboardToPdfBlob(ref: ObjRef, filters?: FilterContextItem[]): Promise<IExportBlobResult> {
+        return this.decorated.exportDashboardToPdfBlob(ref, filters);
     }
 
     createScheduledMail(

--- a/libs/sdk-backend-base/src/decoratedBackend/execution.ts
+++ b/libs/sdk-backend-base/src/decoratedBackend/execution.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2022 GoodData Corporation
+// (C) 2019-2023 GoodData Corporation
 import {
     IDataView,
     IExecutionFactory,
@@ -9,6 +9,7 @@ import {
     ExplainConfig,
     IExplainProvider,
     ExplainType,
+    IExportBlobResult,
 } from "@gooddata/sdk-backend-spi";
 import {
     IAttributeOrMeasure,
@@ -163,6 +164,9 @@ export abstract class DecoratedExecutionResult implements IExecutionResult {
         return this.decorated.export(options);
     }
 
+    public exportToBlob(options: IExportConfig): Promise<IExportBlobResult> {
+        return this.decorated.exportToBlob(options);
+    }
     public readAll(): Promise<IDataView> {
         return this.decorated.readAll();
     }

--- a/libs/sdk-backend-base/src/dummyBackend/index.ts
+++ b/libs/sdk-backend-base/src/dummyBackend/index.ts
@@ -56,6 +56,7 @@ import {
     IElementsQueryResult,
     IPagedResource,
     IEntitlements,
+    IExportBlobResult,
 } from "@gooddata/sdk-backend-spi";
 import {
     defFingerprint,
@@ -363,6 +364,9 @@ function dummyExecutionResult(
             return fp === other.fingerprint();
         },
         export(_: IExportConfig): Promise<IExportResult> {
+            throw new NotSupported("...");
+        },
+        exportToBlob(_: IExportConfig): Promise<IExportBlobResult> {
             throw new NotSupported("...");
         },
         transform(): IPreparedExecution {

--- a/libs/sdk-backend-base/src/normalizingBackend/index.ts
+++ b/libs/sdk-backend-base/src/normalizingBackend/index.ts
@@ -1,4 +1,4 @@
-// (C) 2007-2022 GoodData Corporation
+// (C) 2007-2023 GoodData Corporation
 
 import {
     IAnalyticalBackend,
@@ -11,6 +11,7 @@ import {
     NotSupported,
     isNoDataError,
     NoDataError,
+    IExportBlobResult,
 } from "@gooddata/sdk-backend-spi";
 import { decoratedBackend } from "../decoratedBackend";
 import { DecoratedExecutionFactory, DecoratedPreparedExecution } from "../decoratedBackend/execution";
@@ -129,6 +130,12 @@ class DenormalizingExecutionResult implements IExecutionResult {
         const originalResult = await this.originalExecution.execute();
 
         return originalResult.export(options);
+    };
+
+    public exportToBlob = async (options: IExportConfig): Promise<IExportBlobResult> => {
+        const originalResult = await this.originalExecution.execute();
+
+        return originalResult.exportToBlob(options);
     };
 
     public readAll = (): Promise<IDataView> => {

--- a/libs/sdk-backend-bear/src/backend/workspace/dashboards/index.ts
+++ b/libs/sdk-backend-bear/src/backend/workspace/dashboards/index.ts
@@ -13,6 +13,7 @@ import {
     SupportedDashboardReferenceTypes,
     IDashboardReferences,
     IGetScheduledMailOptions,
+    IExportBlobResult,
 } from "@gooddata/sdk-backend-spi";
 import {
     areObjRefsEqual,
@@ -286,6 +287,17 @@ export class BearWorkspaceDashboards implements IWorkspaceDashboardsService {
         const convertedFilters = filters?.map(fromSdkModel.convertFilterContextItem);
         return this.authCall((sdk) =>
             sdk.dashboard.exportToPdf(this.workspace, dashboardUri, convertedFilters).then((res) => res.uri),
+        );
+    };
+
+    public exportDashboardToPdfBlob = async (
+        dashboardRef: ObjRef,
+        filters?: FilterContextItem[],
+    ): Promise<IExportBlobResult> => {
+        const dashboardUri = await objRefToUri(dashboardRef, this.workspace, this.authCall);
+        const convertedFilters = filters?.map(fromSdkModel.convertFilterContextItem);
+        return this.authCall((sdk) =>
+            sdk.dashboard.exportToPdfBlob(this.workspace, dashboardUri, convertedFilters).then((res) => res),
         );
     };
 

--- a/libs/sdk-backend-bear/src/backend/workspace/execution/executionResult.ts
+++ b/libs/sdk-backend-bear/src/backend/workspace/execution/executionResult.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2022 GoodData Corporation
+// (C) 2019-2023 GoodData Corporation
 
 import { GdcExecution, GdcExport } from "@gooddata/api-model-bear";
 import { transformResultHeaders } from "@gooddata/sdk-backend-base";
@@ -11,6 +11,7 @@ import {
     IPreparedExecution,
     NoDataError,
     UnexpectedError,
+    IExportBlobResult,
 } from "@gooddata/sdk-backend-spi";
 import {
     IExecutionDefinition,
@@ -72,6 +73,28 @@ export class BearExecutionResult implements IExecutionResult {
     }
 
     public async export(options: IExportConfig): Promise<IExportResult> {
+        const optionsForBackend = this.buildExportOptions(options);
+        return this.authApiCall((sdk) =>
+            sdk.report.exportResult(
+                this.definition.workspace,
+                this.execResponse.links.executionResult,
+                optionsForBackend,
+            ),
+        );
+    }
+
+    public async exportToBlob(options: IExportConfig): Promise<IExportBlobResult> {
+        const optionsForBackend = this.buildExportOptions(options);
+        return this.authApiCall((sdk) =>
+            sdk.report.exportResultToBlob(
+                this.definition.workspace,
+                this.execResponse.links.executionResult,
+                optionsForBackend,
+            ),
+        );
+    }
+
+    private buildExportOptions(options: IExportConfig): GdcExport.IExportConfig {
         const optionsForBackend: GdcExport.IExportConfig = {
             format: options.format,
             mergeHeaders: options.mergeHeaders,
@@ -83,13 +106,7 @@ export class BearExecutionResult implements IExecutionResult {
             optionsForBackend.afm = toAfmExecution(this.definition).execution.afm;
         }
 
-        return this.authApiCall((sdk) =>
-            sdk.report.exportResult(
-                this.definition.workspace,
-                this.execResponse.links.executionResult,
-                optionsForBackend,
-            ),
-        );
+        return optionsForBackend;
     }
 
     public equals(other: IExecutionResult): boolean {

--- a/libs/sdk-backend-mockingbird/src/legacyRecordedBackend/index.ts
+++ b/libs/sdk-backend-mockingbird/src/legacyRecordedBackend/index.ts
@@ -35,6 +35,7 @@ import {
     ExplainType,
     IExplainProvider,
     IEntitlements,
+    IExportBlobResult,
 } from "@gooddata/sdk-backend-spi";
 import {
     defFingerprint,
@@ -332,6 +333,9 @@ function recordedExecutionResult(
             return fp === other.fingerprint();
         },
         export(_: IExportConfig): Promise<IExportResult> {
+            throw new NotSupported("...");
+        },
+        exportToBlob(_: IExportConfig): Promise<IExportBlobResult> {
             throw new NotSupported("...");
         },
         transform(): IPreparedExecution {

--- a/libs/sdk-backend-mockingbird/src/recordedBackend/dashboards.ts
+++ b/libs/sdk-backend-mockingbird/src/recordedBackend/dashboards.ts
@@ -14,6 +14,7 @@ import {
     SupportedWidgetReferenceTypes,
     UnexpectedResponseError,
     walkLayout,
+    IExportBlobResult,
 } from "@gooddata/sdk-backend-spi";
 import {
     areObjRefsEqual,
@@ -312,6 +313,17 @@ export class RecordedDashboards implements IWorkspaceDashboardsService {
 
     public exportDashboardToPdf(_ref: ObjRef, _filters?: FilterContextItem[]): Promise<string> {
         return Promise.resolve("/example/export.pdf");
+    }
+
+    public exportDashboardToPdfBlob(
+        _ref: ObjRef,
+        _filters?: FilterContextItem[],
+    ): Promise<IExportBlobResult> {
+        return Promise.resolve({
+            uri: "/example/export.pdf",
+            objectUrl: "blob:/01345454545454",
+            fileName: "export.pdf",
+        });
     }
 
     //

--- a/libs/sdk-backend-mockingbird/src/recordedBackend/execution.ts
+++ b/libs/sdk-backend-mockingbird/src/recordedBackend/execution.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2022 GoodData Corporation
+// (C) 2019-2023 GoodData Corporation
 
 import {
     IDataView,
@@ -11,6 +11,7 @@ import {
     NotSupported,
     IExplainProvider,
     ExplainType,
+    IExportBlobResult,
 } from "@gooddata/sdk-backend-spi";
 import {
     defFingerprint,
@@ -251,6 +252,10 @@ class RecordedExecutionResult implements IExecutionResult {
     }
 
     public export = (_options: IExportConfig): Promise<IExportResult> => {
+        throw new NotSupported("recorded backend does not support exports");
+    };
+
+    public exportToBlob = (_options: IExportConfig): Promise<IExportBlobResult> => {
         throw new NotSupported("recorded backend does not support exports");
     };
 

--- a/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
+++ b/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
@@ -773,6 +773,7 @@ export interface IExecutionResult {
     readonly dimensions: IDimensionDescriptor_2[];
     equals(other: IExecutionResult): boolean;
     export(options: IExportConfig): Promise<IExportResult>;
+    exportToBlob(options: IExportConfig): Promise<IExportBlobResult>;
     fingerprint(): string;
     readAll(): Promise<IDataView>;
     readWindow(offset: number[], size: number[]): Promise<IDataView>;
@@ -798,6 +799,13 @@ export type IExplainResult = {
     ["OPT_QT_SVG"]: string;
     ["SQL"]: string;
 };
+
+// @public
+export interface IExportBlobResult {
+    fileName?: string;
+    objectUrl: string;
+    uri: string;
+}
 
 // @public
 export interface IExportConfig {
@@ -1737,6 +1745,7 @@ export interface IWorkspaceDashboardsService {
     deleteWidgetAlert(ref: ObjRef): Promise<void>;
     deleteWidgetAlerts(refs: ObjRef[]): Promise<void>;
     exportDashboardToPdf(ref: ObjRef, filters?: FilterContextItem_2[]): Promise<string>;
+    exportDashboardToPdfBlob(ref: ObjRef, filters?: FilterContextItem_2[]): Promise<IExportBlobResult>;
     getAllWidgetAlertsForCurrentUser(): Promise<IWidgetAlert_2[]>;
     getDashboard(ref: ObjRef, filterContextRef?: ObjRef, options?: IGetDashboardOptions): Promise<IDashboard_2>;
     getDashboardPermissions(ref: ObjRef): Promise<IDashboardPermissions>;

--- a/libs/sdk-backend-spi/src/index.ts
+++ b/libs/sdk-backend-spi/src/index.ts
@@ -72,7 +72,7 @@ export {
     FilterWithResolvableElements,
 } from "./workspace/attributes/elements";
 
-export { IExportConfig, IExportResult } from "./workspace/execution/export";
+export { IExportConfig, IExportResult, IExportBlobResult } from "./workspace/execution/export";
 
 export { IWorkspaceStylingService } from "./workspace/styling";
 export {

--- a/libs/sdk-backend-spi/src/workspace/dashboards/index.ts
+++ b/libs/sdk-backend-spi/src/workspace/dashboards/index.ts
@@ -20,6 +20,7 @@ import {
     IDashboardPermissions,
     IExistingDashboard,
 } from "@gooddata/sdk-model";
+import { IExportBlobResult } from "../execution/export";
 
 /**
  * Dashboard referenced objects
@@ -240,6 +241,18 @@ export interface IWorkspaceDashboardsService {
      * @returns promise with link to download the exported dashboard
      */
     exportDashboardToPdf(ref: ObjRef, filters?: FilterContextItem[]): Promise<string>;
+
+    /**
+     * Export dashboard to pdf. You can override dashboard filters with custom filters.
+     * When no custom filters are set, the persisted dashboard filters will be used.
+     *
+     * PDF file is downloaded and attached as Blob data to the current window instance.
+     *
+     * @param ref - dashboard reference
+     * @param filters - Override stored dashboard filters with custom filters
+     * @returns promise with object URL pointing to a Blob data of downloaded exported dashboard
+     */
+    exportDashboardToPdfBlob(ref: ObjRef, filters?: FilterContextItem[]): Promise<IExportBlobResult>;
 
     /**
      * Create scheduled mail for the dashboard

--- a/libs/sdk-backend-spi/src/workspace/execution/export.ts
+++ b/libs/sdk-backend-spi/src/workspace/execution/export.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2022 GoodData Corporation
+// (C) 2019-2023 GoodData Corporation
 
 /**
  * Configuration for exports of results into XLSX or CSV.
@@ -41,4 +41,23 @@ export interface IExportConfig {
  */
 export interface IExportResult {
     uri: string;
+}
+
+/**
+ * Result of export is an object URL pointing to a Blob of downloaded data attached to the current
+ * window instance. The result also contains name of the downloaded file provided by the backend export
+ * service.
+ *
+ * {@link URL#revokeObjectURL} method must be used when object URL is no longer needed to release
+ * the blob memory.
+ *
+ * @public
+ */
+export interface IExportBlobResult {
+    /** URI from which can the export be fetched again */
+    uri: string;
+    /** Object URL pointing to the downloaded blob of exported data */
+    objectUrl: string;
+    /** Name of the exported file provided by the export service */
+    fileName?: string;
 }

--- a/libs/sdk-backend-spi/src/workspace/execution/index.ts
+++ b/libs/sdk-backend-spi/src/workspace/execution/index.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2022 GoodData Corporation
+// (C) 2019-2023 GoodData Corporation
 import {
     IAttributeOrMeasure,
     IBucket,
@@ -15,7 +15,7 @@ import {
     IResultHeader,
     IResultWarning,
 } from "@gooddata/sdk-model";
-import { IExportConfig, IExportResult } from "./export";
+import { IExportConfig, IExportResult, IExportBlobResult } from "./export";
 
 /**
  * Execution factory provides several methods to create a prepared execution from different types
@@ -312,10 +312,20 @@ export interface IExecutionResult {
     /**
      * Asynchronously exports all data in this result.
      *
-     * @param options - customize how the result looks like (format etc)
+     * @param options - customize how the result looks like (format etc.)
      * @returns Promise of export result = uri of file with exported data
      */
     export(options: IExportConfig): Promise<IExportResult>;
+
+    /**
+     * Asynchronously exports all data in this result to a blob.
+     *
+     * Exported file is downloaded and attached as Blob data to the current window instance.
+     *
+     * @param options - customize how the result looks like (format etc.)
+     * @returns promise with object URL pointing to a Blob data of downloaded exported insight
+     */
+    exportToBlob(options: IExportConfig): Promise<IExportBlobResult>;
 
     /**
      * Tests if this execution result is same as the other result.

--- a/libs/sdk-backend-tiger/src/utils/downloadFile.ts
+++ b/libs/sdk-backend-tiger/src/utils/downloadFile.ts
@@ -1,4 +1,6 @@
-// (C) 2019-2021 GoodData Corporation
+// (C) 2019-2023 GoodData Corporation
+
+import { AxiosResponse } from "axios";
 
 export function downloadFile(fileName: string, data: any) {
     const url = new Blob([data]);
@@ -10,3 +12,11 @@ export function downloadFile(fileName: string, data: any) {
     URL.revokeObjectURL(link.href);
     document.body.removeChild(link);
 }
+
+export const parseNameFromContentDisposition = (response: AxiosResponse) => {
+    const contentDispositionHeader = response.headers["content-disposition"];
+    // eslint-disable-next-line regexp/no-unused-capturing-group
+    const matches = /filename\*?=([^']*'')?([^;]*)/.exec(contentDispositionHeader);
+    const urlEncodedFileName = matches ? matches[2] : undefined;
+    return urlEncodedFileName ? decodeURIComponent(urlEncodedFileName) : undefined;
+};

--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -79,6 +79,7 @@ import { IErrorProps } from '@gooddata/sdk-ui';
 import { IExecutionConfiguration } from '@gooddata/sdk-ui';
 import { IExecutionDefinition } from '@gooddata/sdk-model';
 import { IExecutionResult } from '@gooddata/sdk-backend-spi';
+import { IExportBlobResult } from '@gooddata/sdk-backend-spi';
 import { IFilter } from '@gooddata/sdk-model';
 import { IFilterableWidget } from '@gooddata/sdk-model';
 import { IFilterContext } from '@gooddata/sdk-model';
@@ -1482,6 +1483,7 @@ export interface DashboardExportToPdfResolved extends IDashboardEvent {
 
 // @beta
 export interface DashboardExportToPdfResolvedPayload {
+    readonly result: IExportBlobResult;
     readonly resultUri: string;
 }
 
@@ -1606,6 +1608,7 @@ export interface DashboardInsightWidgetExportResolved extends IDashboardEvent {
 
 // @beta
 export interface DashboardInsightWidgetExportResolvedPayload {
+    result: IExportBlobResult;
     resultUri: string;
 }
 

--- a/libs/sdk-ui-dashboard/src/_staging/fileUtils/downloadFile.ts
+++ b/libs/sdk-ui-dashboard/src/_staging/fileUtils/downloadFile.ts
@@ -1,12 +1,18 @@
-// (C) 2019-2021 GoodData Corporation
+// (C) 2019-2023 GoodData Corporation
+import { IExportBlobResult } from "@gooddata/sdk-backend-spi";
+
 export const DOWNLOADER_ID = "downloader";
 
-export function downloadFile(uri: string): void {
+export function downloadFile({ objectUrl, fileName }: IExportBlobResult): void {
     const anchor = document.createElement("a");
     anchor.id = DOWNLOADER_ID;
-    anchor.href = uri;
-    anchor.download = uri;
+    anchor.href = objectUrl;
+    anchor.download = fileName ?? "exportedFile";
     document.body.appendChild(anchor);
     anchor.click();
     document.body.removeChild(anchor);
+
+    if (objectUrl) {
+        URL.revokeObjectURL(objectUrl); // release blob memory from window object
+    }
 }

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/exportDashboardToPdfHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/exportDashboardToPdfHandler.ts
@@ -1,4 +1,4 @@
-// (C) 2021-2022 GoodData Corporation
+// (C) 2021-2023 GoodData Corporation
 import { SagaIterator } from "redux-saga";
 import { call, put, select } from "redux-saga/effects";
 import { ObjRef, FilterContextItem } from "@gooddata/sdk-model";
@@ -15,14 +15,15 @@ import { invalidArgumentsProvided } from "../../events/general";
 import { selectFilterContextFilters } from "../../store/filterContext/filterContextSelectors";
 import { ensureAllTimeFilterForExport } from "../../../_staging/exportUtils/filterUtils";
 import { PromiseFnReturnType } from "../../types/sagas";
+import { IExportBlobResult } from "@gooddata/sdk-backend-spi";
 
 function exportDashboardToPdf(
     ctx: DashboardContext,
     dashboardRef: ObjRef,
     filters: FilterContextItem[] | undefined,
-): Promise<string> {
+): Promise<IExportBlobResult> {
     const { backend, workspace } = ctx;
-    return backend.workspace(workspace).dashboards().exportDashboardToPdf(dashboardRef, filters);
+    return backend.workspace(workspace).dashboards().exportDashboardToPdfBlob(dashboardRef, filters);
 }
 
 export function* exportDashboardToPdfHandler(
@@ -42,7 +43,7 @@ export function* exportDashboardToPdfHandler(
 
     const effectiveFilters = ensureAllTimeFilterForExport(filterContextFilters);
 
-    const resultUri: PromiseFnReturnType<typeof exportDashboardToPdf> = yield call(
+    const result: PromiseFnReturnType<typeof exportDashboardToPdf> = yield call(
         exportDashboardToPdf,
         ctx,
         dashboardRef,
@@ -51,8 +52,13 @@ export function* exportDashboardToPdfHandler(
 
     // prepend hostname if provided so that the results are downloaded from there, not from where the app is hosted
     const fullUri = ctx.backend.config.hostname
-        ? new URL(resultUri, ctx.backend.config.hostname).href
-        : resultUri;
+        ? new URL(result.uri, ctx.backend.config.hostname).href
+        : result.uri;
 
-    return dashboardExportToPdfResolved(ctx, fullUri, cmd.correlationId);
+    const sanitizedResult: IExportBlobResult = {
+        ...result,
+        uri: fullUri,
+    };
+
+    return dashboardExportToPdfResolved(ctx, sanitizedResult, cmd.correlationId);
 }

--- a/libs/sdk-ui-dashboard/src/model/events/dashboard.ts
+++ b/libs/sdk-ui-dashboard/src/model/events/dashboard.ts
@@ -1,6 +1,7 @@
 // (C) 2021-2023 GoodData Corporation
 
 import { IInsight, ObjRef, IDashboard, IWorkspacePermissions } from "@gooddata/sdk-model";
+import { IExportBlobResult } from "@gooddata/sdk-backend-spi";
 
 import { DateFilterValidationResult, ISharingProperties } from "../../types";
 import { DashboardConfig, DashboardContext } from "../types/commonTypes";
@@ -520,6 +521,10 @@ export interface DashboardExportToPdfResolvedPayload {
      * URI of the resulting file that can be used to download it.
      */
     readonly resultUri: string;
+    /**
+     * Collection of information used to download the resulting file.
+     */
+    readonly result: IExportBlobResult;
 }
 
 /**
@@ -535,7 +540,7 @@ export interface DashboardExportToPdfResolved extends IDashboardEvent {
 
 export function dashboardExportToPdfResolved(
     ctx: DashboardContext,
-    resultUri: string,
+    result: IExportBlobResult,
     correlationId?: string,
 ): DashboardExportToPdfResolved {
     return {
@@ -543,7 +548,8 @@ export function dashboardExportToPdfResolved(
         ctx,
         correlationId,
         payload: {
-            resultUri,
+            resultUri: result.uri,
+            result,
         },
     };
 }

--- a/libs/sdk-ui-dashboard/src/model/events/insight.ts
+++ b/libs/sdk-ui-dashboard/src/model/events/insight.ts
@@ -16,6 +16,7 @@ import { WidgetDescription, WidgetHeader } from "../types/widgetTypes";
 import { DashboardContext } from "../types/commonTypes";
 import { eventGuard } from "./util";
 import { IExportConfig } from "../types/exportTypes";
+import { IExportBlobResult } from "@gooddata/sdk-backend-spi";
 
 /**
  * Payload of the {@link DashboardInsightWidgetHeaderChanged} event.
@@ -641,6 +642,10 @@ export interface DashboardInsightWidgetExportResolvedPayload {
      * URI of the resulting file that can be used to download it.
      */
     resultUri: string;
+    /**
+     * Collection of information used to download the resulting file.
+     */
+    result: IExportBlobResult;
 }
 
 /**
@@ -658,7 +663,7 @@ export interface DashboardInsightWidgetExportResolved extends IDashboardEvent {
  */
 export function insightWidgetExportResolved(
     ctx: DashboardContext,
-    resultUri: string,
+    result: IExportBlobResult,
     correlationId?: string,
 ): DashboardInsightWidgetExportResolved {
     return {
@@ -666,7 +671,8 @@ export function insightWidgetExportResolved(
         ctx,
         correlationId,
         payload: {
-            resultUri,
+            resultUri: result.uri,
+            result,
         },
     };
 }

--- a/libs/sdk-ui-dashboard/src/presentation/topBar/menuButton/useDefaultMenuItems.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/topBar/menuButton/useDefaultMenuItems.tsx
@@ -59,7 +59,7 @@ export function useDefaultMenuItems(): IMenuButtonItem[] {
                 removeMessage(lastExportMessageId.current);
             }
             addSuccess(messages.messagesExportResultSuccess);
-            downloadFile(e.payload.resultUri);
+            downloadFile(e.payload.result);
         },
         onError: (err) => {
             if (lastExportMessageId.current) {

--- a/libs/sdk-ui-dashboard/src/presentation/widget/common/useExportHandler.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/common/useExportHandler.ts
@@ -1,13 +1,13 @@
-// (C) 2020-2022 GoodData Corporation
+// (C) 2020-2023 GoodData Corporation
 import { useCallback, useRef } from "react";
-import { isProtectedDataError } from "@gooddata/sdk-backend-spi";
+import { isProtectedDataError, IExportBlobResult } from "@gooddata/sdk-backend-spi";
 import { IExtendedExportConfig } from "@gooddata/sdk-ui";
 import { useToastMessage } from "@gooddata/sdk-ui-kit";
 import { downloadFile } from "../../../_staging/fileUtils/downloadFile";
 import { messages } from "../../../locales";
 
 type ExportHandler = (
-    exportFunction: (config: IExtendedExportConfig) => Promise<string>,
+    exportFunction: (config: IExtendedExportConfig) => Promise<IExportBlobResult>,
     exportConfig: IExtendedExportConfig,
 ) => Promise<void>;
 
@@ -22,14 +22,13 @@ export const useExportHandler = (): ExportHandler => {
                 { duration: 0 },
             );
 
-            const exportResultUri = await exportFunction(exportConfig);
+            const exportResult = await exportFunction(exportConfig);
 
             if (lastExportMessageId.current) {
                 removeMessage(lastExportMessageId.current);
             }
             addSuccess(messages.messagesExportResultSuccess);
-
-            downloadFile(exportResultUri);
+            downloadFile(exportResult);
         } catch (err) {
             if (lastExportMessageId.current) {
                 removeMessage(lastExportMessageId.current);

--- a/libs/sdk-ui-dashboard/src/presentation/widget/common/useInsightExport.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/common/useInsightExport.ts
@@ -1,4 +1,4 @@
-// (C) 2021-2022 GoodData Corporation
+// (C) 2021-2023 GoodData Corporation
 import { useCallback, useState } from "react";
 import invariant from "ts-invariant";
 import { IExtendedExportConfig } from "@gooddata/sdk-ui";
@@ -41,7 +41,7 @@ export const useInsightExport = (config: {
                     },
                     uuid(),
                 ),
-            ).then((result) => result.payload.resultUri),
+            ).then((result) => result.payload.result),
         [widgetRef],
     );
 

--- a/libs/sdk-ui-ext/src/dataLoaders/test/dataLoaders.mock.ts
+++ b/libs/sdk-ui-ext/src/dataLoaders/test/dataLoaders.mock.ts
@@ -25,6 +25,7 @@ export const noopWorkspaceDashboardsService: IWorkspaceDashboardsService = {
     deleteWidgetAlerts: noop as any,
     deleteScheduledMail: noop as any,
     exportDashboardToPdf: noop as any,
+    exportDashboardToPdfBlob: noop as any,
     getDashboard: noop as any,
     getDashboardWidgetAlertsForCurrentUser: noop as any,
     getDashboardWithReferences: noop as any,

--- a/libs/sdk-ui-ext/src/insightView/InsightRenderer.tsx
+++ b/libs/sdk-ui-ext/src/insightView/InsightRenderer.tsx
@@ -1,4 +1,4 @@
-// (C) 2020-2022 GoodData Corporation
+// (C) 2020-2023 GoodData Corporation
 import React, { useCallback, useEffect, useRef } from "react";
 import { v4 as uuidv4 } from "uuid";
 import { render } from "react-dom";
@@ -6,7 +6,7 @@ import noop from "lodash/noop";
 import isEqual from "lodash/isEqual";
 import compose from "lodash/flowRight";
 import { injectIntl, WrappedComponentProps } from "react-intl";
-import { IExecutionFactory, IExportResult, IUserWorkspaceSettings } from "@gooddata/sdk-backend-spi";
+import { IExecutionFactory, IExportBlobResult, IUserWorkspaceSettings } from "@gooddata/sdk-backend-spi";
 import {
     IInsightDefinition,
     insightProperties,
@@ -182,7 +182,7 @@ class InsightRendererCore extends React.PureComponent<IInsightRendererProps & Wr
             return;
         }
 
-        const decorator = (exportConfig: IExtendedExportConfig): Promise<IExportResult> => {
+        const decorator = (exportConfig: IExtendedExportConfig): Promise<IExportBlobResult> => {
             if (exportConfig.title || !this.props.insight) {
                 return exportFunction(exportConfig);
             }

--- a/libs/sdk-ui/api/sdk-ui.api.md
+++ b/libs/sdk-ui/api/sdk-ui.api.md
@@ -28,8 +28,8 @@ import { IDimensionDescriptor } from '@gooddata/sdk-model';
 import { IDimensionItemDescriptor } from '@gooddata/sdk-model';
 import { IExecutionDefinition } from '@gooddata/sdk-model';
 import { IExecutionResult } from '@gooddata/sdk-backend-spi';
+import { IExportBlobResult } from '@gooddata/sdk-backend-spi';
 import { IExportConfig } from '@gooddata/sdk-backend-spi';
-import { IExportResult } from '@gooddata/sdk-backend-spi';
 import { IFilter } from '@gooddata/sdk-model';
 import { IInsightDefinition } from '@gooddata/sdk-model';
 import { IMeasure } from '@gooddata/sdk-model';
@@ -1008,7 +1008,7 @@ export interface IExecutionDefinitionMethods {
 }
 
 // @public (undocumented)
-export type IExportFunction = (exportConfig: IExtendedExportConfig) => Promise<IExportResult>;
+export type IExportFunction = (exportConfig: IExtendedExportConfig) => Promise<IExportBlobResult>;
 
 // @public (undocumented)
 export interface IExtendedExportConfig extends IExportConfig {

--- a/libs/sdk-ui/src/base/vis/Events.ts
+++ b/libs/sdk-ui/src/base/vis/Events.ts
@@ -1,5 +1,5 @@
-// (C) 2007-2022 GoodData Corporation
-import { IDataView, IExportConfig, IExportResult } from "@gooddata/sdk-backend-spi";
+// (C) 2007-2023 GoodData Corporation
+import { IDataView, IExportConfig, IExportBlobResult } from "@gooddata/sdk-backend-spi";
 import {
     IColor,
     IColorPalette,
@@ -38,7 +38,7 @@ export interface IExtendedExportConfig extends IExportConfig {
 /**
  * @public
  */
-export type IExportFunction = (exportConfig: IExtendedExportConfig) => Promise<IExportResult>;
+export type IExportFunction = (exportConfig: IExtendedExportConfig) => Promise<IExportBlobResult>;
 
 /**
  * @public


### PR DESCRIPTION
Currently, exported report or dashboard task is polled via fetch API.
When task is not ready, JSON body with polling uri is returned.
When task finishes, export content is returned in response body.
Fetch utility always parsed the response body to text.

Now, when export task is polled, response body is parsed to
ArrayBuffer. When the export content is returned, buffer is converted
to Blob and then ObjectURL is created for the Blob. ObjectURL creation
attaches the blob to window instance and creates a URL that points to
it. This URL is then used in anchor element appended to DOM. Script
simulates the click on the anchor, file is downloaded to user's
filesystem, and anchor is removed from DOM, and ObjectURL revoked to
release blob data from window instance and memory.

This approach saves one additional call to backend when the content
of export is fetched again. Most importantly, it works around the
issues with authentication of this GET request made by click on the
anchor in the case when token authentication is used (no cookies) or
UserAgentReduction mode is enabled by the user's browser.

Name of the download must be parsed from the content-disposition
header, otherwise API uri value would be used.

JIRA: TNT-1344


<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended check plugins`                                | Dashboard plugins tests                                    |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)