### PR TITLE
FEATURE: FET-1233 Report runtime React version via XHR header

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -589,6 +589,7 @@ importers:
       '@types/jest': ^29.5.1
       '@types/json-stable-stringify': ^1.0.32
       '@types/lodash': ^4.14.158
+      '@types/node': ^16.18.23
       '@types/spark-md5': ^3.0.1
       '@types/uuid': ^8.3.4
       '@typescript-eslint/eslint-plugin': ^5.57.1
@@ -631,11 +632,12 @@ importers:
     devDependencies:
       '@gooddata/eslint-config': 4.1.0_e26rfststzmmda6s4rqitickwm
       '@gooddata/reference-workspace': link:../../tools/reference-workspace
-      '@microsoft/api-documenter': 7.21.7
-      '@microsoft/api-extractor': 7.34.4
+      '@microsoft/api-documenter': 7.21.7_@types+node@16.18.23
+      '@microsoft/api-extractor': 7.34.4_@types+node@16.18.23
       '@types/jest': 29.5.1
       '@types/json-stable-stringify': 1.0.34
       '@types/lodash': 4.14.194
+      '@types/node': 16.18.23
       '@types/spark-md5': 3.0.2
       '@types/uuid': 8.3.4
       '@typescript-eslint/eslint-plugin': 5.59.0_j7zcdhslflxhyb4ielvkq3otfy
@@ -651,7 +653,7 @@ importers:
       eslint-plugin-regexp: 1.14.0_eslint@8.38.0
       eslint-plugin-sonarjs: 0.16.0_eslint@8.38.0
       eslint-plugin-tsdoc: 0.2.17
-      jest: 29.5.0
+      jest: 29.5.0_@types+node@16.18.23
       jest-junit: 3.7.0
       prettier: 2.5.1
       ts-jest: 29.1.0_44ttdtjaknnkcgzh5px4h2qxl4
@@ -13612,7 +13614,7 @@ packages:
       '@typescript-eslint/eslint-plugin': 5.59.0_j7zcdhslflxhyb4ielvkq3otfy
       '@typescript-eslint/utils': 5.59.0_gtjzorxa7eg3ns2qwm6k5om4ri
       eslint: 8.38.0
-      jest: 29.5.0
+      jest: 29.5.0_@types+node@16.18.23
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -16425,6 +16427,7 @@ packages:
       - '@types/node'
       - supports-color
       - ts-node
+    dev: true
 
   /jest-cli/29.5.0_@types+node@16.18.23:
     resolution: {integrity: sha512-L1KcP1l4HtfwdxXNFCL5bmUbLQiKrakMUriBEcc1Vfz6gx31ORKdreuWvmQVBit+1ss9NNR3yxjwfwzZNdQXJw==}
@@ -16516,6 +16519,7 @@ packages:
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /jest-config/29.5.0_@types+node@16.18.23:
     resolution: {integrity: sha512-kvDUKBnNJPNBmFFOhDbm59iu1Fii1Q6SxyhXfvylq3UTHbg6o7j/g8k2dZyXWLvfdKB1vAPxNZnMgtKJcmu3kA==}
@@ -16916,6 +16920,7 @@ packages:
       - '@types/node'
       - supports-color
       - ts-node
+    dev: true
 
   /jest/29.5.0_@types+node@16.18.23:
     resolution: {integrity: sha512-juMg3he2uru1QoXX078zTa7pO85QyB9xajZc6bU+d9yEGwrKX6+vGmJQ3UdVZsvTEUARIdObzH68QItim6OSSQ==}

--- a/libs/sdk-backend-base/api/sdk-backend-base.api.md
+++ b/libs/sdk-backend-base/api/sdk-backend-base.api.md
@@ -583,6 +583,9 @@ export class Denormalizer {
     readonly state: NormalizationState;
 }
 
+// @alpha (undocumented)
+export function detectReactRuntimeVersion(): string | undefined;
+
 // @internal
 export function dummyBackend(config?: DummyBackendConfig): IAnalyticalBackend;
 

--- a/libs/sdk-backend-base/package.json
+++ b/libs/sdk-backend-base/package.json
@@ -68,6 +68,7 @@
         "@types/jest": "^29.5.1",
         "@types/json-stable-stringify": "^1.0.32",
         "@types/lodash": "^4.14.158",
+        "@types/node": "^16.18.23",
         "@types/spark-md5": "^3.0.1",
         "@types/uuid": "^8.3.4",
         "@typescript-eslint/eslint-plugin": "^5.57.1",

--- a/libs/sdk-backend-base/src/index.ts
+++ b/libs/sdk-backend-base/src/index.ts
@@ -74,7 +74,7 @@ export {
     AnonymousAuthProvider,
 } from "./toolkit/auth";
 
