### PR TITLE
BUGFIX: EGL-47 - show the continuous line for the combo chart has one metric on the primary area chart

### DIFF
--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/comboChart/PluggableComboChart.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/comboChart/PluggableComboChart.tsx
@@ -134,8 +134,16 @@ export class PluggableComboChart extends PluggableBaseChart {
             uiConfig: this.getUiConfig(),
         };
 
+        /**
+         * Disable the stackMeasures when there is more than one metric in the primary area chart
+         * Highchart won't draw the continuous line for the stacking Area chart.
+         * Should not effect the `stack measures` checkbox (on the primary buckets) on AD, it will checked by default
+         * if there is more than one metric
+         */
+        const isMoreThanOneMeasure =
+            findBucket(referencePoint.buckets, BucketNames.MEASURES)?.items.length > 1;
         this.defaultControlsProperties = {
-            stackMeasures: this.isStackMeasuresByDefault(),
+            stackMeasures: this.isStackMeasuresByDefault() && isMoreThanOneMeasure,
         };
 
         this.configureBuckets(newReferencePoint);


### PR DESCRIPTION
fix: remove default the stackMeasures when
_ the primaryChartType is Area and only has one metric
JIRA: EGL-47

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
