### PR TITLE
RELATED: RAIL-4900 Config loading breaking changes

### DIFF
--- a/common/changes/@gooddata/sdk-ui-all/ach-catalog-export_2023-05-29-15-36.json
+++ b/common/changes/@gooddata/sdk-ui-all/ach-catalog-export_2023-05-29-15-36.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@gooddata/sdk-ui-all",
+      "comment": "catalog-export: unified the way configuration is loaded for tiger and bear",
+      "type": "none"
+    }
+  ],
+  "packageName": "@gooddata/sdk-ui-all"
+}

--- a/examples/playground/scripts/refresh-md.sh
+++ b/examples/playground/scripts/refresh-md.sh
@@ -9,5 +9,5 @@ WORKSPACEID="xms7ga4tf3g3nzucd8380o2bev8oeknp"
 $EXPORTER \
   --backend bear \
   --hostname "https://developer.na.gooddata.com" \
-  --output "${OUTPUT}" \
+  --catalog-output "${OUTPUT}" \
   --workspace-id "${WORKSPACEID}"

--- a/examples/sdk-examples/scripts/refresh-md.sh
+++ b/examples/sdk-examples/scripts/refresh-md.sh
@@ -9,5 +9,5 @@ WORKSPACEID="xms7ga4tf3g3nzucd8380o2bev8oeknp"
 $EXPORTER \
   --backend bear \
   --hostname "https://developer.na.gooddata.com" \
-  --output "${OUTPUT}" \
+  --catalog-output "${OUTPUT}" \
   --workspace-id "${WORKSPACEID}"

--- a/libs/sdk-backend-tiger/scripts/refresh-md.sh
+++ b/libs/sdk-backend-tiger/scripts/refresh-md.sh
@@ -8,6 +8,6 @@ PROJECTID="2b7da2afb0d34f4397481c4d2a2d50b0"
 
 $EXPORTER \
   --hostname "https://staging.anywhere.gooddata.com" \
-  --output "${OUTPUT}" \
+  --catalog-output "${OUTPUT}" \
   --project-id "${PROJECTID}" \
   --backend "tiger"

--- a/libs/sdk-ui-tests-e2e/reference_workspace/export_catalog.js
+++ b/libs/sdk-ui-tests-e2e/reference_workspace/export_catalog.js
@@ -13,7 +13,7 @@ export function exportCatalogBear(host, projectId, username, password) {
     // NOTE: we support this only for goodsales
     const outputFile = BEAR_FIXTURE_CATALOG["goodsales"];
     execSync(
-        `echo '${password}' | npx gdc-catalog-export --accept-untrusted-ssl --hostname "${host}" --workspace-id "${projectId}" --username "${username}" --backend "bear" --output "${outputFile}"`,
+        `echo '${password}' | npx gdc-catalog-export --accept-untrusted-ssl --hostname "${host}" --workspace-id "${projectId}" --username "${username}" --backend "bear" --catalog-output "${outputFile}"`,
         { stdio: "inherit" },
     );
 }
@@ -25,7 +25,7 @@ export function exportCatalogTiger(
     outputFile = TIGER_FIXTURE_CATALOG["goodsales"], // NOTE: we support this only for goodsales
 ) {
     execSync(
-        `export TIGER_API_TOKEN="${tiger_api_token}" && npx gdc-catalog-export --accept-untrusted-ssl --hostname "${host}" --workspace-id "${projectId}" --backend "tiger" --output "${outputFile}"`,
+        `export TIGER_API_TOKEN="${tiger_api_token}" && npx gdc-catalog-export --accept-untrusted-ssl --hostname "${host}" --workspace-id "${projectId}" --backend "tiger" --catalog-output "${outputFile}"`,
         { stdio: "inherit" },
     );
 }

