### PR TITLE
RELATED: CAL-923 use organizationId in FF context

### DIFF
--- a/libs/api-client-tiger/api/api-client-tiger.api.md
+++ b/libs/api-client-tiger/api/api-client-tiger.api.md
@@ -5053,6 +5053,7 @@ export interface FactsApiInterface {
 
 // @public (undocumented)
 export type FeatureContext = {
+    organizationId: string;
     earlyAccess: string;
 };
 

--- a/libs/api-client-tiger/src/profile.ts
+++ b/libs/api-client-tiger/src/profile.ts
@@ -2,6 +2,7 @@
 import { AxiosInstance } from "axios";
 
 export type FeatureContext = {
+    organizationId: string;
     earlyAccess: string;
 };
 

--- a/libs/sdk-backend-tiger/src/backend/features/index.ts
+++ b/libs/sdk-backend-tiger/src/backend/features/index.ts
@@ -55,11 +55,18 @@ function featuresAreStatic(item: any): item is IStaticFeatures {
     return Boolean(item?.static);
 }
 
-export function pickContext(attributes: JsonApiWorkspaceInAttributes | undefined): Partial<FeatureContext> {
+export function pickContext(
+    attributes: JsonApiWorkspaceInAttributes | undefined,
+    organizationId: string | undefined,
+): Partial<FeatureContext> {
     const context: Partial<FeatureContext> = {};
 
-    if (attributes?.["earlyAccess"] !== undefined) {
-        context.earlyAccess = attributes["earlyAccess"];
+    if (attributes?.earlyAccess !== undefined) {
+        context.earlyAccess = attributes.earlyAccess;
+    }
+
+    if (organizationId !== undefined) {
+        context.organizationId = organizationId;
     }
     return context;
 }

--- a/libs/sdk-backend-tiger/src/backend/features/test/hub.test.ts
+++ b/libs/sdk-backend-tiger/src/backend/features/test/hub.test.ts
@@ -10,8 +10,8 @@ import { describe, expect, it, vi } from "vitest";
 const axiosGetSpy = vi.spyOn(axios, "get");
 
 describe("live features", () => {
-    function createFeatures(earlyAccess = ""): ILiveFeatures["live"] {
-        return { configuration: { host: "/", key: "" }, context: { earlyAccess } };
+    function createFeatures(earlyAccess = "", organizationId = ""): ILiveFeatures["live"] {
+        return { configuration: { host: "/", key: "" }, context: { earlyAccess, organizationId } };
     }
 
     function createFeature(key: string, type: FeatureDef["type"], value: any): FeatureDef {
@@ -47,7 +47,7 @@ describe("live features", () => {
             baseURL: "/",
             headers: {
                 "Content-type": "application/json",
-                "X-FeatureHub": "earlyAccess=",
+                "X-FeatureHub": "earlyAccess=,organizationId=",
             },
             method: "GET",
             params: { sdkUrl: "" },
@@ -59,12 +59,12 @@ describe("live features", () => {
     it("call axios with ws context", async () => {
         mockReturn([]);
 
-        await getFeatureHubFeatures(createFeatures(), pickContext({ earlyAccess: "omega" }));
+        await getFeatureHubFeatures(createFeatures(), pickContext({ earlyAccess: "omega" }, "test-org"));
         expect(axiosGetSpy).toHaveBeenCalledWith("/features", {
             baseURL: "/",
             headers: {
                 "Content-type": "application/json",
-                "X-FeatureHub": "earlyAccess=omega",
+                "X-FeatureHub": "earlyAccess=omega,organizationId=test-org",
                 "if-none-match": expect.anything(),
             },
             method: "GET",
@@ -77,12 +77,12 @@ describe("live features", () => {
     it("call axios with context filled", async () => {
         mockReturn([]);
 
-        await getFeatureHubFeatures(createFeatures("beta"));
+        await getFeatureHubFeatures(createFeatures("beta", "org"));
         expect(axiosGetSpy).toHaveBeenCalledWith("/features", {
             baseURL: "/",
             headers: {
                 "Content-type": "application/json",
-                "X-FeatureHub": "earlyAccess=beta",
+                "X-FeatureHub": "earlyAccess=beta,organizationId=org",
                 "if-none-match": expect.anything(),
             },
             method: "GET",
@@ -95,12 +95,15 @@ describe("live features", () => {
     it("call axios with context and ws context filled", async () => {
         mockReturn([]);
 
-        await getFeatureHubFeatures(createFeatures("beta"), pickContext({ earlyAccess: "omega" }));
+        await getFeatureHubFeatures(
+            createFeatures("beta", "org"),
+            pickContext({ earlyAccess: "omega" }, "test-org"),
+        );
         expect(axiosGetSpy).toHaveBeenCalledWith("/features", {
             baseURL: "/",
             headers: {
                 "Content-type": "application/json",
-                "X-FeatureHub": "earlyAccess=omega",
+                "X-FeatureHub": "earlyAccess=omega,organizationId=test-org",
                 "if-none-match": expect.anything(),
             },
             method: "GET",

--- a/libs/sdk-backend-tiger/src/backend/workspace/settings/index.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/settings/index.ts
@@ -144,7 +144,7 @@ export function getSettingsForCurrentUser(
         const profile = await client.profile.getCurrent();
         const features = await new TigerFeaturesService(authCall).getFeatures(
             profile,
-            pickContext(attributes),
+            pickContext(attributes, profile.organizationId),
         );
 
         return {


### PR DESCRIPTION
PDM removal is activated by FF based on organizationId, but this option was not available in UI.SDK

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |
| **Compatibility matrix test commands - TIGER Backend**  |                                                            |
| `extended test - matrix-test <AIO_version>`             | Run integrated tests against AIO versions.                 |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

`<AIO_version>` in commands is used to start test with multiple AIO instances - each instance in triggered by one jenkins build

-   To run with `master` and `stable`, execute command `extended test - matrix-test master,stable` or `extended test - matrix-test latest`
-   To run with specific version,ex: `2.3.0` and `2.3.1`, execute command `extended test - matrix-test 2.3.0,2.3.1`
-   In case `<AIO_version>` is empty, read versions from file `compTigerVersions.txt` of this repo

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
