### PR TITLE
BUGFIX: TNT-1550 Menu config submenu option when no column totals

### DIFF
--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/PluggablePivotTable.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/PluggablePivotTable.tsx
@@ -530,11 +530,12 @@ export function createPivotTableConfig(
             ...tableConfig,
             menu: pivotTableMenuForCapabilities(capabilities, {
                 aggregations: true,
+                aggregationsSubMenu: true,
             }),
         };
     }
 
-    if (enableTableTotalRows)
+    if (enableTableTotalRows) {
         tableConfig = {
             ...tableConfig,
             menu: {
@@ -542,6 +543,7 @@ export function createPivotTableConfig(
                 aggregationsSubMenuForRows: true,
             },
         };
+    }
 
     const autoSize = settings.enableTableColumnsAutoResizing;
 

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/tests/__snapshots__/PluggablePivotTable.test.tsx.snap
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/tests/__snapshots__/PluggablePivotTable.test.tsx.snap
@@ -343,6 +343,7 @@ Object {
   },
   "menu": Object {
     "aggregations": true,
+    "aggregationsSubMenu": true,
   },
   "separators": undefined,
 }
@@ -353,6 +354,7 @@ Object {
   "columnSizing": Object {},
   "menu": Object {
     "aggregations": true,
+    "aggregationsSubMenu": true,
   },
   "separators": undefined,
 }
@@ -365,6 +367,7 @@ Object {
   },
   "menu": Object {
     "aggregations": true,
+    "aggregationsSubMenu": true,
   },
   "separators": undefined,
 }
@@ -384,6 +387,7 @@ Object {
   "columnSizing": Object {},
   "menu": Object {
     "aggregations": true,
+    "aggregationsSubMenu": true,
   },
   "separators": undefined,
 }
@@ -394,6 +398,7 @@ Object {
   "columnSizing": Object {},
   "menu": Object {
     "aggregations": true,
+    "aggregationsSubMenu": true,
   },
   "separators": undefined,
 }
@@ -404,6 +409,7 @@ Object {
   "columnSizing": Object {},
   "menu": Object {
     "aggregations": true,
+    "aggregationsSubMenu": true,
   },
   "separators": undefined,
 }
@@ -425,6 +431,7 @@ Object {
   },
   "menu": Object {
     "aggregations": true,
+    "aggregationsSubMenu": true,
   },
   "separators": undefined,
 }
@@ -435,6 +442,7 @@ Object {
   "columnSizing": Object {},
   "menu": Object {
     "aggregations": true,
+    "aggregationsSubMenu": true,
   },
   "separators": undefined,
 }
@@ -445,6 +453,7 @@ Object {
   "columnSizing": Object {},
   "menu": Object {
     "aggregations": true,
+    "aggregationsSubMenu": true,
   },
   "separators": undefined,
 }
