### PR TITLE
BUGFIX: TNT-1570 Map new column total headers to correct measure

### DIFF
--- a/libs/sdk-backend-bear/src/backend/workspace/execution/executionResult.ts
+++ b/libs/sdk-backend-bear/src/backend/workspace/execution/executionResult.ts
@@ -175,6 +175,13 @@ function preprocessTotalHeaderItems(
     const measures = bucketsMeasures(buckets);
     const columns = bucketsFind(buckets, "columns")?.items || [];
     const columnIdentifiers = columns.map((item) => isAttribute(item) && item.attribute?.localIdentifier);
+    const measuresIdentifiers = measures.map((m) => m.measure.localIdentifier);
+
+    columnTotals.sort(
+        (a, b) =>
+            measuresIdentifiers.indexOf(a.measureIdentifier) -
+            measuresIdentifiers.indexOf(b.measureIdentifier),
+    );
 
     const lookups = columnTotals
         .filter((total) => {
@@ -183,6 +190,8 @@ function preprocessTotalHeaderItems(
         .map((total) => {
             return measures.findIndex((m) => m.measure?.localIdentifier === total.measureIdentifier);
         });
+
+    const uniqueLookups = lookups.filter((lookup, index) => lookups.indexOf(lookup) === index);
 
     return headerItems.map((topHeaderItems) => {
         return topHeaderItems.map((items) => {
@@ -195,7 +204,7 @@ function preprocessTotalHeaderItems(
                             ...item,
                             totalHeaderItem: {
                                 ...item?.totalHeaderItem,
-                                measureIndex: lookups[count % lookups.length],
+                                measureIndex: uniqueLookups[count % uniqueLookups.length],
                             },
                         };
 


### PR DESCRIPTION
Map new totalHeaderItems from columns with correct measureIndex, to display correct title.
Adjust new totals definitions according with measures bucket order.

JIRA: TNT-1570

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |
| **Compatibility matrix test commands - TIGER Backend**  |                                                            |
| `extended test - matrix-test <AIO_version>`             | Run integrated tests against AIO versions.                 |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

`<AIO_version>` in commands is used to start test with multiple AIO instances - each instance in triggered by one jenkins build

-   To run with `master` and `stable`, execute command `extended test - matrix-test master,stable` or `extended test - matrix-test latest`
-   To run with specific version,ex: `2.3.0` and `2.3.1`, execute command `extended test - matrix-test 2.3.0,2.3.1`
-   In case `<AIO_version>` is empty, read versions from file `compTigerVersions.txt` of this repo

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
