### PR TITLE
FEATURE: EGL-64 - extract error response data from api error [DRAFF - DO NOT MERGE]

### DIFF
--- a/libs/sdk-backend-bear/src/errors/BackendApiError.ts
+++ b/libs/sdk-backend-bear/src/errors/BackendApiError.ts
@@ -1,0 +1,23 @@
+// (C) 2023 GoodData Corporation
+
+import {
+    BackendApiError,
+    ErrorResponseData,
+} from "@gooddata/sdk-backend-spi";
+
+export class BearApiError extends BackendApiError {
+    private static REQUEST_ID_HEADER_KEY = "x-gdc-request";
+
+    protected buildErrorResponseData(): ErrorResponseData {
+        const cause: any = this.cause;
+        if (!cause) {
+            return null;
+        }
+
+        return {
+            traceId: cause.response?.headers?.get && cause.response.headers.get(BearApiError.REQUEST_ID_HEADER_KEY),
+            httpStatus: cause.response?.status,
+            rawData: cause.responseBody ? JSON.parse(cause.responseBody) : {},
+        }
+    }
+}

--- a/libs/sdk-backend-bear/src/utils/errorHandling.ts
+++ b/libs/sdk-backend-bear/src/utils/errorHandling.ts
@@ -14,6 +14,7 @@ import {
 import includes from "lodash/includes";
 import isString from "lodash/isString";
 import { StatusCodes as HttpStatusCodes } from "http-status-codes";
+import { BearApiError } from "../errors/BackendApiError";
 
 export function isApiResponseError(error: unknown): error is ApiResponseError {
     return (error as ApiResponseError).response !== undefined;
@@ -60,6 +61,10 @@ export function convertExecutionApiError(error: Error): AnalyticalBackendError {
 }
 
 export function convertApiError(error: Error): AnalyticalBackendError {
+    return new BearApiError(detectApiError(error));
+}
+
+export function detectApiError(error: Error): AnalyticalBackendError {
     if (isAnalyticalBackendError(error)) {
         return error;
     }

--- a/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
+++ b/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
@@ -113,6 +113,15 @@ export type AuthenticationFlow = {
     returnRedirectParam: string;
 };
 
+// @public (undocumented)
+export abstract class BackendApiError extends AnalyticalBackendError {
+    constructor(error: AnalyticalBackendError);
+    // (undocumented)
+    protected abstract buildErrorResponseData(): ErrorResponseData;
+    // (undocumented)
+    readonly errorResponseData: ErrorResponseData;
+}
+
 // @beta
 export type CancelableOptions = {
     signal?: AbortSignal;
@@ -133,6 +142,9 @@ export type ElementsQueryOptionsElementsSpecification = IElementsQueryOptionsEle
 
 // @public
 export type ErrorConverter = (e: Error) => AnalyticalBackendError;
+
+// @public (undocumented)
+export type ErrorResponseData = IErrorResponseData | null;
 
 // @internal
 export type ExplainConfig<T extends ExplainType | undefined> = {
@@ -377,6 +389,18 @@ export type IElementsQueryResult = IPagedResource<IAttributeElement>;
 // @public
 export interface IEntitlements {
     resolveEntitlements(): Promise<IEntitlementDescriptor[]>;
+}
+
+// @public (undocumented)
+export interface IErrorResponseData {
+    // (undocumented)
+    httpStatus: number;
+    // (undocumented)
+    rawData: {
+        [key: string]: any;
+    };
+    // (undocumented)
+    traceId: string;
 }
 
 // @public

--- a/libs/sdk-backend-spi/src/errors/index.ts
+++ b/libs/sdk-backend-spi/src/errors/index.ts
@@ -213,6 +213,39 @@ export class ContractExpired extends AnalyticalBackendError {
 }
 
 /**
+ * @public
+ */
+export interface IErrorResponseData {
+    traceId: string;
+    httpStatus: number;
+    rawData: {
+        [key: string]: any;
+    }
+}
+
+/**
+ * @public
+ */
+export type ErrorResponseData = IErrorResponseData | null;
+
+/**
+ * @public
+ */
+export abstract class BackendApiError extends AnalyticalBackendError {
+    public readonly errorResponseData: ErrorResponseData;
+
+    constructor(error: AnalyticalBackendError) {
+        super(error.message, error.abeType, error.cause);
+
+        Object.setPrototypeOf(this, new.target.prototype);
+
+        this.errorResponseData = this.buildErrorResponseData();
+    }
+
+    protected abstract buildErrorResponseData(): ErrorResponseData;
+}
+
+/**
  * Error converter
  *
  * @public

--- a/libs/sdk-backend-spi/src/index.ts
+++ b/libs/sdk-backend-spi/src/index.ts
@@ -89,6 +89,7 @@ export {
     NotAuthenticatedReason,
     LimitReached,
     ContractExpired,
+    BackendApiError,
     ErrorConverter,
     isAnalyticalBackendError,
     isNoDataError,
@@ -102,6 +103,8 @@ export {
     isLimitReached,
     isContractExpired,
     AuthenticationFlow,
+    IErrorResponseData,
+    ErrorResponseData,
     AnalyticalBackendErrorTypes,
 } from "./errors";
 

--- a/libs/sdk-backend-tiger/src/errors/BackendApiError.ts
+++ b/libs/sdk-backend-tiger/src/errors/BackendApiError.ts
@@ -1,0 +1,22 @@
+// (C) 2023 GoodData Corporation
+import {
+    BackendApiError,
+    ErrorResponseData,
+} from "@gooddata/sdk-backend-spi";
+
+export class TigerApiError extends BackendApiError {
+    private static TRACE_ID_HEADER_KEY = "x-gdc-trace-id";
+
+    protected buildErrorResponseData(): ErrorResponseData {
+        const causeError: any = this.cause;
+        if (!causeError) {
+            return null;
+        }
+
+        return {
+            traceId: causeError.response?.headers && causeError.response.headers[TigerApiError.TRACE_ID_HEADER_KEY],
+            httpStatus: causeError.response?.status,
+            rawData: causeError.response?.data ?? {},
+        };
+    }
+}

--- a/libs/sdk-backend-tiger/src/utils/errorHandling.ts
+++ b/libs/sdk-backend-tiger/src/utils/errorHandling.ts
@@ -8,31 +8,10 @@ import {
     ContractExpired,
 } from "@gooddata/sdk-backend-spi";
 import { AxiosError } from "axios";
+import { TigerApiError } from "../errors/BackendApiError";
 
 export function convertApiError(error: Error): AnalyticalBackendError {
-    if (isAnalyticalBackendError(error)) {
-        return error;
-    }
-
-    const notAuthenticated = createNotAuthenticatedError(error);
-
-    if (notAuthenticated) {
-        throw notAuthenticated;
-    }
-
-    const limitReached = createLimitReachedError(error);
-
-    if (limitReached) {
-        throw limitReached;
-    }
-
-    const contractExpired = createContractExpiredError(error);
-
-    if (contractExpired) {
-        return contractExpired;
-    }
-
-    return new UnexpectedError("An unexpected error has occurred", error);
+    return new TigerApiError(detectApiError(error));
 }
 
 export function createNotAuthenticatedError(error: Error): NotAuthenticated | undefined {
@@ -83,4 +62,30 @@ function createContractExpiredError(error: Error): ContractExpired | undefined {
     }
 
     return new ContractExpired(axiosErrorResponse.data.tier || "unspecified", error);
+}
+
+function detectApiError(error: Error): AnalyticalBackendError {
+    if (isAnalyticalBackendError(error)) {
+        return error;
+    }
+
+    const notAuthenticated = createNotAuthenticatedError(error);
+
+    if (notAuthenticated) {
+        throw notAuthenticated;
+    }
+
+    const limitReached = createLimitReachedError(error);
+
+    if (limitReached) {
+        throw limitReached;
+    }
+
+    const contractExpired = createContractExpiredError(error);
+
+    if (contractExpired) {
+        return contractExpired;
+    }
+
+    return new UnexpectedError("An unexpected error has occurred", error);
 }


### PR DESCRIPTION
JIRA: EGL-64

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |
| **Compatibility matrix test commands - TIGER Backend**  |                                                            |
| `extended test - matrix-test <AIO_version>`             | Run integrated tests against AIO versions.                 |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

`<AIO_version>` in commands is used to start test with multiple AIO instances - each instance in triggered by one jenkins build

-   To run with `master` and `stable`, execute command `extended test - matrix-test master,stable` or `extended test - matrix-test latest`
-   To run with specific version,ex: `2.3.0` and `2.3.1`, execute command `extended test - matrix-test 2.3.0,2.3.1`
-   In case `<AIO_version>` is empty, read versions from file `compTigerVersions.txt` of this repo

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
