### PR TITLE
BUGFIX: MPNT-329 - support single quoted after backslash for quoted_text

### DIFF
--- a/libs/sdk-backend-bear/src/backend/workspace/measures/measureExpressionTokens.ts
+++ b/libs/sdk-backend-bear/src/backend/workspace/measures/measureExpressionTokens.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2022 GoodData Corporation
+// (C) 2019-2023 GoodData Corporation
 import flow from "lodash/flow";
 import filter from "lodash/fp/filter";
 import map from "lodash/fp/map";
@@ -22,7 +22,7 @@ export interface IExpressionToken {
 const REMOVE_BRACKETS_REGEXP = /[[\]{}]/g;
 const TOKEN_TYPE_REGEXP_PAIRS: Array<[ExpressionTokenType, RegExp]> = [
     ["text", /^[^#{}[\]"()0-9.]+/],
-    ["quoted_text", /^"(?:[^"\\]|\\\\.)*"/],
+    ["quoted_text", /^"(?:[^"\\]|\\"|\\'|\\\\.)*"/],
     ["number", /^[+-]?((\d+(\.\d*)?)|(\.\d+))/],
     ["bracket", /^[()]+/],
     ["identifier", /^\{[^}]+\}/],

--- a/libs/sdk-backend-bear/src/backend/workspace/measures/test/measureExpressionTokens.test.ts
+++ b/libs/sdk-backend-bear/src/backend/workspace/measures/test/measureExpressionTokens.test.ts
@@ -1,4 +1,4 @@
-// (C) 2020-2022 GoodData Corporation
+// (C) 2020-2023 GoodData Corporation
 import { tokenizeExpression } from "../measureExpressionTokens";
 
 describe("tokenizeExpression", () => {
@@ -134,6 +134,40 @@ describe("tokenizeExpression", () => {
             { type: "number", value: "123" },
             { type: "text", value: " " },
             { type: "comment", value: "# WHERE SUM({fact/sum}) > 5" },
+        ]);
+    });
+
+    it("parses MAQL with single quoted after backslash", () => {
+        const tokens = tokenizeExpression(
+            `SELECT SUM( {fact/price}) WHERE {label/order_lines.region} like "x\'y\\'z"`,
+        );
+        expect(tokens).toEqual([
+            { type: "text", value: "SELECT SUM" },
+            { type: "bracket", value: "(" },
+            { type: "text", value: " " },
+            { type: "identifier", value: "fact/price" },
+            { type: "bracket", value: ")" },
+            { type: "text", value: " WHERE " },
+            { type: "identifier", value: "label/order_lines.region" },
+            { type: "text", value: " like " },
+            { type: "quoted_text", value: `"x\'y\\'z"` },
+        ]);
+    });
+
+    it("parses MAQL with double quoted after backslash", () => {
+        const tokens = tokenizeExpression(
+            `SELECT SUM( {fact/price}) WHERE {label/order_lines.region} like "x\\"y\\\\"z}"`,
+        );
+        expect(tokens).toEqual([
+            { type: "text", value: "SELECT SUM" },
+            { type: "bracket", value: "(" },
+            { type: "text", value: " " },
+            { type: "identifier", value: "fact/price" },
+            { type: "bracket", value: ")" },
+            { type: "text", value: " WHERE " },
+            { type: "identifier", value: "label/order_lines.region" },
+            { type: "text", value: " like " },
+            { type: "quoted_text", value: '"x\\"y\\\\"z"' },
         ]);
     });
 });

--- a/libs/sdk-backend-tiger/src/backend/workspace/measures/measureExpressionTokens.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/measures/measureExpressionTokens.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2022 GoodData Corporation
+// (C) 2019-2023 GoodData Corporation
 export type ExpressionTokenType =
     | "text"
     | "quoted_text"
@@ -19,7 +19,7 @@ export interface IExpressionToken {
 const REMOVE_BRACKETS_REGEXP = /[[\]{}]/g;
 const TOKEN_TYPE_REGEXP_PAIRS: Array<[ExpressionTokenType, RegExp]> = [
     ["text", /^[^#{}[\]"()0-9.]+/],
-    ["quoted_text", /^"(?:[^"\\]|\\"|\\\\.)*"/],
+    ["quoted_text", /^"(?:[^"\\]|\\"|\\'|\\\\.)*"/],
     ["number", /^[+-]?((\d+(\.\d*)?)|(\.\d+))/],
     ["bracket", /^[()]+/],
     ["fact", /^\{fact\/[^}]*\}/],

--- a/libs/sdk-backend-tiger/src/backend/workspace/measures/test/measureExpressionTokens.test.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/measures/test/measureExpressionTokens.test.ts
@@ -1,4 +1,4 @@
-// (C) 2020-2022 GoodData Corporation
+// (C) 2020-2023 GoodData Corporation
 import { tokenizeExpression } from "../measureExpressionTokens";
 
 describe("tokenizeExpression", () => {
@@ -124,6 +124,40 @@ describe("tokenizeExpression", () => {
             { type: "bracket", value: "(" },
             { type: "dataset", value: "dataset/campaign_channels" },
             { type: "bracket", value: ")" },
+        ]);
+    });
+
+    it("parses MAQL with single quoted after backslash", () => {
+        const tokens = tokenizeExpression(
+            `SELECT SUM( {fact/PRICE}) WHERE {label/order_lines.REGION} like "x\'y\\'z"`,
+        );
+        expect(tokens).toEqual([
+            { type: "text", value: "SELECT SUM" },
+            { type: "bracket", value: "(" },
+            { type: "text", value: " " },
+            { type: "fact", value: "fact/PRICE" },
+            { type: "bracket", value: ")" },
+            { type: "text", value: " WHERE " },
+            { type: "label", value: "label/order_lines.REGION" },
+            { type: "text", value: " like " },
+            { type: "quoted_text", value: `"x\'y\\'z"` },
+        ]);
+    });
+
+    it("parses MAQL with double quoted after backslash", () => {
+        const tokens = tokenizeExpression(
+            `SELECT SUM( {fact/PRICE}) WHERE {label/order_lines.REGION} like "x\\"y\\\\"z}"`,
+        );
+        expect(tokens).toEqual([
+            { type: "text", value: "SELECT SUM" },
+            { type: "bracket", value: "(" },
+            { type: "text", value: " " },
+            { type: "fact", value: "fact/PRICE" },
+            { type: "bracket", value: ")" },
+            { type: "text", value: " WHERE " },
+            { type: "label", value: "label/order_lines.REGION" },
+            { type: "text", value: " like " },
+            { type: "quoted_text", value: '"x\\"y\\\\"z"' },
         ]);
     });
 });


### PR DESCRIPTION
the quoted_text pattern just support double-quoted after the backslash, but the MAQL have a case to support single-quoted after backslash, so we need add more condition to the pattern to support this case

JIRA: TNT-1227

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

---

# PR Checklist

-   [x] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [x] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [x] `extended test - tiger-cypress - isolated` passes
-   [x] `extended test - cypress - isolated` passes
-   [x] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
