### PR TITLE
FEATURE: TNT-1438 Add JWT authentication support

### DIFF
--- a/libs/sdk-backend-tiger/api/sdk-backend-tiger.api.md
+++ b/libs/sdk-backend-tiger/api/sdk-backend-tiger.api.md
@@ -258,6 +258,9 @@ export interface IInvitationUserResponse {
     successful?: boolean;
 }
 
+// @alpha
+export type JwtIsAboutToExpireHandler = (setJwt: SetJwtCallback) => void;
+
 // @internal (undocumented)
 export type OrganizationPermission = JsonApiOrganizationOutMetaPermissionsEnum;
 
@@ -306,6 +309,9 @@ export interface ScanResult {
 // @internal (undocumented)
 export type ScanSqlResult = ScanSqlResponse;
 
+// @alpha
+export type SetJwtCallback = (jwt: string, secondsBeforeTokenExpirationToCallReminder?: number) => void;
+
 // @internal (undocumented)
 export type SetPdmLayoutRequest = LayoutApiSetPdmLayoutRequest;
 
@@ -326,6 +332,13 @@ export abstract class TigerAuthProviderBase implements IAuthenticationProvider {
 // @public
 function tigerFactory(config?: IAnalyticalBackendConfig, implConfig?: any): IAnalyticalBackend;
 export default tigerFactory;
+
+// @alpha
+export class TigerJwtAuthProvider extends TigerTokenAuthProvider {
+    constructor(jwt: string, notAuthenticatedHandler?: NotAuthenticatedHandler, tokenIsAboutToExpireHandler?: JwtIsAboutToExpireHandler | undefined, secondsBeforeTokenExpirationToCallReminder?: number);
+    // (undocumented)
+    initializeClient(client: ITigerClient): void;
+}
 
 // @internal
 export type TigerSpecificFunctions = {

--- a/libs/sdk-backend-tiger/src/index.ts
+++ b/libs/sdk-backend-tiger/src/index.ts
@@ -61,6 +61,9 @@ export {
 export {
     ContextDeferredAuthProvider,
     TigerTokenAuthProvider,
+    SetJwtCallback,
+    JwtIsAboutToExpireHandler,
+    TigerJwtAuthProvider,
     TigerAuthProviderBase,
     createTigerAuthenticationUrl,
     redirectToTigerAuthentication,

--- a/libs/sdk-backend-tiger/src/utils/jwt.ts
+++ b/libs/sdk-backend-tiger/src/utils/jwt.ts
@@ -1,0 +1,78 @@
+// (C) 2023 GoodData Corporation
+
+import { invariant } from "ts-invariant";
+
+/**
+ * Internal interface that contains JWT fields accessed by the authentication provider.
+ * There can be other field (claims) in the token payload as well but these are not important for the
+ * provider right now.
+ */
+export interface IJsonWebTokenPayload {
+    /**
+     * Number of seconds since the start of epoch when the token will expire.
+     */
+    exp: number;
+    /**
+     * Subject to which the token grants the access (ID of the Tiger user in our case).
+     */
+    sub: string;
+}
+
+/**
+ * Decode provided JWT payload
+ *
+ * @param jwt - JWT that should be decoded. Expected JWT structure is "header.payload.signature".
+ *
+ * @returns object with claims decoded from provided JWT payload
+ *
+ * @throws when provided jwt is empty
+ */
+export const decodeJwtPayload = (jwt: string): IJsonWebTokenPayload => {
+    invariant(jwt, "The provided token is empty");
+    const base64UrlPayload = jwt.split(".")[1];
+    const base64Payload = base64UrlPayload.replace(/-/g, "+").replace(/_/g, "/");
+    const jsonPayload = decodeURIComponent(
+        atob(base64Payload)
+            .split("")
+            .map((ch) => "%" + ("00" + ch.charCodeAt(0).toString(16)).slice(-2))
+            .join(""),
+    );
+    return JSON.parse(jsonPayload);
+};
+
+/**
+ * Compare subject from the new and previous JWT and compare if the subject is the same for both ("sub" claim)
+ *
+ * @param newJwt - new JWT
+ * @param previousJwt - previous JWT
+ *
+ * @throws when "sub" claim does not equal in both compared JWTs
+ */
+export const validateJwt = (newJwt: string, previousJwt: string): void => {
+    const previousPayload = decodeJwtPayload(previousJwt);
+    const payload = decodeJwtPayload(newJwt);
+    if (payload.sub !== previousPayload.sub) {
+        throw new Error("The new JWT does not belong to the same subject as the previous one.");
+    }
+};
+
+/**
+ * Compute number of milliseconds till provided JWT expiration from the current time.
+ * The returned value can be used for setTimeout function.
+ *
+ * @param jwt - JWT from which the expiration timestamp is extracted
+ * @param secondsBeforeTokenExpirationToCallReminder - number of seconds subtracted from the final timeout
+ * @param currentTimeInMilliseconds - current time in milliseconds
+ *
+ * @returns number of milliseconds between now and expiration of provided JWT, subtracted by provided number of seconds
+ */
+export const computeExpirationReminderTimeout = (
+    jwt: string,
+    secondsBeforeTokenExpirationToCallReminder: number,
+    currentTimeInMilliseconds: number,
+): number => {
+    const payload = decodeJwtPayload(jwt);
+    const millisecondsToReminder = secondsBeforeTokenExpirationToCallReminder * 1000;
+    const epochMillisecondsToExpiration = payload.exp * 1000;
+    return epochMillisecondsToExpiration - currentTimeInMilliseconds - millisecondsToReminder;
+};

--- a/libs/sdk-backend-tiger/src/utils/tests/__snapshots__/jwt.test.ts.snap
+++ b/libs/sdk-backend-tiger/src/utils/tests/__snapshots__/jwt.test.ts.snap
@@ -1,0 +1,11 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`jwt > decodeJwtPayload > should parse payload of JWT 1`] = `
+{
+  "exp": 1689164227,
+  "iat": 1689164197,
+  "jti": "77fdd289-4092-4d34-98f4-4d4d7f25fc14",
+  "name": "Petr Dolejsi",
+  "sub": "petr.dolejsi",
+}
+`;

--- a/libs/sdk-backend-tiger/src/utils/tests/jwt.test.ts
+++ b/libs/sdk-backend-tiger/src/utils/tests/jwt.test.ts
@@ -1,0 +1,41 @@
+// (C) 2023 GoodData Corporation
+
+import { describe, expect, it } from "vitest";
+
+import { computeExpirationReminderTimeout, validateJwt, decodeJwtPayload } from "../jwt.js";
+
+const jwt1 =
+    "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6Ik1VMm9wT2xnRzV0UFlKNm9pSk9VczFUMXB1OCJ9.eyJzdWIiOiJwZXRyLmRvbGVqc2kiLCJuYW1lIjoiUGV0ciBEb2xlanNpIiwiaWF0IjoxNjg5MTY0MTk3LCJqdGkiOiI3N2ZkZDI4OS00MDkyLTRkMzQtOThmNC00ZDRkN2YyNWZjMTQiLCJleHAiOjE2ODkxNjQyMjd9.keJ9yKu7DuIMM7Z3N8Aaw44PRHqS4NI2FSYcuvABlDz-j2dw3Nc5Djt5qczr_Yfs0HahmstZugoUoszzrc6S9UcJLaoeljn9Ftouwuqr8ArzVurdk51xQDK2u4fMx-S96J93MCbBg2onRoE0WHxzrENwt82QwVXD44dObqYXEzFFh3E5z65F3XMUeuI_BLwAsrdTVwqA9ZyYaXIqOFXFaFZwrXK2EVjg_NISLx0I-8g6yzpVrS5d32ezhWM0aRiy-O2P-b0SC1Eu_BX9FXiSqNvZnkRiERFCfYYYQrf9TvobC7UesBj1bYfgNgHHP18wd2Zru1-V5mvdEnAF19omAw";
+const jwt2 =
+    "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6Ik1VMm9wT2xnRzV0UFlKNm9pSk9VczFUMXB1OCJ9.eyJzdWIiOiJwZXRyLmRvbGVqc2kiLCJuYW1lIjoiUGV0ciBEb2xlanNpIiwiaWF0IjoxNjg5MTY0Mzg5LCJqdGkiOiIxNGNkMTVlYi1lYjgwLTQ1ZGUtOTk2OS1kMjEzZjdiZjVkY2UiLCJleHAiOjE2ODkxNjQ0MTl9.MpIMB1d5JYaxojkrtswN4eaGlH3FKsISnqb7f8iETWDtv6D4J6cJJIuJg34q9v7C8--mAEVVbUyDI4U6jlP4TJ0P2tcvkTmFEjXWLrweOum_E_MzcxvUekksV-k9kIfG6dv0Q11uQn_g7tV40w0GLaPxFPZvOvvNfsXTs1OQlsn_6QpL2-XPQuNE-BE2e9OogOzA_h3A-EkiJCLHn-sn1aNgiRZEeiMweMLuQ2KhMpEFZIrHvA8QHG2QXWtdeeQ05PD6-LnghZRDBLWXxuz7x5JSBapC90R3D4acJ5639Krwvb2x4bKc8sJOm9TPBZ79lKdqKKl4YboNPeX1dDzbTg";
+const jwt3 =
+    "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6Ik1VMm9wT2xnRzV0UFlKNm9pSk9VczFUMXB1OCJ9.eyJzdWIiOiJtb3J0IiwibmFtZSI6IlBldHIgRG9sZWpzaSIsImlhdCI6MTY4OTE2NDQxMCwianRpIjoiOTNmMWI5OGItOWFmNC00OGZiLTgwMGEtN2VlNThhYTA0NjFhIiwiZXhwIjoxNjg5MTY0NDQwfQ.HFEa5Xx5AWaSV16fT7oFWeovKV1WRrqdsyOfQpE8vR-BfNnEVMJ68vO5emM02O-fPvZAjsvwMUjV65YRondSSWo-OKVCVL1DMHzytwA_mAUJyQhXv8WqFa8bdeVrKiV1S3w51p2JmKFLfmBz_EVX5HTSzFlkEXa8MYttiiO_hPOJ3b_F6sv-wiVgTrGDjSn3JJ0tbysC_DCHhc0q-z1LL3t_20lkpOa_1fOGahVOwkXgyn66Fgm7ipTTtz9kxvN2IBy-lVIv-ixqQBW9PlMUosPdn4hMGRz-93qZmByzL3XsdhpfdORr6poQF1lpXxImQg03gXAREoh_vduAF2GK3g";
+
+describe("jwt", () => {
+    describe("decodeJwtPayload", () => {
+        it("should throw when token is not provided", () => {
+            expect(() => decodeJwtPayload("")).toThrowError();
+        });
+
+        it("should parse payload of JWT", () => {
+            expect(decodeJwtPayload(jwt1)).toMatchSnapshot();
+        });
+    });
+
+    describe("validateJwt", () => {
+        it("should not throw when two different JWTs from the same subject are provided", () => {
+            expect(() => validateJwt(jwt1, jwt2)).not.toThrowError();
+        });
+
+        it("should throw when two different JWTs for the different subjects are provided", () => {
+            expect(() => validateJwt(jwt2, jwt3)).toThrowError();
+        });
+    });
+
+    describe("computeExpirationReminderTimeout", () => {
+        it("should correctly count the time to expiration reminder in milliseconds", () => {
+            const timeout = computeExpirationReminderTimeout(jwt1, 6, 1689164199625);
+            expect(timeout).toBe(21375);
+        });
+    });
+});

--- a/libs/sdk-embedding/api/sdk-embedding.api.md
+++ b/libs/sdk-embedding/api/sdk-embedding.api.md
@@ -452,6 +452,7 @@ enum GdcAdCommandType {
 
 // @public
 enum GdcAdEventType {
+    ApiTokenIsAboutToExpire = "apiTokenIsAboutToExpire",
     ClearFinished = "clearFinished",
     ClearInsightFinished = "clearInsightFinished",
     Drill = "drill",
@@ -506,6 +507,7 @@ enum GdcKdCommandType {
 
 // @public
 enum GdcKdEventType {
+    ApiTokenIsAboutToExpire = "apiTokenIsAboutToExpire",
     DashboardCreated = "dashboardCreated",
     DashboardCreationCanceled = "dashboardCreationCanceled",
     DashboardDeleted = "dashboardDeleted",
@@ -1033,12 +1035,16 @@ function isDrillableItemsCommandData_2(obj: unknown): obj is DrillableItemsComma
 
 // @public
 interface ISetApiTokenBody {
+    secondsBeforeTokenExpirationToEmitReminder?: number;
     token: string;
+    type?: "gooddata" | "jwt";
 }
 
 // @public
 interface ISetApiTokenBody_2 {
+    secondsBeforeTokenExpirationToEmitReminder?: number;
     token: string;
+    type?: "gooddata" | "jwt";
 }
 
 // @public

--- a/libs/sdk-embedding/src/iframe/EmbeddedAnalyticalDesigner.ts
+++ b/libs/sdk-embedding/src/iframe/EmbeddedAnalyticalDesigner.ts
@@ -214,6 +214,14 @@ export enum GdcAdEventType {
      * AD will not continue with initialization until the token is set.
      */
     ListeningForApiToken = "listeningForApiToken",
+
+    /**
+     * Type notifies embedding application that API token is about to expire and a new API token
+     * must be set via "setApiToken" command, otherwise session will expire soon (how soon depends on
+     * the reminder settings, by default in 60 seconds, can be changed by optional parameter with
+     * "setApiToken" was called the last time).
+     */
+    ApiTokenIsAboutToExpire = "apiTokenIsAboutToExpire",
 }
 
 /**
@@ -1256,6 +1264,15 @@ export interface ISetApiTokenBody {
      * API token value - used to set up SDK backend instance
      */
     token: string;
+    /**
+     * Type of the API token, default value is "GoodData"
+     */
+    type?: "gooddata" | "jwt";
+    /**
+     * Number of seconds before a postMessage event about to be expired JWT is emitted.
+     * Used only when type == jwt. Default value is 60 seconds.
+     */
+    secondsBeforeTokenExpirationToEmitReminder?: number;
 }
 
 /**

--- a/libs/sdk-embedding/src/iframe/EmbeddedKpiDashboard.ts
+++ b/libs/sdk-embedding/src/iframe/EmbeddedKpiDashboard.ts
@@ -270,6 +270,14 @@ export enum GdcKdEventType {
      * KD will not continue with initialization until the token is set.
      */
     ListeningForApiToken = "listeningForApiToken",
+
+    /**
+     * Type notifies embedding application that API token is about to expire and a new API token
+     * must be set via "setApiToken" command, otherwise session will expire soon (how soon depends on
+     * the reminder settings, by default in 60 seconds, can be changed by optional parameter with
+     * "setApiToken" was called the last time).
+     */
+    ApiTokenIsAboutToExpire = "apiTokenIsAboutToExpire",
 }
 
 /**
@@ -1367,6 +1375,15 @@ export interface ISetApiTokenBody {
      * API token value - used to set up SDK backend instance
      */
     token: string;
+    /**
+     * Type of the API token, default value is "GoodData"
+     */
+    type?: "gooddata" | "jwt";
+    /**
+     * Number of seconds before a postMessage event about to be expired JWT is emitted.
+     * Used only when type == jwt. Default value is 60 seconds.
+     */
+    secondsBeforeTokenExpirationToEmitReminder?: number;
 }
 
 /**


### PR DESCRIPTION
JIRA: TNT-1438

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |
| **Compatibility matrix test commands - TIGER Backend**  |                                                            |
| `extended test - matrix-test <AIO_version>`             | Run integrated tests against AIO versions.                 |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

`<AIO_version>` in commands is used to start test with multiple AIO instances - each instance in triggered by one jenkins build

-   To run with `master` and `stable`, execute command `extended test - matrix-test master,stable` or `extended test - matrix-test latest`
-   To run with specific version,ex: `2.3.0` and `2.3.1`, execute command `extended test - matrix-test 2.3.0,2.3.1`
-   In case `<AIO_version>` is empty, read versions from file `compTigerVersions.txt` of this repo

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
