### PR TITLE
BUGFIX: TNT-1549 rows/columns total sorting

### DIFF
--- a/libs/sdk-backend-tiger/src/convertors/toBackend/afm/TotalsConverter.ts
+++ b/libs/sdk-backend-tiger/src/convertors/toBackend/afm/TotalsConverter.ts
@@ -13,6 +13,7 @@ import {
     MeasureGroupIdentifier,
     TotalType,
     IMeasure,
+    sanitizeBucketTotals,
 } from "@gooddata/sdk-model";
 import flatMap from "lodash/flatMap";
 import { Total, TotalDimension, TotalFunctionEnum } from "@gooddata/api-client-tiger";
@@ -96,7 +97,15 @@ export function convertTotals(def: IExecutionDefinition): Total[] {
         const attributeIdentifiers = getAttributeBucketIdentifiers(matchingAttributeBucket);
         const columnIdentifiers = getAttributeBucketIdentifiers(matchingColumnBucket);
 
-        attributeBucket!.totals?.forEach((attributeTotal, index) => {
+        if (attributeBucket && isEqual(dimensions[0].totals, bucketTotals(attributeBucket))) {
+            dimensions[0].totals = sanitizeBucketTotals(
+                attributeBucket,
+                def.sortBy,
+                bucketTotals(attributeBucket),
+            );
+        }
+
+        dimensions[0].totals?.forEach((attributeTotal, index) => {
             let hasRowAndColumnGrandTotals = false;
             let hasRowAndColumnSubTotals = false;
             let hasRowSubtotalAndColumnGrandTotal = false;
@@ -105,7 +114,7 @@ export function convertTotals(def: IExecutionDefinition): Total[] {
             let columnDimensionIndex = 0;
             let attributeSubtotalDimensionIndex = 0;
             let columnSubtotalDimensionIndex = 0;
-            columnBucket!.totals?.forEach((columnTotal, columnIndex) => {
+            dimensions[1].totals?.forEach((columnTotal, columnIndex) => {
                 const attributeMeasureId = attributeTotal.measureIdentifier;
                 const attributeType = attributeTotal.type;
                 const columnMeasureId = columnTotal.measureIdentifier;


### PR DESCRIPTION
<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |
| **Compatibility matrix test commands - TIGER Backend**  |                                                            |
| `extended test - matrix-test <AIO_version>`             | Run integrated tests against AIO versions.                 |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

`<AIO_version>` in commands is used to start test with multiple AIO instances - each instance in triggered by one jenkins build

-   To run with `master` and `stable`, execute command `extended test - matrix-test master,stable` or `extended test - matrix-test latest`
-   To run with specific version,ex: `2.3.0` and `2.3.1`, execute command `extended test - matrix-test 2.3.0,2.3.1`
-   In case `<AIO_version>` is empty, read versions from file `compTigerVersions.txt` of this repo

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
