### PR TITLE
BUGFIX: QA-19096 export catalog reads pass from env variable

### DIFF
--- a/libs/sdk-ui-tests-e2e/reference_workspace/export_catalog.js
+++ b/libs/sdk-ui-tests-e2e/reference_workspace/export_catalog.js
@@ -9,9 +9,10 @@ import { execSync } from "child_process";
 
 import { TIGER_FIXTURE_CATALOG, BEAR_FIXTURE_CATALOG } from "./constant.js";
 
-export function exportCatalogBear(host, projectId, username) {
+export function exportCatalogBear(host, projectId, username, password) {
     // NOTE: we support this only for goodsales
     const outputFile = BEAR_FIXTURE_CATALOG["goodsales"];
+    process.env["GDC_PASSWORD"] = password;
     execSync(
         `npx gdc-catalog-export --accept-untrusted-ssl --hostname "${host}" --workspace-id "${projectId}" --username "${username}" --backend "bear" --catalog-output "${outputFile}"`,
         { stdio: "inherit" },

--- a/libs/sdk-ui-tests-e2e/reference_workspace/lib/create_bear_workspace.js
+++ b/libs/sdk-ui-tests-e2e/reference_workspace/lib/create_bear_workspace.js
@@ -36,9 +36,7 @@ async function main() {
         );
 
         log("Exporting metadata objects identifiers to local TypeScript file\n");
-        // export catalog reads password from GDC_PASSWORD variable in .env
-        fs.appendFileSync(".env", `GDC_PASSWORD=${PASSWORD}\n`, () => {});
-        exportCatalogBear(HOST, newReferenceWorkspaceId, USER_NAME);
+        exportCatalogBear(HOST, newReferenceWorkspaceId, USER_NAME, PASSWORD);
 
         fs.appendFileSync(".env", `TEST_WORKSPACE_ID=${newReferenceWorkspaceId}\n`, () => {
             log("TEST_WORKSPACE_ID added to the .env file\n");


### PR DESCRIPTION
Passed on my branch: https://checklist.intgdc.com/job/cypress-tests/job/gooddata-ui-sdk-cypress-checklist_integrated_bear/353/console

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |
| **Compatibility matrix test commands - TIGER Backend**  |                                                            |
| `extended test - matrix-test <AIO_version>`             | Run integrated tests against AIO versions.                 |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

`<AIO_version>` in commands is used to start test with multiple AIO instances - each instance in triggered by one jenkins build

-   To run with `master` and `stable`, execute command `extended test - matrix-test master,stable` or `extended test - matrix-test latest`
-   To run with specific version,ex: `2.3.0` and `2.3.1`, execute command `extended test - matrix-test 2.3.0,2.3.1`
-   In case `<AIO_version>` is empty, read versions from file `compTigerVersions.txt` of this repo

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
