### PR TITLE
BUGFIX: RAIL-4894 KPI date filter initial checkbox behaviour

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/widget/kpi/DefaultKpiConfigurationPanel/KpiWidgetDateDatasetFilter.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/kpi/DefaultKpiConfigurationPanel/KpiWidgetDateDatasetFilter.tsx
@@ -1,4 +1,4 @@
-// (C) 2022 GoodData Corporation
+// (C) 2022-2023 GoodData Corporation
 import React, { useEffect } from "react";
 import { IKpiWidget, widgetRef } from "@gooddata/sdk-model";
 
@@ -17,6 +17,7 @@ import {
     useDashboardSelector,
 } from "../../../../model";
 import { useDateDatasetFilter } from "../../common/configuration/useDateDatasetFilter";
+import { safeSerializeObjRef } from "../../../../_staging/metadata/safeSerializeObjRef";
 
 export const KpiWidgetDateDatasetFilter: React.FC<{
     widget: IKpiWidget;
@@ -62,7 +63,9 @@ export const KpiWidgetDateDatasetFilter: React.FC<{
         if (isWidgetDateDatasetAutoSelect) {
             preselectDateDataset(ref, "default");
         }
-    }, [isWidgetDateDatasetAutoSelect, dispatch, ref, preselectDateDataset]);
+        // We need to safely serialize ref here to avoid recalling the effect
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [isWidgetDateDatasetAutoSelect, safeSerializeObjRef(ref), preselectDateDataset]);
 
     const { handleDateDatasetChanged, shouldOpenDateDatasetPicker } = useDateDatasetFilter(
         result?.dateDatasets,


### PR DESCRIPTION
When date filter checkbox in KPI is clicked
right after initialization, it is not persisted.
This fix avoids calling "enableCheckbox"
right after "disableCheckbox" in such cases.

JIRA: RAIL-4894

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
