### PR TITLE
RELATED: TNT-1506 Pivot Table column totals definition

### DIFF
--- a/libs/sdk-ui-pivot/src/impl/cell/cellClass.ts
+++ b/libs/sdk-ui-pivot/src/impl/cell/cellClass.ts
@@ -12,6 +12,7 @@ import { ROW_SUBTOTAL, ROW_TOTAL, MEASURE_COLUMN } from "../base/constants";
 import { isCellDrillable } from "../drilling/cellDrillabilityPredicate";
 import last from "lodash/last";
 import { getCellClassNames } from "./cellUtils";
+import { COLUMN_TOTAL, COLUMN_SUBTOTAL } from "./../base/constants";
 
 export type CellClassProvider = (cellClassParams: CellClassParams) => string;
 
@@ -47,6 +48,8 @@ export function cellClassFactory(
         const drillablePredicates = convertDrillableItemsToPredicates(props.drillableItems!);
         const isRowTotal = row.type === ROW_TOTAL;
         const isRowSubtotal = row.type === ROW_SUBTOTAL;
+        const isColumnTotal = colDef.type === COLUMN_TOTAL;
+        const isColumnSubtotal = colDef.type === COLUMN_SUBTOTAL;
         let hasDrillableHeader = false;
 
         const cellAllowsDrill = !isEmptyCell || colDef.type === MEASURE_COLUMN;
@@ -61,16 +64,29 @@ export function cellClassFactory(
         const rowSeparator = !hiddenCell && table.getGroupingProvider().isGroupBoundary(rowIndex);
         const subtotalStyle = row?.subtotalStyle;
 
+        // All new totals combinations
+        const isColAndRowSubtotal = subtotalStyle && isColumnSubtotal;
+        const isRowTotalAndColSubtotal = isRowTotal && isColumnSubtotal;
+        const isRowAndColumnTotal = isRowTotal && isColumnTotal;
+        const isRowSubtotalColumnTotal = isRowSubtotal && isColumnTotal;
+
         return cx(
             classList,
             measureIndex !== undefined ? `gd-column-measure-${measureIndex}` : null,
             getCellClassNames(rowIndex, colIndex, hasDrillableHeader),
             `gd-column-index-${colIndex}`,
             isRowTotal ? "gd-row-total" : null,
+            isColumnTotal ? "gd-column-total" : null,
+            isColumnSubtotal ? "gd-column-subtotal" : null,
             subtotalStyle ? `gd-table-row-subtotal gd-table-row-subtotal-${subtotalStyle}` : null,
             hiddenCell ? "gd-cell-hide s-gd-cell-hide" : null,
             rowSeparator ? "gd-table-row-separator s-gd-table-row-separator" : null,
             isTopPinned && isEmptyCell ? "gd-hidden-sticky-column" : null,
+            // All new totals combinations
+            isColAndRowSubtotal ? "gd-table-row-column-subtotal" : null,
+            isRowTotalAndColSubtotal ? "gd-table-row-total-column-subtotal" : null,
+            isRowAndColumnTotal ? "gd-table-row-column-total" : null,
+            isRowSubtotalColumnTotal ? "gd-table-row-subtotal-column-total" : null,
         );
     };
 }

--- a/libs/sdk-ui-pivot/src/impl/data/dataSource.ts
+++ b/libs/sdk-ui-pivot/src/impl/data/dataSource.ts
@@ -174,7 +174,7 @@ export class AgGridDatasource implements IDatasource {
                         // table right now). After redrive of execution to change sorts/totals, code must make
                         // sure that the new settings are reflected in the table descriptor.
                         const emptyValue = emptyHeaderTitleFromIntl(this.intl);
-                        this.config.tableDescriptor = TableDescriptor.for(dv, emptyValue);
+                        this.config.tableDescriptor = TableDescriptor.for(dv, emptyValue, this.intl);
 
                         this.processData(dv, params);
                     })

