### PR TITLE
BUGFIX: RAIL-4999 prompt hostname in export catalog

### DIFF
--- a/tools/catalog-export/src/base/constants.ts
+++ b/tools/catalog-export/src/base/constants.ts
@@ -1,7 +1,6 @@
 // (C) 2007-2023 GoodData Corporation
 import { CatalogExportConfig } from "./types.js";
 
-export const DEFAULT_HOSTNAME = "https://secure.gooddata.com";
 export const DEFAULT_CONFIG_FILE_NAME = ".gdcatalogrc";
 export const DEFAULT_OUTPUT_FILE_NAME = "catalog.ts";
 

--- a/tools/catalog-export/src/cli/prompts.ts
+++ b/tools/catalog-export/src/cli/prompts.ts
@@ -89,3 +89,14 @@ export async function requestFilePath(): Promise<string> {
 
     return filePath;
 }
+
+export async function promptHostname(): Promise<string> {
+    const hostnameQuestion: DistinctQuestion = {
+        type: "input",
+        name: "hostname",
+        message: "Enter hostname:",
+    };
+    const response = await prompt(hostnameQuestion);
+
+    return response.hostname;
+}

--- a/tools/catalog-export/src/loaders/bear/index.ts
+++ b/tools/catalog-export/src/loaders/bear/index.ts
@@ -6,7 +6,6 @@ import {
     getConfiguredWorkspaceId,
     WorkspaceMetadata,
 } from "../../base/types.js";
-import { DEFAULT_HOSTNAME } from "../../base/constants.js";
 import pkg from "../../../package.json" assert { type: "json" };
 import ora from "ora";
 import { log, logError } from "../../cli/loggers.js";
@@ -45,7 +44,7 @@ export async function loadWorkspaceMetadataFromBear(config: CatalogExportConfig)
     const { hostname } = config;
     let { username, password } = config;
 
-    gooddata.config.setCustomDomain(hostname || DEFAULT_HOSTNAME);
+    gooddata.config.setCustomDomain(hostname!);
     gooddata.config.setJsPackage(pkg.name, pkg.version);
 
     const logInSpinner = ora();


### PR DESCRIPTION
JIRA: RAIL-4999

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |
| **Compatibility matrix test commands - TIGER Backend**  |                                                            |
| `extended test - matrix-test <AIO_version>`             | Run integrated tests against AIO versions.                 |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

`<AIO_version>` in commands is used to start test with multiple AIO instances - each instance in triggered by one jenkins build

-   To run with `master` and `stable`, execute command `extended test - matrix-test master,stable` or `extended test - matrix-test latest`
-   To run with specific version,ex: `2.3.0` and `2.3.1`, execute command `extended test - matrix-test 2.3.0,2.3.1`
-   In case `<AIO_version>` is empty, read versions from file `compTigerVersions.txt` of this repo

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
