### PR TITLE
BUGFIX: RAIL-4969 Move toast message reset actions to saga

### DIFF
--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/renderMode/changeRenderModeHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/renderMode/changeRenderModeHandler.ts
@@ -13,6 +13,7 @@ import { selectAllAnalyticalWidgets } from "../../store/layout/layoutSelectors";
 import { validateDrillToCustomUrlParams } from "../common/validateDrillToCustomUrlParams";
 import { isInsightWidget } from "@gooddata/sdk-model";
 import { loadInaccessibleDashboards } from "../dashboard/initializeDashboardHandler/loadInaccessibleDashboards";
+import { uiActions } from "../../store/ui";
 
 export function* changeRenderModeHandler(
     ctx: DashboardContext,
@@ -32,10 +33,23 @@ export function* changeRenderModeHandler(
             ctx,
             resetDashboardCommand(correlationId),
         );
-        yield put(batchActions([data.batch, renderModeActions.setRenderMode(renderMode)]));
+        yield put(
+            batchActions([
+                data.batch,
+                uiActions.resetInvalidDrillWidgetRefs(),
+                uiActions.resetAllInvalidCustomUrlDrillParameterWidgetsWarnings(),
+                renderModeActions.setRenderMode(renderMode),
+            ]),
+        );
         yield put(data.reset);
     } else {
-        yield put(batchActions([renderModeActions.setRenderMode(renderMode)]));
+        yield put(
+            batchActions([
+                uiActions.resetInvalidDrillWidgetRefs(),
+                uiActions.resetAllInvalidCustomUrlDrillParameterWidgetsWarnings(),
+                renderModeActions.setRenderMode(renderMode),
+            ]),
+        );
     }
 
     if (renderMode === "edit") {

--- a/libs/sdk-ui-dashboard/src/presentation/dashboard/components/ToastMessages.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/dashboard/components/ToastMessages.tsx
@@ -1,31 +1,15 @@
 // (C) 2022 GoodData Corporation
-import React, { useCallback, useContext, useEffect, useMemo } from "react";
+import React, { useCallback, useContext, useMemo } from "react";
 import { Messages, ToastMessageContext } from "@gooddata/sdk-ui-kit";
 import { useDrillValidationMessages } from "./useDrillValidationMessages";
-import { selectRenderMode, useDashboardSelector } from "../../../model";
 
 /**
  * @internal
  */
 export const ToastMessages: React.FC = () => {
-    const {
-        messages: toastMessages,
-        removeMessage: removeToastMessage,
-        removeAllMessages: removeAllToastMessages,
-    } = useContext(ToastMessageContext);
-    const {
-        messages: drillValidationMessages,
-        removeMessage: removeDrillValidationMessage,
-        removeAllMessages: removeAllDrillValidationMessages,
-    } = useDrillValidationMessages();
-
-    const renderMode = useDashboardSelector(selectRenderMode);
-
-    // remove all messages whenever the render mode changes
-    useEffect(() => {
-        removeAllToastMessages();
-        removeAllDrillValidationMessages();
-    }, [removeAllDrillValidationMessages, removeAllToastMessages, renderMode]);
+    const { messages: toastMessages, removeMessage: removeToastMessage } = useContext(ToastMessageContext);
+    const { messages: drillValidationMessages, removeMessage: removeDrillValidationMessage } =
+        useDrillValidationMessages();
 
     const messages = useMemo(
         () => [...toastMessages, ...drillValidationMessages],


### PR DESCRIPTION
With React 18, toast message ui actions
dispatched by components were racing
with sagas which caused some problems
in tests. After moving these actions
to the sagas, the problem seems fixed.

JIRA: RAIL-4969

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
