### PR TITLE
BUGFIX: EGL-82 - Data label of negative value is missed on Column/Combo charts

### DIFF
--- a/libs/sdk-ui-charts/src/highcharts/adapter/plugins/autohideLabels/autohideColumnLabels.ts
+++ b/libs/sdk-ui-charts/src/highcharts/adapter/plugins/autohideLabels/autohideColumnLabels.ts
@@ -33,6 +33,7 @@ import {
 } from "../../../chartTypes/_chartCreators/dataLabelsHelpers";
 import { VisualizationTypes } from "@gooddata/sdk-ui";
 import { UnsafeInternals, IUnsafeDataLabels, IStackItem } from "../../../typings/unsafe";
+import { isWaterfall } from "../../../chartTypes/_util/common";
 
 /*
  * Code in this file accesses Highchart properties that are not included in
@@ -59,6 +60,7 @@ const toggleNonStackedChartLabels = (
     visiblePoints: any,
     axisRangeForAxes: IAxisRangeForAxes,
     shouldCheckShapeIntersection: boolean = false,
+    type?: string,
 ) => {
     const foundIntersection = toNeighbors(
         // some data labels may not be rendered (too many points)
@@ -87,7 +89,13 @@ const toggleNonStackedChartLabels = (
     if (foundIntersection) {
         hideDataLabels(visiblePoints);
     } else {
-        visiblePoints.forEach((point: any) => showDataLabelInAxisRange(point, point.y, axisRangeForAxes));
+        visiblePoints.forEach((point: any) =>
+            showDataLabelInAxisRange(
+                point,
+                isWaterfall(type) ? Math.abs(point.y) : point.y,
+                axisRangeForAxes,
+            ),
+        );
     }
 };
 
@@ -291,7 +299,7 @@ export const autohideColumnLabels = (chart: Highcharts.Chart): void => {
     if (isStackedChart) {
         toggleStackedChartLabels(visiblePoints.filter(hasLabelInside), axisRangeForAxes);
     } else {
-        toggleNonStackedChartLabels(visiblePoints, axisRangeForAxes, true);
+        toggleNonStackedChartLabels(visiblePoints, axisRangeForAxes, true, chart?.options?.chart?.type);
     }
 };
 

--- a/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartCreators/dataLabelsHelpers.ts
+++ b/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartCreators/dataLabelsHelpers.ts
@@ -107,7 +107,7 @@ export function showDataLabelInAxisRange(
 ): void {
     const isSecondAxis = point?.series?.yAxis?.opposite ?? false;
     const axisRange: IAxisRange = axisRangeForAxes[isSecondAxis ? "second" : "first"];
-    const isInsideAxisRange = pointInRange(Math.abs(value), axisRange);
+    const isInsideAxisRange = pointInRange(value, axisRange);
     if (!isInsideAxisRange) {
         hideDataLabel(point);
     }


### PR DESCRIPTION
When implementing the waterfall chart, I converted the negative values to positive [here](https://github.com/gooddata/gooddata-ui-sdk/commit/75342129e8d63e569a9a0be507b835753c6b01ca#diff-b23585b3caa9ff74b1155ab5dac766fd84228587cca924f7652dfe0d7b6bf435R110):

It will affect to other charts, this fix is only convert the negative value for waterfall chart.

JIRA: EGL-82

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |
| **Compatibility matrix test commands - TIGER Backend**  |                                                            |
| `extended test - matrix-test <AIO_version>`             | Run integrated tests against AIO versions.                 |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

`<AIO_version>` in commands is used to start test with multiple AIO instances - each instance in triggered by one jenkins build

-   To run with `master` and `stable`, execute command `extended test - matrix-test master,stable` or `extended test - matrix-test latest`
-   To run with specific version,ex: `2.3.0` and `2.3.1`, execute command `extended test - matrix-test 2.3.0,2.3.1`
-   In case `<AIO_version>` is empty, read versions from file `compTigerVersions.txt` of this repo

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
