### PR TITLE
FEATURE: SD-2656 adding apis to config date format, timezone for Org.

### DIFF
--- a/common/changes/@gooddata/sdk-ui-all/dedo-sd-2656_2023-04-06-14-31.json
+++ b/common/changes/@gooddata/sdk-ui-all/dedo-sd-2656_2023-04-06-14-31.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@gooddata/sdk-ui-all",
+      "comment": "sdk-backend-tiger: add apis to config localization, timezone for organization",
+      "type": "none"
+    }
+  ],
+  "packageName": "@gooddata/sdk-ui-all"
+}

--- a/libs/sdk-backend-base/src/dummyBackend/index.ts
+++ b/libs/sdk-backend-base/src/dummyBackend/index.ts
@@ -706,6 +706,8 @@ class DummyOrganization implements IOrganization {
         return {
             setWhiteLabeling: () => Promise.resolve(),
             setLocale: () => Promise.resolve(),
+            setTimezone: () => Promise.resolve(),
+            setDateFormat: () => Promise.resolve(),
             getSettings: () => Promise.resolve({}),
         };
     }
@@ -720,6 +722,7 @@ class DummyWorkspaceSettingsService implements IWorkspaceSettingsService {
             testSetting: "test_value",
         });
     }
+
     getSettingsForCurrentUser(): Promise<IUserWorkspaceSettings> {
         return Promise.resolve({
             workspace: this.workspace,
@@ -734,6 +737,14 @@ class DummyWorkspaceSettingsService implements IWorkspaceSettingsService {
     }
 
     setLocale(_locale: string): Promise<void> {
+        return Promise.resolve();
+    }
+
+    setTimezone(_timezone: string): Promise<void> {
+        return Promise.resolve();
+    }
+
+    setDateFormat(_dateFormat: string): Promise<void> {
         return Promise.resolve();
     }
 }

--- a/libs/sdk-backend-mockingbird/src/recordedBackend/index.ts
+++ b/libs/sdk-backend-mockingbird/src/recordedBackend/index.ts
@@ -340,6 +340,8 @@ function recordedOrganization(organizationId: string, implConfig: RecordedBacken
             return {
                 setWhiteLabeling: () => Promise.resolve(),
                 setLocale: () => Promise.resolve(),
+                setTimezone: () => Promise.resolve(),
+                setDateFormat: () => Promise.resolve(),
                 getSettings: () => Promise.resolve({}),
             };
         },

--- a/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
+++ b/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
@@ -1054,7 +1054,9 @@ export interface IOrganizations {
 // @public
 export interface IOrganizationSettingsService {
     getSettings(): Promise<ISettings_2>;
+    setDateFormat(dateFormat: string): Promise<void>;
     setLocale(locale: string): Promise<void>;
+    setTimezone(timezone: string): Promise<void>;
     setWhiteLabeling(whiteLabeling: IWhiteLabeling): Promise<void>;
 }
 

--- a/libs/sdk-backend-spi/src/organization/settings/index.ts
+++ b/libs/sdk-backend-spi/src/organization/settings/index.ts
@@ -27,6 +27,25 @@ export interface IOrganizationSettingsService {
     setLocale(locale: string): Promise<void>;
 
     /**
+     * Sets timezone for organization.
+     *
+     * @param timezone - the value based on IANA time zone database naming convention.
+     * for example: "America/Los_Angeles", etc.
+     *
+     * @returns promise
+     */
+    setTimezone(timezone: string): Promise<void>;
+
+    /**
+     * Sets date format for organization.
+     *
+     * @param dateFormat - the format based on the ICU standard, for example: "en-US", "cs-CZ", etc.
+     *
+     * @returns promise
+     */
+    setDateFormat(dateFormat: string): Promise<void>;
+
+    /**
      * Get all current organization settings.
      *
      * @remarks

--- a/libs/sdk-backend-tiger/src/backend/organization/settings.ts
+++ b/libs/sdk-backend-tiger/src/backend/organization/settings.ts
@@ -18,6 +18,14 @@ export class OrganizationSettingsService
         return this.setSetting("WHITE_LABELING", whiteLabeling);
     }
 
+    public async setTimezone(timezone: string): Promise<void> {
+        return this.setSetting("TIMEZONE", { value: timezone });
+    }
+
+    public async setDateFormat(dateFormat: string): Promise<void> {
+        return this.setSetting("FORMAT_LOCALE", { value: dateFormat });
+    }
+
     public async getSettings(): Promise<ISettings> {
         const { data } = await this.authCall(async (client) =>
             client.entities.getAllEntitiesOrganizationSettings({}),


### PR DESCRIPTION
Also, we should add the type of settings to filter data, because some settings has dynamic id

JIRA: SD-2656

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
