### PR TITLE
FEATURE: QA-18895 support multiple browsers for daily checklist

### DIFF
--- a/libs/sdk-ui-tests-e2e/cypress.config.ts
+++ b/libs/sdk-ui-tests-e2e/cypress.config.ts
@@ -49,8 +49,8 @@ export default defineConfig({
             mochaFile: "./cypress/results/result.[hash].xml",
         },
         specPattern: "./cypress/integration/**/*.spec.ts",
-        video: true,
         videoUploadOnPasses: false,
     },
     scrollBehavior: false,
+    video: true,
 });

--- a/libs/sdk-ui-tests-e2e/docker-compose-integrated.yaml
+++ b/libs/sdk-ui-tests-e2e/docker-compose-integrated.yaml
@@ -32,3 +32,4 @@ services:
             - SDK_BACKEND
             - CYPRESS_TEST_TAGS
             - NO_COLOR
+            - EXECUTION_ENV=$EXECUTION_ENV

--- a/libs/sdk-ui-tests-e2e/scripts/run_integrated.js
+++ b/libs/sdk-ui-tests-e2e/scripts/run_integrated.js
@@ -15,6 +15,7 @@
  * - CYPRESS_TEST_TAGS comma separated list of tags without spaces (optional, defaults to "")
  * - FILTER (optional) filter tests by filename
  * - VISUAL_MODE true | false (optional, defaults to true)
+ * - EXECUTION_ENV (optional, defaults to chrome) browser to run tests
  *
  * Note that you need to make sure that the tests you choose by the tags can
  * run against the SDK_BACKEND you provide and also ensure that file specified with FILTER
@@ -35,6 +36,7 @@ async function main() {
             TIGER_DATASOURCES_PASSWORD,
             TIGER_API_TOKEN_NAME_PREFIX,
             CYPRESS_HOST,
+            EXECUTION_ENV,
         } = process.env;
 
         if (!TEST_WORKSPACE_ID) {
@@ -102,6 +104,12 @@ async function main() {
         const isVisualMode = VISUAL_MODE === "true";
         const visualModeFilter = FILTER && isVisualMode ? `,specPattern=cypress/**/${FILTER}` : "";
 
+        let config = `baseUrl=${HOST},defaultCommandTimeout=40000${visualModeFilter}`;
+        if (EXECUTION_ENV === "firefox") {
+            config += `,video=false`;
+        }
+        process.stdout.write(`Running on browser ${EXECUTION_ENV}\n`);
+
         const cypressProcess = runCypress({
             visual: isVisualMode,
             appHost: `${HOST}`,
@@ -112,9 +120,9 @@ async function main() {
             tigerPermissionDatasourceName: TIGER_DATASOURCES_NAME,
             tigerPermissionDatasourcePassword: TIGER_DATASOURCES_PASSWORD,
             tigerApiTokenNamePrefix: TIGER_API_TOKEN_NAME_PREFIX,
-            browser: "chrome",
+            browser: EXECUTION_ENV ? EXECUTION_ENV : "chrome",
             sdkBackend: SDK_BACKEND,
-            config: `baseUrl=${HOST},defaultCommandTimeout=40000${visualModeFilter}`,
+            config: config,
             ...specFilesFilter,
             customCypressConfig: {
                 CYPRESS_INTEGRATION_FOLDER: "cypress/integration",


### PR DESCRIPTION
JIRA: QA-18895

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |
| **Compatibility matrix test commands - TIGER Backend**  |                                                            |
| `extended test - matrix-test <AIO_version>`             | Run integrated tests against AIO versions.                 |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

`<AIO_version>` in commands is used to start test with multiple AIO instances - each instance in triggered by one jenkins build

-   To run with `master` and `stable`, execute command `extended test - matrix-test master,stable` or `extended test - matrix-test latest`
-   To run with specific version,ex: `2.3.0` and `2.3.1`, execute command `extended test - matrix-test 2.3.0,2.3.1`
-   In case `<AIO_version>` is empty, read versions from file `compTigerVersions.txt` of this repo

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
