### PR TITLE
BUGFIX: TNT-1555 Column totals/subtotals styles

### DIFF
--- a/libs/sdk-ui-pivot/src/impl/cell/cellClass.ts
+++ b/libs/sdk-ui-pivot/src/impl/cell/cellClass.ts
@@ -83,9 +83,9 @@ export function cellClassFactory(
             rowSeparator ? "gd-table-row-separator s-gd-table-row-separator" : null,
             isTopPinned && isEmptyCell ? "gd-hidden-sticky-column" : null,
             // All new totals combinations
-            isColAndRowSubtotal ? "gd-table-row-column-subtotal" : null,
+            isColAndRowSubtotal ? "gd-table-row-subtotal-column-subtotal" : null,
             isRowTotalAndColSubtotal ? "gd-table-row-total-column-subtotal" : null,
-            isRowAndColumnTotal ? "gd-table-row-column-total" : null,
+            isRowAndColumnTotal ? "gd-table-row-total-column-total" : null,
             isRowSubtotalColumnTotal ? "gd-table-row-subtotal-column-total" : null,
         );
     };

--- a/libs/sdk-ui-pivot/src/impl/structure/colDefHeaderClass.ts
+++ b/libs/sdk-ui-pivot/src/impl/structure/colDefHeaderClass.ts
@@ -45,6 +45,10 @@ export function headerClassFactory(
             const indexWithinGroup = treeIndexes ? treeIndexes[treeIndexes.length - 1] : undefined;
             const noLeftBorder = tableDescriptor.isFirstCol(colId) || !tableDescriptor.hasScopingCols();
             const noBottomBorder = isScopeCol(colDesc) && isResultTotalHeader(colDesc.header);
+            const topBottomSolidTotal =
+                isScopeCol(colDesc) &&
+                isResultTotalHeader(colDesc.header) &&
+                colDesc.headersToHere.length === 0;
             const isColumnTotal = (colDef as ColDef).type === COLUMN_TOTAL;
             const isColumnSubtotal = (colDef as ColDef).type === COLUMN_SUBTOTAL;
             const absoluteColIndex = isSeriesCol(colDesc)
@@ -70,6 +74,7 @@ export function headerClassFactory(
                     : null,
                 noLeftBorder ? "gd-column-group-header--first" : null,
                 noBottomBorder ? "gd-column-group-header--subtotal" : null,
+                topBottomSolidTotal ? "gd-column-group-header-total--first" : null,
                 !colDef.headerName && !noBottomBorder ? "gd-column-group-header--empty" : null,
                 isColumnTotal ? "gd-column-total" : null,
                 isColumnSubtotal ? "gd-column-subtotal" : null,

--- a/libs/sdk-ui-pivot/styles/scss/pivotTable.scss
+++ b/libs/sdk-ui-pivot/styles/scss/pivotTable.scss
@@ -41,21 +41,24 @@ $header-hover-background-color: var(
     var(--gd-palette-complementary-1, kit-variables.$gd-palette-primary-dimmed)
 );
 
-$total-background-color: var(--gd-table-totalBackgroundColor, var(--gd-palette-complementary-2, #e7ebef));
+$total-background-color: var(
+    --gd-table-totalBackgroundColor,
+    var(--gd-palette-complementary-2, rgba(176, 190, 202, 0.2))
+);
 
 $row-column-subtotal-background-color: var(
     --gd-table-totalBackgroundColor,
-    var(--gd-palette-complementary-1, #b0beca33)
+    var(--gd-palette-complementary-1, rgba(176, 190, 202, 0.3))
 );
 
 $row-total-column-subtotal-background-color: var(
     --gd-table-totalBackgroundColor,
-    var(--gd-palette-complementary-1, #b0beca4d)
+    var(--gd-palette-complementary-1, rgba(176, 190, 202, 0.3))
 );
 
 $row-column-total-background-color: var(
     --gd-table-totalBackgroundColor,
-    var(--gd-palette-complementary-1, #b0beca66)
+    var(--gd-palette-complementary-1, rgba(176, 190, 202, 0.4))
 );
 
 $total-value-color: var(
@@ -65,11 +68,11 @@ $total-value-color: var(
 
 $subtotal-even-background-color: var(
     --gd-table-subtotalBackgroundColor,
-    var(--gd-palette-complementary-1, #eff2f4)
+    var(--gd-palette-complementary-1, rgba(176, 190, 202, 0.15))
 );
 $subtotal-odd-background-color: var(
     --gd-table-subtotalBackgroundColor,
-    var(--gd-palette-complementary-1, #f7f8f9)
+    var(--gd-palette-complementary-1, rgba(176, 190, 202, 0.1))
 );
 
 @use "@ag-grid-community/all-modules/dist/styles/ag-theme-balham/sass/ag-theme-balham-mixin" as ag-balham;
@@ -128,6 +131,10 @@ $subtotal-odd-background-color: var(
             // prevent empty header cells from being highlighted on hover
             background-color: $custom-background-color;
         }
+
+        .ag-header-row:not(:first-child) .ag-header-cell {
+            border-top: $cell-border;
+        }
     }
 
     .gd-table {
@@ -183,6 +190,22 @@ $subtotal-odd-background-color: var(
         [row-index="0"] {
             .ag-cell {
                 border-top-color: transparent;
+            }
+        }
+
+        .gd-column-group-header.gd-column-total {
+            &:hover {
+                // stylelint-disable-next-line declaration-no-important
+                background-color: $total-background-color !important; // Override ag-grid header hover color
+                cursor: default;
+            }
+        }
+
+        .gd-column-group-header.gd-column-subtotal {
+            &:hover {
+                // stylelint-disable-next-line declaration-no-important
+                background-color: $subtotal-odd-background-color !important; // Override ag-grid header hover color
+                cursor: default;
             }
         }
 
@@ -276,16 +299,10 @@ $subtotal-odd-background-color: var(
         }
 
         .gd-column-total {
-            border-bottom-color: transparent;
+            border-left: 1px solid $cell-border-color;
             color: $total-value-color;
             font-weight: bold;
             background-color: $total-background-color;
-
-            &:hover {
-                // stylelint-disable-next-line declaration-no-important
-                background-color: $total-background-color !important; // Override ag-grid header hover color
-                cursor: default;
-            }
         }
 
         .gd-row-total {
@@ -302,13 +319,7 @@ $subtotal-odd-background-color: var(
 
         .gd-column-subtotal {
             font-weight: bold;
-            background-color: $subtotal-even-background-color;
-
-            &:hover {
-                // stylelint-disable-next-line declaration-no-important
-                background-color: $subtotal-even-background-color !important; // Override ag-grid header hover color
-                cursor: default;
-            }
+            background-color: rgba(176, 190, 202, 0.1);
         }
 
         .gd-table-row-subtotal {
@@ -322,40 +333,20 @@ $subtotal-odd-background-color: var(
             }
         }
 
-        .gd-table-row-column-subtotal {
+        .gd-table-row-subtotal-column-subtotal {
             background-color: $total-background-color;
-
-            &:hover {
-                // stylelint-disable-next-line declaration-no-important
-                background-color: $total-background-color !important; // Override ag-grid header hover color
-            }
         }
 
         .gd-table-row-total-column-subtotal {
             background-color: $row-total-column-subtotal-background-color;
-
-            &:hover {
-                // stylelint-disable-next-line declaration-no-important
-                background-color: $row-total-column-subtotal-background-color !important; // Override ag-grid header hover color
-            }
         }
 
         .gd-table-row-subtotal-column-total {
-            background-color: $total-background-color;
-
-            &:hover {
-                // stylelint-disable-next-line declaration-no-important
-                background-color: $total-background-color !important; // Override ag-grid header hover color
-            }
+            background-color: $row-total-column-subtotal-background-color;
         }
 
-        .gd-table-row-column-total {
+        .gd-table-row-total-column-total {
             background-color: $row-column-total-background-color;
-
-            &:hover {
-                // stylelint-disable-next-line declaration-no-important
-                background-color: $row-column-total-background-color !important; // Override ag-grid header hover color
-            }
         }
 
         .gd-column-merged {


### PR DESCRIPTION
<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |
| **Compatibility matrix test commands - TIGER Backend**  |                                                            |
| `extended test - matrix-test <AIO_version>`             | Run integrated tests against AIO versions.                 |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

`<AIO_version>` in commands is used to start test with multiple AIO instances - each instance in triggered by one jenkins build

-   To run with `master` and `stable`, execute command `extended test - matrix-test master,stable` or `extended test - matrix-test latest`
-   To run with specific version,ex: `2.3.0` and `2.3.1`, execute command `extended test - matrix-test 2.3.0,2.3.1`
-   In case `<AIO_version>` is empty, read versions from file `compTigerVersions.txt` of this repo

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
