### PR TITLE
RELATED: RAIL-4970 dashboard does not show edit button when integrated with plugin

### DIFF
--- a/libs/sdk-backend-tiger/src/backend/features/feature.ts
+++ b/libs/sdk-backend-tiger/src/backend/features/feature.ts
@@ -53,6 +53,13 @@ export function mapFeatures(features: FeaturesMap): Partial<ITigerFeatureFlags> 
         ),
         ...loadFeature(
             features,
+            TigerFeaturesNames.DashboardEditModeDevRollout,
+            "dashboardEditModeDevRollout",
+            "BOOLEAN",
+            FeatureFlagsValues.dashboardEditModeDevRollout,
+        ),
+        ...loadFeature(
+            features,
             TigerFeaturesNames.EnableMetricSqlAndDataExplain,
             "enableMetricSqlAndDataExplain",
             "BOOLEAN",

--- a/libs/sdk-backend-tiger/src/backend/features/test/hub.test.ts
+++ b/libs/sdk-backend-tiger/src/backend/features/test/hub.test.ts
@@ -119,6 +119,7 @@ describe("live features", () => {
     it("full definition - BOOLEAN", async () => {
         mockReturn([
             createFeature("ADMeasureValueFilterNullAsZeroOption", "BOOLEAN", true),
+            createFeature("dashboardEditModeDevRollout", "BOOLEAN", true),
             createFeature("enableKPIDashboardDeleteFilterButton", "BOOLEAN", true),
             createFeature("enableMultipleDates", "BOOLEAN", true),
             createFeature("enableSortingByTotalGroup", "BOOLEAN", true),
@@ -127,6 +128,7 @@ describe("live features", () => {
         const results = await getFeatureHubFeatures(createFeatures());
         expect(results).toEqual({
             ADMeasureValueFilterNullAsZeroOption: true,
+            dashboardEditModeDevRollout: true,
             enableKPIDashboardDeleteFilterButton: true,
             enableMultipleDates: true,
             enableSortingByTotalGroup: true,
@@ -136,6 +138,7 @@ describe("live features", () => {
     it("full definition - STRING", async () => {
         mockReturn([
             createFeature("ADMeasureValueFilterNullAsZeroOption", "STRING", "EnabledUncheckedByDefault"),
+            createFeature("dashboardEditModeDevRollout", "STRING", "ENABLED"),
             createFeature("enableKPIDashboardDeleteFilterButton", "STRING", "ENABLED"),
             createFeature("enableMultipleDates", "STRING", "ENABLED"),
             createFeature("enableSortingByTotalGroup", "STRING", "TRUE"),
@@ -144,6 +147,7 @@ describe("live features", () => {
         const results = await getFeatureHubFeatures(createFeatures());
         expect(results).toEqual({
             ADMeasureValueFilterNullAsZeroOption: "EnabledUncheckedByDefault",
+            dashboardEditModeDevRollout: true,
             enableKPIDashboardDeleteFilterButton: true,
             enableMultipleDates: true,
             enableSortingByTotalGroup: true,

--- a/libs/sdk-backend-tiger/src/backend/features/test/static.test.ts
+++ b/libs/sdk-backend-tiger/src/backend/features/test/static.test.ts
@@ -21,6 +21,7 @@ describe("static features", () => {
                 [TigerFeaturesNames.EnableSortingByTotalGroup]: "ENABLED",
                 [TigerFeaturesNames.EnableMultipleDates]: "ENABLED",
                 [TigerFeaturesNames.EnableKPIDashboardDeleteFilterButton]: "ENABLED",
+                [TigerFeaturesNames.DashboardEditModeDevRollout]: "ENABLED",
                 [TigerFeaturesNames.EnableMetricSqlAndDataExplain]: "ENABLED",
                 [TigerFeaturesNames.EnableLongitudeAndLatitudeLabels]: "TRUE",
                 [TigerFeaturesNames.EnableSqlDatasets]: "TRUE",
@@ -29,6 +30,7 @@ describe("static features", () => {
         );
         expect(results).toEqual({
             ADMeasureValueFilterNullAsZeroOption: "EnabledUncheckedByDefault",
+            dashboardEditModeDevRollout: true,
             enableKPIDashboardDeleteFilterButton: true,
             enableMultipleDates: true,
             enableSortingByTotalGroup: true,
@@ -47,6 +49,7 @@ describe("static features", () => {
                     [TigerFeaturesNames.EnableSortingByTotalGroup]: "ENABLED",
                     [TigerFeaturesNames.EnableMultipleDates]: "ENABLED",
                     [TigerFeaturesNames.EnableKPIDashboardDeleteFilterButton]: "ENABLED",
+                    [TigerFeaturesNames.DashboardEditModeDevRollout]: "ENABLED",
                     [TigerFeaturesNames.EnableMetricSqlAndDataExplain]: "ENABLED",
                     [TigerFeaturesNames.EnableLongitudeAndLatitudeLabels]: "TRUE",
                     [TigerFeaturesNames.EnableSqlDatasets]: "TRUE",
@@ -57,6 +60,7 @@ describe("static features", () => {
         );
         expect(results).toEqual({
             ADMeasureValueFilterNullAsZeroOption: "EnabledUncheckedByDefault",
+            dashboardEditModeDevRollout: true,
             enableKPIDashboardDeleteFilterButton: true,
             enableMultipleDates: true,
             enableSortingByTotalGroup: true,

--- a/libs/sdk-backend-tiger/src/backend/uiFeatures.ts
+++ b/libs/sdk-backend-tiger/src/backend/uiFeatures.ts
@@ -15,6 +15,10 @@ export enum TigerFeaturesNames {
     //boolean + possible values: enabled, disabled
     EnableKPIDashboardDeleteFilterButton = "enableKPIDashboardDeleteFilterButton",
     //boolean + possible values: enabled, disabled
+    // Remove this FF only after 8.12.0 end of life. The following selector is missing parentheses and is not correctly set to true when FF is missing (read more in ticket RAIL-4970)
+    // https://github.com/gooddata/gooddata-ui-sdk/commit/cd47ff9115fc944be721dfda9d58ede00c7c15e9#diff-d047b642946d563ff25cca09624eede9a605d2b8809bac26531324507de4e546R313
+    DashboardEditModeDevRollout = "dashboardEditModeDevRollout",
+    //boolean + possible values: enabled, disabled
     EnableMetricSqlAndDataExplain = "enableMetricSqlAndDataExplain",
     //boolean + possible values: enabled, disabled
     EnableLongitudeAndLatitudeLabels = "enableLongitudeAndLatitudeLabels",
@@ -47,6 +51,7 @@ export type ITigerFeatureFlags = {
     ADMeasureValueFilterNullAsZeroOption: typeof FeatureFlagsValues["ADMeasureValueFilterNullAsZeroOption"][number];
     enableMultipleDates: typeof FeatureFlagsValues["enableMultipleDates"][number];
     enableKPIDashboardDeleteFilterButton: typeof FeatureFlagsValues["enableKPIDashboardDeleteFilterButton"][number];
+    dashboardEditModeDevRollout: typeof FeatureFlagsValues["dashboardEditModeDevRollout"][number];
     enableMetricSqlAndDataExplain: typeof FeatureFlagsValues["enableMetricSqlAndDataExplain"][number];
     enableLongitudeAndLatitudeLabels: typeof FeatureFlagsValues["enableLongitudeAndLatitudeLabels"][number];
     enableDescriptions: typeof FeatureFlagsValues["enableDescriptions"][number];
@@ -67,6 +72,7 @@ export const DefaultFeatureFlags: ITigerFeatureFlags = {
     ADMeasureValueFilterNullAsZeroOption: "EnabledUncheckedByDefault",
     enableMultipleDates: true,
     enableKPIDashboardDeleteFilterButton: false,
+    dashboardEditModeDevRollout: true,
     enableMetricSqlAndDataExplain: false,
     enableLongitudeAndLatitudeLabels: true,
     enableDescriptions: true,
@@ -91,6 +97,7 @@ export const FeatureFlagsValues = {
     ] as const,
     enableMultipleDates: [true, false] as const,
     enableKPIDashboardDeleteFilterButton: [true, false] as const,
+    dashboardEditModeDevRollout: [true, false] as const,
     enableMetricSqlAndDataExplain: [true, false] as const,
     enableLongitudeAndLatitudeLabels: [true, false] as const,
     enableDescriptions: [true, false] as const,

--- a/libs/sdk-backend-tiger/src/backend/uiSettings.ts
+++ b/libs/sdk-backend-tiger/src/backend/uiSettings.ts
@@ -63,6 +63,9 @@ export const DefaultUiSettings: ISettings = {
     enableAlternativeDisplayFormSelection: true,
     enableNewAnalyticalDashboardsNavigation: true,
 
+    // enable the plugin-ready Dashboard component in gdc-dashboards
+    dashboardComponentDevRollout: true,
+
     enableRenamingProjectToWorkspace: true,
     enableRenamingMeasureToMetric: true,
 

--- a/libs/sdk-ui-tests-e2e/cypress/integration/01-sdk-ui-dashboard/headerSection.spec.ts
+++ b/libs/sdk-ui-tests-e2e/cypress/integration/01-sdk-ui-dashboard/headerSection.spec.ts
@@ -78,7 +78,7 @@ describe("Header section", () => {
                 const desc = data["LimitTexts"].description;
                 const headerRow_01 = layoutRow_01.getHeader();
                 const headerRow_02 = layoutRow_02.getHeader();
-
+                insightCatalog.waitForCatalogReload();
                 headerRow_01.setTitle(title).selectTitleInput().hasLimitMessage("128/256 caractères restant");
                 headerRow_02
                     .scrollIntoView()

--- a/libs/sdk-ui-tests-e2e/cypress/support/featureHub.ts
+++ b/libs/sdk-ui-tests-e2e/cypress/support/featureHub.ts
@@ -12,7 +12,17 @@ beforeEach(() => {
         body: [
             {
                 id: "d2f33050-c46b-491e-82a1-17daba57a0a8",
-                features: [],
+                features: [
+                    {
+                        id: "d154cf37-9ffe-4cae-b892-017ff3429a7c",
+                        key: "dashboardEditModeDevRollout",
+                        l: false,
+                        version: 42,
+                        type: "BOOLEAN",
+                        value: true,
+                        strategies: [],
+                    },
+                ],
             },
         ],
     });


### PR DESCRIPTION
JIRA: RAIL-4970

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |
| **Compatibility matrix test commands - TIGER Backend**  |                                                            |
| `extended test - matrix-test <AIO_version>`             | Run integrated tests against AIO versions.                 |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

`<AIO_version>` in commands is used to start test with multiple AIO instances - each instance in triggered by one jenkins build

-   To run with `master` and `stable`, execute command `extended test - matrix-test master,stable` or `extended test - matrix-test latest`
-   To run with specific version,ex: `2.3.0` and `2.3.1`, execute command `extended test - matrix-test 2.3.0,2.3.1`
-   In case `<AIO_version>` is empty, read versions from file `compTigerVersions.txt` of this repo

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
