### PR TITLE
FEATURE: SD-2625 - update the SDK Dashboard to add the embed button on KD

### DIFF
--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -3048,6 +3048,8 @@ export interface IButtonBarProps {
     // (undocumented)
     cancelButtonProps: ICancelButtonProps;
     // (undocumented)
+    childContentPosition?: "left" | "right";
+    // (undocumented)
     DefaultButtonBar: CustomButtonBarComponent;
     // (undocumented)
     editButtonProps: IEditButtonProps;

--- a/libs/sdk-ui-dashboard/src/presentation/topBar/buttonBar/DefaultButtonBar.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/topBar/buttonBar/DefaultButtonBar.tsx
@@ -1,4 +1,4 @@
-// (C) 2021-2022 GoodData Corporation
+// (C) 2021-2023 GoodData Corporation
 import React, { PropsWithChildren } from "react";
 
 import { IButtonBarProps } from "./types";
@@ -15,17 +15,19 @@ export const DefaultButtonBar: React.FC<PropsWithChildren<IButtonBarProps>> = (p
         editButtonProps,
         saveAsNewButtonProps,
         shareButtonProps,
+        childContentPosition = "left",
     } = props;
 
     // TODO INE allow customization of buttons via getter from props
     return (
         <div className="dash-control-buttons">
-            {children}
+            {childContentPosition === "left" && children}
             <CancelButton {...cancelButtonProps} />
             <SaveButton {...saveButtonProps} />
             <EditButton {...editButtonProps} />
             <SaveAsNewButton {...saveAsNewButtonProps} />
             <ShareButton {...shareButtonProps} />
+            {childContentPosition === "right" && children}
         </div>
     );
 };

--- a/libs/sdk-ui-dashboard/src/presentation/topBar/buttonBar/types.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/topBar/buttonBar/types.ts
@@ -13,6 +13,8 @@ import {
  */
 export interface IButtonBarProps {
     buttons?: React.ReactNode;
+    // positioning the children's content for ButtonBar to 'left' (default) or 'right'
+    childContentPosition?: "left" | "right";
     shareButtonProps: IShareButtonProps;
     DefaultButtonBar: CustomButtonBarComponent;
     cancelButtonProps: ICancelButtonProps;


### PR DESCRIPTION
feat: add one more property for the ButtonBar component
one property was added to position the children's content for the ButtonBar component

JIRA: SD-2625

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended check plugins`                                | Dashboard plugins tests                                    |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
