### PR TITLE
RELATED: RAIL-4930 update docker images to respect node version 16.20.0

### DIFF
--- a/common/changes/@gooddata/sdk-ui-all/IMJ-RAIL-4930_2023-04-25-10-25.json
+++ b/common/changes/@gooddata/sdk-ui-all/IMJ-RAIL-4930_2023-04-25-10-25.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@gooddata/sdk-ui-all",
+      "comment": "update minimal node version to 16.20.0",
+      "type": "none"
+    }
+  ],
+  "packageName": "@gooddata/sdk-ui-all"
+}

--- a/common/scripts/ci/docker_apidocs_build.sh
+++ b/common/scripts/ci/docker_apidocs_build.sh
@@ -6,7 +6,7 @@ ROOT_DIR=$(echo $(cd $(dirname "${BASH_SOURCE[0]}")/../../.. && pwd -P))
 # go one level up to "see" the gooddata-ui-apidocs too
 ROOT_DIR="$ROOT_DIR/.."
 
-IMAGE="node:16.13.0-bullseye"
+IMAGE="node:16.20.0-bullseye"
 
 echo "Running apidocs build using ${IMAGE} in root directory ${ROOT_DIR}"
 

--- a/common/scripts/ci/docker_examples.sh
+++ b/common/scripts/ci/docker_examples.sh
@@ -5,7 +5,7 @@ set -o pipefail
 # Absolute root directory - for volumes
 ROOT_DIR=$(echo $(cd $(dirname "${BASH_SOURCE[0]}")/../../.. && pwd -P))
 
-IMAGE="node:16.13.0-bullseye"
+IMAGE="node:16.20.0-bullseye"
 
 echo "Running \"$*\" using ${IMAGE} in root directory ${ROOT_DIR}"
 

--- a/common/scripts/ci/docker_rush.sh
+++ b/common/scripts/ci/docker_rush.sh
@@ -3,7 +3,7 @@
 # Absolute root directory - for volumes
 ROOT_DIR=$(echo $(cd $(dirname "${BASH_SOURCE[0]}")/../../.. && pwd -P))
 
-IMAGE="node:16.13.0-bullseye"
+IMAGE="node:16.20.0-bullseye"
 
 echo "Running \"$*\" using ${IMAGE} in root directory ${ROOT_DIR}"
 

--- a/common/scripts/ci/docker_rushx.sh
+++ b/common/scripts/ci/docker_rushx.sh
@@ -3,7 +3,7 @@
 # Absolute root directory - for volumes
 ROOT_DIR=$(echo $(cd $(dirname "${BASH_SOURCE[0]}")/../../.. && pwd -P))
 
-IMAGE="node:16.13.0-bullseye"
+IMAGE="node:16.20.0-bullseye"
 
 echo "Running \"$*\" using ${IMAGE} in root directory ${ROOT_DIR}"
 

--- a/common/scripts/ci/run-sdk-backend-tiger-integration-tests-with-live-backend.sh
+++ b/common/scripts/ci/run-sdk-backend-tiger-integration-tests-with-live-backend.sh
@@ -6,7 +6,7 @@ ROOT_DIR=$(echo $(cd $(dirname "${BASH_SOURCE[0]}")/../../../ && pwd -P))
 _RUSH="${DIR}/docker_rush.sh"
 _RUSHX="${DIR}/docker_rushx.sh"
 
-NODE_IMAGE='020413372491.dkr.ecr.us-east-1.amazonaws.com/tools/gdc-frontend-node-16:node-16.13.0-yarn-1.22.17'
+NODE_IMAGE='020413372491.dkr.ecr.us-east-1.amazonaws.com/tools/gdc-frontend-node-16:node-16.20.0-yarn-1.22.17'
 NETWORK_ID=network-id-${EXECUTOR_NUMBER}
 CYPRESS_HOST=$HOST
 TIGER_API_TOKEN=$TIGER_API_TOKEN

--- a/rush.json
+++ b/rush.json
@@ -39,7 +39,7 @@
      * Specify a SemVer range to ensure developers use a Node.js version that is appropriate
      * for your repo.
      */
-    "nodeSupportedVersionRange": ">=16.13.0",
+    "nodeSupportedVersionRange": ">=16.20.0",
 
     /**
      * Odd-numbered major versions of Node.js are experimental.  Even-numbered releases


### PR DESCRIPTION
JIRA: RAIL-4930

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
