### PR TITLE
BUGFIX: RAIL-5026 Add assets to exports field

### DIFF
--- a/examples/playground/webpack.config.cjs
+++ b/examples/playground/webpack.config.cjs
@@ -126,20 +126,9 @@ module.exports = async (env, argv) => {
             // Alias for ESM imports with .js suffix because
             // `import { abc } from "../abc.js"` may be in fact importing from `abc.tsx` file
             extensionAlias: {
-                    ".js": [".ts", ".tsx", ".js", ".jsx"],
+                ".js": [".ts", ".tsx", ".js", ".jsx"],
             },
 
-            alias: {
-                react: path.resolve("./node_modules/react"),
-                // fixes tilde imports in CSS
-                "@gooddata/sdk-ui-charts": path.resolve("./node_modules/@gooddata/sdk-ui-charts"),
-                "@gooddata/sdk-ui-dashboard": path.resolve("./node_modules/@gooddata/sdk-ui-dashboard"),
-                "@gooddata/sdk-ui-ext": path.resolve("./node_modules/@gooddata/sdk-ui-ext"),
-
-                "@gooddata/sdk-ui-filters": path.resolve("./node_modules/@gooddata/sdk-ui-filters"),
-                "@gooddata/sdk-ui-kit": path.resolve("./node_modules/@gooddata/sdk-ui-kit"),
-                "@gooddata/sdk-ui-pivot": path.resolve("./node_modules/@gooddata/sdk-ui-pivot"),
-            },
             // Prefer ESM versions of packages to enable tree shaking and easier dev experience
             mainFields: ["module", "browser", "main"],
         },

--- a/examples/sdk-examples/webpack.config.js
+++ b/examples/sdk-examples/webpack.config.js
@@ -114,19 +114,6 @@ module.exports = async (env, argv) => {
         },
         resolve: {
             extensions: [".js", ".jsx", ".ts", ".tsx"],
-            alias: {
-                react: path.resolve("./node_modules/react"),
-                "react-dom":  path.resolve("./node_modules/react-dom"),
-
-                // fixes tilde imports in CSS from sdk-ui-ext
-                "@gooddata/sdk-ui-ext": path.resolve("./node_modules/@gooddata/sdk-ui-ext"),
-                "@gooddata/sdk-ui-kit": path.resolve("./node_modules/@gooddata/sdk-ui-kit"),
-                "@gooddata/sdk-ui-dashboard": path.resolve("./node_modules/@gooddata/sdk-ui-dashboard"),
-                "@gooddata/sdk-ui-pivot": path.resolve("./node_modules/@gooddata/sdk-ui-pivot"),
-                "@gooddata/sdk-ui-charts": path.resolve("./node_modules/@gooddata/sdk-ui-charts"),
-                "@gooddata/sdk-ui-filters": path.resolve("./node_modules/@gooddata/sdk-ui-filters"),
-                "@gooddata/sdk-ui-geo": path.resolve("./node_modules/@gooddata/sdk-ui-geo"),
-            },
             // Prefer ESM versions of packages to enable tree shaking and easier dev experience
             mainFields: ["module", "browser", "main"],
         },