--- a/tools/app-toolkit/scripts/preparePackageJson.ts
+++ b/tools/app-toolkit/scripts/preparePackageJson.ts
@@ -129,6 +129,11 @@ function removeTs(packageJson: Record<string, any>) {
     removeItems(TypeScriptDependencies, dependencies);
 
     delete packageJson.typings;
+
+    if (packageJson.gooddata?.catalogOutput) {
+        // Use .js file for catalog export
+        packageJson.gooddata.catalogOutput = packageJson.gooddata.catalogOutput.replace(/\.ts$/, ".js");
+    }
 }
 
 if (process.argv.length !== 4) {

--- a/tools/catalog-export/src/base/constants.ts
+++ b/tools/catalog-export/src/base/constants.ts
@@ -5,11 +5,14 @@ export const DEFAULT_HOSTNAME = "https://secure.gooddata.com";
 export const DEFAULT_CONFIG_FILE_NAME = ".gdcatalogrc";
 export const DEFAULT_OUTPUT_FILE_NAME = "catalog.ts";
 
+export const API_TOKEN_VAR_NAME = "TIGER_API_TOKEN";
+
 export const DEFAULT_CONFIG: CatalogExportConfig = {
     hostname: null,
     workspaceId: null,
     username: null,
     password: null,
-    output: null,
+    token: null,
+    catalogOutput: null,
     backend: "tiger",
 };

--- a/tools/catalog-export/src/base/tests/__mocks__/fs/promises.ts
+++ b/tools/catalog-export/src/base/tests/__mocks__/fs/promises.ts
@@ -7,6 +7,12 @@ type MockedFs = typeof fsType & {
 
 const fs = jest.genMockFromModule<MockedFs>("fs/promises");
 
+class MockError extends Error {
+    constructor(message: string, public code: string | number) {
+        super(message);
+    }
+}
+
 let mockFiles = Object.create(null);
 fs.__setMockFiles = function __setMockFiles(newMockFiles) {
     mockFiles = newMockFiles;
@@ -14,10 +20,7 @@ fs.__setMockFiles = function __setMockFiles(newMockFiles) {
 const readFile = (fs.readFile = async function (path: any) {
     if (mockFiles[path]) return mockFiles[path];
 
-    const err = new Error("File does not exist");
-    //@ts-ignore
-    err.code = "ENOENT";
-    throw err;
+    throw new MockError("File does not exist", "ENOENT");
 });
 
 export default fs;

--- a/tools/catalog-export/src/base/tests/__mocks__/fs/promises.ts
+++ b/tools/catalog-export/src/base/tests/__mocks__/fs/promises.ts
@@ -1,0 +1,24 @@
+// (C) 2023 GoodData Corporation
+import type * as fsType from "fs/promises";
+
+type MockedFs = typeof fsType & {
+    __setMockFiles(files: { [path: string]: string }): void;
+};
+
+const fs = jest.genMockFromModule<MockedFs>("fs/promises");
+
+let mockFiles = Object.create(null);
+fs.__setMockFiles = function __setMockFiles(newMockFiles) {
+    mockFiles = newMockFiles;
+};
+const readFile = (fs.readFile = async function (path: any) {
+    if (mockFiles[path]) return mockFiles[path];
+
+    const err = new Error("File does not exist");
+    //@ts-ignore
+    err.code = "ENOENT";
+    throw err;
+});
+
+export default fs;
+export { readFile };

--- a/tools/catalog-export/src/base/tests/__snapshots__/config.test.ts.snap
+++ b/tools/catalog-export/src/base/tests/__snapshots__/config.test.ts.snap
@@ -1,67 +1,75 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`getConfigFromProgram should complement config from defaults 1`] = `
+exports[`configuration getConfigFromConfigFile should read the given config file and return allowed values from it 1`] = `
 Object {
-  "backend": "tiger",
-  "hostname": null,
-  "output": null,
-  "password": null,
-  "username": "valid",
-  "workspaceId": "abc",
+  "backend": "backend",
+  "catalogOutput": "catalogOutput",
+  "hostname": "hostname",
+  "workspaceId": "workspaceId",
 }
 `;
 
-exports[`getConfigFromProgram should handle case sensitivity 1`] = `
+exports[`configuration getConfigFromEnv should parse credentials and ignore everything else 1`] = `
 Object {
-  "backend": "tiger",
-  "hostname": null,
-  "output": null,
-  "password": null,
-  "username": "valid",
-  "workspaceId": null,
+  "password": "password",
+  "token": "token",
+  "username": "username",
 }
 `;
 
-exports[`getConfigFromProgram should handle empty object 1`] = `
+exports[`configuration getConfigFromEnv should return null for credentials if not present in env 1`] = `
 Object {
-  "backend": "tiger",
-  "hostname": null,
-  "output": null,
   "password": null,
+  "token": null,
   "username": null,
-  "workspaceId": null,
 }
 `;
 
-exports[`getConfigFromProgram should handle object with just some of the needed props 1`] = `
+exports[`configuration getConfigFromOptions should output allowed values from the input object 1`] = `
+Object {
+  "backend": "backend",
+  "catalogOutput": "catalogOutput",
+  "hostname": "hostname",
+  "password": "password",
+  "token": "token",
+  "username": "username",
+  "workspaceId": "workspaceId",
+}
+`;
+
+exports[`configuration getConfigFromPackage should ignore credentials and not supported values 1`] = `
+Object {
+  "hostname": "hostname",
+  "workspaceId": "workspaceId",
+}
+`;
+
+exports[`configuration getConfigFromPackage should override parent folder package.jsons with child ones 1`] = `
+Object {
+  "backend": "backend",
+  "catalogOutput": "catalogOutput",
+  "hostname": "hostname-new",
+  "workspaceId": "workspaceId-new",
+}
+`;
+
+exports[`configuration getConfigFromPackage should parse allowed values from the package.json file in a given folder 1`] = `
+Object {
+  "backend": "backend",
+  "catalogOutput": "catalogOutput",
+  "hostname": "hostname",
+  "workspaceId": "workspaceId",
+}
+`;
+
+exports[`configuration mergeConfigs should only output allowed values 1`] = `
 Object {
   "backend": "tiger",
-  "hostname": null,
-  "output": null,
-  "password": null,
-  "username": "noone",
-  "workspaceId": null,
-}
-`;
-
-exports[`getConfigFromProgram should prefer input over default 1`] = `
-Object {
-  "backend": "tiger",
-  "hostname": null,
-  "output": null,
-  "password": null,
-  "username": "valid",
-  "workspaceId": "abc",
-}
-`;
-
-exports[`getConfigFromProgram should propagate bear backend type 1`] = `
-Object {
-  "backend": "bear",
-  "hostname": null,
-  "output": null,
-  "password": null,
-  "username": null,
-  "workspaceId": null,
+  "catalogOutput": "./cat.ts",
+  "hostname": "https://cloud.gooddata.com/",
+  "password": "secret",
+  "token": "secret",
+  "username": "tomas",
+  "workspaceId": "123",
 }
 `;

--- a/tools/catalog-export/src/base/tests/config.test.ts
+++ b/tools/catalog-export/src/base/tests/config.test.ts
@@ -1,35 +1,227 @@
 // (C) 2007-2023 GoodData Corporation
-import { getConfigFromOptions } from "../config";
-import { CatalogExportConfig } from "../types";
+import {
+    getConfigFromConfigFile,
+    getConfigFromEnv,
+    getConfigFromOptions,
+    mergeConfigs,
+    getConfigFromPackage,
+} from "../config";
 
-describe("getConfigFromProgram", () => {
-    const EMPTY_CONFIG: CatalogExportConfig = {
-        hostname: null,
-        output: null,
-        password: null,
-        workspaceId: null,
-        username: null,
-        backend: null,
-    };
+jest.mock("fs/promises");
 
-    const TEST_DATA: Array<[string, any, CatalogExportConfig | null]> = [
-        ["handle empty object", {}, null],
-        ["handle object with just some of the needed props", { username: "noone" }, null],
-        ["handle case sensitivity", { USERNAME: "not valid", username: "valid" }, null],
-        ["complement config from defaults", { username: "valid" }, { ...EMPTY_CONFIG, workspaceId: "abc" }],
-        [
-            "prefer input over default",
-            { username: "valid", workspaceId: "abc" },
-            { ...EMPTY_CONFIG, workspaceId: "xyz" },
-        ],
-        ["propagate bear backend type", { backend: "bear" }, null],
-    ];
+describe("configuration", () => {
+    describe("mergeConfigs", () => {
+        it("should override the values based on the order", () => {
+            const merged = mergeConfigs({ hostname: "old value" }, { hostname: "new value" });
 
-    it.each(TEST_DATA)("should %s", (_, input: any, defaultOptions: CatalogExportConfig | null) => {
-        if (!defaultOptions) {
-            expect(getConfigFromOptions(input)).toMatchSnapshot();
-        } else {
-            expect(getConfigFromOptions(input, defaultOptions)).toMatchSnapshot();
-        }
+            expect(merged).toEqual({ hostname: "new value" });
+        });
+
+        it("should only override with defined, non-null values", () => {
+            const merged = mergeConfigs(
+                {
+                    hostname: "value",
+                },
+                {
+                    hostname: null,
+                },
+                {
+                    hostname: undefined,
+                },
+            );
+
+            expect(merged).toEqual({ hostname: "value" });
+        });
+
+        it("should only output allowed values", () => {
+            const merged = mergeConfigs({
+                hostname: "https://cloud.gooddata.com/",
+                backend: "tiger",
+                catalogOutput: "./cat.ts",
+                workspaceId: "123",
+                username: "tomas",
+                password: "secret",
+                token: "secret",
+                // @ts-ignore - technically, we can't prevent user from putting random vars in JSON file...
+                unknown: "value",
+            });
+
+            expect(merged).toMatchSnapshot();
+        });
+    });
+
+    describe("getConfigFromEnv", () => {
+        it("should parse credentials and ignore everything else", () => {
+            const config = getConfigFromEnv({
+                GDC_USERNAME: "username",
+                GDC_PASSWORD: "password",
+                TIGER_API_TOKEN: "token",
+                RANDOM: "random variable",
+            });
+
+            expect(config).toMatchSnapshot();
+        });
+
+        it("should return null for credentials if not present in env", () => {
+            const config = getConfigFromEnv({});
+
+            expect(config).toMatchSnapshot();
+        });
+    });
+
+    describe("getConfigFromOptions", () => {
+        it("should output allowed values from the input object", () => {
+            const config = getConfigFromOptions({
+                hostname: "hostname",
+                workspaceId: "workspaceId",
+                username: "username",
+                password: "password",
+                token: "token",
+                catalogOutput: "catalogOutput",
+                backend: "backend",
+            });
+
+            expect(config).toMatchSnapshot();
+        });
+
+        it("should ignore empty or non-existing props", () => {
+            const config = getConfigFromOptions({});
+
+            expect(config).toEqual({});
+        });
+
+        it("should not output additional props", () => {
+            const config = getConfigFromOptions({ random: "random" });
+
+            expect(config).toEqual({});
+        });
+    });
+
+    describe("getConfigFromConfigFile", () => {
+        it("should read the given config file and return allowed values from it", async () => {
+            const fs = (await import("fs/promises")).default;
+
+            // @ts-ignore
+            fs.__setMockFiles({
+                "/path/to/config.json": JSON.stringify({
+                    hostname: "hostname",
+                    workspaceId: "workspaceId",
+                    catalogOutput: "catalogOutput",
+                    backend: "backend",
+                }),
+            });
+
+            await expect(getConfigFromConfigFile("/path/to/config.json")).resolves.toMatchSnapshot();
+        });
+
+        it("should return an empty object if there is no config file", async () => {
+            const fs = (await import("fs/promises")).default;
+
+            // @ts-ignore
+            fs.__setMockFiles({});
+
+            await expect(getConfigFromConfigFile("/path/to/config.json")).resolves.toEqual({});
+        });
+
+        it("should not parse credentials out of config file", async () => {
+            const fs = (await import("fs/promises")).default;
+
+            // @ts-ignore
+            fs.__setMockFiles({
+                "/path/to/config.json": JSON.stringify({
+                    token: "token",
+                    username: "username",
+                    password: "password",
+                }),
+            });
+
+            await expect(getConfigFromConfigFile("/path/to/config.json")).resolves.toEqual({});
+        });
+    });
+
+    describe("getConfigFromPackage", () => {
+        it("should parse allowed values from the package.json file in a given folder", async () => {
+            const fs = (await import("fs/promises")).default;
+
+            // @ts-ignore
+            fs.__setMockFiles({
+                "/path/to/project/package.json": JSON.stringify({
+                    gooddata: {
+                        hostname: "hostname",
+                        workspaceId: "workspaceId",
+                        catalogOutput: "catalogOutput",
+                        backend: "backend",
+                    },
+                }),
+            });
+
+            await expect(getConfigFromPackage("/path/to/project")).resolves.toMatchSnapshot();
+        });
+
+        it("should override parent folder package.jsons with child ones", async () => {
+            const fs = (await import("fs/promises")).default;
+
+            // @ts-ignore
+            fs.__setMockFiles({
+                "/path/to/package.json": JSON.stringify({
+                    gooddata: {
+                        hostname: "hostname",
+                        workspaceId: "workspaceId",
+                        catalogOutput: "catalogOutput",
+                        backend: "backend",
+                    },
+                }),
+                "/path/to/project/package.json": JSON.stringify({
+                    gooddata: {
+                        hostname: "hostname-new",
+                        workspaceId: "workspaceId-new",
+                    },
+                }),
+            });
+
+            await expect(getConfigFromPackage("/path/to/project")).resolves.toMatchSnapshot();
+        });
+
+        it("should ignore credentials and not supported values", async () => {
+            const fs = (await import("fs/promises")).default;
+
+            // @ts-ignore
+            fs.__setMockFiles({
+                "/path/to/project/package.json": JSON.stringify({
+                    gooddata: {
+                        hostname: "hostname",
+                        workspaceId: "workspaceId",
+                        token: "token",
+                        username: "username",
+                        password: "password",
+                        random: "random",
+                    },
+                }),
+            });
+
+            await expect(getConfigFromPackage("/path/to/project")).resolves.toMatchSnapshot();
+        });
+
+        it("should return an empty object if file does not exist", async () => {
+            const fs = (await import("fs/promises")).default;
+
+            // @ts-ignore
+            fs.__setMockFiles({});
+
+            await expect(getConfigFromPackage("/path/to/project")).resolves.toEqual({});
+        });
+        it("should return an empty object if file does not have gooddata property", async () => {
+            const fs = (await import("fs/promises")).default;
+
+            // @ts-ignore
+            fs.__setMockFiles({
+                "/path/to/project/package.json": JSON.stringify({
+                    name: "my-package",
+                    version: "v1.0.0",
+                }),
+            });
+
+            await expect(getConfigFromPackage("/path/to/project")).resolves.toEqual({});
+        });
     });
 });

--- a/tools/catalog-export/src/base/types.ts
+++ b/tools/catalog-export/src/base/types.ts
@@ -47,9 +47,14 @@ export type CatalogExportConfig = {
     password: string | null;
 
     /**
+     * Tiger API Token for authentication
+     */
+    token: string | null;
+
+    /**
      * File to write output to.
      */
-    output: string | null;
+    catalogOutput: string | null;
 
     /**
      * Indicates type of backend

--- a/tools/catalog-export/src/loaders/tiger/index.ts
+++ b/tools/catalog-export/src/loaders/tiger/index.ts
@@ -13,7 +13,7 @@ import { ITigerClient, jsonApiHeaders, JsonApiWorkspaceOutList } from "@gooddata
 import { tigerLoad } from "./tigerLoad";
 import { createTigerClient } from "./tigerClient";
 import open from "open";
-import dotenv from "dotenv";
+import { API_TOKEN_VAR_NAME } from "../../base/constants";
 
 /**
  * Tests if the provided tiger client can access the backend.
@@ -44,15 +44,12 @@ async function probeAccess(client: ITigerClient): Promise<boolean> {
     }
 }
 
-const TigerApiTokenVariable = "TIGER_API_TOKEN";
-
 /**
- * Gets token defined in TIGER_API_TOKEN or undefined if no such env variable or the variable contains
+ * Gets token from config or undefined if no such env variable or the variable contains
  * empty value.
  */
-function getTigerApiToken(): string | undefined {
-    dotenv.config({ path: ".env" });
-    const token = process.env[TigerApiTokenVariable];
+function getTigerApiToken(config: CatalogExportConfig): string | undefined {
+    const token = config.token;
 
     return token?.length ? token : undefined;
 }
@@ -61,7 +58,7 @@ function getTigerApiToken(): string | undefined {
  * Gets the tiger client asking for credentials if they are needed.
  */
 async function getTigerClient(config: CatalogExportConfig): Promise<ITigerClient> {
-    const token = getTigerApiToken();
+    const token = getTigerApiToken(config);
     const hasToken = token !== undefined;
     let askedForLogin: boolean = false;
 
@@ -75,9 +72,9 @@ async function getTigerClient(config: CatalogExportConfig): Promise<ITigerClient
 
         if (!hasAccess) {
             if (hasToken) {
-                logError(`It looks like the token you have set in ${TigerApiTokenVariable} has expired.`);
+                logError(`It looks like the token you have set in ${API_TOKEN_VAR_NAME} has expired.`);
             } else {
-                logError(`You do not have the ${TigerApiTokenVariable} environment variable set.`);
+                logError(`You do not have the ${API_TOKEN_VAR_NAME} environment variable set.`);
             }
 
             logInfo("To obtain a token value, follow these steps:");
@@ -90,11 +87,11 @@ async function getTigerClient(config: CatalogExportConfig): Promise<ITigerClient
             logInfo(
                 "2. Once you are on your Tiger developer settings page please " +
                     `create a new personal access token by clicking Manage button in Personal access tokens section. ` +
-                    "For other methods to generate the token see: https://www.gooddata.com/developers/cloud-native/doc/latest/administration/auth/user-token ",
+                    "For other methods to generate the token see: https://www.gooddata.com/developers/cloud-native/doc/cloud/getting-started/create-api-token/ ",
             );
 
             logInfo(
-                `3. Once you have the token value, please set the ${TigerApiTokenVariable} environment variable and try again.`,
+                `3. Once you have the token value, please set the ${API_TOKEN_VAR_NAME} environment variable and try again.`,
             );
 
             await open(settingsPage, { wait: false });

--- a/tools/catalog-export/src/loaders/tiger/index.ts
+++ b/tools/catalog-export/src/loaders/tiger/index.ts
@@ -21,7 +21,7 @@ import { API_TOKEN_VAR_NAME } from "../../base/constants";
  */
 async function probeAccess(client: ITigerClient): Promise<boolean> {
     try {
-        await client.entities.getAllEntitiesWorkspaces({ page: 0, size: 1 }, { headers: jsonApiHeaders });
+        await client.profile.getCurrent();
 
         return true;
     } catch (err: any) {

--- a/tools/dashboard-plugin-template/scripts/refresh-md.js
+++ b/tools/dashboard-plugin-template/scripts/refresh-md.js
@@ -19,7 +19,7 @@ process.argv.push(
     hostname,
     "--workspace-id",
     workspace,
-    "--output",
+    "--catalog-output",
     output,
 );
 

--- a/tools/experimental-workspace/bin/refresh-md.sh
+++ b/tools/experimental-workspace/bin/refresh-md.sh
@@ -11,4 +11,4 @@ $EXPORTER \
   --hostname "staging3.intgdc.com" \
   --workspace-id "d79dpgty2b4ydewi6kbzqm4fq1be2ltm" \
   --accept-untrusted-ssl \
-  --output "${OUTPUT}"
+  --catalog-output "${OUTPUT}"

--- a/tools/live-examples-workspace/bin/refresh-md.sh
+++ b/tools/live-examples-workspace/bin/refresh-md.sh
@@ -10,4 +10,4 @@ $EXPORTER \
   --backend bear \
   --hostname "developer.na.gooddata.com" \
   --workspace-id "xms7ga4tf3g3nzucd8380o2bev8oeknp" \
-  --output "${OUTPUT}"
+  --catalog-output "${OUTPUT}"

--- a/tools/react-app-template/.gitignore
+++ b/tools/react-app-template/.gitignore
@@ -1,3 +1,3 @@
-.env.secrets
+.env
 dist
 node_modules

--- a/tools/react-app-template/README.template.md
+++ b/tools/react-app-template/README.template.md
@@ -181,20 +181,67 @@ By default, GoodData React SDK is connecting to [the same demo data](https://www
 as you would get in your GoodData Cloud or GoodData.CN trial account. Here are a few steps on how to connect to
 your own data instead.
 
-1. In [`webpack.config.js`](./webpack.config.js) replace the hostname of the server we are loading data from:
+1. In [`package.json`](./package.json) replace `hostname` and `workspaceId` to your own values:
     ```diff
-    -   const BACKEND_URL = "https://public-examples.gooddata.com";
-    +   const BACKEND_URL = "https://<your-gooddata-instance-host>";
+    -    "hostname": "https://public-examples.gooddata.com",
+    -    "workspaceId": "demo",
+    +    "hostname": "https://<your-gooddata-instance-host>",
+    +    "workspaceId": "<your-workspace-id>",
     ```
-    If you're running dev server, you'll need to restart it for the change to take effect. If you have a demo data
-    connected to your trial account [as per our docs](https://www.gooddata.com/developers/cloud-native/doc/cloud/getting-started/connect-data/#example-database),
-    you should have a working project at this point.
-2. Update your workspace ID to point to the workspace where your own data is connected to. In `App.{{language}}x`
+2. Generate an [API Token](https://www.gooddata.com/developers/cloud-native/doc/cloud/getting-started/create-api-token/) for development
+   and put it to the [`.env` file](./.env):
+    ```
+    TIGER_API_TOKEN=<your_api_token>
+    ```
+   Make sure you do not commit the `.env` file to your VCS (e.g. Git)
+3. Refresh [the metadata catalog](https://sdk.gooddata.com/gooddata-ui/docs/export_catalog.html) for the newly configured workspace: `npm run refresh-md`.
+4. Update the `App.{{language}}x`. Since we've switched to your own data, the reference to the insight in `App.{{language}}x` is no longer valid.
+   Select a new insight to render from the catalog and update `App.{{language}}x`:
     ```diff
-    -   <WorkspaceProvider workspace="demo">
-    +   <WorkspaceProvider workspace="<your-workspace-id>">
+    -   <InsightView insight={Md.Insights.ProductCategoriesPieChart} showTitle />
+    +   <InsightView insight={Md.Insights.<your-insight-id>} showTitle />
     ```
-    TODO - where do I get workspaceID???
-3. Fetch the new metadata.
+
+Read more about integration with GoodData Cloud or GoodData.CN in [our docs](https://sdk.gooddata.com/gooddata-ui/docs/cloudnative_getting_started.html).
 
 ### Connect your own data from _GoodData Platform_
+
+By default, GoodData React SDK is configured to connect to GoodData Cloud or GoodData.CN server. Here is how you can switch to GoodData Platform instead.
+
+1. Edit `./src/backend.{{language}}` file to use "bear" backend instead of "tiger" one:
+    ```diff
+    -    import backendFactory, { ContextDeferredAuthProvider } from "@gooddata/sdk-backend-tiger";
+    +    import backendFactory, { ContextDeferredAuthProvider } from "@gooddata/sdk-backend-bear";
+    ```
+   You'll also need to define a logic on what to do if user is not logged in. The simplest case could look something like this:
+    ```diff
+    -     backendFactory().withAuthentication(new ContextDeferredAuthProvider()),
+    +     backendFactory().withAuthentication(new ContextDeferredAuthProvider(() => {
+    +         window.location.replace(`${window.location.origin}/account.html?lastUrl=${encodeURIComponent(window.location.href)}`);
+    +     })),
+    ```
+   Your setup may vary, see our [documentation on different authentication options GoodData Platform provides](https://sdk.gooddata.com/gooddata-ui/docs/platform_sso.html).
+2. Update `./package.json` to specify you're using "bear" backend. Update the hostname and workspaceId to the ones you'd like to connect to:
+    ```diff
+    -    "hostname": "https://public-examples.gooddata.com",
+    -    "workspaceId": "demo",
+    -    "backend": "tiger",
+    +    "hostname": "https://<your-gooddata-instance-host>",
+    +    "workspaceId": "<your-workspace-id>",
+    +    "backend": "bear",
+    ```
+3. Update `.env` file and put there your `USERNAME` and `PASSWORD`.
+    ```diff
+    -    USERNAME=
+    -    PASSWORD=
+    +    USERNAME=<your-username>
+    +    PASSWORD=<your-password>
+    ```
+   Make sure you do not commit the `.env` file to your VCS (e.g. Git).
+4. Refresh [the metadata catalog](https://sdk.gooddata.com/gooddata-ui/docs/export_catalog.html) for the newly configured workspace: `npm run refresh-md`.
+5. Update the `App.{{language}}x`. Since we've switched to your own data, the reference to the insight in `App.{{language}}x` is no longer valid.
+   Select a new insight to render from the catalog and update `App.{{language}}x`:
+    ```diff
+    -   <InsightView insight={Md.Insights.ProductCategoriesPieChart} showTitle />
+    +   <InsightView insight={Md.Insights.<your-insight-id>} showTitle />
+    ```

--- a/tools/react-app-template/configTemplates/js/.env
+++ b/tools/react-app-template/configTemplates/js/.env
@@ -1,0 +1,6 @@
+# For GoodData Cloud or GoodData.CN
+TIGER_API_TOKEN=
+
+# For GoodData Platform
+GDC_USERNAME=
+GDC_PASSWORD=

--- a/tools/react-app-template/configTemplates/js/.gdcatalogrc
+++ b/tools/react-app-template/configTemplates/js/.gdcatalogrc
@@ -1,7 +1,0 @@
-{
-    "hostname": "https://public-examples.gooddata.com",
-    "workspaceId": "demo",
-    "output": "src/catalog.js",
-    "backend": "tiger",
-    "demo": true
-}

--- a/tools/react-app-template/configTemplates/ts/.env
+++ b/tools/react-app-template/configTemplates/ts/.env
@@ -1,0 +1,6 @@
+# For GoodData Cloud or GoodData.CN
+TIGER_API_TOKEN=
+
+# For GoodData Platform
+GDC_USERNAME=
+GDC_PASSWORD=

--- a/tools/react-app-template/configTemplates/ts/.gdcatalogrc
+++ b/tools/react-app-template/configTemplates/ts/.gdcatalogrc
@@ -1,7 +1,0 @@
-{
-    "hostname": "https://public-examples.gooddata.com",
-    "workspaceId": "demo",
-    "output": "src/catalog.ts",
-    "backend": "tiger",
-    "demo": true
-}

--- a/tools/react-app-template/package.json
+++ b/tools/react-app-template/package.json
@@ -23,6 +23,12 @@
         "dist/**/*.map",
         "dist/**/*.svg"
     ],
+    "gooddata": {
+        "hostname": "https://public-examples.gooddata.com",
+        "workspaceId": "demo",
+        "backend": "tiger",
+        "catalogOutput": "src/catalog.ts"
+    },
     "scripts": {
         "clean": "rm -rf ci dist esm coverage *.log styles/css && jest --clearCache",
         "build": "webpack --mode production",

--- a/tools/react-app-template/src/App.tsx
+++ b/tools/react-app-template/src/App.tsx
@@ -7,10 +7,13 @@ import { backend } from "./backend";
 import * as Md from "./catalog";
 import img from "./assets/gooddata-logo.svg";
 
+// Workspace ID is injected by WebPack based on the value in package.json
+const workspaceId = WORKSPACE_ID;
+
 export const App: React.FC = () => {
     return (
         <BackendProvider backend={backend}>
-            <WorkspaceProvider workspace="demo">
+            <WorkspaceProvider workspace={workspaceId}>
                 <div className="app">
                     <h1>Hello GoodWorld!</h1>
                     <p>

--- a/tools/react-app-template/src/backend.ts
+++ b/tools/react-app-template/src/backend.ts
@@ -3,6 +3,9 @@ import { IAnalyticalBackend } from "@gooddata/sdk-backend-spi";
 import { withCaching, RecommendedCachingConfiguration } from "@gooddata/sdk-backend-base";
 import backendFactory, { ContextDeferredAuthProvider } from "@gooddata/sdk-backend-tiger";
 
+// Configure backend connection with context deferred auth provider.
+// See our docs on complete auth setup:
+// https://sdk.gooddata.com/gooddata-ui/docs/cloudnative_authentication.html
 export const backend: IAnalyticalBackend = withCaching(
     backendFactory().withAuthentication(new ContextDeferredAuthProvider()),
     RecommendedCachingConfiguration,

--- a/tools/react-app-template/src/typings.d.ts
+++ b/tools/react-app-template/src/typings.d.ts
@@ -1,2 +1,3 @@
 // (C) 2019-2022 GoodData Corporation
 declare module "*.svg";
+declare const WORKSPACE_ID: string;

--- a/tools/reference-workspace-mgmt/bin/refresh-md.sh
+++ b/tools/reference-workspace-mgmt/bin/refresh-md.sh
@@ -9,4 +9,4 @@ OUTPUT="${ROOTDIR}/../reference-workspace/src/md/full.ts"
 $EXPORTER \
   --backend bear \
   --hostname "secure.gooddata.com" \
-  --output "${OUTPUT}"
+  --catalog-output "${OUTPUT}"


### PR DESCRIPTION
* Tiger token is now treated same way as bear credentials - it used to be read from .env ad-hoc, right before usage.
* User can't save credentials in config file anymore. Thus, we'll promote saving `.gdcatalogrc` in Git, as it's no longer unsafe.
* All credentials are now loaded from `.env` for both bear and tiger. This is the file that should not go to Git.
* User can now store configs in package.json, under `gooddata` key. This is a convenience feature for boilerplate app setup.
* `--output` is now `--catalog-output` to avoid confusion, since config is used for both catalog export and webpack config in boilerplate app.

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |
| **Compatibility matrix test commands - TIGER Backend**  |                                                            |
| `extended test - matrix-test <AIO_version>`             | Run integrated tests against AIO versions.                 |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

`<AIO_version>` in commands is used to start test with multiple AIO instances - each instance in triggered by one jenkins build

-   To run with `master` and `stable`, execute command `extended test - matrix-test master,stable` or `extended test - matrix-test latest`
-   To run with specific version,ex: `2.3.0` and `2.3.1`, execute command `extended test - matrix-test 2.3.0,2.3.1`
-   In case `<AIO_version>` is empty, read versions from file `compTigerVersions.txt` of this repo

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
