### PR TITLE
FEATURE: EGL-55 - add the disable tooltip message for waterfall total section

### DIFF
--- a/libs/sdk-ui-ext/src/internal/components/configurationControls/total/TotalSection.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/configurationControls/total/TotalSection.tsx
@@ -11,7 +11,7 @@ import { IVisualizationProperties } from "../../../interfaces/Visualization";
 import { getTranslation } from "../../../utils/translations";
 import { isTotalSectionEnabled } from "../../../utils/propertiesHelper";
 
-interface ITotalSectionProps {
+export interface ITotalSectionProps {
     controlsDisabled: boolean;
     properties: IVisualizationProperties;
     propertiesMeta: any;
@@ -22,10 +22,17 @@ const TotalSection: React.FC<ITotalSectionProps & WrappedComponentProps> = (
     props: ITotalSectionProps & WrappedComponentProps,
 ) => {
     const { intl, controlsDisabled, properties, propertiesMeta, pushData } = props;
+    const hasTotalMeasure = properties.controls?.total?.measures?.length > 0;
+    const isToggleDisabled = controlsDisabled || hasTotalMeasure;
     //always toggle to false when the control is disabled, otherwise depend on the properties config
-    const isTotalEnabled = controlsDisabled ? false : isTotalSectionEnabled(properties);
+    const isTotalEnabled = isToggleDisabled ? false : isTotalSectionEnabled(properties);
     const totalColumnName = properties?.controls?.total?.name;
     const defaultTotalColumnName = getTranslation(messages.totalTitle.id, intl);
+    const toggleMessageId = hasTotalMeasure
+        ? messages.totalMeasuresTooltip.id
+        : !controlsDisabled
+        ? messages.totalToggleTooltip.id
+        : undefined;
 
     useEffect(() => {
         if (isTotalEnabled && !totalColumnName) {
@@ -44,11 +51,11 @@ const TotalSection: React.FC<ITotalSectionProps & WrappedComponentProps> = (
             properties={properties}
             pushData={pushData}
             canBeToggled={true}
-            toggleDisabled={controlsDisabled}
+            toggleDisabled={isToggleDisabled}
             toggledOn={isTotalEnabled}
             valuePath="total.enabled"
             showDisabledMessage={true}
-            toggleMessageId={!controlsDisabled ? messages.totalToggleTooltip.id : undefined}
+            toggleMessageId={toggleMessageId}
         >
             <InputControl
                 type="text"

--- a/libs/sdk-ui-ext/src/internal/components/configurationControls/total/tests/TotalSection.test.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/configurationControls/total/tests/TotalSection.test.tsx
@@ -1,0 +1,91 @@
+// (C) 2023 GoodData Corporation
+import React from "react";
+import { render, screen, fireEvent, act, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import noop from "lodash/noop";
+
+import { InternalIntlWrapper } from "../../../../utils/internalIntlProvider";
+import TotalSection, { ITotalSectionProps } from "../TotalSection";
+
+describe("TotalSection", () => {
+    const defaultProps: ITotalSectionProps = {
+        controlsDisabled: false,
+        properties: {
+            controls: {
+                total: {
+                    enabled: true,
+                    name: "Total",
+                    measures: [],
+                },
+            },
+        },
+        propertiesMeta: {
+            total_section: {
+                collapsed: false,
+            },
+        },
+        pushData: noop,
+    };
+
+    function createComponent(customProps: Partial<ITotalSectionProps> = {}) {
+        const props = { ...defaultProps, ...customProps };
+        return render(
+            <InternalIntlWrapper>
+                <TotalSection {...props} />
+            </InternalIntlWrapper>,
+        );
+    }
+
+    it("should render Total section", () => {
+        createComponent();
+        expect(screen.getByText("Total")).toBeInTheDocument();
+    });
+
+    it("should be toggle by default", () => {
+        createComponent();
+        expect(screen.getByRole("checkbox")).toBeChecked();
+    });
+
+    it("should be enabled the toggle by default", () => {
+        createComponent();
+        expect(screen.getByRole("checkbox")).toBeEnabled();
+    });
+
+    it("should render the input field with the default Total text", () => {
+        createComponent();
+        expect(screen.getByRole("textbox")).toHaveValue("Total");
+    });
+
+    it("should disable the toggle when the controls is disabled", () => {
+        createComponent({ controlsDisabled: true });
+        expect(screen.getByRole("checkbox")).toBeDisabled();
+        expect(screen.getByRole("textbox")).toBeDisabled();
+    });
+
+    it("should render disabled checkbox if there is any metric as total metric", async () => {
+        createComponent({ properties: { controls: { total: { measures: ["measure_id"] } } } });
+        expect(screen.getByRole("checkbox")).toBeDisabled();
+        expect(screen.getByRole("textbox")).toBeDisabled();
+
+        fireEvent.mouseOver(screen.getByRole("checkbox"));
+
+        await waitFor(() =>
+            expect(
+                screen.getByText(
+                    "Disable “is total” options in metric to add sum of all values as a column at the end.",
+                ),
+            ).toBeInTheDocument(),
+        );
+    });
+
+    it("should call pushData when the toggle value changes", async () => {
+        const pushData = jest.fn();
+        createComponent({
+            properties: {},
+            pushData,
+        });
+        pushData.mockReset();
+        await act(() => userEvent.click(screen.getByRole("checkbox")));
+        expect(pushData).toHaveBeenCalledTimes(1);
+    });
+});

--- a/libs/sdk-ui-ext/src/internal/components/configurationPanels/WaterfallChartConfigurationPanel.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/configurationPanels/WaterfallChartConfigurationPanel.tsx
@@ -37,7 +37,6 @@ export default class WaterfallChartConfigurationPanel extends BaseChartConfigura
         const { properties, propertiesMeta, pushData, dataLabelDefaultValue = false } = this.props;
 
         const controlsDisabled = this.isControlDisabled();
-        const isTotalControlDisabled = controlsDisabled || this.hasTotalMeasure();
 
         return (
             <BubbleHoverTrigger showDelay={SHOW_DELAY_DEFAULT} hideDelay={HIDE_DELAY_DEFAULT}>
@@ -47,7 +46,7 @@ export default class WaterfallChartConfigurationPanel extends BaseChartConfigura
                     {this.renderLegendSection()}
 
                     <TotalSection
-                        controlsDisabled={isTotalControlDisabled}
+                        controlsDisabled={controlsDisabled}
                         properties={properties}
                         propertiesMeta={propertiesMeta}
                         pushData={pushData}
@@ -158,10 +157,5 @@ export default class WaterfallChartConfigurationPanel extends BaseChartConfigura
                 </ConfigSection>
             );
         });
-    }
-
-    private hasTotalMeasure() {
-        const { properties } = this.props;
-        return properties.controls?.total?.measures?.length > 0;
     }
 }

--- a/libs/sdk-ui-ext/src/internal/translations/en-US.json
+++ b/libs/sdk-ui-ext/src/internal/translations/en-US.json
@@ -781,6 +781,11 @@
         "comment": "",
         "limit": 0
     },
+    "properties.total.measures.tooltip": {
+        "value": "Disable “is total” options in metric to add sum of all values as a column at the end.",
+        "comment": "The tooltip for the toggle total section when there is any metric set to total metric",
+        "limit": 0
+    },
     "properties.color.total": {
         "value": "Total",
         "comment": "",

--- a/libs/sdk-ui-ext/src/locales.ts
+++ b/libs/sdk-ui-ext/src/locales.ts
@@ -189,6 +189,7 @@ export const messages: Record<string, MessageDescriptor> = defineMessages({
     totalTitle: { id: "properties.total.title" },
     totalNameLabel: { id: "properties.total.name" },
     totalToggleTooltip: { id: "properties.total.tooltip" },
+    totalMeasuresTooltip: { id: "properties.total.measures.tooltip" },
     colorTotalLabel: { id: "properties.color.total" },
     colorPositiveLabel: { id: "properties.color.positive" },
     colorNegativeLabel: { id: "properties.color.negative" },


### PR DESCRIPTION
feat: update waterfall total section
add the disable tooltip if any total measures
JIRA: EGL-55

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |
| **Compatibility matrix test commands - TIGER Backend**  |                                                            |
| `extended test - matrix-test <AIO_version>`             | Run integrated tests against AIO versions.                 |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

`<AIO_version>` in commands is used to start test with multiple AIO instances - each instance in triggered by one jenkins build

-   To run with `master` and `stable`, execute command `extended test - matrix-test master,stable` or `extended test - matrix-test latest`
-   To run with specific version,ex: `2.3.0` and `2.3.1`, execute command `extended test - matrix-test 2.3.0,2.3.1`
-   In case `<AIO_version>` is empty, read versions from file `compTigerVersions.txt` of this repo

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