--- a/libs/sdk-ui-charts/package.json
+++ b/libs/sdk-ui-charts/package.json
@@ -13,7 +13,7 @@
     "browser": "./esm/index.js",
     "exports": {
         ".": "./esm/index.js",
-        "./styles/css/main.css": "./styles/css/main.css",
+        "./styles/css/*": "./styles/css/*",
         "./internal-tests/CoreAreaChart": "./esm/charts/areaChart/CoreAreaChart.js",
         "./internal-tests/CoreBarChart": "./esm/charts/barChart/CoreBarChart.js",
         "./internal-tests/CoreBubbleChart": "./esm/charts/bubbleChart/CoreBubbleChart.js",

--- a/libs/sdk-ui-dashboard/package.json
+++ b/libs/sdk-ui-dashboard/package.json
@@ -13,8 +13,9 @@
     "browser": "./esm/index.js",
     "exports": {
         ".": "./esm/index.js",
-        "./styles/css/main.css": "./styles/css/main.css",
-        "./internal": "./esm/internal.js"
+        "./internal": "./esm/internal.js",
+        "./styles/css/*": "./styles/css/*",
+        "./esm/assets/*": "./esm/assets/*"
     },
     "types": "./esm/index.d.ts",
     "sideEffects": [

--- a/libs/sdk-ui-ext/package.json
+++ b/libs/sdk-ui-ext/package.json
@@ -13,9 +13,10 @@
     "browser": "./esm/index.js",
     "exports": {
         ".": "./esm/index.js",
-        "./styles/css/main.css": "./styles/css/main.css",
+        "./styles/css/*": "./styles/css/*",
         "./internal": "./esm/internal/index.js",
-        "./internal/assets/*": "./esm/internal/assets/*"
+        "./esm/internal/assets/*": "./esm/internal/assets/*",
+        "./styles/internal/*": "./styles/internal/*"
     },
     "types": "./esm/index.d.ts",
     "sideEffects": [

--- a/libs/sdk-ui-filters/package.json
+++ b/libs/sdk-ui-filters/package.json
@@ -13,7 +13,7 @@
     "browser": "./esm/index.js",
     "exports": {
         ".": "./esm/index.js",
-        "./styles/css/main.css": "./styles/css/main.css",
+        "./styles/css/*": "./styles/css/*",
         "./internal": "./esm/internal.js"
     },
     "types": "./esm/index.d.ts",

--- a/libs/sdk-ui-geo/package.json
+++ b/libs/sdk-ui-geo/package.json
@@ -13,7 +13,7 @@
     "browser": "./esm/index.js",
     "exports": {
         ".": "./esm/index.js",
-        "./styles/css/main.css": "./styles/css/main.css",
+        "./styles/css/*": "./styles/css/*",
         "./internal-tests/GeoChartOptionsWrapper": "./esm/core/geoChart/GeoChartOptionsWrapper.js"
     },
     "types": "./esm/index.d.ts",

--- a/libs/sdk-ui-kit/package.json
+++ b/libs/sdk-ui-kit/package.json
@@ -13,7 +13,8 @@
     "browser": "./esm/index.js",
     "exports": {
         ".": "./esm/index.js",
-        "./styles/css/main.css": "./styles/css/main.css"
+        "./styles/*": "./styles/*",
+        "./esm/assets/*": "./esm/assets/*"
     },
     "types": "./esm/index.d.ts",
     "sideEffects": [

--- a/libs/sdk-ui-pivot/package.json
+++ b/libs/sdk-ui-pivot/package.json
@@ -13,7 +13,7 @@
     "browser": "./esm/index.js",
     "exports": {
         ".": "./esm/index.js",
-        "./styles/css/main.css": "./styles/css/main.css",
+        "./styles/css/*": "./styles/css/*",
         "./internal-tests/CorePivotTableAgImpl": "./esm/CorePivotTable.js"
     },
     "types": "./esm/index.d.ts",

--- a/libs/sdk-ui-tests-e2e/scenarios/webpack.config.cjs
+++ b/libs/sdk-ui-tests-e2e/scenarios/webpack.config.cjs
@@ -145,18 +145,6 @@ module.exports = async (env, argv) => {
             extensionAlias: {
                 ".js": [".ts", ".tsx", ".js", ".jsx"],
             },
-            alias: {
-                react: path.resolve("./node_modules/react"),
-                // fixes tilde imports in CSS from sdk-ui-ext
-                "@gooddata/sdk-ui-ext": path.resolve("./node_modules/@gooddata/sdk-ui-ext"),
-                "@gooddata/sdk-ui-kit": path.resolve("./node_modules/@gooddata/sdk-ui-kit"),
-                "@gooddata/sdk-ui-dashboard": path.resolve("./node_modules/@gooddata/sdk-ui-dashboard"),
-                "@gooddata/sdk-ui-charts": path.resolve("./node_modules/@gooddata/sdk-ui-charts"),
-                "@gooddata/sdk-ui-filters": path.resolve("./node_modules/@gooddata/sdk-ui-filters"),
-                "@gooddata/sdk-ui-geo": path.resolve("./node_modules/@gooddata/sdk-ui-geo"),
-                "@gooddata/sdk-ui-pivot": path.resolve("./node_modules/@gooddata/sdk-ui-pivot"),
-            },
-
             // Prefer ESM versions of packages to enable tree shaking and easier dev experience
             mainFields: ["module", "browser", "main"],
         },

--- a/libs/sdk-ui-tests/.storybook/main.cjs
+++ b/libs/sdk-ui-tests/.storybook/main.cjs
@@ -28,18 +28,10 @@ module.exports = {
             },
             alias: {
                 ...config.resolve.alias,
-                // fixes tilde imports in CSS from sdk-ui-ext
+                // fixes internal exports from sdk-ui-ext
                 "@gooddata/sdk-ui-ext/internal": path.resolve(
                     "./node_modules/@gooddata/sdk-ui-ext/esm/internal",
                 ),
-                "@gooddata/sdk-ui-ext": path.resolve("./node_modules/@gooddata/sdk-ui-ext"),
-                "@gooddata/sdk-ui-kit": path.resolve("./node_modules/@gooddata/sdk-ui-kit"),
-                "@gooddata/sdk-ui-dashboard": path.resolve("./node_modules/@gooddata/sdk-ui-dashboard"),
-                "@gooddata/sdk-ui": path.resolve("./node_modules/@gooddata/sdk-ui"),
-                "@gooddata/sdk-ui-charts": path.resolve("./node_modules/@gooddata/sdk-ui-charts"),
-                "@gooddata/sdk-ui-filters": path.resolve("./node_modules/@gooddata/sdk-ui-filters"),
-                "@gooddata/sdk-ui-geo": path.resolve("./node_modules/@gooddata/sdk-ui-geo"),
-                "@gooddata/sdk-ui-pivot": path.resolve("./node_modules/@gooddata/sdk-ui-pivot"),
             },
         },
         plugins: [

--- a/libs/sdk-ui-web-components/webpack.config.cjs
+++ b/libs/sdk-ui-web-components/webpack.config.cjs
@@ -39,20 +39,6 @@ module.exports = (env, argv) => ({
             ".js": [".ts", ".tsx", ".js", ".jsx"],
         },
 
-        alias: {
-            react: path.resolve("./node_modules/react"),
-            "react-dom": path.resolve("./node_modules/react-dom"),
-
-            // fixes tilde imports in CSS from sdk-ui-* packages
-            "@gooddata/sdk-ui-filters": path.resolve("./node_modules/@gooddata/sdk-ui-filters"),
-            "@gooddata/sdk-ui-charts": path.resolve("./node_modules/@gooddata/sdk-ui-charts"),
-            "@gooddata/sdk-ui-geo": path.resolve("./node_modules/@gooddata/sdk-ui-geo"),
-            "@gooddata/sdk-ui-pivot": path.resolve("./node_modules/@gooddata/sdk-ui-pivot"),
-            "@gooddata/sdk-ui-dashboard": path.resolve("./node_modules/@gooddata/sdk-ui-dashboard"),
-            "@gooddata/sdk-ui-ext": path.resolve("./node_modules/@gooddata/sdk-ui-ext"),
-            "@gooddata/sdk-ui-kit": path.resolve("./node_modules/@gooddata/sdk-ui-kit"),
-        },
-
         // Prefer ESM versions of packages to enable tree shaking
         mainFields: ["module", "browser", "main"],
     },

--- a/tools/dashboard-plugin-template/webpack.config.cjs
+++ b/tools/dashboard-plugin-template/webpack.config.cjs
@@ -77,17 +77,6 @@ module.exports = (_env, argv) => {
                     ".js": [".ts", ".tsx", ".js", ".jsx"],
             },
 
-            alias: {
-
-                // fixes tilde imports in CSS from sdk-ui-* packages
-                "@gooddata/sdk-ui-filters": path.resolve("./node_modules/@gooddata/sdk-ui-filters"),
-                "@gooddata/sdk-ui-charts": path.resolve("./node_modules/@gooddata/sdk-ui-charts"),
-                "@gooddata/sdk-ui-pivot": path.resolve("./node_modules/@gooddata/sdk-ui-pivot"),
-                "@gooddata/sdk-ui-kit": path.resolve("./node_modules/@gooddata/sdk-ui-kit"),
-                "@gooddata/sdk-ui-ext": path.resolve("./node_modules/@gooddata/sdk-ui-ext"),
-                "@gooddata/sdk-ui-dashboard": path.resolve("./node_modules/@gooddata/sdk-ui-dashboard"),
-            },
-
             // Prefer ESM versions of packages to enable tree shaking
             mainFields: ["module", "browser", "main"],
 

--- a/tools/react-app-template/webpack.config.cjs
+++ b/tools/react-app-template/webpack.config.cjs
@@ -64,17 +64,6 @@ module.exports = (_env, argv) => {
                     ".js": [".ts", ".tsx", ".js", ".jsx"],
                 },
 
-                alias: {
-                    // fixes tilde imports in CSS from sdk-ui-* packages
-                    "@gooddata/sdk-ui-filters": path.resolve("./node_modules/@gooddata/sdk-ui-filters"),
-                    "@gooddata/sdk-ui-charts": path.resolve("./node_modules/@gooddata/sdk-ui-charts"),
-                    "@gooddata/sdk-ui-pivot": path.resolve("./node_modules/@gooddata/sdk-ui-pivot"),
-                    "@gooddata/sdk-ui-kit": path.resolve("./node_modules/@gooddata/sdk-ui-kit"),
-                    "@gooddata/sdk-ui-ext": path.resolve("./node_modules/@gooddata/sdk-ui-ext"),
-                    "@gooddata/sdk-ui-geo": path.resolve("./node_modules/@gooddata/sdk-ui-geo"),
-                    "@gooddata/sdk-ui-dashboard": path.resolve("./node_modules/@gooddata/sdk-ui-dashboard"),
-                },
-
                 // Prefer ESM versions of packages to enable tree shaking
                 mainFields: ["module", "browser", "main"],
             },


### PR DESCRIPTION
Add fonts and other assets imported across the packages in css to `package.json` `"exports"` field, so most bundlers are able to handle them out of the box, without additional setup.

Also remove aliases workaround for this,
which is not needed anymore.

JIRA: RAIL-5026

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |
| **Compatibility matrix test commands - TIGER Backend**  |                                                            |
| `extended test - matrix-test <AIO_version>`             | Run integrated tests against AIO versions.                 |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

`<AIO_version>` in commands is used to start test with multiple AIO instances - each instance in triggered by one jenkins build

-   To run with `master` and `stable`, execute command `extended test - matrix-test master,stable` or `extended test - matrix-test latest`
-   To run with specific version,ex: `2.3.0` and `2.3.1`, execute command `extended test - matrix-test 2.3.0,2.3.1`
-   In case `<AIO_version>` is empty, read versions from file `compTigerVersions.txt` of this repo

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
