### PR TITLE
BUGFIX: TNT-1619 Insight view accepts new transposed metrics

### DIFF
--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/PluggablePivotTable.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/PluggablePivotTable.tsx
@@ -313,11 +313,11 @@ export class PluggablePivotTable extends AbstractPluggableVisualization {
         insight: IInsightDefinition,
         executionFactory: IExecutionFactory,
     ) {
-        const { dateFormat, executionConfig } = options;
+        const { dateFormat, executionConfig, customVisualizationConfig } = options;
 
         return executionFactory
             .forInsight(insight)
-            .withDimensions(...this.getDimensions(insight))
+            .withDimensions(...this.getDimensions(insight, customVisualizationConfig))
             .withSorting(...(getPivotTableSortItems(insight) ?? []))
             .withDateFormat(dateFormat)
             .withExecConfig(executionConfig);
@@ -490,8 +490,8 @@ export class PluggablePivotTable extends AbstractPluggableVisualization {
         }
     }
 
-    protected getDimensions(insight: IInsightDefinition): IDimension[] {
-        return generateDimensions(insight, VisualizationTypes.TABLE);
+    protected getDimensions(insight: IInsightDefinition, customVisualizationConfig?: any): IDimension[] {
+        return generateDimensions(insight, VisualizationTypes.TABLE, customVisualizationConfig);
     }
 
     private adaptPropertiesToInsight(

--- a/libs/sdk-ui-ext/src/internal/utils/dimensions.ts
+++ b/libs/sdk-ui-ext/src/internal/utils/dimensions.ts
@@ -21,21 +21,28 @@ import {
     getPivotTableDimensions as getPivotTableDimensionsShared,
 } from "@gooddata/sdk-ui-pivot";
 
+const COLUMNS = "columns";
+const ROWS = "rows";
+
 function safeBucketAttributes(insight: IInsightDefinition, idOrFun: string | BucketPredicate): IAttribute[] {
     const matchingBucket = insightBucket(insight, idOrFun);
     return matchingBucket ? bucketAttributes(matchingBucket) : [];
 }
 
-function isTransposed(insight: IInsightDefinition) {
+function isTransposed(insight: IInsightDefinition, customVisualizationConfig?: any) {
     const measureGroupDimension: MeasureGroupDimension =
-        getMeasureGroupDimensionFromProperties(insightProperties(insight)) ?? "columns";
-    return measureGroupDimension === "rows";
+        getMeasureGroupDimensionFromProperties(insightProperties(insight)) ?? COLUMNS;
+
+    return measureGroupDimension === ROWS || customVisualizationConfig?.measureGroupDimension === ROWS;
 }
 
-export function getPivotTableDimensions(insight: IInsightDefinition): IDimension[] {
+export function getPivotTableDimensions(
+    insight: IInsightDefinition,
+    customVisualizationConfig?: any,
+): IDimension[] {
     const buckets = insightBuckets(insight);
 
-    const transposed = isTransposed(insight);
+    const transposed = isTransposed(insight, customVisualizationConfig);
 
     return getPivotTableDimensionsShared(buckets, transposed);
 }
@@ -121,10 +128,14 @@ function getSankeyDimensions(insight: IInsightDefinition): IDimension[] {
  * @param type - visualization type string
  * @internal
  */
-export function generateDimensions(insight: IInsightDefinition, type: VisType): IDimension[] {
+export function generateDimensions(
+    insight: IInsightDefinition,
+    type: VisType,
+    customVisualizationConfig?: any,
+): IDimension[] {
     switch (type) {
         case VisualizationTypes.TABLE:
-            return getPivotTableDimensions(insight);
+            return getPivotTableDimensions(insight, customVisualizationConfig);
 
         case VisualizationTypes.PIE:
         case VisualizationTypes.DONUT:


### PR DESCRIPTION
JIRA: TNT-1619

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |
| **Compatibility matrix test commands - TIGER Backend**  |                                                            |
| `extended test - matrix-test <AIO_version>`             | Run integrated tests against AIO versions.                 |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

`<AIO_version>` in commands is used to start test with multiple AIO instances - each instance in triggered by one jenkins build

-   To run with `master` and `stable`, execute command `extended test - matrix-test master,stable` or `extended test - matrix-test latest`
-   To run with specific version,ex: `2.3.0` and `2.3.1`, execute command `extended test - matrix-test 2.3.0,2.3.1`
-   In case `<AIO_version>` is empty, read versions from file `compTigerVersions.txt` of this repo

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
