### PR TITLE
BUGFIX: EGL-75, EGL-77 - can't save the insight when changed the color

### DIFF
--- a/libs/sdk-ui-ext/src/internal/utils/colors.ts
+++ b/libs/sdk-ui-ext/src/internal/utils/colors.ts
@@ -128,6 +128,8 @@ export function getValidProperties(
                 return isUriRef(colorAssignment.headerItem.attributeHeader.ref)
                     ? colorAssignment.headerItem.attributeHeader.uri === id
                     : colorAssignment.headerItem.attributeHeader.identifier === id;
+            } else if (isColorDescriptor(colorAssignment.headerItem)) {
+                return colorAssignment.headerItem.colorHeaderItem.id === id;
             }
 
             return false;

--- a/libs/sdk-ui-ext/src/internal/utils/tests/colors.test.ts
+++ b/libs/sdk-ui-ext/src/internal/utils/tests/colors.test.ts
@@ -77,6 +77,18 @@ describe("color utils", () => {
         },
     ];
 
+    const waterfallColorHeaderColorAssignments = [
+        {
+            headerItem: {
+                colorHeaderItem: {
+                    id: "properties.color.total",
+                    name: "properties.color.total",
+                },
+            },
+            color: color1,
+        },
+    ];
+
     describe("getValidProperties", () => {
         function getProperties(colorMapping: any) {
             return {
@@ -174,6 +186,28 @@ describe("color utils", () => {
             const properties = getProperties(richColorMapping);
 
             const result = getValidProperties(properties, tigerAttributeHeaderColorAssignments);
+            expect(result.controls.colorMapping).toEqual(colorMapping);
+        });
+
+        it("should keep color mapping for the waterfall color header which are in color assignment", () => {
+            const colorMapping = [
+                {
+                    id: "properties.color.total",
+                    color: color1,
+                },
+            ];
+
+            const richColorMapping = [
+                ...colorMapping,
+                {
+                    id: "label.a2",
+                    color: color1,
+                },
+            ];
+
+            const properties = getProperties(richColorMapping);
+
+            const result = getValidProperties(properties, waterfallColorHeaderColorAssignments);
             expect(result.controls.colorMapping).toEqual(colorMapping);
         });
     });

--- a/libs/sdk-ui-kit/src/Icon/icons/InsightIcons/Waterfall.tsx
+++ b/libs/sdk-ui-kit/src/Icon/icons/InsightIcons/Waterfall.tsx
@@ -11,13 +11,14 @@ export const Waterfall: React.FC<IIconProps> = ({ className, width, height, colo
             width={width}
             height={height}
             className={className}
-            viewBox="0 0 24 19"
+            viewBox="0 0 15 15"
+            fill="none"
             xmlns="http://www.w3.org/2000/svg"
         >
-            <rect x="5" y="18" width="4" height="8" fill={color ?? "#B0BECA"} fillOpacity="0.6" />
-            <rect x="11" y="12" width="4" height="6" fill={color ?? "#B0BECA"} fillOpacity="0.6" />
-            <rect x="17" y="4" width="4" height="8" fill={color ?? "#B0BECA"} fillOpacity="0.6" />
-            <rect x="23" y="4" width="4" height="22" fill={color ?? "#B0BECA"} />
+            <rect y="9" width="3.00022" height="6.00044" fill={color ?? "#B0BECA"} />
+            <rect x="4" y="5" width="3" height="4" fill={color ?? "#B0BECA"} />
+            <rect x="8" width="3" height="5" fill={color ?? "#B0BECA"} />
+            <rect x="12" width="3" height="15" fill={color ?? "#B0BECA"} />
         </svg>
     );
 };

--- a/libs/sdk-ui-vis-commons/src/coloring/color.ts
+++ b/libs/sdk-ui-vis-commons/src/coloring/color.ts
@@ -5,6 +5,7 @@ import {
     IColorPaletteItem,
     IRgbColorValue,
     isAttributeDescriptor,
+    isColorDescriptor,
     isResultAttributeHeader,
 } from "@gooddata/sdk-model";
 import {
@@ -212,6 +213,10 @@ export function getColorMappingPredicate(testValue: string): IHeaderPredicate {
             return testValue
                 ? testValue === header.attributeHeader.uri || testValue === header.attributeHeader.identifier
                 : false;
+        }
+
+        if (isColorDescriptor(header)) {
+            return testValue ? testValue === header.colorHeaderItem.id : false;
         }
 
         const headerLocalIdentifier = getMappingHeaderLocalIdentifier(header);


### PR DESCRIPTION
fix: can't save the insight when changed the color
update the waterfall icon on Schedule Email dialog
JIRA: EGL-75, EGL-77

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |
| **Compatibility matrix test commands - TIGER Backend**  |                                                            |
| `extended test - matrix-test <AIO_version>`             | Run integrated tests against AIO versions.                 |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

`<AIO_version>` in commands is used to start test with multiple AIO instances - each instance in triggered by one jenkins build

-   To run with `master` and `stable`, execute command `extended test - matrix-test master,stable` or `extended test - matrix-test latest`
-   To run with specific version,ex: `2.3.0` and `2.3.1`, execute command `extended test - matrix-test 2.3.0,2.3.1`
-   In case `<AIO_version>` is empty, read versions from file `compTigerVersions.txt` of this repo

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
