### PR TITLE
FEATURE: QA-18623 PoC automation for new boiler app

### DIFF
--- a/common/scripts/ci/run_boiler_app_integration_tests_with_live_backend.sh
+++ b/common/scripts/ci/run_boiler_app_integration_tests_with_live_backend.sh
@@ -1,0 +1,54 @@
+#!/bin/bash -i
+set -ex
+
+: "${HOST:?}"
+: "${SDK_BACKEND:?}"
+: "${SDK_VERSION:?}"
+if [[ "$SDK_BACKEND" == 'BEAR' ]]; then
+    : "${USER_NAME:?}"
+fi
+
+export BOILER_APP_NAME=new-boiler-app-$SDK_LANG
+export BOILER_APP_VERSION=app-toolkit@$SDK_VERSION
+export BOILER_APP_HOST=https://127.0.0.1:8080
+CYPRESS_IMAGE='cypress/included:12.10.0'
+
+DIR=$(echo $(cd $(dirname "${BASH_SOURCE[0]}") && pwd -P))
+ROOT_DIR=$(echo $(cd $(dirname "${BASH_SOURCE[0]}")/../../../ && pwd -P))
+E2E_TEST_DIR=$ROOT_DIR/libs/sdk-ui-tests-e2e
+_RUSH="${DIR}/docker_rush.sh"
+_RUSHX="${DIR}/docker_rushx.sh"
+export sdk_backend=$(tr <<< "${SDK_BACKEND:?}" '[:upper:]' '[:lower:]')
+
+if [[ ! "${HOST:?}" =~ https?:// ]]; then
+    export HOST="https://${HOST}"
+fi
+
+pushd $E2E_TEST_DIR
+cat > .env <<-EOF
+SDK_BACKEND=${SDK_BACKEND:-TIGER}
+HOST=${HOST:-}
+CYPRESS_TEST_TAGS=checklist_integrated_${sdk_backend}
+FIXTURE_TYPE=${FIXTURE_TYPE:-}
+FILTER=${FILTER:-}
+TIGER_DATASOURCES_NAME=${TIGER_DATASOURCES_NAME:?}
+EOF
+
+$_RUSH install
+$_RUSH build -t sdk-ui-tests-e2e
+trap "docker rmi --force $CYPRESS_IMAGE || true" EXIT
+
+docker run --rm --entrypoint '' \
+-e BOILER_APP_NAME \
+-e BOILER_APP_VERSION \
+-e SDK_LANG \
+-e BOILER_APP_HOST \
+-e VISUAL_MODE=false \
+-e HOST \
+-e TIGER_API_TOKEN \
+-e sdk_backend \
+-e USER_NAME \
+-e PASSWORD \
+-e AUTH_TOKEN \
+-w /workspace/libs/sdk-ui-tests-e2e -v $ROOT_DIR:/workspace $CYPRESS_IMAGE \
+sh -c "./scripts/run_boiler_app.sh" || exit 1

--- a/common/scripts/ci/utils.sh
+++ b/common/scripts/ci/utils.sh
@@ -31,3 +31,21 @@ function get_release_commit_hash {
 
   echo $(git log --grep "^Release $version\$" | sed 's/commit //g' | head -1)
 }
+
+log() {
+  local now;
+  now=$(date '+%Y-%m-%d %H:%M:%S')
+  echo "$now $*" 1>&2
+}
+
+health_check() {
+  for ((i = 1; i <= 50; i++)); do
+    log "Check $1 is up, try $i"
+    if curl -k "$1" ; then
+      return 0
+    else
+      sleep 3
+    fi
+  done
+  return 1
+}

--- a/libs/sdk-ui-tests-e2e/cypress/integration/03-sdk-ui-charts/boilerapp.spec.ts
+++ b/libs/sdk-ui-tests-e2e/cypress/integration/03-sdk-ui-charts/boilerapp.spec.ts
@@ -1,0 +1,21 @@
+// (C) 2023 GoodData Corporation
+import * as Navigation from "../../tools/navigation";
+import { Headline } from "../../tools/headline";
+import { getBackend } from "../../support/constants";
+
+describe("Boiler app Chart", () => {
+    beforeEach(() => {
+        Navigation.visitBoilerApp();
+    });
+
+    it(
+        `check boiler app tiger`,
+        { tags: ["checklist_integrated_tiger", "checklist_integrated_bear"] },
+        () => {
+            const headline = new Headline(".insight-view-container .headline");
+            headline.waitLoaded();
+            if (getBackend() === "BEAR") headline.hasValue("$116,625,456.54");
+            else headline.hasValue("35,844,132");
+        },
+    );
+});

--- a/libs/sdk-ui-tests-e2e/cypress/tools/navigation.ts
+++ b/libs/sdk-ui-tests-e2e/cypress/tools/navigation.ts
@@ -1,6 +1,6 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2023 GoodData Corporation
 import { ISettings } from "@gooddata/sdk-model";
-import { getHost } from "../support/constants";
+import { getHost, getBackend, getUserName, getPassword } from "../support/constants";
 import VisitOptions = Cypress.VisitOptions;
 import { DashboardMenu } from "./dashboardMenu";
 
@@ -12,6 +12,7 @@ declare global {
 
 const VISIT_TIMEOUT = 40000;
 const CONFIRM_BUTTON = ".s-create_dashboard";
+const boilerAppHost = "https://127.0.0.1:8080";
 
 function getDashboardUrl() {
     return `${getHost()}`;
@@ -31,6 +32,19 @@ export function visit(componentName: string, workspaceSettings?: ISettings): voi
             win["customWorkspaceSettings"] = workspaceSettings;
         },
     });
+}
+
+export function visitBoilerApp(workspaceSettings?: ISettings): void {
+    visitUrl(`${boilerAppHost}`, {
+        onBeforeLoad(win: Cypress.AUTWindow) {
+            win["customWorkspaceSettings"] = workspaceSettings;
+        },
+    });
+    if (getBackend() === "BEAR") {
+        cy.get(".s-login-login").type(getUserName());
+        cy.get(".s-login-password").type(getPassword());
+        cy.get(".s-login-button").click();
+    }
 }
 
 export function visitCopyOf(componentName: string) {

--- a/libs/sdk-ui-tests-e2e/scripts/backend_bear.template
+++ b/libs/sdk-ui-tests-e2e/scripts/backend_bear.template
@@ -1,0 +1,15 @@
+// (C) 2023 GoodData Corporation
+
+import { withCaching, RecommendedCachingConfiguration } from "@gooddata/sdk-backend-base";
+import backendFactory, { ContextDeferredAuthProvider } from "@gooddata/sdk-backend-bear";
+
+export const backend = withCaching(
+    backendFactory().withAuthentication(
+        new ContextDeferredAuthProvider(() => {
+            window.location.replace(
+                `${window.location.origin}/account.html?lastUrl=${encodeURIComponent(window.location.href)}`,
+            );
+        }),
+    ),
+    RecommendedCachingConfiguration,
+);

--- a/libs/sdk-ui-tests-e2e/scripts/run_boiler_app.sh
+++ b/libs/sdk-ui-tests-e2e/scripts/run_boiler_app.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# (C) 2023 GoodData Corporation
+set -e
+
+source /workspace/common/scripts/ci/utils.sh
+
+trap "npm run delete-ref-workspace || true" EXIT
+
+npm run create-ref-workspace
+export TEST_WORKSPACE_ID=$(grep TEST_WORKSPACE_ID .env | cut -d '=' -f 2)
+
+apt-get update && apt-get install -y curl jq sed && apt-get clean
+
+npx --yes @gooddata/$BOILER_APP_VERSION init $BOILER_APP_NAME --language $SDK_LANG
+
+tmp=$(mktemp)
+jq --arg host "${HOST}" --arg ws "${TEST_WORKSPACE_ID}" --arg backend "${sdk_backend}" \
+'.gooddata.hostname = $host | .gooddata.workspaceId = $ws | .gooddata.backend = $backend' \
+$BOILER_APP_NAME/package.json > $tmp
+mv $tmp $BOILER_APP_NAME/package.json
+
+if [[ "$sdk_backend" == 'bear' ]]; then
+    export GDC_USERNAME=${USER_NAME:?}
+    export GDC_PASSWORD=${PASSWORD:?}
+    cp -fr ./scripts/backend_bear.template $BOILER_APP_NAME/src/backend.${SDK_LANG}
+else
+    export TIGER_API_TOKEN=${TIGER_API_TOKEN:?}
+fi
+
+sed -i 's/ProductCategoriesPieChart/Headline/g' $BOILER_APP_NAME/src/App.${SDK_LANG}x
+
+npm run --prefix $BOILER_APP_NAME refresh-md
+npm run --prefix $BOILER_APP_NAME start &
+
+if ! health_check $BOILER_APP_HOST; then
+    log "Can't run test, Boiler app are not ready"
+    exit 1
+fi
+
+npm run run-integrated
+npm run delete-ref-workspace


### PR DESCRIPTION
JIRA: QA-18623

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |
| **Compatibility matrix test commands - TIGER Backend**  |                                                            |
| `extended test - matrix-test <AIO_version>`             | Run integrated tests against AIO versions.                 |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

`<AIO_version>` in commands is used to start test with multiple AIO instances - each instance in triggered by one jenkins build

-   To run with `master` and `stable`, execute command `extended test - matrix-test master,stable` or `extended test - matrix-test latest`
-   To run with specific version,ex: `2.3.0` and `2.3.1`, execute command `extended test - matrix-test 2.3.0,2.3.1`
-   In case `<AIO_version>` is empty, read versions from file `compTigerVersions.txt` of this repo

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
