### PR TITLE
BUGFIX: EGL-103 - waterfall tooltip displays wrong text

### DIFF
--- a/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartOptions/chartTooltips.ts
+++ b/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartOptions/chartTooltips.ts
@@ -344,9 +344,10 @@ export function getTooltipWaterfallChart(
         percentageValue?: number,
     ): string => {
         const formattedValue = getFormattedValueForTooltip(false, false, point, separators, percentageValue);
-        const textData = [[customEscape(point.name), formattedValue]];
+        const isNormalDataPoint = viewByAttribute && !point?.isSum;
+        const textData = [[customEscape(isNormalDataPoint ? point.series.name : point.name), formattedValue]];
 
-        if (viewByAttribute && !point?.isSum) {
+        if (isNormalDataPoint) {
             textData.unshift([
                 customEscape(viewByAttribute.formOf.name),
                 customEscape(point.category?.name || point.name),

--- a/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartOptions/test/__snapshots__/chartTooltips.test.ts.snap
+++ b/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartOptions/test/__snapshots__/chartTooltips.test.ts.snap
@@ -1,0 +1,58 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`chartTooltips getTooltipWaterfallChart should render the tooltip for normal data point when only metrics with the expected format 1`] = `
+"<div class=\\"gd-viz-tooltip-item gd-multiline-supported\\">
+                        <span class=\\"gd-viz-tooltip-title\\" style=\\"max-width: 300px;\\">Grants</span>
+                        <div class=\\"gd-viz-tooltip-value-wraper\\" style=\\"max-width: 300px;\\">
+                            <span class=\\"gd-viz-tooltip-value gd-clamp-two-line\\" style=\\"max-width: 300px;\\">553,495,299</span>
+                        </div>
+                        <div class=\\"gd-viz-tooltip-value-wraper\\" style=\\"max-width: 300px;\\">
+                            <span class=\\"gd-viz-tooltip-value-max-content\\" style=\\"max-width: 300px;\\">553,495,299</span>
+                        </div>
+                    </div>"
+`;
+
+exports[`chartTooltips getTooltipWaterfallChart should render the tooltip for normal data point with the expected format 1`] = `
+"<div class=\\"gd-viz-tooltip-item gd-multiline-supported\\">
+                        <span class=\\"gd-viz-tooltip-title\\" style=\\"max-width: 300px;\\">Stage Name</span>
+                        <div class=\\"gd-viz-tooltip-value-wraper\\" style=\\"max-width: 300px;\\">
+                            <span class=\\"gd-viz-tooltip-value gd-clamp-two-line\\" style=\\"max-width: 300px;\\">Grants</span>
+                        </div>
+                        <div class=\\"gd-viz-tooltip-value-wraper\\" style=\\"max-width: 300px;\\">
+                            <span class=\\"gd-viz-tooltip-value-max-content\\" style=\\"max-width: 300px;\\">Grants</span>
+                        </div>
+                    </div>
+<div class=\\"gd-viz-tooltip-item gd-multiline-supported\\">
+                        <span class=\\"gd-viz-tooltip-title\\" style=\\"max-width: 300px;\\">Sum of Amount</span>
+                        <div class=\\"gd-viz-tooltip-value-wraper\\" style=\\"max-width: 300px;\\">
+                            <span class=\\"gd-viz-tooltip-value gd-clamp-two-line\\" style=\\"max-width: 300px;\\">553,495,299</span>
+                        </div>
+                        <div class=\\"gd-viz-tooltip-value-wraper\\" style=\\"max-width: 300px;\\">
+                            <span class=\\"gd-viz-tooltip-value-max-content\\" style=\\"max-width: 300px;\\">553,495,299</span>
+                        </div>
+                    </div>"
+`;
+
+exports[`chartTooltips getTooltipWaterfallChart should render the tooltip for total data point when only metrics with the expected format 1`] = `
+"<div class=\\"gd-viz-tooltip-item gd-multiline-supported\\">
+                        <span class=\\"gd-viz-tooltip-title\\" style=\\"max-width: 300px;\\">Total</span>
+                        <div class=\\"gd-viz-tooltip-value-wraper\\" style=\\"max-width: 300px;\\">
+                            <span class=\\"gd-viz-tooltip-value gd-clamp-two-line\\" style=\\"max-width: 300px;\\">553,495,299</span>
+                        </div>
+                        <div class=\\"gd-viz-tooltip-value-wraper\\" style=\\"max-width: 300px;\\">
+                            <span class=\\"gd-viz-tooltip-value-max-content\\" style=\\"max-width: 300px;\\">553,495,299</span>
+                        </div>
+                    </div>"
+`;
+
+exports[`chartTooltips getTooltipWaterfallChart should render the tooltip for total data point with the expected format 1`] = `
+"<div class=\\"gd-viz-tooltip-item gd-multiline-supported\\">
+                        <span class=\\"gd-viz-tooltip-title\\" style=\\"max-width: 300px;\\">Total</span>
+                        <div class=\\"gd-viz-tooltip-value-wraper\\" style=\\"max-width: 300px;\\">
+                            <span class=\\"gd-viz-tooltip-value gd-clamp-two-line\\" style=\\"max-width: 300px;\\">553,495,299</span>
+                        </div>
+                        <div class=\\"gd-viz-tooltip-value-wraper\\" style=\\"max-width: 300px;\\">
+                            <span class=\\"gd-viz-tooltip-value-max-content\\" style=\\"max-width: 300px;\\">553,495,299</span>
+                        </div>
+                    </div>"
+`;

--- a/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartOptions/test/chartTooltips.test.ts
+++ b/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartOptions/test/chartTooltips.test.ts
@@ -1,0 +1,92 @@
+// (C) 2023 GoodData Corporation
+import { ReferenceRecordings } from "@gooddata/reference-workspace";
+
+import { getTooltipWaterfallChart } from "../chartTooltips";
+import { recordedDataFacade } from "../../../../../__mocks__/recordings";
+import { getMVS } from "../../_util/test/helper";
+import { IChartConfig } from "../../../../interfaces";
+import { IUnsafeHighchartsTooltipPoint } from "../../../../highcharts/typings/unsafe";
+
+describe("chartTooltips", () => {
+    describe("getTooltipWaterfallChart", () => {
+        const chartConfig: Partial<IChartConfig> = {
+            separators: {
+                decimal: ".",
+                thousand: ",",
+            },
+        };
+        const normalDataPoint: Partial<IUnsafeHighchartsTooltipPoint> = {
+            color: "rgb(0,193,141)",
+            borderColor: "rgb(0,193,141)",
+            id: "highcharts-h5pzvxn-64",
+            name: "Grants",
+            format: "#,##0",
+            y: 553495299,
+            series: {
+                name: "Sum of Amount",
+            },
+        };
+
+        const totalDataPoint: Partial<IUnsafeHighchartsTooltipPoint> = {
+            color: "rgb(136,219,244)",
+            borderColor: "rgb(136,219,244)",
+            id: "highcharts-h5pzvxn-45",
+            name: "Total",
+            format: "#,##0",
+            y: 553495299,
+            isSum: true,
+            series: {
+                name: "Sum of Amount",
+            },
+        };
+        const maxItemWidth = 320;
+
+        it("should render the tooltip for normal data point with the expected format", () => {
+            const dv = recordedDataFacade(
+                ReferenceRecordings.Scenarios.WaterfallChart.SingleMeasureWithViewBy,
+            );
+            const { viewByAttribute } = getMVS(dv);
+            const tooltipRenderer = getTooltipWaterfallChart(viewByAttribute, chartConfig);
+            const tooltipContent = tooltipRenderer(normalDataPoint, maxItemWidth, undefined);
+
+            expect(tooltipContent).toMatchSnapshot();
+            expect(tooltipContent).toContain(normalDataPoint.series.name);
+            expect(tooltipContent).toContain(normalDataPoint.name);
+        });
+
+        it("should render the tooltip for total data point with the expected format", () => {
+            const dv = recordedDataFacade(
+                ReferenceRecordings.Scenarios.WaterfallChart.SingleMeasureWithViewBy,
+            );
+            const { viewByAttribute } = getMVS(dv);
+            const tooltipRenderer = getTooltipWaterfallChart(viewByAttribute, chartConfig);
+            const tooltipContent = tooltipRenderer(totalDataPoint, maxItemWidth, undefined);
+
+            expect(tooltipContent).toMatchSnapshot();
+            expect(tooltipContent).not.toContain(totalDataPoint.series.name);
+            expect(tooltipContent).toContain(totalDataPoint.name);
+        });
+
+        it("should render the tooltip for normal data point when only metrics with the expected format", () => {
+            const dv = recordedDataFacade(ReferenceRecordings.Scenarios.WaterfallChart.MultiMeasures);
+            const { viewByAttribute } = getMVS(dv);
+            const tooltipRenderer = getTooltipWaterfallChart(viewByAttribute, chartConfig);
+            const tooltipContent = tooltipRenderer(normalDataPoint, maxItemWidth, undefined);
+
+            expect(tooltipContent).toMatchSnapshot();
+            expect(tooltipContent).not.toContain(normalDataPoint.series.name);
+            expect(tooltipContent).toContain(normalDataPoint.name);
+        });
+
+        it("should render the tooltip for total data point when only metrics with the expected format", () => {
+            const dv = recordedDataFacade(ReferenceRecordings.Scenarios.WaterfallChart.MultiMeasures);
+            const { viewByAttribute } = getMVS(dv);
+            const tooltipRenderer = getTooltipWaterfallChart(viewByAttribute, chartConfig);
+            const tooltipContent = tooltipRenderer(totalDataPoint, maxItemWidth, undefined);
+
+            expect(tooltipContent).toMatchSnapshot();
+            expect(tooltipContent).not.toContain(totalDataPoint.series.name);
+            expect(tooltipContent).toContain(totalDataPoint.name);
+        });
+    });
+});


### PR DESCRIPTION
fix: waterfall tooltip displays wrong text
JIRA: EGL-103

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |
| **Compatibility matrix test commands - TIGER Backend**  |                                                            |
| `extended test - matrix-test <AIO_version>`             | Run integrated tests against AIO versions.                 |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

`<AIO_version>` in commands is used to start test with multiple AIO instances - each instance in triggered by one jenkins build

-   To run with `master` and `stable`, execute command `extended test - matrix-test master,stable` or `extended test - matrix-test latest`
-   To run with specific version,ex: `2.3.0` and `2.3.1`, execute command `extended test - matrix-test 2.3.0,2.3.1`
-   In case `<AIO_version>` is empty, read versions from file `compTigerVersions.txt` of this repo

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
