### PR TITLE
RELATED: TNT-1537 Fix order of totals and their naming for bear/tiger

### DIFF
--- a/libs/sdk-backend-bear/src/backend/workspace/execution/executionResult.ts
+++ b/libs/sdk-backend-bear/src/backend/workspace/execution/executionResult.ts
@@ -173,8 +173,7 @@ function preprocessTotalHeaderItems(
 
     const buckets = definition.buckets;
     const measures = bucketsMeasures(buckets);
-    // get only attributes which can be part of inline totals (all except first one)
-    const columns = bucketsFind(buckets, "columns")?.items?.slice(1) || [];
+    const columns = bucketsFind(buckets, "columns")?.items || [];
     const columnIdentifiers = columns.map((item) => isAttribute(item) && item.attribute?.localIdentifier);
 
     const lookups = columnTotals

--- a/libs/sdk-backend-tiger/src/convertors/fromBackend/afm/DimensionHeaderConverter.ts
+++ b/libs/sdk-backend-tiger/src/convertors/fromBackend/afm/DimensionHeaderConverter.ts
@@ -189,10 +189,10 @@ export function getTransformDimensionHeaders(
                     dimensions[dimensionIndex].headers[headerGroupIndex],
                 );
 
-                const baseHeaders = headerGroup.headers.map((header): IResultHeader => {
+                const baseHeaders = headerGroup.headers.map((header, index): IResultHeader => {
                     return getTransformedBaseHeader(
                         header,
-                        headerGroupIndex,
+                        index,
                         measureDescriptors,
                         dateFormatProps,
                         dateValueFormatter,

--- a/libs/sdk-backend-tiger/src/convertors/toBackend/afm/tests/TotalsConverter.test.ts
+++ b/libs/sdk-backend-tiger/src/convertors/toBackend/afm/tests/TotalsConverter.test.ts
@@ -145,6 +145,29 @@ const Test15 = defWithDimensions(
     newDimension([MeasureGroupIdentifier]),
 );
 
+// subtotals, with unsorted totals
+const Test16 = defSetDimensions(
+    newDefForBuckets("test", [
+        newBucket("measure", ReferenceMd.WinRate, ReferenceMd.Won),
+        newBucket("attribute", ReferenceMd.Account.Name, ReferenceMd.ForecastCategory),
+        bucketSetTotals(newBucket("columns", ReferenceMd.Department, ReferenceMd.IsActive), [
+            newTotal("sum", ReferenceMd.Won, ReferenceMd.Department),
+            newTotal("sum", ReferenceMd.WinRate, ReferenceMd.Department),
+        ]),
+    ]),
+    newTwoDimensional(
+        [ReferenceMd.Account.Name, ReferenceMd.ForecastCategory],
+        [
+            ReferenceMd.Department,
+            ReferenceMd.IsActive,
+            MeasureGroupIdentifier,
+            // it should be ordered as WinRate, Won in the snapshot
+            newTotal("sum", ReferenceMd.Won, ReferenceMd.Department),
+            newTotal("sum", ReferenceMd.WinRate, ReferenceMd.Department),
+        ],
+    ),
+);
+
 describe("convertTotals", () => {
     const Scenarios: Array<[string, IExecutionDefinition]> = [
         ["no totals", Test0],
@@ -162,6 +185,7 @@ describe("convertTotals", () => {
         ["two subtotals and marginal total", Test12],
         ["row total and column subtotal", Test13],
         ["column total and row subtotal", Test14],
+        ["subtotals with non-sorted totals", Test16],
     ];
     const ErrorScenarios: Array<[string, IExecutionDefinition]> = [["native total", Test15]];
 

--- a/libs/sdk-backend-tiger/src/convertors/toBackend/afm/tests/__snapshots__/TotalsConverter.test.ts.snap
+++ b/libs/sdk-backend-tiger/src/convertors/toBackend/afm/tests/__snapshots__/TotalsConverter.test.ts.snap
@@ -262,6 +262,51 @@ Array [
 ]
 `;
 
+exports[`convertTotals should correctly convert subtotals with non-sorted totals 1`] = `
+Array [
+  Object {
+    "function": "SUM",
+    "localIdentifier": "total_sum_m_abZgFKGPaGYM_by_a_label.owner.department_1",
+    "metric": "m_abZgFKGPaGYM",
+    "totalDimensions": Array [
+      Object {
+        "dimensionIdentifier": "dim_0",
+        "totalDimensionItems": Array [
+          "a_label.account.id.name",
+          "a_label.opportunitysnapshot.forecastcategory",
+        ],
+      },
+      Object {
+        "dimensionIdentifier": "dim_1",
+        "totalDimensionItems": Array [
+          "measureGroup",
+        ],
+      },
+    ],
+  },
+  Object {
+    "function": "SUM",
+    "localIdentifier": "total_sum_m_acugFHNJgsBy_by_a_label.owner.department_1",
+    "metric": "m_acugFHNJgsBy",
+    "totalDimensions": Array [
+      Object {
+        "dimensionIdentifier": "dim_0",
+        "totalDimensionItems": Array [
+          "a_label.account.id.name",
+          "a_label.opportunitysnapshot.forecastcategory",
+        ],
+      },
+      Object {
+        "dimensionIdentifier": "dim_1",
+        "totalDimensionItems": Array [
+          "measureGroup",
+        ],
+      },
+    ],
+  },
+]
+`;
+
 exports[`convertTotals should correctly convert three dimensions 1`] = `
 Array [
   Object {


### PR DESCRIPTION
<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |
| **Compatibility matrix test commands - TIGER Backend**  |                                                            |
| `extended test - matrix-test <AIO_version>`             | Run integrated tests against AIO versions.                 |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

`<AIO_version>` in commands is used to start test with multiple AIO instances - each instance in triggered by one jenkins build

-   To run with `master` and `stable`, execute command `extended test - matrix-test master,stable` or `extended test - matrix-test latest`
-   To run with specific version,ex: `2.3.0` and `2.3.1`, execute command `extended test - matrix-test 2.3.0,2.3.1`
-   In case `<AIO_version>` is empty, read versions from file `compTigerVersions.txt` of this repo

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)