@@ -455,6 +464,7 @@ Object {
   "columnSizing": Object {},
   "menu": Object {
     "aggregations": true,
+    "aggregationsSubMenu": true,
   },
   "separators": Object {
     "decimal": ".",
@@ -468,6 +478,7 @@ Object {
   "columnSizing": Object {},
   "menu": Object {
     "aggregations": true,
+    "aggregationsSubMenu": true,
   },
   "separators": undefined,
 }
@@ -478,6 +489,7 @@ Object {
   "columnSizing": Object {},
   "menu": Object {
     "aggregations": true,
+    "aggregationsSubMenu": true,
     "aggregationsSubMenuForRows": true,
   },
   "separators": undefined,

--- a/libs/sdk-ui-ext/src/internal/components/tests/__snapshots__/VisualizationCatalog.test.ts.snap
+++ b/libs/sdk-ui-ext/src/internal/components/tests/__snapshots__/VisualizationCatalog.test.ts.snap
@@ -36410,6 +36410,7 @@ const config: IPivotTableConfig = {
     columnSizing: {defaultWidth: \\"autoresizeAll\\"},
     menu: {
         aggregations: true,
+        aggregationsSubMenu: true,
         aggregationsSubMenuForRows: true
     },
     separators: {decimal: \\".\\", thousand: \\",\\"}
@@ -36450,6 +36451,7 @@ const config: IPivotTableConfig = {
     columnSizing: {defaultWidth: \\"autoresizeAll\\"},
     menu: {
         aggregations: true,
+        aggregationsSubMenu: true,
         aggregationsSubMenuForRows: true
     },
     separators: {decimal: \\".\\", thousand: \\",\\"}
@@ -36491,6 +36493,7 @@ const config: IPivotTableConfig = {
     columnSizing: {defaultWidth: \\"autoresizeAll\\"},
     menu: {
         aggregations: true,
+        aggregationsSubMenu: true,
         aggregationsSubMenuForRows: true
     },
     separators: {decimal: \\".\\", thousand: \\",\\"}
@@ -36532,6 +36535,7 @@ const config: IPivotTableConfig = {
     columnSizing: {defaultWidth: \\"autoresizeAll\\"},
     menu: {
         aggregations: true,
+        aggregationsSubMenu: true,
         aggregationsSubMenuForRows: true
     },
     separators: {decimal: \\".\\", thousand: \\",\\"}
@@ -36573,6 +36577,7 @@ const config: IPivotTableConfig = {
     columnSizing: {defaultWidth: \\"autoresizeAll\\"},
     menu: {
         aggregations: true,
+        aggregationsSubMenu: true,
         aggregationsSubMenuForRows: true
     },
     separators: {decimal: \\".\\", thousand: \\",\\"}
@@ -36614,6 +36619,7 @@ const config: IPivotTableConfig = {
     columnSizing: {defaultWidth: \\"autoresizeAll\\"},
     menu: {
         aggregations: true,
+        aggregationsSubMenu: true,
         aggregationsSubMenuForRows: true
     },
     separators: {decimal: \\".\\", thousand: \\",\\"}
@@ -36655,6 +36661,7 @@ const config: IPivotTableConfig = {
     columnSizing: {defaultWidth: \\"autoresizeAll\\"},
     menu: {
         aggregations: true,
+        aggregationsSubMenu: true,
         aggregationsSubMenuForRows: true
     },
     separators: {decimal: \\".\\", thousand: \\",\\"}
@@ -36696,6 +36703,7 @@ const config: IPivotTableConfig = {
     columnSizing: {defaultWidth: \\"autoresizeAll\\"},
     menu: {
         aggregations: true,
+        aggregationsSubMenu: true,
         aggregationsSubMenuForRows: true
     },
     separators: {decimal: \\".\\", thousand: \\",\\"}
@@ -36734,6 +36742,7 @@ const config: IPivotTableConfig = {
     columnSizing: {defaultWidth: \\"autoresizeAll\\"},
     menu: {
         aggregations: true,
+        aggregationsSubMenu: true,
         aggregationsSubMenuForRows: true
     },
     separators: {decimal: \\".\\", thousand: \\",\\"}
@@ -36776,6 +36785,7 @@ const config: IPivotTableConfig = {
     },
     menu: {
         aggregations: true,
+        aggregationsSubMenu: true,
         aggregationsSubMenuForRows: true
     },
     separators: {decimal: \\".\\", thousand: \\",\\"}
@@ -36818,6 +36828,7 @@ const config: IPivotTableConfig = {
     },
     menu: {
         aggregations: true,
+        aggregationsSubMenu: true,
         aggregationsSubMenuForRows: true
     },
     separators: {decimal: \\".\\", thousand: \\",\\"}
@@ -36860,6 +36871,7 @@ const config: IPivotTableConfig = {
     },
     menu: {
         aggregations: true,
+        aggregationsSubMenu: true,
         aggregationsSubMenuForRows: true
     },
     separators: {decimal: \\".\\", thousand: \\",\\"}
@@ -36902,6 +36914,7 @@ const config: IPivotTableConfig = {
     },
     menu: {
         aggregations: true,
+        aggregationsSubMenu: true,
         aggregationsSubMenuForRows: true
     },
     separators: {decimal: \\".\\", thousand: \\",\\"}
@@ -36943,6 +36956,7 @@ const config: IPivotTableConfig = {
     },
     menu: {
         aggregations: true,
+        aggregationsSubMenu: true,
         aggregationsSubMenuForRows: true
     },
     separators: {decimal: \\".\\", thousand: \\",\\"}
@@ -36984,6 +36998,7 @@ const config: IPivotTableConfig = {
     },
     menu: {
         aggregations: true,
+        aggregationsSubMenu: true,
         aggregationsSubMenuForRows: true
     },
     separators: {decimal: \\".\\", thousand: \\",\\"}
@@ -37025,6 +37040,7 @@ const config: IPivotTableConfig = {
     },
     menu: {
         aggregations: true,
+        aggregationsSubMenu: true,
         aggregationsSubMenuForRows: true
     },
     separators: {decimal: \\".\\", thousand: \\",\\"}
@@ -37066,6 +37082,7 @@ const config: IPivotTableConfig = {
     },
     menu: {
         aggregations: true,
+        aggregationsSubMenu: true,
         aggregationsSubMenuForRows: true
     },
     separators: {decimal: \\".\\", thousand: \\",\\"}
@@ -37107,6 +37124,7 @@ const config: IPivotTableConfig = {
     },
     menu: {
         aggregations: true,
+        aggregationsSubMenu: true,
         aggregationsSubMenuForRows: true
     },
     separators: {decimal: \\".\\", thousand: \\",\\"}
@@ -37148,6 +37166,7 @@ const config: IPivotTableConfig = {
     },
     menu: {
         aggregations: true,
+        aggregationsSubMenu: true,
         aggregationsSubMenuForRows: true
     },
     separators: {decimal: \\".\\", thousand: \\",\\"}
@@ -37189,6 +37208,7 @@ const config: IPivotTableConfig = {
     },
     menu: {
         aggregations: true,
+        aggregationsSubMenu: true,
         aggregationsSubMenuForRows: true
     },
     separators: {decimal: \\".\\", thousand: \\",\\"}
@@ -37230,6 +37250,7 @@ const config: IPivotTableConfig = {
     },
     menu: {
         aggregations: true,
+        aggregationsSubMenu: true,
         aggregationsSubMenuForRows: true
     },
     separators: {decimal: \\".\\", thousand: \\",\\"}
@@ -37262,6 +37283,7 @@ const config: IPivotTableConfig = {
     columnSizing: {defaultWidth: \\"autoresizeAll\\"},
     menu: {
         aggregations: true,
+        aggregationsSubMenu: true,
         aggregationsSubMenuForRows: true
     },
     separators: {decimal: \\".\\", thousand: \\",\\"}
@@ -37293,6 +37315,7 @@ const config: IPivotTableConfig = {
     columnSizing: {defaultWidth: \\"autoresizeAll\\"},
     menu: {
         aggregations: true,
+        aggregationsSubMenu: true,
         aggregationsSubMenuForRows: true
     },
     separators: {decimal: \\".\\", thousand: \\",\\"}
@@ -37324,6 +37347,7 @@ const config: IPivotTableConfig = {
     columnSizing: {defaultWidth: \\"autoresizeAll\\"},
     menu: {
         aggregations: true,
+        aggregationsSubMenu: true,
         aggregationsSubMenuForRows: true
     },
     separators: {decimal: \\".\\", thousand: \\",\\"}
@@ -37369,6 +37393,7 @@ const config: IPivotTableConfig = {
     columnSizing: {defaultWidth: \\"autoresizeAll\\"},
     menu: {
         aggregations: true,
+        aggregationsSubMenu: true,
         aggregationsSubMenuForRows: true
     },
     separators: {decimal: \\".\\", thousand: \\",\\"}
@@ -37414,6 +37439,7 @@ const config: IPivotTableConfig = {
     columnSizing: {defaultWidth: \\"autoresizeAll\\"},
     menu: {
         aggregations: true,
+        aggregationsSubMenu: true,
         aggregationsSubMenuForRows: true
     },
     separators: {decimal: \\".\\", thousand: \\",\\"}
@@ -37459,6 +37485,7 @@ const config: IPivotTableConfig = {
     columnSizing: {defaultWidth: \\"autoresizeAll\\"},
     menu: {
         aggregations: true,
+        aggregationsSubMenu: true,
         aggregationsSubMenuForRows: true
     },
     separators: {decimal: \\".\\", thousand: \\",\\"}
@@ -37504,6 +37531,7 @@ const config: IPivotTableConfig = {
     columnSizing: {defaultWidth: \\"autoresizeAll\\"},
     menu: {
         aggregations: true,
+        aggregationsSubMenu: true,
         aggregationsSubMenuForRows: true
     },
     separators: {decimal: \\".\\", thousand: \\",\\"}
@@ -37545,6 +37573,7 @@ const config: IPivotTableConfig = {
     columnSizing: {defaultWidth: \\"autoresizeAll\\"},
     menu: {
         aggregations: true,
+        aggregationsSubMenu: true,
         aggregationsSubMenuForRows: true
     },
     separators: {decimal: \\".\\", thousand: \\",\\"}
@@ -37583,6 +37612,7 @@ const config: IPivotTableConfig = {
     columnSizing: {defaultWidth: \\"autoresizeAll\\"},
     menu: {
         aggregations: true,
+        aggregationsSubMenu: true,
         aggregationsSubMenuForRows: true
     },
     separators: {decimal: \\".\\", thousand: \\",\\"}
@@ -37623,6 +37653,7 @@ const config: IPivotTableConfig = {
     columnSizing: {defaultWidth: \\"autoresizeAll\\"},
     menu: {
         aggregations: true,
+        aggregationsSubMenu: true,
         aggregationsSubMenuForRows: true
     },
     separators: {decimal: \\".\\", thousand: \\",\\"}
@@ -37659,6 +37690,7 @@ const config: IPivotTableConfig = {
     columnSizing: {defaultWidth: \\"autoresizeAll\\"},
     menu: {
         aggregations: true,
+        aggregationsSubMenu: true,
         aggregationsSubMenuForRows: true
     },
     separators: {decimal: \\".\\", thousand: \\",\\"}
@@ -37697,6 +37729,7 @@ const config: IPivotTableConfig = {
     columnSizing: {defaultWidth: \\"autoresizeAll\\"},
     menu: {
         aggregations: true,
+        aggregationsSubMenu: true,
         aggregationsSubMenuForRows: true
     },
     separators: {decimal: \\".\\", thousand: \\",\\"}
@@ -37733,6 +37766,7 @@ const config: IPivotTableConfig = {
     columnSizing: {defaultWidth: \\"autoresizeAll\\"},
     menu: {
         aggregations: true,
+        aggregationsSubMenu: true,
         aggregationsSubMenuForRows: true
     },
     separators: {decimal: \\".\\", thousand: \\",\\"}
@@ -37772,6 +37806,7 @@ const config: IPivotTableConfig = {
     columnSizing: {defaultWidth: \\"autoresizeAll\\"},
     menu: {
         aggregations: true,
+        aggregationsSubMenu: true,
         aggregationsSubMenuForRows: true
     },
     separators: {decimal: \\".\\", thousand: \\",\\"}
@@ -37813,6 +37848,7 @@ const config: IPivotTableConfig = {
     columnSizing: {defaultWidth: \\"autoresizeAll\\"},
     menu: {
         aggregations: true,
+        aggregationsSubMenu: true,
         aggregationsSubMenuForRows: true
     },
     separators: {decimal: \\".\\", thousand: \\",\\"}
@@ -37859,6 +37895,7 @@ const config: IPivotTableConfig = {
     },
     menu: {
         aggregations: true,
+        aggregationsSubMenu: true,
         aggregationsSubMenuForRows: true
     },
     separators: {decimal: \\".\\", thousand: \\",\\"}
@@ -37905,6 +37942,7 @@ const config: IPivotTableConfig = {
     },
     menu: {
         aggregations: true,
+        aggregationsSubMenu: true,
         aggregationsSubMenuForRows: true
     },
     separators: {decimal: \\".\\", thousand: \\",\\"}
@@ -37951,6 +37989,7 @@ const config: IPivotTableConfig = {
     },
     menu: {
         aggregations: true,
+        aggregationsSubMenu: true,
         aggregationsSubMenuForRows: true
     },
     separators: {decimal: \\".\\", thousand: \\",\\"}
@@ -37997,6 +38036,7 @@ const config: IPivotTableConfig = {
     },
     menu: {
         aggregations: true,
+        aggregationsSubMenu: true,
         aggregationsSubMenuForRows: true
     },
     separators: {decimal: \\".\\", thousand: \\",\\"}
@@ -38038,6 +38078,7 @@ const config: IPivotTableConfig = {
     columnSizing: {defaultWidth: \\"autoresizeAll\\"},
     menu: {
         aggregations: true,
+        aggregationsSubMenu: true,
         aggregationsSubMenuForRows: true
     },
     separators: {decimal: \\".\\", thousand: \\",\\"}
@@ -38084,6 +38125,7 @@ const config: IPivotTableConfig = {
     columnSizing: {defaultWidth: \\"autoresizeAll\\"},
     menu: {
         aggregations: true,
+        aggregationsSubMenu: true,
         aggregationsSubMenuForRows: true
     },
     separators: {decimal: \\".\\", thousand: \\",\\"}
@@ -38131,6 +38173,7 @@ const config: IPivotTableConfig = {
     columnSizing: {defaultWidth: \\"autoresizeAll\\"},
     menu: {
         aggregations: true,
+        aggregationsSubMenu: true,
         aggregationsSubMenuForRows: true
     },
     separators: {decimal: \\".\\", thousand: \\",\\"}
@@ -38176,6 +38219,7 @@ const config: IPivotTableConfig = {
     columnSizing: {defaultWidth: \\"autoresizeAll\\"},
     menu: {
         aggregations: true,
+        aggregationsSubMenu: true,
         aggregationsSubMenuForRows: true
     },
     separators: {decimal: \\".\\", thousand: \\",\\"}
@@ -38211,6 +38255,7 @@ const config: IPivotTableConfig = {
     columnSizing: {defaultWidth: \\"autoresizeAll\\"},
     menu: {
         aggregations: true,
+        aggregationsSubMenu: true,
         aggregationsSubMenuForRows: true
     },
     separators: {decimal: \\".\\", thousand: \\",\\"}
@@ -38261,6 +38306,7 @@ const config: IPivotTableConfig = {
     columnSizing: {defaultWidth: \\"autoresizeAll\\"},
     menu: {
         aggregations: true,
+        aggregationsSubMenu: true,
         aggregationsSubMenuForRows: true
     },
     separators: {decimal: \\".\\", thousand: \\",\\"}
@@ -38310,6 +38356,7 @@ const config: IPivotTableConfig = {
     columnSizing: {defaultWidth: \\"autoresizeAll\\"},
     menu: {
         aggregations: true,
+        aggregationsSubMenu: true,
         aggregationsSubMenuForRows: true
     },
     separators: {decimal: \\".\\", thousand: \\",\\"}
@@ -38359,6 +38406,7 @@ const config: IPivotTableConfig = {
     columnSizing: {defaultWidth: \\"autoresizeAll\\"},
     menu: {
         aggregations: true,
+        aggregationsSubMenu: true,
         aggregationsSubMenuForRows: true
     },
     separators: {decimal: \\".\\", thousand: \\",\\"}
@@ -38405,6 +38453,7 @@ const config: IPivotTableConfig = {
     columnSizing: {defaultWidth: \\"autoresizeAll\\"},
     menu: {
         aggregations: true,
+        aggregationsSubMenu: true,
         aggregationsSubMenuForRows: true
     },
     separators: {decimal: \\".\\", thousand: \\",\\"}
@@ -38455,6 +38504,7 @@ const config: IPivotTableConfig = {
     columnSizing: {defaultWidth: \\"autoresizeAll\\"},
     menu: {
         aggregations: true,
+        aggregationsSubMenu: true,
         aggregationsSubMenuForRows: true
     },
     separators: {decimal: \\".\\", thousand: \\",\\"}
@@ -38503,6 +38553,7 @@ const config: IPivotTableConfig = {
     columnSizing: {defaultWidth: \\"autoresizeAll\\"},
     menu: {
         aggregations: true,
+        aggregationsSubMenu: true,
         aggregationsSubMenuForRows: true
     },
     separators: {decimal: \\".\\", thousand: \\",\\"}
@@ -38549,6 +38600,7 @@ const config: IPivotTableConfig = {
     columnSizing: {defaultWidth: \\"autoresizeAll\\"},
     menu: {
         aggregations: true,
+        aggregationsSubMenu: true,
         aggregationsSubMenuForRows: true
     },
     separators: {decimal: \\".\\", thousand: \\",\\"}
@@ -38598,6 +38650,7 @@ const config: IPivotTableConfig = {
     columnSizing: {defaultWidth: \\"autoresizeAll\\"},
     menu: {
         aggregations: true,
+        aggregationsSubMenu: true,
         aggregationsSubMenuForRows: true
     },
     separators: {decimal: \\".\\", thousand: \\",\\"}
@@ -38637,6 +38690,7 @@ const config: IPivotTableConfig = {
     columnSizing: {defaultWidth: \\"autoresizeAll\\"},
     menu: {
         aggregations: true,
+        aggregationsSubMenu: true,
         aggregationsSubMenuForRows: true
     },
     separators: {decimal: \\".\\", thousand: \\",\\"}
@@ -38676,6 +38730,7 @@ const config: IPivotTableConfig = {
     columnSizing: {defaultWidth: \\"autoresizeAll\\"},
     menu: {
         aggregations: true,
+        aggregationsSubMenu: true,
         aggregationsSubMenuForRows: true
     },
     separators: {decimal: \\".\\", thousand: \\",\\"}
@@ -38713,6 +38768,7 @@ const config: IPivotTableConfig = {
     columnSizing: {defaultWidth: \\"autoresizeAll\\"},
     menu: {
         aggregations: true,
+        aggregationsSubMenu: true,
         aggregationsSubMenuForRows: true
     },
     separators: {decimal: \\".\\", thousand: \\",\\"}
@@ -38750,6 +38806,7 @@ const config: IPivotTableConfig = {
     columnSizing: {defaultWidth: \\"autoresizeAll\\"},
     menu: {
         aggregations: true,
+        aggregationsSubMenu: true,
         aggregationsSubMenuForRows: true
     },
     separators: {decimal: \\".\\", thousand: \\",\\"}
@@ -38788,6 +38845,7 @@ const config: IPivotTableConfig = {
     columnSizing: {defaultWidth: \\"autoresizeAll\\"},
     menu: {
         aggregations: true,
+        aggregationsSubMenu: true,
         aggregationsSubMenuForRows: true
     },
     separators: {decimal: \\".\\", thousand: \\",\\"}
@@ -38831,6 +38889,7 @@ const config: IPivotTableConfig = {
     columnSizing: {defaultWidth: \\"autoresizeAll\\"},
     menu: {
         aggregations: true,
+        aggregationsSubMenu: true,
         aggregationsSubMenuForRows: true
     },
     separators: {decimal: \\".\\", thousand: \\",\\"}
@@ -38872,6 +38931,7 @@ const config: IPivotTableConfig = {
     columnSizing: {defaultWidth: \\"autoresizeAll\\"},
     menu: {
         aggregations: true,
+        aggregationsSubMenu: true,
         aggregationsSubMenuForRows: true
     },
     separators: {decimal: \\".\\", thousand: \\",\\"}
@@ -38914,6 +38974,7 @@ const config: IPivotTableConfig = {
     columnSizing: {defaultWidth: \\"autoresizeAll\\"},
     menu: {
         aggregations: true,
+        aggregationsSubMenu: true,
         aggregationsSubMenuForRows: true
     },
     separators: {decimal: \\".\\", thousand: \\",\\"}
@@ -38951,6 +39012,7 @@ const config: IPivotTableConfig = {
     columnSizing: {defaultWidth: \\"autoresizeAll\\"},
     menu: {
         aggregations: true,
+        aggregationsSubMenu: true,
         aggregationsSubMenuForRows: true
     },
     separators: {decimal: \\".\\", thousand: \\",\\"}
@@ -38983,6 +39045,7 @@ const config: IPivotTableConfig = {
     columnSizing: {defaultWidth: \\"autoresizeAll\\"},
     menu: {
         aggregations: true,
+        aggregationsSubMenu: true,
         aggregationsSubMenuForRows: true
     },
     separators: {decimal: \\".\\", thousand: \\",\\"}
@@ -39026,6 +39089,7 @@ const config: IPivotTableConfig = {
     columnSizing: {defaultWidth: \\"autoresizeAll\\"},
     menu: {
         aggregations: true,
+        aggregationsSubMenu: true,
         aggregationsSubMenuForRows: true
     },
     separators: {decimal: \\".\\", thousand: \\",\\"}
@@ -39070,6 +39134,7 @@ const config: IPivotTableConfig = {
     columnSizing: {defaultWidth: \\"autoresizeAll\\"},
     menu: {
         aggregations: true,
+        aggregationsSubMenu: true,
         aggregationsSubMenuForRows: true
     },
     separators: {decimal: \\".\\", thousand: \\",\\"}
@@ -39113,6 +39178,7 @@ const config: IPivotTableConfig = {
     columnSizing: {defaultWidth: \\"autoresizeAll\\"},
     menu: {
         aggregations: true,
+        aggregationsSubMenu: true,
         aggregationsSubMenuForRows: true
     },
     separators: {decimal: \\".\\", thousand: \\",\\"}
@@ -39154,6 +39220,7 @@ const config: IPivotTableConfig = {
     columnSizing: {defaultWidth: \\"autoresizeAll\\"},
     menu: {
         aggregations: true,
+        aggregationsSubMenu: true,
         aggregationsSubMenuForRows: true
     },
     separators: {decimal: \\".\\", thousand: \\",\\"}
@@ -39191,6 +39258,7 @@ const config: IPivotTableConfig = {
     columnSizing: {defaultWidth: \\"autoresizeAll\\"},
     menu: {
         aggregations: true,
+        aggregationsSubMenu: true,
         aggregationsSubMenuForRows: true
     },
     separators: {decimal: \\".\\", thousand: \\",\\"}
@@ -39227,6 +39295,7 @@ const config: IPivotTableConfig = {
     columnSizing: {defaultWidth: \\"autoresizeAll\\"},
     menu: {
         aggregations: true,
+        aggregationsSubMenu: true,
         aggregationsSubMenuForRows: true
     },
     separators: {decimal: \\".\\", thousand: \\",\\"}
@@ -39278,6 +39347,7 @@ const config: IPivotTableConfig = {
     columnSizing: {defaultWidth: \\"autoresizeAll\\"},
     menu: {
         aggregations: true,
+        aggregationsSubMenu: true,
         aggregationsSubMenuForRows: true
     },
     separators: {decimal: \\".\\", thousand: \\",\\"}
@@ -39331,6 +39401,7 @@ const config: IPivotTableConfig = {
     columnSizing: {defaultWidth: \\"autoresizeAll\\"},
     menu: {
         aggregations: true,
+        aggregationsSubMenu: true,
         aggregationsSubMenuForRows: true
     },
     separators: {decimal: \\".\\", thousand: \\",\\"}
@@ -39366,6 +39437,7 @@ const config: IPivotTableConfig = {
     columnSizing: {defaultWidth: \\"autoresizeAll\\"},
     menu: {
         aggregations: true,
+        aggregationsSubMenu: true,
         aggregationsSubMenuForRows: true
     },
     separators: {decimal: \\".\\", thousand: \\",\\"}

--- a/libs/sdk-ui-pivot/api/sdk-ui-pivot.api.md
+++ b/libs/sdk-ui-pivot/api/sdk-ui-pivot.api.md
@@ -139,6 +139,7 @@ export interface IMeasureColumnWidthItemBody {
 // @public (undocumented)
 export interface IMenu {
     aggregations?: boolean;
+    aggregationsSubMenu?: boolean;
     aggregationsSubMenuForRows?: boolean;
     aggregationTypes?: TotalType[];
 }

--- a/libs/sdk-ui-pivot/src/publicTypes.ts
+++ b/libs/sdk-ui-pivot/src/publicTypes.ts
@@ -26,6 +26,14 @@ export interface IMenu {
      */
     aggregations?: boolean;
     /**
+     * If true, subtotals can be added to the table using table menu.
+     * TODO: remove for SDK9
+     *
+     * @remarks
+     * Default: false
+     */
+    aggregationsSubMenu?: boolean;
+    /**
      * Specifies which aggregation functions can be selected from the menu.
      *
      * @remarks


### PR DESCRIPTION
<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |
| **Compatibility matrix test commands - TIGER Backend**  |                                                            |
| `extended test - matrix-test <AIO_version>`             | Run integrated tests against AIO versions.                 |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

`<AIO_version>` in commands is used to start test with multiple AIO instances - each instance in triggered by one jenkins build

-   To run with `master` and `stable`, execute command `extended test - matrix-test master,stable` or `extended test - matrix-test latest`
-   To run with specific version,ex: `2.3.0` and `2.3.1`, execute command `extended test - matrix-test 2.3.0,2.3.1`
-   In case `<AIO_version>` is empty, read versions from file `compTigerVersions.txt` of this repo

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