-export { TelemetryData } from "./toolkit/backend";
+export { TelemetryData, detectReactRuntimeVersion } from "./toolkit/backend";
 
 export {
     AbstractExecutionFactory,

--- a/libs/sdk-backend-base/src/toolkit/backend.ts
+++ b/libs/sdk-backend-base/src/toolkit/backend.ts
@@ -9,20 +9,22 @@ export type TelemetryData = {
 
 let cachedRuntimeReactVersion: string | undefined = undefined;
 
-function detectAndCacheReactRuntimeVersion() {
+(async () => {
     try {
-        // eslint-disable-next-line @typescript-eslint/no-var-requires
-        const react = require("react");
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        // eslint-disable-next-line import/no-unresolved
+        const react = await import("react");
         cachedRuntimeReactVersion = react.version ?? "not-supported";
     } catch {
         cachedRuntimeReactVersion = "no-react";
     }
-    return cachedRuntimeReactVersion;
-}
+
+})();
 
 /**
  * @alpha
  */
 export function detectReactRuntimeVersion(): string | undefined {
-    return cachedRuntimeReactVersion ? cachedRuntimeReactVersion : detectAndCacheReactRuntimeVersion();
+    return cachedRuntimeReactVersion;
 }

--- a/libs/sdk-backend-base/src/toolkit/backend.ts
+++ b/libs/sdk-backend-base/src/toolkit/backend.ts
@@ -6,3 +6,23 @@ export type TelemetryData = {
     componentName?: string;
     props?: string[];
 };
+
+let cachedRuntimeReactVersion: string | undefined = undefined;
+
+function detectAndCacheReactRuntimeVersion() {
+    try {
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        const react = require("react");
+        cachedRuntimeReactVersion = react.version ?? "not-supported";
+    } catch {
+        cachedRuntimeReactVersion = "no-react";
+    }
+    return cachedRuntimeReactVersion;
+}
+
+/**
+ * @alpha
+ */
+export function detectReactRuntimeVersion(): string | undefined {
+    return cachedRuntimeReactVersion ? cachedRuntimeReactVersion : detectAndCacheReactRuntimeVersion();
+}

--- a/libs/sdk-backend-bear/src/backend/index.ts
+++ b/libs/sdk-backend-bear/src/backend/index.ts
@@ -39,7 +39,7 @@ import {
     AuthenticatedAsyncCall,
     IAuthenticatedAsyncCallContext,
     AuthProviderCallGuard,
-    TelemetryData,
+    TelemetryData, detectReactRuntimeVersion,
 } from "@gooddata/sdk-backend-base";
 import { IDrillableItemsCommandBody } from "@gooddata/sdk-embedding";
 import { BearOrganization, BearOrganizations } from "./organization";
@@ -507,6 +507,12 @@ function newSdkInstance(
         if (telemetry.props && !isEmpty(telemetry.props)) {
             sdk.config.setRequestHeader("X-GDC-JS-SDK-COMP-PROPS", telemetry.props.join(","));
         }
+    }
+
+    const reactVersion = detectReactRuntimeVersion();
+    
+    if (reactVersion) {
+        sdk.config.setRequestHeader("X-GDC-JS-SDK-REACT", reactVersion);
     }
 
     return sdk;

--- a/libs/sdk-backend-tiger/src/backend/index.ts
+++ b/libs/sdk-backend-tiger/src/backend/index.ts
@@ -38,7 +38,7 @@ import {
     IAuthenticatedAsyncCallContext,
     TelemetryData,
     AnonymousAuthProvider,
-    IAuthProviderCallGuard,
+    IAuthProviderCallGuard, detectReactRuntimeVersion,
 } from "@gooddata/sdk-backend-base";
 import { DateFormatter } from "../convertors/fromBackend/dateFormatting/types";
 import { defaultDateFormatter } from "../convertors/fromBackend/dateFormatting/defaultDateFormatter";
@@ -375,6 +375,12 @@ function createHeaders(implConfig: TigerBackendConfig, telemetry: TelemetryData)
 
     if (telemetry.props && !isEmpty(telemetry.props)) {
         headers["X-GDC-JS-SDK-COMP-PROPS"] = telemetry.props.join(",");
+    }
+
+    const reactVersion = detectReactRuntimeVersion();
+
+    if (reactVersion) {
+        headers["X-GDC-JS-SDK-REACT"] = reactVersion;
     }
 
     if (implConfig.packageName && implConfig.packageVersion) {


### PR DESCRIPTION
Used React runtime version is reported in XHR header X-GDC-JS-SDK-REACT with each XHR call. The detection of version is done just once, then the cached value is used.

- "no-react" value is sent when react package is not installed.
- "not-supported" value is sent when react package do not export version property (React.version).
- Otherwise, version of imported npm react package is sent.

JIRA: FET-1233

![image](https://github.com/gooddata/gooddata-ui-sdk/assets/1880148/559f156c-de1d-4b80-9f3a-5482fca41b9d)


<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |
| **Compatibility matrix test commands - TIGER Backend**  |                                                            |
| `extended test - matrix-test <AIO_version>`             | Run integrated tests against AIO versions.                 |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

`<AIO_version>` in commands is used to start test with multiple AIO instances - each instance in triggered by one jenkins build

-   To run with `master` and `stable`, execute command `extended test - matrix-test master,stable` or `extended test - matrix-test latest`
-   To run with specific version,ex: `2.3.0` and `2.3.1`, execute command `extended test - matrix-test 2.3.0,2.3.1`
-   In case `<AIO_version>` is empty, read versions from file `compTigerVersions.txt` of this repo

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
