### PR TITLE
BUGFIX: RAIL-4989, RAIL-5004, RAIL-4990, RAIL-5002, RAIL-5028 Fix react-app-template

### DIFF
--- a/common/config/rush/browser-approved-packages.json
+++ b/common/config/rush/browser-approved-packages.json
@@ -455,6 +455,10 @@
       "allowedCategories": [ "production" ]
     },
     {
+      "name": "@types/validate-npm-package-name",
+      "allowedCategories": [ "tools" ]
+    },
+    {
       "name": "@types/webpack-env",
       "allowedCategories": [ "examples" ]
     },
@@ -1065,6 +1069,10 @@
     {
       "name": "uuid",
       "allowedCategories": [ "production" ]
+    },
+    {
+      "name": "validate-npm-package-name",
+      "allowedCategories": [ "tools" ]
     },
     {
       "name": "vitest",

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -3255,6 +3255,7 @@ importers:
       ts-node: ^10.4.0
       tslib: ^2.5.0
       typescript: 5.0.2
+      validate-npm-package-name: ^5.0.0
       vitest: 0.31.4
     dependencies:
       '@babel/cli': 7.21.0_@babel+core@7.21.4
@@ -3278,6 +3279,7 @@ importers:
       strip-ansi: 6.0.1
       tar: 6.1.13
       tslib: 2.5.0
+      validate-npm-package-name: 5.0.0
     devDependencies:
       '@gooddata/eslint-config': 4.1.0_e26rfststzmmda6s4rqitickwm
       '@types/columnify': 1.5.1
@@ -3894,6 +3896,7 @@ importers:
       ts-node: ^10.4.0
       tslib: ^2.5.0
       typescript: 5.0.2
+      validate-npm-package-name: ^5.0.0
       vitest: 0.31.4
     dependencies:
       '@babel/cli': 7.21.0_@babel+core@7.21.4
@@ -3918,6 +3921,7 @@ importers:
       strip-ansi: 6.0.1
       tar: 6.1.13
       tslib: 2.5.0
+      validate-npm-package-name: 5.0.0
     devDependencies:
       '@gooddata/eslint-config': 4.1.0_e26rfststzmmda6s4rqitickwm
       '@types/columnify': 1.5.1
@@ -10989,6 +10993,12 @@ packages:
 
   /builtin-status-codes/3.0.0:
     resolution: {integrity: sha512-HpGFw18DgFWlncDfjTa2rcQ4W88O1mC8e8yZ2AvQY5KDaktSTwo+KRf6nHK6FRI5FyRyb/5T6+TSxfP7QyGsmQ==}
+    dev: false
+
+  /builtins/5.0.1:
+    resolution: {integrity: sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==}
+    dependencies:
+      semver: 7.5.1
     dev: false
 
   /bundle-name/3.0.0:
@@ -21997,6 +22007,13 @@ packages:
     dependencies:
       spdx-correct: 3.2.0
       spdx-expression-parse: 3.0.1
+
+  /validate-npm-package-name/5.0.0:
+    resolution: {integrity: sha512-YuKoXDAhBYxY7SfOKxHBDoSyENFeW5VvIIQp2TGQuit8gpK6MnWaQelBKxso72DoxTZfZdcP3W90LqpSkgPzLQ==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+    dependencies:
+      builtins: 5.0.1
+    dev: false
 
   /validator/13.9.0:
     resolution: {integrity: sha512-B+dGG8U3fdtM0/aNK4/X8CXq/EcxU2WPrPEkJGslb47qyHsxmbggTWK0yEA4qnYVNF+nxNlN88o14hIcPmSIEA==}

--- a/libs/sdk-ui-dashboard/src/internal.ts
+++ b/libs/sdk-ui-dashboard/src/internal.ts
@@ -21,3 +21,4 @@ export * from "./_staging/dashboard/fluidLayout/config.js";
 export * from "./_staging/layout/sizing.js";
 export * from "./_staging/dateFilterConfig/dateFilterOptionMapping.js";
 export * from "./_staging/dateFilterConfig/dateFilterConfigConverters.js";
+export * from "./_staging/dashboard/dashboardFilterConverter.js";

--- a/tools/app-toolkit/package.json
+++ b/tools/app-toolkit/package.json
@@ -63,7 +63,8 @@
         "ora": "^5.3.0",
         "strip-ansi": "^6.0.0",
         "tar": "^6.1.11",
-        "tslib": "^2.5.0"
+        "tslib": "^2.5.0",
+        "validate-npm-package-name": "^5.0.0"
     },
     "devDependencies": {
         "@gooddata/eslint-config": "^4.1.0",

--- a/tools/app-toolkit/src/_base/inputHandling/validators.ts
+++ b/tools/app-toolkit/src/_base/inputHandling/validators.ts
@@ -1,5 +1,7 @@
 // (C) 2007-2022 GoodData Corporation
+import validateNpmPackageName from "validate-npm-package-name";
 import isEmpty from "lodash/isEmpty.js";
+import capitalize from "lodash/capitalize.js";
 import { InputValidationError } from "../types.js";
 
 export type InputValidator<T = string> = (value: T) => boolean | string;
@@ -17,13 +19,14 @@ export function applicationNameValidator(value: string): boolean | string {
         return "Please enter non-empty application name.";
     }
 
-    // pattern used by VS code:
-    if (!value.match(/^(?:@[a-z0-9-*~][a-z0-9-*._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$/)) {
-        return "Invalid application name. Application name must be a valid package name.";
-    }
+    const result = validateNpmPackageName(value);
 
-    if (value.length > 214) {
-        return "Invalid application name. Name is too long.";
+    if (result.errors?.length) {
+        return `Invalid application name. ${result.errors
+            .map((e: string) => {
+                return `${capitalize(e)}.`;
+            })
+            .join(" ")}`;
     }
 
     return true;

--- a/tools/app-toolkit/src/typings.d.ts
+++ b/tools/app-toolkit/src/typings.d.ts
@@ -14,3 +14,14 @@ declare module "*.json" {
     const value: any;
     export default value;
 }
+
+declare module "validate-npm-package-name" {
+    const validate: (value: string) => {
+        validForNewPackages: boolean;
+        validForOldPackages: boolean;
+        errors?: string[];
+        warnings?: string[];
+    };
+
+    export default validate;
+}

--- a/tools/plugin-toolkit/package.json
+++ b/tools/plugin-toolkit/package.json
@@ -65,7 +65,8 @@
         "ora": "^5.3.0",
         "strip-ansi": "^6.0.0",
         "tar": "^6.1.11",
-        "tslib": "^2.5.0"
+        "tslib": "^2.5.0",
+        "validate-npm-package-name": "^5.0.0"
     },
     "devDependencies": {
         "@gooddata/eslint-config": "^4.1.0",

--- a/tools/plugin-toolkit/src/typings.d.ts
+++ b/tools/plugin-toolkit/src/typings.d.ts
@@ -13,3 +13,14 @@ declare module "*.json" {
     const value: any;
     export default value;
 }
+
+declare module "validate-npm-package-name" {
+    const validate: (value: string) => {
+        validForNewPackages: boolean;
+        validForOldPackages: boolean;
+        errors?: string[];
+        warnings?: string[];
+    };
+
+    export default validate;
+}

--- a/tools/react-app-template/README.template.md
+++ b/tools/react-app-template/README.template.md
@@ -7,8 +7,6 @@ See it action by running `{{packageManager}} start` command.
 
 ## Quick Introduction
 
-> TODO - describe the data that is used in the project, with link to CN docs
-
 The project includes:
 
 -   All necessary NPM dependencies in [`package.json`](./package.json).
@@ -18,7 +16,7 @@ The project includes:
     -   `{{packageManager}} run clean` - to clear the results of the previous build.
     -   `{{packageManager}} run refresh-md` - to update the [metadata catalogue](https://sdk.gooddata.com/gooddata-ui/docs/export_catalog.html).
 -   A sample [Webpack configuration](./webpack.config.js).
--   A development proxy to easily connect to the public demo data for visualizations without the need to work around CORS.
+-   A development proxy to easily connect to the public [demo data](https://www.gooddata.com/developers/cloud-native/doc/cloud/getting-started/connect-data#ConnectData-SampleDatabase) for visualizations without the need to work around CORS.
 -   An example code for GoodData Rect SDK in the [`App.{{language}}x`](./src/App.{{language}}x) file.
 
 ## What's next?
@@ -194,7 +192,7 @@ your own data instead.
     TIGER_API_TOKEN=<your_api_token>
     ```
    Make sure you do not commit the `.env` file to your VCS (e.g. Git)
-3. Refresh [the metadata catalog](https://sdk.gooddata.com/gooddata-ui/docs/export_catalog.html) for the newly configured workspace: `npm run refresh-md`.
+3. Refresh [the metadata catalog](https://sdk.gooddata.com/gooddata-ui/docs/export_catalog.html) for the newly configured workspace: `{{packageManager}} run refresh-md`.
 4. Update the `App.{{language}}x`. Since we've switched to your own data, the reference to the insight in `App.{{language}}x` is no longer valid.
    Select a new insight to render from the catalog and update `App.{{language}}x`:
     ```diff
@@ -238,7 +236,7 @@ By default, GoodData React SDK is configured to connect to GoodData Cloud or Goo
     +    PASSWORD=<your-password>
     ```
    Make sure you do not commit the `.env` file to your VCS (e.g. Git).
-4. Refresh [the metadata catalog](https://sdk.gooddata.com/gooddata-ui/docs/export_catalog.html) for the newly configured workspace: `npm run refresh-md`.
+4. Refresh [the metadata catalog](https://sdk.gooddata.com/gooddata-ui/docs/export_catalog.html) for the newly configured workspace: `{{packageManager}} run refresh-md`.
 5. Update the `App.{{language}}x`. Since we've switched to your own data, the reference to the insight in `App.{{language}}x` is no longer valid.
    Select a new insight to render from the catalog and update `App.{{language}}x`:
     ```diff

--- a/tools/react-app-template/src/index.css
+++ b/tools/react-app-template/src/index.css
@@ -83,6 +83,7 @@ body {
     margin: 2em 0 0;
     padding: 0 1em;
     background: var(--white);
+    overflow: auto;
 }
 
 .app footer {

--- a/tools/react-app-template/src/index.tsx
+++ b/tools/react-app-template/src/index.tsx
@@ -7,6 +7,7 @@ import { App } from "./App.js";
 // Include GoodData styles, needed for correct visualizations rendering
 // You may exclude some file if you're not planning to use all visualizations
 // For example, you can exclude sdk-ui-geo styles if you're not planning to use PushPin GeoChart
+import "@gooddata/sdk-ui-kit/styles/css/main.css";
 import "@gooddata/sdk-ui-filters/styles/css/main.css";
 import "@gooddata/sdk-ui-charts/styles/css/main.css";
 import "@gooddata/sdk-ui-pivot/styles/css/main.css";


### PR DESCRIPTION
A batch of minor fixes for the react-app-template and app-toolkit.

- Add `overflow: auto` to the content of the application, so when the user replaces insight with the dashboard, it still looks ok. (RAIL-4989)
- Add `sdk-ui-kit` styles as they are required by the dashboard. (RAIL-5004)
- Replace hardcoded `npm` in readme with used package manager. (RAIL-4990)
- Improve validation of the npm package name in `plugin-toolkit` and `app-toolkit` with more helpful error messages. (RAIL-5002)
- Reexport also `dashboardFilterConverter` as it
is used in professional services app. (RAIL-5028)

JIRA: RAIL-4989, RAIL-5004, RAIL-4990, RAIL-5002, RAIL-5028

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |
| **Compatibility matrix test commands - TIGER Backend**  |                                                            |
| `extended test - matrix-test <AIO_version>`             | Run integrated tests against AIO versions.                 |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

`<AIO_version>` in commands is used to start test with multiple AIO instances - each instance in triggered by one jenkins build

-   To run with `master` and `stable`, execute command `extended test - matrix-test master,stable` or `extended test - matrix-test latest`
-   To run with specific version,ex: `2.3.0` and `2.3.1`, execute command `extended test - matrix-test 2.3.0,2.3.1`
-   In case `<AIO_version>` is empty, read versions from file `compTigerVersions.txt` of this repo

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