--- a/libs/sdk-ui-pivot/src/impl/gridOptions.ts
+++ b/libs/sdk-ui-pivot/src/impl/gridOptions.ts
@@ -25,6 +25,7 @@ import {
     columnAttributeTemplate,
     measureColumnTemplate,
     rowAttributeTemplate,
+    totalSubTotalColumnTemplate,
 } from "./structure/colDefTemplates";
 import { TableFacade } from "./tableFacade";
 import { ICorePivotTableProps } from "../publicTypes";
@@ -122,9 +123,8 @@ export function createGridOptions(
             [ROW_ATTRIBUTE_COLUMN]: rowAttributeTemplate(table, props),
             [COLUMN_ATTRIBUTE_COLUMN]: columnAttributeTemplate(table, props),
             [MEASURE_COLUMN]: measureColumnTemplate(table, props),
-            // This is temporary, totals/subtotals will receive their corresponding templates
-            [COLUMN_TOTAL]: columnAttributeTemplate(table, props),
-            [COLUMN_SUBTOTAL]: columnAttributeTemplate(table, props),
+            [COLUMN_TOTAL]: totalSubTotalColumnTemplate(table, props),
+            [COLUMN_SUBTOTAL]: totalSubTotalColumnTemplate(table, props),
         },
 
         // Custom renderers

--- a/libs/sdk-ui-pivot/src/impl/structure/colDefHeaderClass.ts
+++ b/libs/sdk-ui-pivot/src/impl/structure/colDefHeaderClass.ts
@@ -2,8 +2,16 @@
 import { TableFacade } from "../tableFacade";
 import { ColDef, ColGroupDef } from "@ag-grid-community/all-modules";
 import cx from "classnames";
-import { agColId, ColumnGroupingDescriptorId, isSeriesCol, isSliceCol } from "./tableDescriptorTypes";
+import {
+    agColId,
+    ColumnGroupingDescriptorId,
+    isScopeCol,
+    isSeriesCol,
+    isSliceCol,
+} from "./tableDescriptorTypes";
 import { ICorePivotTableProps } from "../../publicTypes";
+import { isResultTotalHeader } from "@gooddata/sdk-model";
+import { COLUMN_TOTAL, COLUMN_SUBTOTAL } from "../base/constants";
 
 export type HeaderClassProvider = (headerClassParams: any) => string;
 
@@ -36,6 +44,9 @@ export function headerClassFactory(
             const treeIndexes = colDesc.fullIndexPathToHere;
             const indexWithinGroup = treeIndexes ? treeIndexes[treeIndexes.length - 1] : undefined;
             const noLeftBorder = tableDescriptor.isFirstCol(colId) || !tableDescriptor.hasScopingCols();
+            const noBottomBorder = isScopeCol(colDesc) && isResultTotalHeader(colDesc.header);
+            const isColumnTotal = (colDef as ColDef).type === COLUMN_TOTAL;
+            const isColumnSubtotal = (colDef as ColDef).type === COLUMN_SUBTOTAL;
             const absoluteColIndex = isSeriesCol(colDesc)
                 ? tableDescriptor.getAbsoluteLeafColIndex(colDesc)
                 : undefined;
@@ -58,7 +69,10 @@ export function headerClassFactory(
                     ? `s-table-measure-column-header-index-${absoluteColIndex}`
                     : null,
                 noLeftBorder ? "gd-column-group-header--first" : null,
-                !colDef.headerName ? "gd-column-group-header--empty" : null,
+                noBottomBorder ? "gd-column-group-header--subtotal" : null,
+                !colDef.headerName && !noBottomBorder ? "gd-column-group-header--empty" : null,
+                isColumnTotal ? "gd-column-total" : null,
+                isColumnSubtotal ? "gd-column-subtotal" : null,
             );
         }
     };

--- a/libs/sdk-ui-pivot/src/impl/structure/colDefTemplates.ts
+++ b/libs/sdk-ui-pivot/src/impl/structure/colDefTemplates.ts
@@ -10,6 +10,7 @@ import { invariant } from "ts-invariant";
 import { isSeriesCol } from "./tableDescriptorTypes";
 import { cellClassFactory } from "../cell/cellClass";
 import { createCellRenderer } from "../cell/cellRenderer";
