### PR TITLE
BUGFIX: SD-2639, SD-2641 - fix some issues in the Embed Insight Dialog

### DIFF
--- a/libs/sdk-ui-ext/src/internal/components/dialogs/embedInsightDialog/EmbedInsightDialog.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/dialogs/embedInsightDialog/EmbedInsightDialog.tsx
@@ -99,7 +99,9 @@ const useEmbedInsightDialog = (props: IEmbedInsightDialogProps) => {
     }, [currentTab]);
 
     const code = useMemo(() => {
-        if (!insight.insight.identifier) {
+        const isReactDefinitionCode =
+            codeOption.type === "react" && codeOption.componentType === "definition";
+        if (!insight.insight.identifier && !isReactDefinitionCode) {
             return null;
         }
         const inputBase = {

--- a/libs/sdk-ui-ext/src/internal/utils/embeddingCodeGenerator/getWebComponentsCodeGenerator.ts
+++ b/libs/sdk-ui-ext/src/internal/utils/embeddingCodeGenerator/getWebComponentsCodeGenerator.ts
@@ -10,7 +10,7 @@ const LOCALE = "<locale>";
 const CUSTOM_HEIGHT = "<customHeight>";
 const CUSTOM_TITLE = "Custom insight title";
 const WEB_COMPONENTS_EMBED_CODE = `<!-- Load the library... -->
-<script type="module" src="https://${HOST_NAME}/components/${WORKSPACE_ID}?auth=sso"></script>
+<script type="module" src="https://${HOST_NAME}/components/${WORKSPACE_ID}.js?auth=sso"></script>
 <!-- ...and embed an insight -->
 
 <gd-insight\n    insight="${INSIGHT_ID}"${INSIGHT_TITLE}${LOCALE}${CUSTOM_HEIGHT}
@@ -21,7 +21,10 @@ export const getWebComponentsCodeGenerator = (
     insight: IInsight,
     codeOption: IWebComponentsOptions,
 ) => {
-    const { displayTitle, customTitle, customHeight, height, locale, allowLocale } = codeOption;
+    const { displayTitle, customTitle, height, locale, allowLocale } = codeOption;
+    // when the heigh is number, we should add the `px` unit to the height. Otherwise, the unit already added to the height.
+    // Ex: style="height: 400px" instead of style="height: 400"
+    const customHeightValue = `${height}${typeof height === "number" ? "px" : ""}`;
     return WEB_COMPONENTS_EMBED_CODE.replace(HOST_NAME, window.location.hostname)
         .replace(WORKSPACE_ID, workspaceId)
         .replace(INSIGHT_ID, insight.insight.identifier)
@@ -30,5 +33,5 @@ export const getWebComponentsCodeGenerator = (
             displayTitle ? `\n    title="${customTitle ? CUSTOM_TITLE : insight.insight.title}"` : "",
         )
         .replace(LOCALE, allowLocale ? `\n    locale="${locale}"` : "")
-        .replace(CUSTOM_HEIGHT, customHeight ? `\n    style="${height}"` : "");
+        .replace(CUSTOM_HEIGHT, `\n    style="height: ${customHeightValue}"`);
 };

--- a/libs/sdk-ui-ext/src/internal/utils/embeddingCodeGenerator/tests/__snapshots__/getWebComponentsCodeGenerator.test.ts.snap
+++ b/libs/sdk-ui-ext/src/internal/utils/embeddingCodeGenerator/tests/__snapshots__/getWebComponentsCodeGenerator.test.ts.snap
@@ -2,57 +2,61 @@
 
 exports[`getWebComponentsCodeGenerator display the custom insight title 1`] = `
 "<!-- Load the library... -->
-<script type=\\"module\\" src=\\"https://localhost/components/workspaceId?auth=sso\\"></script>
+<script type=\\"module\\" src=\\"https://localhost/components/workspaceId.js?auth=sso\\"></script>
 <!-- ...and embed an insight -->
 
 <gd-insight
     insight=\\"insightId\\"
     title=\\"Custom insight title\\"
+    style=\\"height: 400px\\"
 ></gd-insight>"
 `;
 
 exports[`getWebComponentsCodeGenerator display the insight title 1`] = `
 "<!-- Load the library... -->
-<script type=\\"module\\" src=\\"https://localhost/components/workspaceId?auth=sso\\"></script>
+<script type=\\"module\\" src=\\"https://localhost/components/workspaceId.js?auth=sso\\"></script>
 <!-- ...and embed an insight -->
 
 <gd-insight
     insight=\\"insightId\\"
     title=\\"Insight title\\"
+    style=\\"height: 400px\\"
 ></gd-insight>"
 `;
 
 exports[`getWebComponentsCodeGenerator with the custom height 1`] = `
 "<!-- Load the library... -->
-<script type=\\"module\\" src=\\"https://localhost/components/workspaceId?auth=sso\\"></script>
+<script type=\\"module\\" src=\\"https://localhost/components/workspaceId.js?auth=sso\\"></script>
 <!-- ...and embed an insight -->
 
 <gd-insight
     insight=\\"insightId\\"
     title=\\"Custom insight title\\"
     locale=\\"en-US\\"
-    style=\\"600px\\"
+    style=\\"height: 600px\\"
 ></gd-insight>"
 `;
 
 exports[`getWebComponentsCodeGenerator with the locale 1`] = `
 "<!-- Load the library... -->
-<script type=\\"module\\" src=\\"https://localhost/components/workspaceId?auth=sso\\"></script>
+<script type=\\"module\\" src=\\"https://localhost/components/workspaceId.js?auth=sso\\"></script>
 <!-- ...and embed an insight -->
 
 <gd-insight
     insight=\\"insightId\\"
     title=\\"Custom insight title\\"
     locale=\\"en-US\\"
+    style=\\"height: 400px\\"
 ></gd-insight>"
 `;
 
 exports[`getWebComponentsCodeGenerator without any configuration 1`] = `
 "<!-- Load the library... -->
-<script type=\\"module\\" src=\\"https://localhost/components/workspaceId?auth=sso\\"></script>
+<script type=\\"module\\" src=\\"https://localhost/components/workspaceId.js?auth=sso\\"></script>
 <!-- ...and embed an insight -->
 
 <gd-insight
     insight=\\"insightId\\"
+    style=\\"height: 400px\\"
 ></gd-insight>"
 `;

--- a/libs/sdk-ui-ext/src/internal/utils/embeddingCodeGenerator/tests/getWebComponentsCodeGenerator.test.ts
+++ b/libs/sdk-ui-ext/src/internal/utils/embeddingCodeGenerator/tests/getWebComponentsCodeGenerator.test.ts
@@ -1,6 +1,6 @@
 // (C) 2022-2023 GoodData Corporation
 import { IInsight, newInsightDefinition } from "@gooddata/sdk-model";
-import { IWebComponentsOptions } from "@gooddata/sdk-ui-kit";
+import { IWebComponentsOptions, getHeightWithUnitsForEmbedCode } from "@gooddata/sdk-ui-kit";
 import { getWebComponentsCodeGenerator } from "../getWebComponentsCodeGenerator";
 
 describe("getWebComponentsCodeGenerator", () => {
@@ -15,7 +15,11 @@ describe("getWebComponentsCodeGenerator", () => {
                 title: "Insight title",
             },
         };
-        return getWebComponentsCodeGenerator("workspaceId", mockInsight, config);
+        const height = getHeightWithUnitsForEmbedCode(config) as string;
+        return getWebComponentsCodeGenerator("workspaceId", mockInsight, {
+            ...config,
+            height,
+        } as IWebComponentsOptions);
     };
     beforeAll(() => {
         delete window.location;
@@ -78,7 +82,8 @@ describe("getWebComponentsCodeGenerator", () => {
             allowLocale: true,
             locale: "en-US",
             customHeight: true,
-            height: "600px",
+            height: "600",
+            unit: "px",
             customTitle: true,
             displayTitle: true,
         });


### PR DESCRIPTION
fix: some issues in the Embed Insight Dialog
_ update the web components code snippet
_ always have default height for the web components
_ disable code area for the definition code snippet

JIRA: SD-2639, SD-2641

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended check plugins`                                | Dashboard plugins tests                                    |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
