### PR TITLE
BUGFIX: RAIL-5041 replace require by import in catalog-export

### DIFF
--- a/common/config/rush/browser-approved-packages.json
+++ b/common/config/rush/browser-approved-packages.json
@@ -279,6 +279,10 @@
       "allowedCategories": [ "production" ]
     },
     {
+      "name": "@types/babel__core",
+      "allowedCategories": [ "tools" ]
+    },
+    {
       "name": "@types/blessed",
       "allowedCategories": [ "tools" ]
     },

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -3382,6 +3382,7 @@ importers:
       '@gooddata/api-model-bear': workspace:*
       '@gooddata/eslint-config': ^4.1.0
       '@gooddata/sdk-model': workspace:*
+      '@types/babel__core': ^7.20.1
       '@types/inquirer': ^8.2.6
       '@types/lodash': ^4.14.158
       '@types/node': ^16.18.23
@@ -3436,6 +3437,7 @@ importers:
       tslib: 2.5.0
     devDependencies:
       '@gooddata/eslint-config': 4.1.0_e26rfststzmmda6s4rqitickwm
+      '@types/babel__core': 7.20.1
       '@types/inquirer': 8.2.6
       '@types/lodash': 4.14.194
       '@types/node': 16.18.23
@@ -8725,7 +8727,7 @@ packages:
     resolution: {integrity: sha512-v9piuwp8FvTiHXIOOi5lEyTEJKhnbcbhVxgJ3VFhhXYFd0DTz6Bst0XIIgkgs21ITb3xhkfPbCRUueMcbXO1MA==}
     dependencies:
       '@storybook/channels': 7.0.7
-      '@types/babel__core': 7.20.0
+      '@types/babel__core': 7.20.1
       '@types/express': 4.17.17
       file-system-cache: 2.1.1
     dev: false
@@ -8875,34 +8877,30 @@ packages:
     resolution: {integrity: sha512-XTIieEY+gvJ39ChLcB4If5zHtPxt3Syj5rgZR+e1ctpmK8NjPf0zFqsz4JpLJT0xla9GFDKjy8Cpu331nrmE1Q==}
     dev: true
 
-  /@types/babel__core/7.20.0:
-    resolution: {integrity: sha512-+n8dL/9GWblDO0iU6eZAwEIJVr5DWigtle+Q6HLOrh/pdbXOhOtqzq8VPPE2zvNJzSKY4vH/z3iT3tn0A3ypiQ==}
+  /@types/babel__core/7.20.1:
+    resolution: {integrity: sha512-aACu/U/omhdk15O4Nfb+fHgH/z3QsfQzpnvRZhYhThms83ZnAOZz7zZAWO7mn2yyNQaA4xTO8GLK3uqFU4bYYw==}
     dependencies:
       '@babel/parser': 7.21.4
       '@babel/types': 7.21.4
       '@types/babel__generator': 7.6.4
       '@types/babel__template': 7.4.1
       '@types/babel__traverse': 7.18.3
-    dev: false
 
   /@types/babel__generator/7.6.4:
     resolution: {integrity: sha512-tFkciB9j2K755yrTALxD44McOrk+gfpIpvC3sxHjRawj6PfnQxrse4Clq5y/Rq+G3mrBurMax/lG8Qn2t9mSsg==}
     dependencies:
       '@babel/types': 7.21.4
-    dev: false
 
   /@types/babel__template/7.4.1:
     resolution: {integrity: sha512-azBFKemX6kMg5Io+/rdGT0dkGreboUVR0Cdm3fz9QJWpaQGJRQXl7C+6hOTCZcMll7KFyEQpgbYI2lHdsS4U7g==}
     dependencies:
       '@babel/parser': 7.21.4
       '@babel/types': 7.21.4
-    dev: false
 
   /@types/babel__traverse/7.18.3:
     resolution: {integrity: sha512-1kbcJ40lLB7MHsj39U4Sh1uTd2E7rLEa79kmDpI6cy+XiXsteB3POdQomoq4FxszMrO3ZYchkhYJw7A2862b3w==}
     dependencies:
       '@babel/types': 7.21.4
-    dev: false
 
   /@types/blessed/0.1.21:
     resolution: {integrity: sha512-nlJHCM/wDUtvhDF7FBW2fWTP1JIPMm16xKXTdaAgOaqXiT4VkB/GIc7LAX5BxhTR09BVeNF2JzxszHC9Tres2w==}

--- a/tools/catalog-export/package.json
+++ b/tools/catalog-export/package.json
@@ -60,6 +60,7 @@
     },
     "devDependencies": {
         "@gooddata/eslint-config": "^4.1.0",
+        "@types/babel__core": "^7.20.1",
         "@types/inquirer": "^8.2.6",
         "@types/lodash": "^4.14.158",
         "@types/node": "^16.18.23",

--- a/tools/catalog-export/src/exports/metaToJavascript.ts
+++ b/tools/catalog-export/src/exports/metaToJavascript.ts
@@ -3,6 +3,8 @@ import { transformToTypescript } from "../transform/toTypescript.js";
 import pkg from "prettier";
 const { format } = pkg;
 
+import { transform } from "@babel/core";
+
 import * as fs from "fs";
 import { WorkspaceMetadata } from "../base/types.js";
 
@@ -26,10 +28,9 @@ export async function exportMetadataToJavascript(
     const generatedTypescript = output.sourceFile.getFullText();
     const formattedTypescript = format(generatedTypescript, { parser: "typescript", printWidth: 120 });
 
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const javascript = require("@babel/core").transform(formattedTypescript, {
+    const javascript = transform(formattedTypescript, {
         plugins: ["@babel/plugin-transform-typescript"],
     });
 
-    fs.writeFileSync(outputFile, javascript.code, { encoding: "utf-8" });
+    fs.writeFileSync(outputFile, javascript?.code ?? "", { encoding: "utf-8" });
 }


### PR DESCRIPTION
JIRA: RAIL-5041

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |
| **Compatibility matrix test commands - TIGER Backend**  |                                                            |
| `extended test - matrix-test <AIO_version>`             | Run integrated tests against AIO versions.                 |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

`<AIO_version>` in commands is used to start test with multiple AIO instances - each instance in triggered by one jenkins build

-   To run with `master` and `stable`, execute command `extended test - matrix-test master,stable` or `extended test - matrix-test latest`
-   To run with specific version,ex: `2.3.0` and `2.3.1`, execute command `extended test - matrix-test 2.3.0,2.3.1`
-   In case `<AIO_version>` is empty, read versions from file `compTigerVersions.txt` of this repo

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