+import ColumnTotalHeader from "./headers/ColumnTotalHeader";
 
 export function rowAttributeTemplate(table: TableFacade, props: Readonly<ICorePivotTableProps>): ColDef {
     const cellRenderer = createCellRenderer();
@@ -69,6 +70,35 @@ export function measureColumnTemplate(table: TableFacade, props: Readonly<ICoreP
                   )
                 : (null as any);
         },
+        cellStyle: (params) => {
+            const colDesc = table.tableDescriptor.getCol(params.colDef);
+
+            invariant(isSeriesCol(colDesc));
+
+            return params.value !== undefined
+                ? getMeasureCellStyle(
+                      params.value,
+                      colDesc.seriesDescriptor.measureFormat(),
+                      separators,
+                      true,
+                  )
+                : null;
+        },
+        cellRenderer,
+    };
+}
+
+export function totalSubTotalColumnTemplate(
+    table: TableFacade,
+    props: Readonly<ICorePivotTableProps>,
+): ColDef {
+    const cellRenderer = createCellRenderer();
+    const separators = props.config?.separators;
+
+    return {
+        headerComponent: ColumnTotalHeader,
+        cellClass: cellClassFactory(table, props, cx(AG_NUMERIC_CELL_CLASSNAME, "gd-total-column")),
+        headerClass: headerClassFactory(table, props, "gd-total-column-header"),
         cellStyle: (params) => {
             const colDesc = table.tableDescriptor.getCol(params.colDef);
 

--- a/libs/sdk-ui-pivot/src/impl/structure/colLocatorFactory.ts
+++ b/libs/sdk-ui-pivot/src/impl/structure/colLocatorFactory.ts
@@ -2,7 +2,12 @@
 
 import { isScopeCol, LeafDataCol } from "./tableDescriptorTypes";
 import { ColumnLocator, IAttributeColumnLocator, IMeasureColumnLocator } from "../../columnWidths";
-import { IMeasureDescriptor, IAttributeDescriptor, IResultAttributeHeader } from "@gooddata/sdk-model";
+import {
+    IMeasureDescriptor,
+    IAttributeDescriptor,
+    IResultAttributeHeader,
+    isResultTotalHeader,
+} from "@gooddata/sdk-model";
 import { invariant } from "ts-invariant";
 import zip from "lodash/zip";
 
@@ -18,7 +23,9 @@ function createAttributeLocator(
     return {
         attributeLocatorItem: {
             attributeIdentifier: descriptor.attributeHeader.localIdentifier,
-            element: header.attributeHeaderItem.uri,
+            element: isResultTotalHeader(header)
+                ? `${header.totalHeaderItem.name}-${header.totalHeaderItem.measureIndex}`
+                : header.attributeHeaderItem.uri,
         },
     };
 }

--- a/libs/sdk-ui-pivot/src/impl/structure/headers/ColumnTotalGroupHeader.tsx
+++ b/libs/sdk-ui-pivot/src/impl/structure/headers/ColumnTotalGroupHeader.tsx
@@ -1,0 +1,35 @@
+// (C) 2023 GoodData Corporation
+import { IHeaderGroupParams } from "@ag-grid-community/all-modules";
+import React from "react";
+import { IMenu } from "../../../publicTypes";
+import { agColId } from "../tableDescriptorTypes";
+
+import HeaderCell, { ALIGN_LEFT, ICommonHeaderParams } from "./HeaderCell";
+
+export interface IColumnHeaderProps extends ICommonHeaderParams, IHeaderGroupParams {
+    menu?: () => IMenu;
+}
+
+class ColumnTotalGroupHeader extends React.Component<IColumnHeaderProps> {
+    public render() {
+        const colGroupDef = this.props.columnGroup.getColGroupDef()!;
+        const colId = agColId(colGroupDef);
+
+        return (
+            <HeaderCell
+                className="gd-pivot-table-column-total-group-header s-pivot-table-column-total-group-header"
+                textAlign={ALIGN_LEFT}
+                displayText={this.props.displayName}
+                enableSorting={false}
+                colId={colId}
+                getTableDescriptor={this.props.getTableDescriptor}
+                getExecutionDefinition={this.props.getExecutionDefinition}
+                getColumnTotals={this.props.getColumnTotals}
+                getRowTotals={this.props.getRowTotals}
+                intl={this.props.intl}
+            />
+        );
+    }
+}
+
+export default ColumnTotalGroupHeader;

--- a/libs/sdk-ui-pivot/src/impl/structure/headers/ColumnTotalHeader.tsx
+++ b/libs/sdk-ui-pivot/src/impl/structure/headers/ColumnTotalHeader.tsx
@@ -1,0 +1,39 @@
+// (C) 2023 GoodData Corporation
+import { IHeaderParams } from "@ag-grid-community/all-modules";
+import React from "react";
+import { IMenu } from "../../../publicTypes";
+
+import HeaderCell, { ALIGN_LEFT, ALIGN_RIGHT, ICommonHeaderParams } from "./HeaderCell";
+import { isEmptyScopeCol, isSliceCol } from "../tableDescriptorTypes";
+
+export interface IColumnHeaderProps extends ICommonHeaderParams, IHeaderParams {
+    menu?: () => IMenu;
+}
+
+class ColumnTotalHeader extends React.Component<IColumnHeaderProps> {
+    public render() {
+        const { displayName, column } = this.props;
+        const col = this.getColDescriptor();
+        const textAlign = isSliceCol(col) || isEmptyScopeCol(col) ? ALIGN_LEFT : ALIGN_RIGHT;
+
+        return (
+            <HeaderCell
+                className="gd-pivot-table-column-total-header s-pivot-table-column-total-header"
+                textAlign={textAlign}
+                displayText={displayName}
+                enableSorting={false}
+                colId={column.getColDef().field}
+                getTableDescriptor={this.props.getTableDescriptor}
+                getExecutionDefinition={this.props.getExecutionDefinition}
+                getColumnTotals={this.props.getColumnTotals}
+                getRowTotals={this.props.getRowTotals}
+                intl={this.props.intl}
+            />
+        );
+    }
+    private getColDescriptor() {
+        return this.props.getTableDescriptor().getCol(this.props.column);
+    }
+}
+
+export default ColumnTotalHeader;

--- a/libs/sdk-ui-pivot/src/impl/structure/tableDescriptor.ts
+++ b/libs/sdk-ui-pivot/src/impl/structure/tableDescriptor.ts
@@ -1,5 +1,5 @@
 // (C) 2021-2022 GoodData Corporation
-
+import { IntlShape } from "react-intl";
 import {
     AnyCol,
     isScopeCol,
@@ -77,8 +77,8 @@ export class TableDescriptor {
      * @param dv - data view facade
      * @param emptyHeaderTitle - what to show for title of headers with empty title
      */
-    public static for(dv: DataViewFacade, emptyHeaderTitle: string): TableDescriptor {
-        const { headers, colDefs } = createHeadersAndColDefs(dv, emptyHeaderTitle);
+    public static for(dv: DataViewFacade, emptyHeaderTitle: string, intl?: IntlShape): TableDescriptor {
+        const { headers, colDefs } = createHeadersAndColDefs(dv, emptyHeaderTitle, intl);
 
         invariant(headers.leafDataCols.length === colDefs.leafDataColDefs.length);
 

--- a/libs/sdk-ui-pivot/src/impl/structure/tableDescriptorFactory.ts
+++ b/libs/sdk-ui-pivot/src/impl/structure/tableDescriptorFactory.ts
@@ -1,5 +1,6 @@
 // (C) 2007-2022 GoodData Corporation
-import { DataViewFacade } from "@gooddata/sdk-ui";
+import { IntlShape } from "react-intl";
+import { DataViewFacade, getTotalInfo } from "@gooddata/sdk-ui";
 import {
     IAttributeDescriptor,
     IResultAttributeHeader,
@@ -124,6 +125,8 @@ function groupColumns(
             const groupLevel = columnGroupLevels[level];
             let currentGroup: ScopeCol | undefined = groupLevel.pkToGroup[pathToGroup];
 
+            const { isTotal, isSubtotal } = getTotalInfo(attributeHeaders);
+
             if (!currentGroup) {
                 const fullIndexPathToHere: number[] = parentGroup
                     ? [...parentGroup.fullIndexPathToHere, parentGroup.children.length]
@@ -138,6 +141,8 @@ function groupColumns(
                     headersToHere: attributeHeaders.slice(0, level),
                     children: [],
                     fullIndexPathToHere,
+                    isTotal,
+                    isSubtotal,
                 };
 
                 groupLevel.pkToGroup[pathToGroup] = currentGroup;
@@ -310,12 +315,14 @@ function createTableHeaders(dv: DataViewFacade): TableCols {
 export function createHeadersAndColDefs(
     dv: DataViewFacade,
     emptyHeaderTitle: string,
+    intl?: IntlShape,
 ): { headers: TableCols; colDefs: TableColDefs } {
     const headers = createTableHeaders(dv);
     const colDefs = createColDefsFromTableDescriptor(
         headers,
         dv.meta().effectiveSortItems(),
         emptyHeaderTitle,
+        intl,
     );
 
     return { headers, colDefs };

--- a/libs/sdk-ui-pivot/src/impl/structure/tableDescriptorTypes.ts
+++ b/libs/sdk-ui-pivot/src/impl/structure/tableDescriptorTypes.ts
@@ -168,6 +168,16 @@ export interface ScopeCol extends TableCol {
      * current group.
      */
     readonly headersToHere: IResultAttributeHeader[];
+
+    /**
+     * Checks whether this column group is part of grand total.
+     */
+    readonly isTotal?: boolean;
+
+    /**
+     * Checks whether this column group is part of sub-total.
+     */
+    readonly isSubtotal?: boolean;
 }
 
 export function isScopeCol(obj: unknown): obj is ScopeCol {
@@ -215,7 +225,7 @@ export type DataCol = RootCol | LeafDataCol;
 /**
  * Any table col. May be either the col describing the table slicing or col describing the data part of the table.
  */
-export type AnyCol = SliceCol | DataCol;
+export type AnyCol = SliceCol | DataCol | ScopeCol;
 
 /**
  * Descriptors of all table columns. The table columns are divided into two groups:

--- a/libs/sdk-ui-pivot/src/impl/tableFacade.ts
+++ b/libs/sdk-ui-pivot/src/impl/tableFacade.ts
@@ -134,7 +134,11 @@ export class TableFacade {
         this.currentResult = result;
         this.visibleData = DataViewFacade.for(dataView);
         this.currentFingerprint = defFingerprint(this.currentResult.definition);
-        this.tableDescriptor = TableDescriptor.for(this.visibleData, emptyHeaderTitleFromIntl(props.intl));
+        this.tableDescriptor = TableDescriptor.for(
+            this.visibleData,
+            emptyHeaderTitleFromIntl(props.intl),
+            props.intl,
+        );
 
         this.autoResizedColumns = {};
         this.growToFittedColumns = {};

--- a/libs/sdk-ui-pivot/styles/scss/pivotTable.scss
+++ b/libs/sdk-ui-pivot/styles/scss/pivotTable.scss
@@ -43,6 +43,21 @@ $header-hover-background-color: var(
 
 $total-background-color: var(--gd-table-totalBackgroundColor, var(--gd-palette-complementary-2, #e7ebef));
 
+$row-column-subtotal-background-color: var(
+    --gd-table-totalBackgroundColor,
+    var(--gd-palette-complementary-1, #b0beca33)
+);
+
+$row-total-column-subtotal-background-color: var(
+    --gd-table-totalBackgroundColor,
+    var(--gd-palette-complementary-1, #b0beca4d)
+);
+
+$row-column-total-background-color: var(
+    --gd-table-totalBackgroundColor,
+    var(--gd-palette-complementary-1, #b0beca66)
+);
+
 $total-value-color: var(
     --gd-table-totalValueColor,
     var(--gd-palette-complementary-9, kit-variables.$gd-color-dark)
@@ -175,6 +190,10 @@ $subtotal-odd-background-color: var(
         .gd-column-group-header {
             border-bottom: $cell-border;
             border-bottom-color: $cell-border-color;
+
+            &.gd-column-group-header--subtotal {
+                border-bottom: none;
+            }
         }
 
         .gd-column-group-header-0,
@@ -256,6 +275,19 @@ $subtotal-odd-background-color: var(
             border: none;
         }
 
+        .gd-column-total {
+            border-bottom-color: transparent;
+            color: $total-value-color;
+            font-weight: bold;
+            background-color: $total-background-color;
+
+            &:hover {
+                // stylelint-disable-next-line declaration-no-important
+                background-color: $total-background-color !important; // Override ag-grid header hover color
+                cursor: default;
+            }
+        }
+
         .gd-row-total {
             border-bottom-color: transparent;
             color: $total-value-color;
@@ -268,6 +300,17 @@ $subtotal-odd-background-color: var(
             }
         }
 
+        .gd-column-subtotal {
+            font-weight: bold;
+            background-color: $subtotal-even-background-color;
+
+            &:hover {
+                // stylelint-disable-next-line declaration-no-important
+                background-color: $subtotal-even-background-color !important; // Override ag-grid header hover color
+                cursor: default;
+            }
+        }
+
         .gd-table-row-subtotal {
             font-weight: bold;
             border-top: 1px solid $cell-border-color;
@@ -276,6 +319,42 @@ $subtotal-odd-background-color: var(
             }
             &-odd {
                 background-color: $subtotal-odd-background-color;
+            }
+        }
+
+        .gd-table-row-column-subtotal {
+            background-color: $total-background-color;
+
+            &:hover {
+                // stylelint-disable-next-line declaration-no-important
+                background-color: $total-background-color !important; // Override ag-grid header hover color
+            }
+        }
+
+        .gd-table-row-total-column-subtotal {
+            background-color: $row-total-column-subtotal-background-color;
+
+            &:hover {
+                // stylelint-disable-next-line declaration-no-important
+                background-color: $row-total-column-subtotal-background-color !important; // Override ag-grid header hover color
+            }
+        }
+
+        .gd-table-row-subtotal-column-total {
+            background-color: $total-background-color;
+
+            &:hover {
+                // stylelint-disable-next-line declaration-no-important
+                background-color: $total-background-color !important; // Override ag-grid header hover color
+            }
+        }
+
+        .gd-table-row-column-total {
+            background-color: $row-column-total-background-color;
+
+            &:hover {
+                // stylelint-disable-next-line declaration-no-important
+                background-color: $row-column-total-background-color !important; // Override ag-grid header hover color
             }
         }
 

--- a/libs/sdk-ui/api/sdk-ui.api.md
+++ b/libs/sdk-ui/api/sdk-ui.api.md
@@ -266,6 +266,8 @@ export type DataSeriesDescriptor = DataSeriesHeaders & DataSeriesDescriptorMetho
     readonly measureDefinition: IMeasure;
     readonly attributeDescriptors?: IAttributeDescriptor[];
     readonly attributeDefinitions?: IAttribute[];
+    readonly isSubtotal?: boolean;
+    readonly isTotal?: boolean;
 };
 
 // @public (undocumented)
@@ -487,6 +489,12 @@ export function getMappingHeaderName(header: IMappingHeader): string | undefined
 
 // @internal (undocumented)
 export function getMappingHeaderUri(header: IMappingHeader): string | undefined;
+
+// @internal (undocumented)
+export function getTotalInfo(attributeHeaders: IResultAttributeHeader[]): {
+    isTotal: boolean;
+    isSubtotal: boolean;
+};
 
 // @internal
 export function getTranslation(translationId: string | MessageDescriptor, locale: ILocale, values?: {}): string;

--- a/libs/sdk-ui/src/base/index.tsx
+++ b/libs/sdk-ui/src/base/index.tsx
@@ -362,3 +362,5 @@ export {
     createNumberJsFormatter,
     DefaultDataAccessConfig,
 } from "./results/dataAccessConfig";
+
+export { getTotalInfo } from "./results/internal/utils";

--- a/libs/sdk-ui/src/base/results/dataAccess.ts
+++ b/libs/sdk-ui/src/base/results/dataAccess.ts
@@ -156,6 +156,16 @@ export type DataSeriesDescriptor = DataSeriesHeaders &
          * the same index.
          */
         readonly attributeDefinitions?: IAttribute[];
+
+        /**
+         * Identifies whether the Data Serie is part of sub-total.
+         */
+        readonly isSubtotal?: boolean;
+
+        /**
+         * Identifies whether the Data Serie is part of grand total.
+         */
+        readonly isTotal?: boolean;
     };
 
 /**

--- a/libs/sdk-ui/src/base/results/internal/dataAccessImpl.ts
+++ b/libs/sdk-ui/src/base/results/internal/dataAccessImpl.ts
@@ -12,7 +12,7 @@ import { DataPoint, DataSeriesDescriptor, DataSliceDescriptor, IDataSeries, IDat
 import { createDataAccessDigest, DataAccessDigest } from "./dataAccessDigest";
 import { LazyInitArray } from "./lazyInitArray";
 import invariant, { InvariantError } from "ts-invariant";
-import { measureFormat, measureName } from "./utils";
+import { getTotalInfo, measureFormat, measureName } from "./utils";
 import { DataAccessConfig } from "../dataAccessConfig";
 import partial from "lodash/partial";
 import isArray from "lodash/isArray";
@@ -425,6 +425,8 @@ export class DataAccessImpl {
         const measureDefinition = fromMeasuresDef[measureIndex];
         const { headerTranslator } = this.config;
 
+        const { isTotal, isSubtotal } = getTotalInfo(attributeHeaders);
+
         return {
             id: `${seriesIdx}`,
             measureDescriptor,
@@ -433,6 +435,8 @@ export class DataAccessImpl {
             attributeDefinitions: scopingAttributesDef,
             measureHeader,
             attributeHeaders,
+            isTotal,
+            isSubtotal,
             measureFormat: (): string => {
                 return measureFormat(measureDescriptor);
             },

--- a/libs/sdk-ui/src/base/results/internal/utils.ts
+++ b/libs/sdk-ui/src/base/results/internal/utils.ts
@@ -6,6 +6,8 @@ import {
     IDimensionItemDescriptor,
     IMeasureGroupDescriptor,
     IResultHeader,
+    IResultAttributeHeader,
+    isResultTotalHeader,
 } from "@gooddata/sdk-model";
 
 /**
@@ -43,4 +45,15 @@ export function measureFormat(measureDescriptor: IMeasureDescriptor): string {
  */
 export function measureName(measureDescriptor: IMeasureDescriptor): string {
     return measureDescriptor.measureHeaderItem.name;
+}
+
+/**
+ * @internal
+ */
+export function getTotalInfo(attributeHeaders: IResultAttributeHeader[]) {
+    const numberOfTotalHeaders = attributeHeaders.filter(isResultTotalHeader).length;
+    return {
+        isTotal: numberOfTotalHeaders > 0 && numberOfTotalHeaders === attributeHeaders.length,
+        isSubtotal: numberOfTotalHeaders > 0 && numberOfTotalHeaders !== attributeHeaders.length,
+    };
 }


### PR DESCRIPTION
<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |
| **Compatibility matrix test commands - TIGER Backend**  |                                                            |
| `extended test - matrix-test <AIO_version>`             | Run integrated tests against AIO versions.                 |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

`<AIO_version>` in commands is used to start test with multiple AIO instances - each instance in triggered by one jenkins build

-   To run with `master` and `stable`, execute command `extended test - matrix-test master,stable` or `extended test - matrix-test latest`
-   To run with specific version,ex: `2.3.0` and `2.3.1`, execute command `extended test - matrix-test 2.3.0,2.3.1`
-   In case `<AIO_version>` is empty, read versions from file `compTigerVersions.txt` of this repo

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
