### PR TITLE
FEATURE: RAIL-5024 Introduce createRoot provider for react 18

### DIFF
--- a/examples/playground/src/index.tsx
+++ b/examples/playground/src/index.tsx
@@ -12,6 +12,7 @@ if (process.env.WDYR === "true") {
 import "@babel/polyfill";
 import React from "react";
 import { createRoot } from "react-dom/client";
+import { provideCreateRoot } from "@gooddata/sdk-ui-ext";
 
 import "@gooddata/sdk-ui-filters/styles/css/main.css";
 import "@gooddata/sdk-ui-charts/styles/css/main.css";
@@ -21,6 +22,9 @@ import "@gooddata/sdk-ui-ext/styles/css/main.css";
 import "@gooddata/sdk-ui-dashboard/styles/css/main.css";
 
 import { App } from "./App.js";
+
+// provide React18 root API for visualization rendering
+provideCreateRoot(createRoot);
 
 const rootDOMNode = document.createElement("div");
 rootDOMNode.className = "root";

--- a/libs/sdk-ui-charts/src/highcharts/ChartTransformation.tsx
+++ b/libs/sdk-ui-charts/src/highcharts/ChartTransformation.tsx
@@ -2,7 +2,7 @@
 import { IDataView } from "@gooddata/sdk-backend-spi";
 import { ITheme } from "@gooddata/sdk-model";
 import { invariant } from "ts-invariant";
-import React from "react";
+import React, { useEffect } from "react";
 import { ContentRect } from "react-measure";
 
 import {
@@ -135,14 +135,16 @@ const ChartTransformationImpl = (props: IChartTransformationProps) => {
         onNegativeValues(chartOptions);
     }
 
-    pushData({
-        propertiesMeta: {
-            legend_enabled: legendOptions.toggleEnabled,
-        },
-        colors: {
-            colorAssignments: chartOptions.colorAssignments,
-            colorPalette: chartOptions.colorPalette,
-        },
+    useEffect(() => {
+        pushData({
+            propertiesMeta: {
+                legend_enabled: legendOptions.toggleEnabled,
+            },
+            colors: {
+                colorAssignments: chartOptions.colorAssignments,
+                colorPalette: chartOptions.colorPalette,
+            },
+        });
     });
 
     if (!isChartSupported(visType)) {

--- a/libs/sdk-ui-ext/.dependency-cruiser.cjs
+++ b/libs/sdk-ui-ext/.dependency-cruiser.cjs
@@ -15,6 +15,7 @@ const options = {
         depCruiser.moduleWithDependencies("insightView", "src/insightView", [
             "src/dataLoaders",
             "src/internal",
+            "src/internal/createRootProvider.ts",
             "src/internal/utils/embeddingCodeGenerator",
             "src/internal/utils/embeddingCodeGenerator/types.ts",
         ]),

--- a/libs/sdk-ui-ext/api/sdk-ui-ext.api.md
+++ b/libs/sdk-ui-ext/api/sdk-ui-ext.api.md
@@ -4,6 +4,8 @@
 
 ```ts
 
+/// <reference types="react" />
+
 import { CopyCodeOriginType } from '@gooddata/sdk-ui-kit';
 import { EmbedType } from '@gooddata/sdk-ui-kit';
 import { ExplicitDrill } from '@gooddata/sdk-ui';
@@ -38,6 +40,9 @@ export function addIntersectionFiltersToInsight(source: IInsight, intersection: 
 
 // @public
 export function clearInsightViewCaches(): void;
+
+// @public
+export type CreateRoot = (container: Element | DocumentFragment, options?: any) => Root;
 
 // @internal (undocumented)
 export const DASHBOARD_LAYOUT_DEFAULT_VIS_HEIGHT_PX = 450;
@@ -270,6 +275,17 @@ export const PluggableVisualizationErrorCodes: {
 
 // @alpha (undocumented)
 export type PluggableVisualizationErrorType = keyof typeof PluggableVisualizationErrorCodes;
+
+// @public
+export function provideCreateRoot(createRoot: CreateRoot): void;
+
+// @public
+export interface Root {
+    // (undocumented)
+    render(children: React.ReactNode): void;
+    // (undocumented)
+    unmount(): void;
+}
 
 // @internal (undocumented)
 export const WIDGET_DROPZONE_SIZE_INFO_DEFAULT: IVisualizationDefaultSizeInfo;

--- a/libs/sdk-ui-ext/src/index.ts
+++ b/libs/sdk-ui-ext/src/index.ts
@@ -53,6 +53,8 @@ export {
     IEmbedInsightDialogProps,
 } from "./internal/index.js";
 
+export { provideCreateRoot, CreateRoot, Root } from "./internal/createRootProvider.js";
+
 // below functions are exported only for sdk-ui-dashboard use to avoid exporting the whole FullVisualizationCatalog
 /**
  * @internal

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/PluggableUnknownChart.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/PluggableUnknownChart.tsx
@@ -12,6 +12,7 @@ import {
     IReferencePoint,
     IVisProps,
     RenderFunction,
+    UnmountFunction,
 } from "../../interfaces/Visualization.js";
 
 export type IIntlLocalizedUnknownVisualizationClass = WrappedComponentProps;
@@ -38,9 +39,12 @@ export const IntlLocalizedUnknownVisualizationClass = injectIntl<
 
 export class PluggableUnknownChart extends AbstractPluggableVisualization {
     private renderFun: RenderFunction;
+    private unmountFun: UnmountFunction;
+
     constructor(props: IVisConstruct) {
         super(props);
         this.renderFun = props.renderFun;
+        this.unmountFun = props.unmountFun;
     }
 
     public getExtendedReferencePoint(referencePoint: IReferencePoint): Promise<IExtendedReferencePoint> {
@@ -72,5 +76,7 @@ export class PluggableUnknownChart extends AbstractPluggableVisualization {
         this.onLoadingChanged?.({ isLoading: false });
     }
 
-    public unmount(): void {}
+    public unmount(): void {
+        this.unmountFun([this.getElement()]);
+    }
 }

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/baseChart/PluggableBaseChart.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/baseChart/PluggableBaseChart.tsx
@@ -38,6 +38,8 @@ import {
     IVisConstruct,
     IVisProps,
     IVisualizationProperties,
+    RenderFunction,
+    UnmountFunction,
 } from "../../../interfaces/Visualization.js";
 import { IAvailableSortsGroup } from "../../../interfaces/SortConfig.js";
 import { configureOverTimeComparison, configurePercent } from "../../../utils/bucketConfig.js";
@@ -54,7 +56,6 @@ import {
 } from "../../../utils/bucketHelper.js";
 import { getValidProperties } from "../../../utils/colors.js";
 import { generateDimensions } from "../../../utils/dimensions.js";
-import { unmountComponentsAtNodes } from "../../../utils/domHelper.js";
 import {
     getReferencePointWithSupportedProperties,
     getSupportedPropertiesControls,
@@ -93,7 +94,8 @@ export class PluggableBaseChart extends AbstractPluggableVisualization {
     protected axis: string;
     protected secondaryAxis: AxisType;
     protected environment: string;
-    protected readonly renderFun: (component: any, target: Element) => void;
+    protected readonly renderFun: RenderFunction;
+    protected readonly unmountFun: UnmountFunction;
 
     constructor(props: IVisConstruct) {
         super(props);
@@ -106,11 +108,12 @@ export class PluggableBaseChart extends AbstractPluggableVisualization {
         this.defaultControlsProperties = {};
         this.setCustomControlsProperties({});
         this.renderFun = props.renderFun;
+        this.unmountFun = props.unmountFun;
         this.supportedPropertiesList = this.getSupportedPropertiesList();
     }
 
     public unmount(): void {
-        unmountComponentsAtNodes([this.getElement(), this.getConfigPanelElement()].filter(Boolean));
+        this.unmountFun([this.getElement(), this.getConfigPanelElement()].filter(Boolean));
     }
 
     public getUiConfig(): IUiConfig {

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/headline/PluggableHeadline.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/headline/PluggableHeadline.tsx
@@ -24,6 +24,7 @@ import {
     IVisConstruct,
     IVisProps,
     RenderFunction,
+    UnmountFunction,
 } from "../../../interfaces/Visualization.js";
 
 import { configureOverTimeComparison, configurePercent } from "../../../utils/bucketConfig.js";
@@ -38,7 +39,6 @@ import {
     sanitizeFilters,
 } from "../../../utils/bucketHelper.js";
 import { hasGlobalDateFilter } from "../../../utils/bucketRules.js";
-import { unmountComponentsAtNodes } from "../../../utils/domHelper.js";
 import {
     getReferencePointWithSupportedProperties,
     getSupportedProperties,
@@ -86,16 +86,18 @@ import cloneDeep from "lodash/cloneDeep.js";
 export class PluggableHeadline extends AbstractPluggableVisualization {
     private readonly settings?: ISettings;
     private readonly renderFun: RenderFunction;
+    private readonly unmountFun: UnmountFunction;
 
     constructor(props: IVisConstruct) {
         super(props);
 
         this.settings = props.featureFlags;
         this.renderFun = props.renderFun;
+        this.unmountFun = props.unmountFun;
     }
 
     public unmount(): void {
-        unmountComponentsAtNodes([this.getElement(), this.getConfigPanelElement()]);
+        this.unmountFun([this.getElement(), this.getConfigPanelElement()]);
     }
 
     public getExtendedReferencePoint(

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/PluggablePivotTable.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/PluggablePivotTable.tsx
@@ -54,6 +54,7 @@ import {
     IVisProps,
     IVisualizationProperties,
     RenderFunction,
+    UnmountFunction,
 } from "../../../interfaces/Visualization.js";
 import { configureOverTimeComparison, configurePercent } from "../../../utils/bucketConfig.js";
 
@@ -65,7 +66,6 @@ import {
     sanitizeFilters,
 } from "../../../utils/bucketHelper.js";
 import { generateDimensions } from "../../../utils/dimensions.js";
-import { unmountComponentsAtNodes } from "../../../utils/domHelper.js";
 import {
     getColumnWidthsFromProperties,
     getReferencePointWithSupportedProperties,
@@ -158,6 +158,7 @@ const PROPERTIES_AFFECTING_REFERENCE_POINT = ["measureGroupDimension"];
 export class PluggablePivotTable extends AbstractPluggableVisualization {
     private environment: VisualizationEnvironment;
     private renderFun: RenderFunction;
+    private unmountFun: UnmountFunction;
     private readonly settings: ISettings;
     private backendCapabilities: IBackendCapabilities;
 
@@ -166,6 +167,7 @@ export class PluggablePivotTable extends AbstractPluggableVisualization {
 
         this.environment = props.environment;
         this.renderFun = props.renderFun;
+        this.unmountFun = props.unmountFun;
         this.settings = props.featureFlags ?? {};
         this.onColumnResized = this.onColumnResized.bind(this);
         this.handlePushData = this.handlePushData.bind(this);
@@ -176,7 +178,7 @@ export class PluggablePivotTable extends AbstractPluggableVisualization {
     }
 
     public unmount(): void {
-        unmountComponentsAtNodes([this.getElement(), this.getConfigPanelElement()]);
+        this.unmountFun([this.getElement(), this.getConfigPanelElement()]);
     }
 
     public getExtendedReferencePoint(

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/xirr/PluggableXirr.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/xirr/PluggableXirr.tsx
@@ -21,6 +21,7 @@ import {
     IVisProps,
     IVisualizationOptions,
     RenderFunction,
+    UnmountFunction,
 } from "../../../interfaces/Visualization.js";
 import {
     removeAllArithmeticMeasuresFromDerived,
@@ -29,7 +30,6 @@ import {
 } from "../../../utils/bucketHelper.js";
 
 import { hasGlobalDateFilter } from "../../../utils/bucketRules.js";
-import { unmountComponentsAtNodes } from "../../../utils/domHelper.js";
 import {
     getReferencePointWithSupportedProperties,
     getSupportedProperties,
@@ -73,16 +73,18 @@ import cloneDeep from "lodash/cloneDeep.js";
 export class PluggableXirr extends AbstractPluggableVisualization {
     private settings?: ISettings;
     private renderFun: RenderFunction;
+    private unmountFun: UnmountFunction;
 
     constructor(props: IVisConstruct) {
         super(props);
 
         this.settings = props.featureFlags;
         this.renderFun = props.renderFun;
+        this.unmountFun = props.unmountFun;
     }
 
     public unmount(): void {
-        unmountComponentsAtNodes([this.getElement(), this.getConfigPanelElement()]);
+        this.unmountFun([this.getElement(), this.getConfigPanelElement()]);
     }
 
     public getExtendedReferencePoint = async (

--- a/libs/sdk-ui-ext/src/internal/createRootProvider.ts
+++ b/libs/sdk-ui-ext/src/internal/createRootProvider.ts
@@ -1,0 +1,35 @@
+// (C) 2023 GoodData Corporation
+
+/**
+ * React18 Root type.
+ *
+ * @public
+ */
+export interface Root {
+    render(children: React.ReactNode): void;
+    unmount(): void;
+}
+
+/**
+ * React18 createRoot function type.
+ *
+ * @public
+ */
+export type CreateRoot = (container: Element | DocumentFragment, options?: any) => Root;
+
+/**
+ * Global createRoot function for React18 root creation.
+ *
+ * @internal
+ */
+export let _createRoot: CreateRoot = null;
+
+/**
+ * In order to use React18 for visualization rendering, one has to provide createRoot function.
+ * Older React17 render is used by default.
+ *
+ * @public
+ */
+export function provideCreateRoot(createRoot: CreateRoot) {
+    _createRoot = createRoot;
+}

--- a/libs/sdk-ui-ext/src/internal/index.ts
+++ b/libs/sdk-ui-ext/src/internal/index.ts
@@ -92,3 +92,5 @@ export { EmbedInsightDialog } from "./components/dialogs/embedInsightDialog/Embe
 export type { IEmbedInsightDialogProps } from "./components/dialogs/embedInsightDialog/EmbedInsightDialog.js";
 
 export type { IInsightTitleProps, IInsightViewProps } from "./interfaces/InsightView.js";
+
+export { unmountComponentsAtNodes } from "./utils/domHelper.js";

--- a/libs/sdk-ui-ext/src/internal/interfaces/Visualization.ts
+++ b/libs/sdk-ui-ext/src/internal/interfaces/Visualization.ts
@@ -33,6 +33,8 @@ import { IAvailableSortsGroup, ISortConfig } from "./SortConfig.js";
 
 export type RenderFunction = (component: any, target: Element) => void;
 
+export type UnmountFunction = (elementsOrSelectors?: (string | HTMLElement)[]) => void;
+
 export type ElementSelectorFunction = () => HTMLElement | null;
 
 export interface IVisConstruct {
@@ -49,6 +51,7 @@ export interface IVisConstruct {
     featureFlags?: ISettings;
     visualizationProperties: VisualizationProperties;
     renderFun: RenderFunction;
+    unmountFun: UnmountFunction;
 }
 
 export interface ICustomProps {

--- a/libs/sdk-ui-ext/src/internal/utils/domHelper.ts
+++ b/libs/sdk-ui-ext/src/internal/utils/domHelper.ts
@@ -1,6 +1,9 @@
 // (C) 2019-2022 GoodData Corporation
 import { unmountComponentAtNode } from "react-dom";
 
+/**
+ * @internal
+ */
 export function unmountComponentsAtNodes(
     elementsOrSelectors: Array<HTMLElement | string> = [],
     {

--- a/libs/sdk-ui-pivot/src/CorePivotTable.tsx
+++ b/libs/sdk-ui-pivot/src/CorePivotTable.tsx
@@ -815,6 +815,11 @@ export class CorePivotTableAgImpl extends React.Component<ICorePivotTableProps, 
 
         const didResize = await this.internal.table?.autoresizeColumns(this.getResizingConfig(), force);
 
+        if (didResize) {
+            // after column resizing, horizontal scroolbar may change and table height may need resizing
+            this.updateDesiredHeight();
+        }
+
         if (didResize && !this.state.resized) {
             this.setState({
                 resized: true,

--- a/libs/sdk-ui-tests-e2e/scenarios/src/App.tsx
+++ b/libs/sdk-ui-tests-e2e/scenarios/src/App.tsx
@@ -5,6 +5,11 @@ import { BackendProvider } from "@gooddata/sdk-ui";
 import AppRouter from "./routes/AppRouter";
 import { useAuth } from "./contexts/Auth";
 import { WorkspaceListProvider } from "./contexts/WorkspaceList";
+import { provideCreateRoot } from "@gooddata/sdk-ui-ext";
+import { createRoot } from "react-dom/client";
+
+// provide React18 root API for visualization rendering
+provideCreateRoot(createRoot);
 
 function App() {
     const { backend } = useAuth();

--- a/libs/sdk-ui-tests-e2e/scenarios/src/index.tsx
+++ b/libs/sdk-ui-tests-e2e/scenarios/src/index.tsx
@@ -4,6 +4,7 @@ import { createRoot } from "react-dom/client";
 import "@babel/polyfill";
 import App from "./App";
 import { AppProviders } from "./contexts";
+import { provideCreateRoot } from "@gooddata/sdk-ui-ext";
 
 import "@gooddata/sdk-ui-filters/styles/css/main.css";
 import "@gooddata/sdk-ui-charts/styles/css/main.css";
@@ -12,6 +13,9 @@ import "@gooddata/sdk-ui-geo/styles/css/main.css";
 import "@gooddata/sdk-ui-kit/styles/css/main.css";
 import "@gooddata/sdk-ui-ext/styles/css/main.css";
 import "@gooddata/sdk-ui-dashboard/styles/css/main.css";
+
+// provide React18 root API for visualization rendering
+provideCreateRoot(createRoot);
 
 const rootDOMNode = document.getElementById("root");
 const root = createRoot(rootDOMNode!);

--- a/libs/sdk-ui-tests/backstop/story-extractor.test.ts
+++ b/libs/sdk-ui-tests/backstop/story-extractor.test.ts
@@ -19,7 +19,6 @@ const targetFile = path.resolve(__dirname, "stories.json");
 describe("story-extractor", () => {
     it("dumps stories into a file", () => {
         const fileContents = toBackstopJson();
-        console.log("test");
         writeFileSync(targetFile, fileContents, { encoding: "utf8" });
         expect(existsSync(targetFile)).toBe(true);
     });

--- a/libs/sdk-ui-tests/src/scenario.tsx
+++ b/libs/sdk-ui-tests/src/scenario.tsx
@@ -10,6 +10,11 @@ import { IInsight, ISettings } from "@gooddata/sdk-model";
 import { IExecuteProps } from "@gooddata/sdk-ui";
 import { IGeoPushpinChartProps, IGeoPushpinChartLatitudeLongitudeProps } from "@gooddata/sdk-ui-geo";
 import { DataViewRequests } from "@gooddata/mock-handling";
+import { provideCreateRoot } from "@gooddata/sdk-ui-ext";
+import { createRoot } from "react-dom/client";
+
+// provide React18 root API for visualization rendering
+provideCreateRoot(createRoot);
 
 export type VisProps =
     | IPivotTableProps

--- a/libs/sdk-ui-tests/stories/visual-regression/web-components/insightStories.tsx
+++ b/libs/sdk-ui-tests/stories/visual-regression/web-components/insightStories.tsx
@@ -60,5 +60,5 @@ storiesOf(`${WebComponents}/Insight`)
                 ))}
             </>
         ),
-        { screenshot: true },
+        { screenshot: { postInteractionWait: 1000 } },
     );

--- a/tools/dashboard-plugin-template/src/harness/index.tsx
+++ b/tools/dashboard-plugin-template/src/harness/index.tsx
@@ -1,6 +1,7 @@
 // (C) 2019-2022 GoodData Corporation
 import React from "react";
 import { createRoot } from "react-dom/client";
+import { provideCreateRoot } from "@gooddata/sdk-ui-ext";
 
 import "@gooddata/sdk-ui-filters/styles/css/main.css";
 import "@gooddata/sdk-ui-charts/styles/css/main.css";
@@ -10,6 +11,9 @@ import "@gooddata/sdk-ui-ext/styles/css/main.css";
 import "@gooddata/sdk-ui-dashboard/styles/css/main.css";
 
 import { Root } from "./Root.js";
+
+// provide React18 root API for visualization rendering
+provideCreateRoot(createRoot);
 
 const rootDOMNode = document.getElementById("root");
 const root = createRoot(rootDOMNode!);

--- a/tools/react-app-template/src/index.tsx
+++ b/tools/react-app-template/src/index.tsx
@@ -1,6 +1,7 @@
 // (C) 2019-2023 GoodData Corporation
 import React from "react";
 import { createRoot } from "react-dom/client";
+import { provideCreateRoot } from "@gooddata/sdk-ui-ext";
 
 import { App } from "./App.js";
 
@@ -16,6 +17,9 @@ import "@gooddata/sdk-ui-ext/styles/css/main.css";
 import "@gooddata/sdk-ui-dashboard/styles/css/main.css";
 
 import "./index.css";
+
+// provide React18 root API for visualization rendering
+provideCreateRoot(createRoot);
 
 const rootDOMNode = document.getElementById("root");
 const root = createRoot(rootDOMNode!);


### PR DESCRIPTION
When createRoot is provided, its API is used for rendering instead of older react render.

JIRA: RAIL-5024

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |
| **Compatibility matrix test commands - TIGER Backend**  |                                                            |
| `extended test - matrix-test <AIO_version>`             | Run integrated tests against AIO versions.                 |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

`<AIO_version>` in commands is used to start test with multiple AIO instances - each instance in triggered by one jenkins build

-   To run with `master` and `stable`, execute command `extended test - matrix-test master,stable` or `extended test - matrix-test latest`
-   To run with specific version,ex: `2.3.0` and `2.3.1`, execute command `extended test - matrix-test 2.3.0,2.3.1`
-   In case `<AIO_version>` is empty, read versions from file `compTigerVersions.txt` of this repo

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
