### PR TITLE
RELATED: QA-19500 extracting logs from AIO container in matrix tests

### DIFF
--- a/common/scripts/ci/run-sdk-backend-tiger-integration-tests-with-live-backend.sh
+++ b/common/scripts/ci/run-sdk-backend-tiger-integration-tests-with-live-backend.sh
@@ -15,6 +15,7 @@ TIGER_DATASOURCES_NAME=$TIGER_DATASOURCES_NAME
 IS_AIO=$IS_AIO
 AIO_VERSION=$AIO_VERSION
 EXTRA_PARAMS=""
+IMAGE_ID=gooddata-cn-ce-aio-${EXECUTOR_NUMBER}
 
 $_RUSH install
 $_RUSH build -t sdk-backend-tiger
@@ -38,6 +39,8 @@ health_check() {
 }
 
 function shutdownAIO() {
+  log "Extracting logs from container $IMAGE_ID"
+  docker logs $IMAGE_ID > AIO-logs.txt 2>&1
   log "Shutting down AIO! Stop docker ! Remove network"
   docker stop $IMAGE_ID
   docker rm -f $IMAGE_ID
@@ -46,7 +49,6 @@ function shutdownAIO() {
 
 if [[ "$IS_AIO" == true ]]; then
   DATA_LOADER_IMAGE='registry.gitlab.com/gooddata/gdc-nas/data-loader:master'
-  IMAGE_ID=gooddata-cn-ce-aio-${EXECUTOR_NUMBER}
   PORT_NUMBER=300${EXECUTOR_NUMBER}
   HOST=http://localhost:$PORT_NUMBER
   TEST_HOST=http://$IMAGE_ID:$PORT_NUMBER

--- a/common/scripts/ci/run-sdk-backend-tiger-integration-tests-with-live-backend.sh
+++ b/common/scripts/ci/run-sdk-backend-tiger-integration-tests-with-live-backend.sh
@@ -15,7 +15,7 @@ TIGER_DATASOURCES_NAME=$TIGER_DATASOURCES_NAME
 IS_AIO=$IS_AIO
 AIO_VERSION=$AIO_VERSION
 EXTRA_PARAMS=""
-IMAGE_ID=gooddata-cn-ce-aio-${EXECUTOR_NUMBER}
+CONTAINER_ID=gooddata-cn-ce-aio-${EXECUTOR_NUMBER}
 
 $_RUSH install
 $_RUSH build -t sdk-backend-tiger
@@ -29,7 +29,7 @@ log() {
 health_check() {
   for ((i = 1; i <= 200; i++)); do
     log "Check AIO is up, try $i"
-    if curl -f -s -H "Authorization: Bearer $TIGER_API_TOKEN" -H "Host: $IMAGE_ID" "$HOST/api/v1/entities/admin/organizations/default" ; then
+    if curl -f -s -H "Authorization: Bearer $TIGER_API_TOKEN" -H "Host: $CONTAINER_ID" "$HOST/api/v1/entities/admin/organizations/default" ; then
       return 0
     else
       sleep 3
@@ -39,11 +39,11 @@ health_check() {
 }
 
 function shutdownAIO() {
-  log "Extracting logs from container $IMAGE_ID"
-  docker logs $IMAGE_ID > AIO-logs.txt 2>&1
+  log "Extracting logs from container $CONTAINER_ID"
+  docker logs $CONTAINER_ID > AIO-logs.txt 2>&1
   log "Shutting down AIO! Stop docker ! Remove network"
-  docker stop $IMAGE_ID
-  docker rm -f $IMAGE_ID
+  docker stop $CONTAINER_ID
+  docker rm -f $CONTAINER_ID
   docker network rm $NETWORK_ID
 }
 
@@ -51,8 +51,8 @@ if [[ "$IS_AIO" == true ]]; then
   DATA_LOADER_IMAGE='registry.gitlab.com/gooddata/gdc-nas/data-loader:master'
   PORT_NUMBER=300${EXECUTOR_NUMBER}
   HOST=http://localhost:$PORT_NUMBER
-  TEST_HOST=http://$IMAGE_ID:$PORT_NUMBER
-  CYPRESS_HOST=http://$IMAGE_ID:3000
+  TEST_HOST=http://$CONTAINER_ID:$PORT_NUMBER
+  CYPRESS_HOST=http://$CONTAINER_ID:3000
   TIGER_API_TOKEN=YWRtaW46Ym9vdHN0cmFwOmFkbWluMTIz
   TIGER_DATASOURCES_NAME=pg_staging-goodsales
   EXTRA_PARAMS=" --net=$NETWORK_ID "
@@ -66,7 +66,7 @@ if [[ "$IS_AIO" == true ]]; then
   trap shutdownAIO EXIT
   docker network create $NETWORK_ID
 
-  docker run --name $IMAGE_ID -e APP_LOGLEVEL=INFO -e LICENSE_AND_PRIVACY_POLICY_ACCEPTED=YES \
+  docker run --name $CONTAINER_ID -e APP_LOGLEVEL=INFO -e LICENSE_AND_PRIVACY_POLICY_ACCEPTED=YES \
       -e BUNDLE_TYPE=gdc -e GDCN_PUBLIC_URL=$TEST_HOST -p $PORT_NUMBER:3000 --net=$NETWORK_ID -d $AIO_IMAGE
 
   if ! health_check; then
@@ -75,7 +75,7 @@ if [[ "$IS_AIO" == true ]]; then
   fi
 
   docker run --rm \
-  -e DB_HOST=$IMAGE_ID \
+  -e DB_HOST=$CONTAINER_ID \
   -e DB_PORT=5432 \
   -e DB_USER=demouser \
   -e DB_NAME=demo \
@@ -88,7 +88,7 @@ if [[ "$IS_AIO" == true ]]; then
     -H "Content-Type: application/vnd.gooddata.api+json" \
     -H "Accept: application/vnd.gooddata.api+json" \
     -H "Authorization: Bearer $TIGER_API_TOKEN" \
-    -H "Host: $IMAGE_ID" \
+    -H "Host: $CONTAINER_ID" \
     -X POST \
     -d '{
         "data": {


### PR DESCRIPTION
JIRA: QA-19500

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |
| **Compatibility matrix test commands - TIGER Backend**  |                                                            |
| `extended test - matrix-test <AIO_version>`             | Run integrated tests against AIO versions.                 |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

`<AIO_version>` in commands is used to start test with multiple AIO instances - each instance in triggered by one jenkins build

-   To run with `master` and `stable`, execute command `extended test - matrix-test master,stable` or `extended test - matrix-test latest`
-   To run with specific version,ex: `2.3.0` and `2.3.1`, execute command `extended test - matrix-test 2.3.0,2.3.1`
-   In case `<AIO_version>` is empty, read versions from file `compTigerVersions.txt` of this repo

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
