### PR TITLE
BUGFIX: TNT-1580 new total columns group resizing

### DIFF
--- a/libs/sdk-ui-pivot/src/impl/base/agUtils.ts
+++ b/libs/sdk-ui-pivot/src/impl/base/agUtils.ts
@@ -1,6 +1,6 @@
 // (C) 2007-2022 GoodData Corporation
 import { ColDef, Column, ColumnResizedEvent } from "@ag-grid-community/all-modules";
-import { MEASURE_COLUMN } from "./constants";
+import { MEASURE_COLUMN, COLUMN_TOTAL, COLUMN_SUBTOTAL } from "./constants";
 import { agColId } from "../structure/tableDescriptorTypes";
 import { ColumnEventSourceType } from "../../columnWidths";
 
@@ -21,6 +21,12 @@ export function isMeasureColumn(item: Column | ColDef): boolean {
         return item.getColDef().type === MEASURE_COLUMN;
     }
     return item.type === MEASURE_COLUMN;
+}
+
+export function isMeasureOrAnyColumnTotal(item: Column): boolean {
+    const type = item.getColDef().type;
+
+    return type === MEASURE_COLUMN || type === COLUMN_TOTAL || type === COLUMN_SUBTOTAL;
 }
 
 export function agColIds(columns: Column[]): string[] {

--- a/libs/sdk-ui-pivot/src/impl/resizing/columnSizing.ts
+++ b/libs/sdk-ui-pivot/src/impl/resizing/columnSizing.ts
@@ -3,7 +3,7 @@ import invariant, { InvariantError } from "ts-invariant";
 import omit from "lodash/omit";
 import omitBy from "lodash/omitBy";
 import chunk from "lodash/chunk";
-import { isMeasureColumn } from "../base/agUtils";
+import { isMeasureColumn, isMeasureOrAnyColumnTotal } from "../base/agUtils";
 import {
     COLUMN_SUBTOTAL_CLASS,
     DEFAULT_HEADER_FONT,
@@ -639,7 +639,7 @@ export function resizeAllMeasuresColumns(
     const columnWidth = column.getActualWidth();
     const allColumns = columnApi.getAllColumns();
 
-    const resizeData = allColumns?.filter(isMeasureColumn).map((col): ColumnsResizeSpec => {
+    const resizeData = allColumns?.filter(isMeasureOrAnyColumnTotal).map((col): ColumnsResizeSpec => {
         return {
             key: col,
             newWidth: columnWidth,


### PR DESCRIPTION
Treat new column totals/subtotals same way as measures when manual resizing.
<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |
| **Compatibility matrix test commands - TIGER Backend**  |                                                            |
| `extended test - matrix-test <AIO_version>`             | Run integrated tests against AIO versions.                 |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

`<AIO_version>` in commands is used to start test with multiple AIO instances - each instance in triggered by one jenkins build

-   To run with `master` and `stable`, execute command `extended test - matrix-test master,stable` or `extended test - matrix-test latest`
-   To run with specific version,ex: `2.3.0` and `2.3.1`, execute command `extended test - matrix-test 2.3.0,2.3.1`
-   In case `<AIO_version>` is empty, read versions from file `compTigerVersions.txt` of this repo

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
