### PR TITLE
RELATED: TNT-1560 Notify about sort&totals at once and fix setting

### DIFF
--- a/libs/sdk-backend-base/src/normalizingBackend/normalizer.ts
+++ b/libs/sdk-backend-base/src/normalizingBackend/normalizer.ts
@@ -41,6 +41,7 @@ import {
     isResultMeasureHeader,
     isMeasureDefinition,
     isPositiveAttributeFilter,
+    ITotal,
 } from "@gooddata/sdk-model";
 import invariant from "ts-invariant";
 import cloneDeep from "lodash/cloneDeep";
@@ -342,6 +343,26 @@ export class Normalizer {
         });
     };
 
+    private normalizeTotal = (total: ITotal): ITotal => {
+        // safely normalize total, when not found in the converted
+        // attributes/measures, keep the original identifier
+        return {
+            ...total,
+            attributeIdentifier:
+                this.maybeNormalizedLocalId(total.attributeIdentifier) ?? total.attributeIdentifier,
+            measureIdentifier:
+                this.maybeNormalizedLocalId(total.measureIdentifier) ?? total.measureIdentifier,
+        };
+    };
+
+    private normalizeTotals = () => {
+        this.normalized.buckets.forEach((bucket) => {
+            if (bucket.totals) {
+                bucket.totals = bucket.totals.map(this.normalizeTotal);
+            }
+        });
+    };
+
     /**
      * Simple measure normalization will toss away noop filters. There is nothing else to do.
      */
@@ -508,6 +529,7 @@ export class Normalizer {
         this.normalizeFilters();
         this.normalizeSorts();
         this.normalizeDimensions();
+        this.normalizeTotals();
 
         return {
             normalized: this.normalized,

--- a/libs/sdk-backend-base/src/normalizingBackend/tests/__snapshots__/normalizer.test.ts.snap
+++ b/libs/sdk-backend-base/src/normalizingBackend/tests/__snapshots__/normalizer.test.ts.snap
@@ -1,5 +1,111 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Normalizer should also normalize col & row totals in buckets 1`] = `
+Array [
+  Object {
+    "items": Array [
+      Object {
+        "measure": Object {
+          "definition": Object {
+            "measureDefinition": Object {
+              "item": Object {
+                "identifier": "acugFHNJgsBy",
+                "type": "measure",
+              },
+            },
+          },
+          "localIdentifier": "m_acugFHNJgsBy",
+        },
+      },
+      Object {
+        "measure": Object {
+          "definition": Object {
+            "measureDefinition": Object {
+              "item": Object {
+                "identifier": "aangOxLSeztu",
+                "type": "measure",
+              },
+            },
+          },
+          "localIdentifier": "m_aangOxLSeztu",
+        },
+      },
+    ],
+    "localIdentifier": "bucket",
+  },
+  Object {
+    "items": Array [
+      Object {
+        "attribute": Object {
+          "displayForm": Object {
+            "identifier": "label.owner.region",
+            "type": "displayForm",
+          },
+          "localIdentifier": "a_label.owner.region",
+        },
+      },
+      Object {
+        "attribute": Object {
+          "displayForm": Object {
+            "identifier": "label.product.id.name",
+            "type": "displayForm",
+          },
+          "localIdentifier": "a_label.product.id.name",
+        },
+      },
+    ],
+    "localIdentifier": "attribute",
+    "totals": Array [
+      Object {
+        "attributeIdentifier": "a_label.product.id.name",
+        "measureIdentifier": "m_acugFHNJgsBy",
+        "type": "sum",
+      },
+      Object {
+        "attributeIdentifier": "a_label.product.id.name",
+        "measureIdentifier": "m_acugFHNJgsBy",
+        "type": "max",
+      },
+    ],
+  },
+  Object {
+    "items": Array [
+      Object {
+        "attribute": Object {
+          "displayForm": Object {
+            "identifier": "label.account.id.name",
+            "type": "displayForm",
+          },
+          "localIdentifier": "a_label.account.id.name",
+        },
+      },
+      Object {
+        "attribute": Object {
+          "displayForm": Object {
+            "identifier": "label.owner.id.name",
+            "type": "displayForm",
+          },
+          "localIdentifier": "a_label.owner.id.name",
+        },
+      },
+    ],
+    "localIdentifier": "columns",
+    "totals": Array [
+      Object {
+        "attributeIdentifier": "a_label.owner.id.name",
+        "measureIdentifier": "m_acugFHNJgsBy",
+        "type": "sum",
+      },
+      Object {
+        "attributeIdentifier": "a_label.owner.id.name",
+        "measureIdentifier": "m_acugFHNJgsBy",
+        "type": "avg",
+      },
+    ],
+  },
+]
+`;
+
 exports[`Normalizer should normalize arithmetic measures 1`] = `
 Object {
   "attributes": Array [],

--- a/libs/sdk-backend-tiger/src/backend/uiSettings.ts
+++ b/libs/sdk-backend-tiger/src/backend/uiSettings.ts
@@ -85,6 +85,7 @@ export const DefaultUiSettings: ISettings = {
 
     enablePushpinGeoChart: true,
     ...DefaultFeatureFlags,
+    tableSortingCheckDisabled: true,
 };
 
 /**

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/PluggablePivotTable.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/PluggablePivotTable.tsx
@@ -484,9 +484,16 @@ export class PluggablePivotTable extends AbstractPluggableVisualization {
 
     private handlePushData(data: any) {
         if (data?.properties?.sortItems) {
+            const addTotals = data?.properties?.totals
+                ? {
+                      totals: data?.properties?.totals,
+                      bucketType: data?.properties?.bucketType,
+                  }
+                : {};
             this.pushData({
                 properties: {
                     sortItems: data.properties.sortItems,
+                    ...addTotals,
                 },
             });
         } else {


### PR DESCRIPTION
Notify sortItems and totals in one pushData call when sorting changes.
Also, switch tableSortingCheckDisabled to true for tiger
as this is true by default on bear as well.



<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |
| **Compatibility matrix test commands - TIGER Backend**  |                                                            |
| `extended test - matrix-test <AIO_version>`             | Run integrated tests against AIO versions.                 |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

`<AIO_version>` in commands is used to start test with multiple AIO instances - each instance in triggered by one jenkins build

-   To run with `master` and `stable`, execute command `extended test - matrix-test master,stable` or `extended test - matrix-test latest`
-   To run with specific version,ex: `2.3.0` and `2.3.1`, execute command `extended test - matrix-test 2.3.0,2.3.1`
-   In case `<AIO_version>` is empty, read versions from file `compTigerVersions.txt` of this repo

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)