### PR TITLE
RELATED: RAIL-5022, RAIL-5023 fix build plugin and refresh-md

### DIFF
--- a/tools/dashboard-plugin-template/.eslintrc.cjs
+++ b/tools/dashboard-plugin-template/.eslintrc.cjs
@@ -15,7 +15,7 @@ module.exports = {
     parserOptions: { tsconfigRootDir: __dirname },
     ignorePatterns: [
         "webpack.config.cjs",
-        "scripts/refresh-md.cjs",
+        "scripts/refresh-md.js",
         "configTemplates/ts/vite.config.ts",
         "configTemplates/js/vite.config.js",
     ],

--- a/tools/dashboard-plugin-template/package.json
+++ b/tools/dashboard-plugin-template/package.json
@@ -47,7 +47,7 @@
         "dep-cruiser-ci": "depcruise --validate .dependency-cruiser.jsc --output-type err-long src/",
         "validate": "npm run dep-cruiser && npm run eslint && npm run prettier-check",
         "validate-ci": "npm run dep-cruiser-ci && npm run eslint-ci && npm run prettier-check",
-        "refresh-md": "node ./scripts/refresh-md.cjs"
+        "refresh-md": "node ./scripts/refresh-md.js"
     },
     "dependencies": {
         "@gooddata/sdk-ui-dashboard": "workspace:*",

--- a/tools/dashboard-plugin-template/scripts/refresh-md.js
+++ b/tools/dashboard-plugin-template/scripts/refresh-md.js
@@ -1,8 +1,12 @@
 #!/usr/bin/env node
 // (C) 2022 GoodData Corporation
 
-const dotenv = require("dotenv");
-const path = require("path");
+import dotenv from "dotenv";
+import path from "path";
+import {fileURLToPath} from 'url';
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
 dotenv.config({ path: path.resolve(__dirname, "../.env") });
 dotenv.config({ path: path.resolve(__dirname, "../.env.secrets") });
 
@@ -23,4 +27,4 @@ process.argv.push(
     output,
 );
 
-require("@gooddata/catalog-export");
+await import("@gooddata/catalog-export");

--- a/tools/dashboard-plugin-template/webpack.config.cjs
+++ b/tools/dashboard-plugin-template/webpack.config.cjs
@@ -206,15 +206,15 @@ module.exports = (_env, argv) => {
                          * this is the main entry point providing info about the engine and plugin
                          * this allows us to only load the plugin and/or engine when needed
                          */
-                        [`./${MODULE_FEDERATION_NAME}_ENTRY`]: `./src/${MODULE_FEDERATION_NAME}_entry`,
+                        [`./${MODULE_FEDERATION_NAME}_ENTRY`]: `./src/${MODULE_FEDERATION_NAME}_entry/index.js`,
                         /**
                          * this is the entry to the plugin itself
                          */
-                        [`./${MODULE_FEDERATION_NAME}_PLUGIN`]: `./src/${MODULE_FEDERATION_NAME}`,
+                        [`./${MODULE_FEDERATION_NAME}_PLUGIN`]: `./src/${MODULE_FEDERATION_NAME}/index.js`,
                         /**
                          * this is the entry to the engine
                          */
-                        [`./${MODULE_FEDERATION_NAME}_ENGINE`]: `./src/${MODULE_FEDERATION_NAME}_engine`,
+                        [`./${MODULE_FEDERATION_NAME}_ENGINE`]: `./src/${MODULE_FEDERATION_NAME}_engine/index.js`,
                     },
 
                     // adds react as shared module

--- a/tools/plugin-toolkit/src/initCmd/index.ts
+++ b/tools/plugin-toolkit/src/initCmd/index.ts
@@ -140,7 +140,7 @@ function performReplacementsInFiles(dir: string, config: InitCmdActionConfig): P
             },
         ],
         scripts: {
-            "refresh-md.cjs": [
+            "refresh-md.js": [
                 {
                     regex: /const backend = "bear"/g,
                     value: 'const backend = "tiger"',


### PR DESCRIPTION
JIRA: RAIL-5022, RAIL-5023

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |
| **Compatibility matrix test commands - TIGER Backend**  |                                                            |
| `extended test - matrix-test <AIO_version>`             | Run integrated tests against AIO versions.                 |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

`<AIO_version>` in commands is used to start test with multiple AIO instances - each instance in triggered by one jenkins build

-   To run with `master` and `stable`, execute command `extended test - matrix-test master,stable` or `extended test - matrix-test latest`
-   To run with specific version,ex: `2.3.0` and `2.3.1`, execute command `extended test - matrix-test 2.3.0,2.3.1`
-   In case `<AIO_version>` is empty, read versions from file `compTigerVersions.txt` of this repo

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
