### PR TITLE
BUGFIX: EGL-88 - clear total measures array if only one metric

### DIFF
--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/waterfallChart/PluggableWaterfallChart.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/waterfallChart/PluggableWaterfallChart.tsx
@@ -263,10 +263,16 @@ export class PluggableWaterfallChart extends PluggableBaseChart {
     private setPropertiesTotalMeasures(referencePoint: IExtendedReferencePoint) {
         const { buckets, properties } = referencePoint;
         const viewItems = getViewItems(buckets);
-        const listTotalMeasures = getMeasureItems(buckets)
+        const measureItems = getMeasureItems(buckets);
+        const listTotalMeasures = measureItems
             .filter((item) => item.isTotalMeasure)
             .map((item) => item.localIdentifier);
         const existingTotalMeasures = properties?.controls?.total?.measures || [];
+
+        if (measureItems.length <= 1 && existingTotalMeasures.length > 0) {
+            // In case one view item, we need to reset the total measures is empty
+            set(referencePoint, "properties.controls.total.measures", []);
+        }
 
         if (viewItems.length > 0 || isEqual(listTotalMeasures, existingTotalMeasures)) {
             return referencePoint;

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/waterfallChart/tests/PluggableWaterfallChart.test.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/waterfallChart/tests/PluggableWaterfallChart.test.tsx
@@ -1,0 +1,220 @@
+// (C) 2023 GoodData Corporation
+import noop from "lodash/noop";
+import { dummyBackend } from "@gooddata/sdk-backend-mockingbird";
+
+import { PluggableWaterfallChart } from "../PluggableWaterfallChart";
+import * as referencePointMocks from "../../../../tests/mocks/referencePointMocks";
+import * as testMocks from "../../../../tests/mocks/testMocks";
+import { getLastRenderEl } from "../../tests/testHelpers";
+
+describe("PluggableWaterfallChart", () => {
+    const mockElement = document.createElement("div");
+    const mockConfigElement = document.createElement("div");
+    const mockRenderFun = jest.fn();
+    const executionFactory = dummyBackend().workspace("PROJECTID").execution();
+    const defaultProps = {
+        projectId: "PROJECTID",
+        element: () => mockElement,
+        configPanelElement: () => mockConfigElement,
+        callbacks: {
+            afterRender: noop,
+            pushData: noop,
+        },
+        backend: dummyBackend(),
+        visualizationProperties: {},
+        renderFun: mockRenderFun,
+    };
+
+    function createComponent(props = defaultProps) {
+        return new PluggableWaterfallChart(props);
+    }
+
+    afterEach(() => {
+        mockRenderFun.mockReset();
+    });
+
+    it("should create visualization", () => {
+        const visualization = createComponent();
+
+        expect(visualization).toBeTruthy();
+    });
+
+    it("should return reference point with multi measures", async () => {
+        const waterfall = createComponent();
+
+        const extendedReferencePoint = await waterfall.getExtendedReferencePoint(
+            referencePointMocks.multipleMetricsNoCategoriesReferencePoint,
+        );
+
+        expect(extendedReferencePoint).toMatchSnapshot();
+    });
+
+    it("should return reference point with one measure, one view attribute", async () => {
+        const waterfall = createComponent();
+
+        const extendedReferencePoint = await waterfall.getExtendedReferencePoint(
+            referencePointMocks.onePrimaryMetricAndOneViewByRefPoint,
+        );
+
+        expect(extendedReferencePoint).toMatchSnapshot();
+    });
+
+    it("should return reference point after switching from Geo Chart", async () => {
+        const waterfall = createComponent();
+
+        const extendedReferencePoint = await waterfall.getExtendedReferencePoint(
+            referencePointMocks.simpleGeoPushpinReferencePoint,
+        );
+
+        expect(extendedReferencePoint).toMatchSnapshot();
+    });
+
+    it("should accept one first attribute on the view bucket", async () => {
+        const waterfall = createComponent();
+
+        const extendedReferencePoint = await waterfall.getExtendedReferencePoint({
+            buckets: [
+                {
+                    localIdentifier: "measures",
+                    items: [referencePointMocks.masterMeasureItems[0]],
+                },
+                {
+                    localIdentifier: "view",
+                    items: referencePointMocks.attributeItems,
+                },
+            ],
+            filters: {
+                localIdentifier: "filters",
+                items: [referencePointMocks.overTimeComparisonDateItem],
+            },
+        });
+
+        expect(extendedReferencePoint.buckets).toEqual([
+            {
+                localIdentifier: "measures",
+                items: [referencePointMocks.masterMeasureItems[0]],
+            },
+            {
+                localIdentifier: "view",
+                items: [referencePointMocks.attributeItems[0]],
+            },
+        ]);
+    });
+
+    describe("Arithmetic measures", () => {
+        it("should accept AM when there are multi measures", async () => {
+            const waterfall = createComponent();
+
+            const extendedReferencePoint = await waterfall.getExtendedReferencePoint({
+                buckets: [
+                    {
+                        localIdentifier: "measures",
+                        items: [
+                            referencePointMocks.masterMeasureItems[0],
+                            referencePointMocks.masterMeasureItems[1],
+                            referencePointMocks.arithmeticMeasureItems[0],
+                        ],
+                    },
+                ],
+                filters: {
+                    localIdentifier: "filters",
+                    items: [referencePointMocks.overTimeComparisonDateItem],
+                },
+            });
+
+            expect(extendedReferencePoint.buckets).toEqual([
+                {
+                    localIdentifier: "measures",
+                    items: [
+                        referencePointMocks.masterMeasureItems[0],
+                        referencePointMocks.masterMeasureItems[1],
+                        referencePointMocks.arithmeticMeasureItems[0],
+                    ],
+                },
+                {
+                    localIdentifier: "view",
+                    items: [],
+                },
+            ]);
+        });
+    });
+
+    describe("Over Time Comparison", () => {
+        it("should return reference point containing uiConfig with no supported comparison types", async () => {
+            const component = createComponent();
+
+            const extendedReferencePoint = await component.getExtendedReferencePoint(
+                referencePointMocks.emptyReferencePoint,
+            );
+
+            expect(extendedReferencePoint.uiConfig.supportedOverTimeComparisonTypes).toEqual([]);
+        });
+    });
+
+    describe("`renderVisualization` and `renderConfigurationPanel`", () => {
+        it("should mount on the element defined by the callback", () => {
+            const visualization = createComponent();
+
+            visualization.update({}, testMocks.insightWithSingleMeasure, {}, executionFactory);
+
+            // 1st call for rendering element
+            // 2nd call for rendering config panel
+            expect(mockRenderFun).toHaveBeenCalledTimes(2);
+            expect(getLastRenderEl(mockRenderFun, mockElement)).toBeDefined();
+            expect(getLastRenderEl(mockRenderFun, mockConfigElement)).toBeDefined();
+        });
+    });
+
+    describe("total measures", () => {
+        it("should set the total measures value if there is any measure is total", async () => {
+            const waterfall = createComponent();
+
+            const extendedReferencePoint = await waterfall.getExtendedReferencePoint({
+                buckets: [
+                    {
+                        localIdentifier: "measures",
+                        items: [
+                            referencePointMocks.masterMeasureItems[0],
+                            {
+                                ...referencePointMocks.masterMeasureItems[1],
+                                isTotalMeasure: true,
+                            },
+                        ],
+                    },
+                ],
+                filters: {
+                    localIdentifier: "filters",
+                    items: [referencePointMocks.overTimeComparisonDateItem],
+                },
+            });
+
+            expect(extendedReferencePoint.properties.controls.total.measures).toEqual([
+                referencePointMocks.masterMeasureItems[1].localIdentifier,
+            ]);
+        });
+
+        it("should set the total measures value is empty if there is only one measure in the bucket items", async () => {
+            const waterfall = createComponent();
+
+            const extendedReferencePoint = await waterfall.getExtendedReferencePoint({
+                buckets: [
+                    {
+                        localIdentifier: "measures",
+                        items: [referencePointMocks.masterMeasureItems[0]],
+                    },
+                ],
+                filters: {
+                    localIdentifier: "filters",
+                    items: [referencePointMocks.overTimeComparisonDateItem],
+                },
+                properties: {
+                    controls: {
+                        total: { measures: ["m1"] },
+                    },
+                },
+            });
+
+            expect(extendedReferencePoint.properties.controls.total.measures).toEqual([]);
+        });
+    });
+});

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/waterfallChart/tests/__snapshots__/PluggableWaterfallChart.test.tsx.snap
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/waterfallChart/tests/__snapshots__/PluggableWaterfallChart.test.tsx.snap
@@ -1,0 +1,354 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PluggableWaterfallChart should return reference point after switching from Geo Chart 1`] = `
+Object {
+  "buckets": Array [
+    Object {
+      "items": Array [
+        Object {
+          "aggregation": null,
+          "attribute": "aazb6kroa3iC",
+          "localIdentifier": "m1",
+          "showInPercent": null,
+          "showOnSecondaryAxis": null,
+          "type": "metric",
+        },
+      ],
+      "localIdentifier": "measures",
+    },
+    Object {
+      "items": Array [
+        Object {
+          "aggregation": null,
+          "attribute": "attr.owner.country",
+          "dfRef": Object {
+            "uri": "/geo/attribute/displayform/uri/2",
+          },
+          "localIdentifier": "a1",
+          "locationDisplayFormRef": Object {
+            "uri": "/geo/attribute/displayform/uri/1",
+          },
+          "type": "attribute",
+        },
+      ],
+      "localIdentifier": "view",
+    },
+  ],
+  "filters": Object {
+    "items": Array [
+      Object {
+        "aggregation": null,
+        "attribute": "attr.owner.country",
+        "filters": Array [
+          Object {
+            "attribute": "attr.owner.country",
+            "displayFormRef": Object {
+              "uri": "owner/attribute/df/uri",
+            },
+            "isInverted": false,
+            "selectedElements": Array [
+              Object {
+                "title": "string",
+                "uri": "string",
+              },
+            ],
+            "totalElementsCount": 10,
+          },
+        ],
+        "localIdentifier": "a1",
+        "type": "attribute",
+      },
+    ],
+    "localIdentifier": "filters",
+  },
+  "properties": Object {},
+  "uiConfig": Object {
+    "buckets": Object {
+      "filters": Object {
+        "accepts": Array [
+          "attribute",
+          "date",
+        ],
+        "allowsReordering": false,
+        "enabled": true,
+        "isShowInPercentEnabled": false,
+        "itemsLimit": 20,
+        "itemsLimitByType": Object {
+          "date": 1,
+        },
+      },
+      "measures": Object {
+        "accepts": Array [
+          "metric",
+          "fact",
+          "attribute",
+        ],
+        "allowsDuplicateItems": true,
+        "allowsReordering": false,
+        "allowsSwapping": true,
+        "canAddItems": true,
+        "enabled": true,
+        "icon": "local:waterfall/bucket-title-measures.svg",
+        "isShowInPercentEnabled": true,
+        "isShowInPercentVisible": true,
+        "isTotalMeasureEnabled": false,
+        "isTotalMeasureVisible": true,
+        "itemsLimit": 1,
+        "title": "Measures",
+      },
+      "view": Object {
+        "accepts": Array [
+          "attribute",
+          "date",
+        ],
+        "allowsReordering": false,
+        "allowsSwapping": true,
+        "canAddItems": true,
+        "enabled": true,
+        "icon": "local:waterfall/bucket-title-view.svg",
+        "isShowInPercentEnabled": false,
+        "itemsLimit": 1,
+        "itemsLimitByType": Object {
+          "date": 1,
+        },
+        "title": "View by",
+      },
+    },
+    "exportConfig": Object {
+      "supported": true,
+    },
+    "openAsReport": Object {
+      "supported": true,
+    },
+    "optionalStacking": Object {
+      "stackMeasures": false,
+      "supported": true,
+    },
+    "recommendations": Object {},
+    "supportedOverTimeComparisonTypes": Array [],
+  },
+}
+`;
+
+exports[`PluggableWaterfallChart should return reference point with multi measures 1`] = `
+Object {
+  "buckets": Array [
+    Object {
+      "items": Array [
+        Object {
+          "aggregation": null,
+          "attribute": "aazb6kroa3iC",
+          "localIdentifier": "m1",
+          "showInPercent": null,
+          "showOnSecondaryAxis": null,
+          "type": "metric",
+        },
+        Object {
+          "aggregation": null,
+          "attribute": "af2Ewj9Re2vK",
+          "localIdentifier": "m2",
+          "showInPercent": null,
+          "showOnSecondaryAxis": null,
+          "type": "metric",
+        },
+        Object {
+          "aggregation": null,
+          "attribute": "dt.opportunitysnapshot.snapshotdate",
+          "localIdentifier": "m3",
+          "showInPercent": null,
+          "showOnSecondaryAxis": true,
+          "type": "metric",
+        },
+        Object {
+          "aggregation": null,
+          "attribute": "acfWntEMcom0",
+          "localIdentifier": "m4",
+          "showInPercent": null,
+          "showOnSecondaryAxis": true,
+          "type": "metric",
+        },
+      ],
+      "localIdentifier": "measures",
+    },
+    Object {
+      "items": Array [],
+      "localIdentifier": "view",
+    },
+  ],
+  "filters": Object {
+    "items": Array [],
+    "localIdentifier": "filters",
+  },
+  "properties": Object {},
+  "uiConfig": Object {
+    "buckets": Object {
+      "filters": Object {
+        "accepts": Array [
+          "attribute",
+          "date",
+        ],
+        "allowsReordering": false,
+        "enabled": true,
+        "isShowInPercentEnabled": false,
+        "itemsLimit": 20,
+        "itemsLimitByType": Object {
+          "date": 1,
+        },
+      },
+      "measures": Object {
+        "accepts": Array [
+          "metric",
+          "fact",
+          "attribute",
+        ],
+        "allowsDuplicateItems": true,
+        "allowsReordering": true,
+        "allowsSwapping": true,
+        "canAddItems": true,
+        "enabled": true,
+        "icon": "local:waterfall/bucket-title-measures.svg",
+        "isShowInPercentEnabled": false,
+        "isShowInPercentVisible": true,
+        "isTotalMeasureEnabled": true,
+        "isTotalMeasureVisible": true,
+        "itemsLimit": 20,
+        "title": "Measures",
+      },
+      "view": Object {
+        "accepts": Array [
+          "attribute",
+          "date",
+        ],
+        "allowsReordering": false,
+        "allowsSwapping": true,
+        "canAddItems": false,
+        "enabled": true,
+        "icon": "local:waterfall/bucket-title-view.svg",
+        "isShowInPercentEnabled": false,
+        "itemsLimit": 0,
+        "itemsLimitByType": Object {
+          "date": 1,
+        },
+        "title": "View by",
+        "warningMessage": "To view by, an insight can have only one measure",
+      },
+    },
+    "exportConfig": Object {
+      "supported": true,
+    },
+    "openAsReport": Object {
+      "supported": true,
+    },
+    "optionalStacking": Object {
+      "stackMeasures": false,
+      "supported": true,
+    },
+    "recommendations": Object {},
+    "supportedOverTimeComparisonTypes": Array [],
+  },
+}
+`;
+
+exports[`PluggableWaterfallChart should return reference point with one measure, one view attribute 1`] = `
+Object {
+  "buckets": Array [
+    Object {
+      "items": Array [
+        Object {
+          "aggregation": null,
+          "attribute": "aazb6kroa3iC",
+          "localIdentifier": "m1",
+          "showInPercent": null,
+          "showOnSecondaryAxis": null,
+          "type": "metric",
+        },
+      ],
+      "localIdentifier": "measures",
+    },
+    Object {
+      "items": Array [
+        Object {
+          "aggregation": null,
+          "attribute": "attr.owner.department",
+          "dfRef": Object {
+            "uri": "a1/df",
+          },
+          "localIdentifier": "a1",
+          "type": "attribute",
+        },
+      ],
+      "localIdentifier": "view",
+    },
+  ],
+  "filters": Object {
+    "items": Array [],
+    "localIdentifier": "filters",
+  },
+  "properties": Object {},
+  "uiConfig": Object {
+    "buckets": Object {
+      "filters": Object {
+        "accepts": Array [
+          "attribute",
+          "date",
+        ],
+        "allowsReordering": false,
+        "enabled": true,
+        "isShowInPercentEnabled": false,
+        "itemsLimit": 20,
+        "itemsLimitByType": Object {
+          "date": 1,
+        },
+      },
+      "measures": Object {
+        "accepts": Array [
+          "metric",
+          "fact",
+          "attribute",
+        ],
+        "allowsDuplicateItems": true,
+        "allowsReordering": false,
+        "allowsSwapping": true,
+        "canAddItems": true,
+        "enabled": true,
+        "icon": "local:waterfall/bucket-title-measures.svg",
+        "isShowInPercentEnabled": true,
+        "isShowInPercentVisible": true,
+        "isTotalMeasureEnabled": false,
+        "isTotalMeasureVisible": true,
+        "itemsLimit": 1,
+        "title": "Measures",
+      },
+      "view": Object {
+        "accepts": Array [
+          "attribute",
+          "date",
+        ],
+        "allowsReordering": false,
+        "allowsSwapping": true,
+        "canAddItems": true,
+        "enabled": true,
+        "icon": "local:waterfall/bucket-title-view.svg",
+        "isShowInPercentEnabled": false,
+        "itemsLimit": 1,
+        "itemsLimitByType": Object {
+          "date": 1,
+        },
+        "title": "View by",
+      },
+    },
+    "exportConfig": Object {
+      "supported": true,
+    },
+    "openAsReport": Object {
+      "supported": true,
+    },
+    "optionalStacking": Object {
+      "stackMeasures": false,
+      "supported": true,
+    },
+    "recommendations": Object {},
+    "supportedOverTimeComparisonTypes": Array [],
+  },
+}
+`;


### PR DESCRIPTION
fix: clear total measures array if only one metric
JIRA: EGL-88

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |
| **Compatibility matrix test commands - TIGER Backend**  |                                                            |
| `extended test - matrix-test <AIO_version>`             | Run integrated tests against AIO versions.                 |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

`<AIO_version>` in commands is used to start test with multiple AIO instances - each instance in triggered by one jenkins build

-   To run with `master` and `stable`, execute command `extended test - matrix-test master,stable` or `extended test - matrix-test latest`
-   To run with specific version,ex: `2.3.0` and `2.3.1`, execute command `extended test - matrix-test 2.3.0,2.3.1`
-   In case `<AIO_version>` is empty, read versions from file `compTigerVersions.txt` of this repo

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
