### PR TITLE
FEATURE: RAIL-4850 deduplicate export methods

### DIFF
--- a/libs/api-client-bear/src/dashboard/dashboard.ts
+++ b/libs/api-client-bear/src/dashboard/dashboard.ts
@@ -1,10 +1,5 @@
 // (C) 2019-2023 GoodData Corporation
-import {
-    FilterContextItem,
-    IExportBlobResponse,
-    IExportResponse,
-    sanitizeFiltersForExport,
-} from "@gooddata/api-model-bear";
+import { FilterContextItem, IExportResponse, sanitizeFiltersForExport } from "@gooddata/api-model-bear";
 import { ApiResponse, XhrModule } from "../xhr.js";
 import { handleHeadPolling, IPollingOptions } from "../util.js";
 import { isExportFinished } from "../utils/export.js";
@@ -25,20 +20,6 @@ export class DashboardModule {
         filters: FilterContextItem[] = [],
         pollingOptions: IPollingOptions = {},
     ): Promise<IExportResponse> {
-        return this.exportToPdfBlob(projectId, dashboardUri, filters, pollingOptions).then((result) => {
-            URL.revokeObjectURL(result.objectUrl); // release blob memory as it will not be used
-            return {
-                uri: result.uri,
-            };
-        });
-    }
-
-    public async exportToPdfBlob(
-        projectId: string,
-        dashboardUri: string,
-        filters: FilterContextItem[] = [],
-        pollingOptions: IPollingOptions = {},
-    ): Promise<IExportBlobResponse> {
         const sanitizedFilters = sanitizeFiltersForExport(filters);
         const payload = this.getDashboardExportPayload(dashboardUri, sanitizedFilters);
 
@@ -53,7 +34,7 @@ export class DashboardModule {
     private async pollPdfFile(
         response: ApiResponse,
         pollingOptions: IPollingOptions,
-    ): Promise<IExportBlobResponse> {
+    ): Promise<IExportResponse> {
         const data: IExportResponse = response.getData();
         return handleHeadPolling(this.xhr.head.bind(this.xhr), data.uri, isExportFinished, {
             ...pollingOptions,

--- a/libs/api-client-bear/src/report/report.ts
+++ b/libs/api-client-bear/src/report/report.ts
@@ -3,7 +3,6 @@ import {
     CompatibilityFilter,
     IAfm,
     IBaseExportConfig,
-    IExportBlobResponse,
     IExportConfig,
     IExportResponse,
 } from "@gooddata/api-model-bear";
@@ -39,6 +38,8 @@ export class ReportModule {
      * request new result export
      * request new export of existing AFM execution
      *
+     * Export file is downloaded and attached as Blob data to the current window instance.
+     *
      * @experimental
      * @param projectId - GoodData projectId
      * @param executionResult - report which should be exported
@@ -53,37 +54,6 @@ export class ReportModule {
         exportConfig: IExportConfig = {},
         pollingOptions: IPollingOptions = {},
     ): Promise<IExportResponse> {
-        return this.exportResultToBlob(projectId, executionResult, exportConfig, pollingOptions).then(
-            (result) => {
-                URL.revokeObjectURL(result.objectUrl); // release blob memory as it will not be used
-                return {
-                    uri: result.uri,
-                };
-            },
-        );
-    }
-
-    /**
-     * exportResult
-     * request new result export
-     * request new export of existing AFM execution
-     *
-     * Export file is downloaded and attached as Blob data to the current window instance.
-     *
-     * @experimental
-     * @param projectId - GoodData projectId
-     * @param executionResult - report which should be exported
-     * @param exportConfig - requested export options
-     * @param pollingOptions - for polling (maxAttempts, pollStep)
-     * @returns Resolves if export successfully,
-     *                   Reject if export has error (network error, api error)
-     */
-    public exportResultToBlob(
-        projectId: string,
-        executionResult: string,
-        exportConfig: IExportConfig = {},
-        pollingOptions: IPollingOptions = {},
-    ): Promise<IExportBlobResponse> {
         const requestPayload: IExportResultPayload = {
             resultExport: {
                 executionResult,

--- a/libs/api-model-bear/api/api-model-bear.api.md
+++ b/libs/api-model-bear/api/api-model-bear.api.md
@@ -875,22 +875,16 @@ export interface IExecutionResultWrapper {
     executionResult: IExecutionResult;
 }
 
-// @public
-export interface IExportBlobResponse {
-    fileName?: string;
-    objectUrl: string;
-    uri: string;
-}
-
 // @public (undocumented)
 export interface IExportConfig extends IBaseExportConfig {
     afm?: IAfm;
     showFilters?: boolean;
 }
 
-// @public (undocumented)
+// @public
 export interface IExportResponse {
-    // (undocumented)
+    fileName?: string;
+    objectUrl: string;
     uri: string;
 }
 

--- a/libs/api-model-bear/src/export/GdcExport.ts
+++ b/libs/api-model-bear/src/export/GdcExport.ts
@@ -39,13 +39,6 @@ export interface IExportConfig extends IBaseExportConfig {
 }
 
 /**
- * @public
- */
-export interface IExportResponse {
-    uri: string;
-}
-
-/**
  * Result of export is an object URL pointing to a Blob of downloaded data attached to the current
  * window instance. The result also contains name of the downloaded file provided by the backend export
  * service.
@@ -55,7 +48,7 @@ export interface IExportResponse {
  *
  * @public
  */
-export interface IExportBlobResponse {
+export interface IExportResponse {
     /** URI from which can the export be fetched again */
     uri: string;
     /** Object URL pointing to the downloaded blob of exported data */

--- a/libs/sdk-backend-base/api/sdk-backend-base.api.md
+++ b/libs/sdk-backend-base/api/sdk-backend-base.api.md
@@ -48,7 +48,6 @@ import { IExecutionFactory } from '@gooddata/sdk-backend-spi';
 import { IExecutionResult } from '@gooddata/sdk-backend-spi';
 import { IExistingDashboard } from '@gooddata/sdk-model';
 import { IExplainProvider } from '@gooddata/sdk-backend-spi';
-import { IExportBlobResult } from '@gooddata/sdk-backend-spi';
 import { IExportConfig } from '@gooddata/sdk-backend-spi';
 import { IExportResult } from '@gooddata/sdk-backend-spi';
 import { IFactMetadataObject } from '@gooddata/sdk-model';
@@ -390,8 +389,6 @@ export abstract class DecoratedExecutionResult implements IExecutionResult {
     // (undocumented)
     export(options: IExportConfig): Promise<IExportResult>;
     // (undocumented)
-    exportToBlob(options: IExportConfig): Promise<IExportBlobResult>;
-    // (undocumented)
     fingerprint(): string;
     // (undocumented)
     readAll(): Promise<IDataView>;
@@ -507,9 +504,7 @@ export abstract class DecoratedWorkspaceDashboardsService implements IWorkspaceD
     // (undocumented)
     deleteWidgetAlerts(refs: ObjRef[]): Promise<void>;
     // (undocumented)
-    exportDashboardToPdf(ref: ObjRef, filters?: FilterContextItem[]): Promise<string>;
-    // (undocumented)
-    exportDashboardToPdfBlob(ref: ObjRef, filters?: FilterContextItem[]): Promise<IExportBlobResult>;
+    exportDashboardToPdf(ref: ObjRef, filters?: FilterContextItem[]): Promise<IExportResult>;
     // (undocumented)
     getAllWidgetAlertsForCurrentUser(): Promise<IWidgetAlert[]>;
     // (undocumented)

--- a/libs/sdk-backend-base/src/customBackend/execution.ts
+++ b/libs/sdk-backend-base/src/customBackend/execution.ts
@@ -25,7 +25,6 @@ import {
     NotImplemented,
     IExplainProvider,
     ExplainType,
-    IExportBlobResult,
 } from "@gooddata/sdk-backend-spi";
 import isEqual from "lodash/isEqual.js";
 import {
@@ -189,10 +188,6 @@ class CustomExecutionResult implements IExecutionResult {
     };
 
     public export = (_options: IExportConfig): Promise<IExportResult> => {
-        throw new NotSupported("exports from custom backend are not supported");
-    };
-
-    public exportToBlob = (_options: IExportConfig): Promise<IExportBlobResult> => {
         throw new NotSupported("exports from custom backend are not supported");
     };
 }

--- a/libs/sdk-backend-base/src/decoratedBackend/dashboards.ts
+++ b/libs/sdk-backend-base/src/decoratedBackend/dashboards.ts
@@ -9,7 +9,7 @@ import {
     IWidgetAlertCount,
     SupportedWidgetReferenceTypes,
     IWidgetReferences,
-    IExportBlobResult,
+    IExportResult,
 } from "@gooddata/sdk-backend-spi";
 import {
     IFilter,
@@ -76,12 +76,8 @@ export abstract class DecoratedWorkspaceDashboardsService implements IWorkspaceD
         return this.decorated.deleteDashboard(ref);
     }
 
-    exportDashboardToPdf(ref: ObjRef, filters?: FilterContextItem[]): Promise<string> {
+    exportDashboardToPdf(ref: ObjRef, filters?: FilterContextItem[]): Promise<IExportResult> {
         return this.decorated.exportDashboardToPdf(ref, filters);
-    }
-
-    exportDashboardToPdfBlob(ref: ObjRef, filters?: FilterContextItem[]): Promise<IExportBlobResult> {
-        return this.decorated.exportDashboardToPdfBlob(ref, filters);
     }
 
     createScheduledMail(

--- a/libs/sdk-backend-base/src/decoratedBackend/execution.ts
+++ b/libs/sdk-backend-base/src/decoratedBackend/execution.ts
@@ -9,7 +9,6 @@ import {
     ExplainConfig,
     IExplainProvider,
     ExplainType,
-    IExportBlobResult,
 } from "@gooddata/sdk-backend-spi";
 import {
     IAttributeOrMeasure,
@@ -164,9 +163,6 @@ export abstract class DecoratedExecutionResult implements IExecutionResult {
         return this.decorated.export(options);
     }
 
-    public exportToBlob(options: IExportConfig): Promise<IExportBlobResult> {
-        return this.decorated.exportToBlob(options);
-    }
     public readAll(): Promise<IDataView> {
         return this.decorated.readAll();
     }

--- a/libs/sdk-backend-base/src/dummyBackend/index.ts
+++ b/libs/sdk-backend-base/src/dummyBackend/index.ts
@@ -56,7 +56,6 @@ import {
     IElementsQueryResult,
     IPagedResource,
     IEntitlements,
-    IExportBlobResult,
 } from "@gooddata/sdk-backend-spi";
 import {
     defFingerprint,
@@ -364,9 +363,6 @@ function dummyExecutionResult(
             return fp === other.fingerprint();
         },
         export(_: IExportConfig): Promise<IExportResult> {
-            throw new NotSupported("...");
-        },
-        exportToBlob(_: IExportConfig): Promise<IExportBlobResult> {
             throw new NotSupported("...");
         },
         transform(): IPreparedExecution {

--- a/libs/sdk-backend-base/src/normalizingBackend/index.ts
+++ b/libs/sdk-backend-base/src/normalizingBackend/index.ts
@@ -11,7 +11,6 @@ import {
     NotSupported,
     isNoDataError,
     NoDataError,
-    IExportBlobResult,
 } from "@gooddata/sdk-backend-spi";
 import { decoratedBackend } from "../decoratedBackend/index.js";
 import { DecoratedExecutionFactory, DecoratedPreparedExecution } from "../decoratedBackend/execution.js";
@@ -130,12 +129,6 @@ class DenormalizingExecutionResult implements IExecutionResult {
         const originalResult = await this.originalExecution.execute();
 
         return originalResult.export(options);
-    };
-
-    public exportToBlob = async (options: IExportConfig): Promise<IExportBlobResult> => {
-        const originalResult = await this.originalExecution.execute();
-
-        return originalResult.exportToBlob(options);
     };
 
     public readAll = (): Promise<IDataView> => {

--- a/libs/sdk-backend-bear/src/backend/workspace/dashboards/index.ts
+++ b/libs/sdk-backend-bear/src/backend/workspace/dashboards/index.ts
@@ -13,7 +13,7 @@ import {
     SupportedDashboardReferenceTypes,
     IDashboardReferences,
     IGetScheduledMailOptions,
-    IExportBlobResult,
+    IExportResult,
 } from "@gooddata/sdk-backend-spi";
 import {
     areObjRefsEqual,
@@ -285,22 +285,11 @@ export class BearWorkspaceDashboards implements IWorkspaceDashboardsService {
     public exportDashboardToPdf = async (
         dashboardRef: ObjRef,
         filters?: FilterContextItem[],
-    ): Promise<string> => {
+    ): Promise<IExportResult> => {
         const dashboardUri = await objRefToUri(dashboardRef, this.workspace, this.authCall);
         const convertedFilters = filters?.map(fromSdkModel.convertFilterContextItem);
         return this.authCall((sdk) =>
-            sdk.dashboard.exportToPdf(this.workspace, dashboardUri, convertedFilters).then((res) => res.uri),
-        );
-    };
-
-    public exportDashboardToPdfBlob = async (
-        dashboardRef: ObjRef,
-        filters?: FilterContextItem[],
-    ): Promise<IExportBlobResult> => {
-        const dashboardUri = await objRefToUri(dashboardRef, this.workspace, this.authCall);
-        const convertedFilters = filters?.map(fromSdkModel.convertFilterContextItem);
-        return this.authCall((sdk) =>
-            sdk.dashboard.exportToPdfBlob(this.workspace, dashboardUri, convertedFilters).then((res) => res),
+            sdk.dashboard.exportToPdf(this.workspace, dashboardUri, convertedFilters).then((res) => res),
         );
     };
 

--- a/libs/sdk-backend-bear/src/backend/workspace/execution/executionResult.ts
+++ b/libs/sdk-backend-bear/src/backend/workspace/execution/executionResult.ts
@@ -16,7 +16,6 @@ import {
     IPreparedExecution,
     NoDataError,
     UnexpectedError,
-    IExportBlobResult,
 } from "@gooddata/sdk-backend-spi";
 import {
     IExecutionDefinition,
@@ -101,17 +100,6 @@ export class BearExecutionResult implements IExecutionResult {
         const optionsForBackend = this.buildExportOptions(options);
         return this.authApiCall((sdk) =>
             sdk.report.exportResult(
-                this.definition.workspace,
-                this.execResponse.links.executionResult,
-                optionsForBackend,
-            ),
-        );
-    }
-
-    public async exportToBlob(options: IExportConfig): Promise<IExportBlobResult> {
-        const optionsForBackend = this.buildExportOptions(options);
-        return this.authApiCall((sdk) =>
-            sdk.report.exportResultToBlob(
                 this.definition.workspace,
                 this.execResponse.links.executionResult,
                 optionsForBackend,

--- a/libs/sdk-backend-mockingbird/src/legacyRecordedBackend/index.ts
+++ b/libs/sdk-backend-mockingbird/src/legacyRecordedBackend/index.ts
@@ -40,7 +40,6 @@ import {
     ExplainType,
     IExplainProvider,
     IEntitlements,
-    IExportBlobResult,
 } from "@gooddata/sdk-backend-spi";
 import {
     defFingerprint,
@@ -337,9 +336,6 @@ function recordedExecutionResult(
             return fp === other.fingerprint();
         },
         export(_: IExportConfig): Promise<IExportResult> {
-            throw new NotSupported("...");
-        },
-        exportToBlob(_: IExportConfig): Promise<IExportBlobResult> {
             throw new NotSupported("...");
         },
         transform(): IPreparedExecution {

--- a/libs/sdk-backend-mockingbird/src/recordedBackend/dashboards.ts
+++ b/libs/sdk-backend-mockingbird/src/recordedBackend/dashboards.ts
@@ -3,6 +3,7 @@
 import {
     IDashboardReferences,
     IDashboardWithReferences,
+    IExportResult,
     IGetDashboardOptions,
     IGetScheduledMailOptions,
     IWidgetAlertCount,
@@ -14,7 +15,6 @@ import {
     SupportedWidgetReferenceTypes,
     UnexpectedResponseError,
     walkLayout,
-    IExportBlobResult,
 } from "@gooddata/sdk-backend-spi";
 import {
     areObjRefsEqual,
@@ -322,14 +322,7 @@ export class RecordedDashboards implements IWorkspaceDashboardsService {
         throw new NotSupported("recorded backend does not support this call");
     }
 
-    public exportDashboardToPdf(_ref: ObjRef, _filters?: FilterContextItem[]): Promise<string> {
-        return Promise.resolve("/example/export.pdf");
-    }
-
-    public exportDashboardToPdfBlob(
-        _ref: ObjRef,
-        _filters?: FilterContextItem[],
-    ): Promise<IExportBlobResult> {
+    public exportDashboardToPdf(_ref: ObjRef, _filters?: FilterContextItem[]): Promise<IExportResult> {
         return Promise.resolve({
             uri: "/example/export.pdf",
             objectUrl: "blob:/01345454545454",

--- a/libs/sdk-backend-mockingbird/src/recordedBackend/execution.ts
+++ b/libs/sdk-backend-mockingbird/src/recordedBackend/execution.ts
@@ -11,7 +11,6 @@ import {
     NotSupported,
     IExplainProvider,
     ExplainType,
-    IExportBlobResult,
 } from "@gooddata/sdk-backend-spi";
 import {
     defFingerprint,
@@ -257,10 +256,6 @@ class RecordedExecutionResult implements IExecutionResult {
     }
 
     public export = (_options: IExportConfig): Promise<IExportResult> => {
-        throw new NotSupported("recorded backend does not support exports");
-    };
-
-    public exportToBlob = (_options: IExportConfig): Promise<IExportBlobResult> => {
         throw new NotSupported("recorded backend does not support exports");
     };
 

--- a/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
+++ b/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
@@ -394,7 +394,6 @@ export interface IExecutionResult {
     readonly dimensions: IDimensionDescriptor[];
     equals(other: IExecutionResult): boolean;
     export(options: IExportConfig): Promise<IExportResult>;
-    exportToBlob(options: IExportConfig): Promise<IExportBlobResult>;
     fingerprint(): string;
     readAll(): Promise<IDataView>;
     readWindow(offset: number[], size: number[]): Promise<IDataView>;
@@ -422,13 +421,6 @@ export type IExplainResult = {
 };
 
 // @public
-export interface IExportBlobResult {
-    fileName?: string;
-    objectUrl: string;
-    uri: string;
-}
-
-// @public
 export interface IExportConfig {
     format?: "xlsx" | "csv" | "raw";
     mergeHeaders?: boolean;
@@ -438,7 +430,8 @@ export interface IExportConfig {
 
 // @public
 export interface IExportResult {
-    // (undocumented)
+    fileName?: string;
+    objectUrl: string;
     uri: string;
 }
 
@@ -798,8 +791,7 @@ export interface IWorkspaceDashboardsService {
     deleteScheduledMail(ref: ObjRef): Promise<void>;
     deleteWidgetAlert(ref: ObjRef): Promise<void>;
     deleteWidgetAlerts(refs: ObjRef[]): Promise<void>;
-    exportDashboardToPdf(ref: ObjRef, filters?: FilterContextItem[]): Promise<string>;
-    exportDashboardToPdfBlob(ref: ObjRef, filters?: FilterContextItem[]): Promise<IExportBlobResult>;
+    exportDashboardToPdf(ref: ObjRef, filters?: FilterContextItem[]): Promise<IExportResult>;
     getAllWidgetAlertsForCurrentUser(): Promise<IWidgetAlert[]>;
     getDashboard(ref: ObjRef, filterContextRef?: ObjRef, options?: IGetDashboardOptions): Promise<IDashboard>;
     getDashboardPermissions(ref: ObjRef): Promise<IDashboardPermissions>;

--- a/libs/sdk-backend-spi/src/index.ts
+++ b/libs/sdk-backend-spi/src/index.ts
@@ -72,7 +72,7 @@ export {
     FilterWithResolvableElements,
 } from "./workspace/attributes/elements/index.js";
 
-export { IExportConfig, IExportResult, IExportBlobResult } from "./workspace/execution/export.js";
+export { IExportConfig, IExportResult } from "./workspace/execution/export.js";
 
 export { IWorkspaceStylingService } from "./workspace/styling/index.js";
 export {

--- a/libs/sdk-backend-spi/src/workspace/dashboards/index.ts
+++ b/libs/sdk-backend-spi/src/workspace/dashboards/index.ts
@@ -20,7 +20,7 @@ import {
     IDashboardPermissions,
     IExistingDashboard,
 } from "@gooddata/sdk-model";
-import { IExportBlobResult } from "../execution/export.js";
+import { IExportResult } from "../execution/export.js";
 
 /**
  * Dashboard referenced objects
@@ -236,23 +236,13 @@ export interface IWorkspaceDashboardsService {
      * Export dashboard to pdf. You can override dashboard filters with custom filters.
      * When no custom filters are set, the persisted dashboard filters will be used.
      *
-     * @param ref - dashboard reference
-     * @param filters - Override stored dashboard filters with custom filters
-     * @returns promise with link to download the exported dashboard
-     */
-    exportDashboardToPdf(ref: ObjRef, filters?: FilterContextItem[]): Promise<string>;
-
-    /**
-     * Export dashboard to pdf. You can override dashboard filters with custom filters.
-     * When no custom filters are set, the persisted dashboard filters will be used.
-     *
      * PDF file is downloaded and attached as Blob data to the current window instance.
      *
      * @param ref - dashboard reference
      * @param filters - Override stored dashboard filters with custom filters
      * @returns promise with object URL pointing to a Blob data of downloaded exported dashboard
      */
-    exportDashboardToPdfBlob(ref: ObjRef, filters?: FilterContextItem[]): Promise<IExportBlobResult>;
+    exportDashboardToPdf(ref: ObjRef, filters?: FilterContextItem[]): Promise<IExportResult>;
 
     /**
      * Create scheduled mail for the dashboard

--- a/libs/sdk-backend-spi/src/workspace/execution/export.ts
+++ b/libs/sdk-backend-spi/src/workspace/execution/export.ts
@@ -35,15 +35,6 @@ export interface IExportConfig {
 }
 
 /**
- * Result of export is a link to prepared file that can be downloaded.
- *
- * @public
- */
-export interface IExportResult {
-    uri: string;
-}
-
-/**
  * Result of export is an object URL pointing to a Blob of downloaded data attached to the current
  * window instance. The result also contains name of the downloaded file provided by the backend export
  * service.
@@ -53,7 +44,7 @@ export interface IExportResult {
  *
  * @public
  */
-export interface IExportBlobResult {
+export interface IExportResult {
     /** URI from which can the export be fetched again */
     uri: string;
     /** Object URL pointing to the downloaded blob of exported data */

--- a/libs/sdk-backend-spi/src/workspace/execution/index.ts
+++ b/libs/sdk-backend-spi/src/workspace/execution/index.ts
@@ -15,7 +15,7 @@ import {
     IResultHeader,
     IResultWarning,
 } from "@gooddata/sdk-model";
-import { IExportConfig, IExportResult, IExportBlobResult } from "./export.js";
+import { IExportConfig, IExportResult } from "./export.js";
 
 /**
  * Execution factory provides several methods to create a prepared execution from different types
@@ -310,14 +310,6 @@ export interface IExecutionResult {
     transform(): IPreparedExecution;
 
     /**
-     * Asynchronously exports all data in this result.
-     *
-     * @param options - customize how the result looks like (format etc.)
-     * @returns Promise of export result = uri of file with exported data
-     */
-    export(options: IExportConfig): Promise<IExportResult>;
-
-    /**
      * Asynchronously exports all data in this result to a blob.
      *
      * Exported file is downloaded and attached as Blob data to the current window instance.
@@ -325,7 +317,7 @@ export interface IExecutionResult {
      * @param options - customize how the result looks like (format etc.)
      * @returns promise with object URL pointing to a Blob data of downloaded exported insight
      */
-    exportToBlob(options: IExportConfig): Promise<IExportBlobResult>;
+    export(options: IExportConfig): Promise<IExportResult>;
 
     /**
      * Tests if this execution result is same as the other result.

--- a/libs/sdk-backend-tiger/src/backend/workspace/dashboards/index.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/dashboards/index.ts
@@ -21,7 +21,7 @@ import {
     SupportedDashboardReferenceTypes,
     UnexpectedError,
     TimeoutError,
-    IExportBlobResult,
+    IExportResult,
 } from "@gooddata/sdk-backend-spi";
 import {
     areObjRefsEqual,
@@ -347,17 +347,7 @@ export class TigerWorkspaceDashboards implements IWorkspaceDashboardsService {
     public exportDashboardToPdf = async (
         dashboardRef: ObjRef,
         filters?: FilterContextItem[],
-    ): Promise<string> => {
-        return this.exportDashboardToPdfBlob(dashboardRef, filters).then((result) => {
-            URL.revokeObjectURL(result.objectUrl); // release blob memory as it will not be used
-            return result.uri;
-        });
-    };
-
-    public exportDashboardToPdfBlob = async (
-        dashboardRef: ObjRef,
-        filters?: FilterContextItem[],
-    ): Promise<IExportBlobResult> => {
+    ): Promise<IExportResult> => {
         const dashboardId = await objRefToIdentifier(dashboardRef, this.authCall);
 
         // skip all time date filter from stored filters, when missing, it's correctly
@@ -396,7 +386,7 @@ export class TigerWorkspaceDashboards implements IWorkspaceDashboardsService {
     private async handleExportResultPolling(
         client: ITigerClient,
         payload: { exportId: string; workspaceId: string },
-    ): Promise<IExportBlobResult> {
+    ): Promise<IExportResult> {
         for (let i = 0; i < MAX_POLL_ATTEMPTS; i++) {
             const result = await client.export.getExportedFile(payload, {
                 transformResponse: (x) => x,

--- a/libs/sdk-backend-tiger/src/backend/workspace/execution/executionResult.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/execution/executionResult.ts
@@ -18,7 +18,6 @@ import {
     NoDataError,
     UnexpectedError,
     TimeoutError,
-    IExportBlobResult,
 } from "@gooddata/sdk-backend-spi";
 import { IExecutionDefinition, DataValue, IDimensionDescriptor, IResultHeader } from "@gooddata/sdk-model";
 import SparkMD5 from "spark-md5";
@@ -108,15 +107,6 @@ export class TigerExecutionResult implements IExecutionResult {
     }
 
     public async export(options: IExportConfig): Promise<IExportResult> {
-        return this.exportToBlob(options).then((result) => {
-            URL.revokeObjectURL(result.objectUrl); // release blob memory as it will not be used
-            return {
-                uri: result.uri,
-            };
-        });
-    }
-
-    public async exportToBlob(options: IExportConfig): Promise<IExportBlobResult> {
         const isXlsx = options.format?.toUpperCase() === "XLSX";
         const format = isXlsx ? TabularExportRequestFormatEnum.XLSX : TabularExportRequestFormatEnum.CSV;
         const payload: TabularExportRequest = {
@@ -180,7 +170,7 @@ export class TigerExecutionResult implements IExecutionResult {
         client: ITigerClient,
         payload: ActionsApiGetTabularExportRequest,
         format: TabularExportRequestFormatEnum,
-    ): Promise<IExportBlobResult> {
+    ): Promise<IExportResult> {
         for (let i = 0; i < MAX_POLL_ATTEMPTS; i++) {
             const result = await client.export.getTabularExport(payload, {
                 transformResponse: (x) => x,

--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -177,7 +177,7 @@ import { IErrorProps } from '@gooddata/sdk-ui';
 import { IExecutionConfiguration } from '@gooddata/sdk-ui';
 import { IExecutionDefinition } from '@gooddata/sdk-model';
 import { IExecutionResult } from '@gooddata/sdk-backend-spi';
-import { IExportBlobResult } from '@gooddata/sdk-backend-spi';
+import { IExportResult } from '@gooddata/sdk-backend-spi';
 import { IFilter } from '@gooddata/sdk-model';
 import { IFilterableWidget } from '@gooddata/sdk-model';
 import { IFilterContext } from '@gooddata/sdk-model';
@@ -1614,7 +1614,7 @@ export interface DashboardExportToPdfResolved extends IDashboardEvent {
 
 // @beta
 export interface DashboardExportToPdfResolvedPayload {
-    readonly result: IExportBlobResult;
+    readonly result: IExportResult;
     readonly resultUri: string;
 }
 
@@ -1739,7 +1739,7 @@ export interface DashboardInsightWidgetExportResolved extends IDashboardEvent {
 
 // @beta
 export interface DashboardInsightWidgetExportResolvedPayload {
-    result: IExportBlobResult;
+    result: IExportResult;
     resultUri: string;
 }
 

--- a/libs/sdk-ui-dashboard/src/_staging/fileUtils/downloadFile.ts
+++ b/libs/sdk-ui-dashboard/src/_staging/fileUtils/downloadFile.ts
@@ -1,9 +1,9 @@
 // (C) 2019-2023 GoodData Corporation
-import { IExportBlobResult } from "@gooddata/sdk-backend-spi";
+import { IExportResult } from "@gooddata/sdk-backend-spi";
 
 export const DOWNLOADER_ID = "downloader";
 
-export function downloadFile({ objectUrl, fileName }: IExportBlobResult): void {
+export function downloadFile({ objectUrl, fileName }: IExportResult): void {
     const anchor = document.createElement("a");
     anchor.id = DOWNLOADER_ID;
     anchor.href = objectUrl;

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/exportDashboardToPdfHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/exportDashboardToPdfHandler.ts
@@ -15,15 +15,15 @@ import { invalidArgumentsProvided } from "../../events/general.js";
 import { selectFilterContextFilters } from "../../store/filterContext/filterContextSelectors.js";
 import { ensureAllTimeFilterForExport } from "../../../_staging/exportUtils/filterUtils.js";
 import { PromiseFnReturnType } from "../../types/sagas.js";
-import { IExportBlobResult } from "@gooddata/sdk-backend-spi";
+import { IExportResult } from "@gooddata/sdk-backend-spi";
 
 function exportDashboardToPdf(
     ctx: DashboardContext,
     dashboardRef: ObjRef,
     filters: FilterContextItem[] | undefined,
-): Promise<IExportBlobResult> {
+): Promise<IExportResult> {
     const { backend, workspace } = ctx;
-    return backend.workspace(workspace).dashboards().exportDashboardToPdfBlob(dashboardRef, filters);
+    return backend.workspace(workspace).dashboards().exportDashboardToPdf(dashboardRef, filters);
 }
 
 export function* exportDashboardToPdfHandler(
@@ -55,7 +55,7 @@ export function* exportDashboardToPdfHandler(
         ? new URL(result.uri, ctx.backend.config.hostname).href
         : result.uri;
 
-    const sanitizedResult: IExportBlobResult = {
+    const sanitizedResult: IExportResult = {
         ...result,
         uri: fullUri,
     };

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/exportInsightWidgetHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/exportInsightWidgetHandler.ts
@@ -2,7 +2,7 @@
 import { SagaIterator } from "redux-saga";
 import { call, put, select } from "redux-saga/effects";
 import { ObjRef, serializeObjRef } from "@gooddata/sdk-model";
-import { IExecutionResult, IExportBlobResult } from "@gooddata/sdk-backend-spi";
+import { IExecutionResult, IExportResult } from "@gooddata/sdk-backend-spi";
 import { invariant } from "ts-invariant";
 
 import { ExportInsightWidget } from "../../commands/index.js";
@@ -25,7 +25,7 @@ import { PromiseFnReturnType } from "../../types/sagas.js";
 async function performExport(
     executionResult: IExecutionResult,
     config: IExtendedExportConfig,
-): Promise<IExportBlobResult> {
+): Promise<IExportResult> {
     const exporter = createExportFunction(executionResult);
     return exporter(config);
 }
@@ -102,7 +102,7 @@ export function* exportInsightWidgetHandler(
         ? new URL(result.uri, ctx.backend.config.hostname).href
         : result.uri;
 
-    const sanitizedResult: IExportBlobResult = {
+    const sanitizedResult: IExportResult = {
         ...result,
         uri: fullUri,
     };

--- a/libs/sdk-ui-dashboard/src/model/events/dashboard.ts
+++ b/libs/sdk-ui-dashboard/src/model/events/dashboard.ts
@@ -1,7 +1,7 @@
 // (C) 2021-2023 GoodData Corporation
 
 import { IInsight, ObjRef, IDashboard, IWorkspacePermissions } from "@gooddata/sdk-model";
-import { IExportBlobResult } from "@gooddata/sdk-backend-spi";
+import { IExportResult } from "@gooddata/sdk-backend-spi";
 
 import { DateFilterValidationResult, ISharingProperties } from "../../types.js";
 import { DashboardConfig, DashboardContext } from "../types/commonTypes.js";
@@ -524,7 +524,7 @@ export interface DashboardExportToPdfResolvedPayload {
     /**
      * Collection of information used to download the resulting file.
      */
-    readonly result: IExportBlobResult;
+    readonly result: IExportResult;
 }
 
 /**
@@ -540,7 +540,7 @@ export interface DashboardExportToPdfResolved extends IDashboardEvent {
 
 export function dashboardExportToPdfResolved(
     ctx: DashboardContext,
-    result: IExportBlobResult,
+    result: IExportResult,
     correlationId?: string,
 ): DashboardExportToPdfResolved {
     return {

--- a/libs/sdk-ui-dashboard/src/model/events/insight.ts
+++ b/libs/sdk-ui-dashboard/src/model/events/insight.ts
@@ -16,7 +16,7 @@ import { WidgetDescription, WidgetHeader } from "../types/widgetTypes.js";
 import { DashboardContext } from "../types/commonTypes.js";
 import { eventGuard } from "./util.js";
 import { IExportConfig } from "../types/exportTypes.js";
-import { IExportBlobResult } from "@gooddata/sdk-backend-spi";
+import { IExportResult } from "@gooddata/sdk-backend-spi";
 
 /**
  * Payload of the {@link DashboardInsightWidgetHeaderChanged} event.
@@ -645,7 +645,7 @@ export interface DashboardInsightWidgetExportResolvedPayload {
     /**
      * Collection of information used to download the resulting file.
      */
-    result: IExportBlobResult;
+    result: IExportResult;
 }
 
 /**
@@ -663,7 +663,7 @@ export interface DashboardInsightWidgetExportResolved extends IDashboardEvent {
  */
 export function insightWidgetExportResolved(
     ctx: DashboardContext,
-    result: IExportBlobResult,
+    result: IExportResult,
     correlationId?: string,
 ): DashboardInsightWidgetExportResolved {
     return {

--- a/libs/sdk-ui-dashboard/src/presentation/widget/common/useExportHandler.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/common/useExportHandler.ts
@@ -1,13 +1,13 @@
 // (C) 2020-2023 GoodData Corporation
 import { useCallback, useRef } from "react";
-import { isProtectedDataError, IExportBlobResult } from "@gooddata/sdk-backend-spi";
+import { isProtectedDataError, IExportResult } from "@gooddata/sdk-backend-spi";
 import { IExtendedExportConfig } from "@gooddata/sdk-ui";
 import { useToastMessage } from "@gooddata/sdk-ui-kit";
 import { downloadFile } from "../../../_staging/fileUtils/downloadFile.js";
 import { messages } from "../../../locales.js";
 
 type ExportHandler = (
-    exportFunction: (config: IExtendedExportConfig) => Promise<IExportBlobResult>,
+    exportFunction: (config: IExtendedExportConfig) => Promise<IExportResult>,
     exportConfig: IExtendedExportConfig,
 ) => Promise<void>;
 

--- a/libs/sdk-ui-ext/src/insightView/InsightRenderer.tsx
+++ b/libs/sdk-ui-ext/src/insightView/InsightRenderer.tsx
@@ -6,7 +6,7 @@ import noop from "lodash/noop.js";
 import isEqual from "lodash/isEqual.js";
 import compose from "lodash/flowRight.js";
 import { injectIntl, WrappedComponentProps } from "react-intl";
-import { IExecutionFactory, IExportBlobResult, IUserWorkspaceSettings } from "@gooddata/sdk-backend-spi";
+import { IExecutionFactory, IExportResult, IUserWorkspaceSettings } from "@gooddata/sdk-backend-spi";
 import {
     IInsightDefinition,
     insightProperties,
@@ -219,7 +219,7 @@ class InsightRendererCore extends React.PureComponent<IInsightRendererProps & Wr
             return;
         }
 
-        const decorator = (exportConfig: IExtendedExportConfig): Promise<IExportBlobResult> => {
+        const decorator = (exportConfig: IExtendedExportConfig): Promise<IExportResult> => {
             if (exportConfig.title || !this.props.insight) {
                 return exportFunction(exportConfig);
             }

--- a/libs/sdk-ui/api/sdk-ui.api.md
+++ b/libs/sdk-ui/api/sdk-ui.api.md
@@ -27,8 +27,8 @@ import { IDimensionDescriptor } from '@gooddata/sdk-model';
 import { IDimensionItemDescriptor } from '@gooddata/sdk-model';
 import { IExecutionDefinition } from '@gooddata/sdk-model';
 import { IExecutionResult } from '@gooddata/sdk-backend-spi';
-import { IExportBlobResult } from '@gooddata/sdk-backend-spi';
 import { IExportConfig } from '@gooddata/sdk-backend-spi';
+import { IExportResult } from '@gooddata/sdk-backend-spi';
 import { IFilter } from '@gooddata/sdk-model';
 import { IInsightDefinition } from '@gooddata/sdk-model';
 import { IMeasure } from '@gooddata/sdk-model';
@@ -924,7 +924,7 @@ export interface IExecutionDefinitionMethods {
 }
 
 // @public (undocumented)
-export type IExportFunction = (exportConfig: IExtendedExportConfig) => Promise<IExportBlobResult>;
+export type IExportFunction = (exportConfig: IExtendedExportConfig) => Promise<IExportResult>;
 
 // @public (undocumented)
 export interface IExtendedExportConfig extends IExportConfig {

--- a/libs/sdk-ui/src/base/vis/Events.ts
+++ b/libs/sdk-ui/src/base/vis/Events.ts
@@ -1,5 +1,5 @@
 // (C) 2007-2023 GoodData Corporation
-import { IDataView, IExportConfig, IExportBlobResult } from "@gooddata/sdk-backend-spi";
+import { IDataView, IExportConfig, IExportResult } from "@gooddata/sdk-backend-spi";
 import {
     IColor,
     IColorPalette,
@@ -38,7 +38,7 @@ export interface IExtendedExportConfig extends IExportConfig {
 /**
  * @public
  */
-export type IExportFunction = (exportConfig: IExtendedExportConfig) => Promise<IExportBlobResult>;
+export type IExportFunction = (exportConfig: IExtendedExportConfig) => Promise<IExportResult>;
 
 /**
  * @public

--- a/libs/sdk-ui/src/base/vis/export.ts
+++ b/libs/sdk-ui/src/base/vis/export.ts
@@ -1,6 +1,6 @@
 // (C) 2007-2023 GoodData Corporation
 
-import { IExecutionResult, IExportConfig, IExportBlobResult } from "@gooddata/sdk-backend-spi";
+import { IExecutionResult, IExportConfig, IExportResult } from "@gooddata/sdk-backend-spi";
 import { IExportFunction, IExtendedExportConfig } from "./Events.js";
 import { GoodDataSdkError } from "../errors/GoodDataSdkError.js";
 
@@ -33,9 +33,9 @@ function buildExportRequestConfig(exportConfig: IExtendedExportConfig, exportTit
  * @internal
  */
 export function createExportFunction(result: IExecutionResult, exportTitle?: string): IExportFunction {
-    return (exportConfig: IExtendedExportConfig): Promise<IExportBlobResult> => {
+    return (exportConfig: IExtendedExportConfig): Promise<IExportResult> => {
         const exportRequestConfig = buildExportRequestConfig(exportConfig, exportTitle);
-        return result.exportToBlob(exportRequestConfig);
+        return result.export(exportRequestConfig);
     };
 }
 
@@ -47,7 +47,7 @@ export function createExportFunction(result: IExecutionResult, exportTitle?: str
  * @internal
  */
 export function createExportErrorFunction(error: GoodDataSdkError): IExportFunction {
-    return (_exportConfig: IExtendedExportConfig): Promise<IExportBlobResult> => {
+    return (_exportConfig: IExtendedExportConfig): Promise<IExportResult> => {
         return Promise.reject(error);
     };
 }


### PR DESCRIPTION
Make regular export methods behave as current
blob export methods and remove all blob leftovers.

JIRA: RAIL-4850

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |
| **Compatibility matrix test commands - TIGER Backend**  |                                                            |
| `extended test - matrix-test <AIO_version>`             | Run integrated tests against AIO versions.                 |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

`<AIO_version>` in commands is used to start test with multiple AIO instances - each instance in triggered by one jenkins build

-   To run with `master` and `stable`, execute command `extended test - matrix-test master,stable` or `extended test - matrix-test latest`
-   To run with specific version,ex: `2.3.0` and `2.3.1`, execute command `extended test - matrix-test 2.3.0,2.3.1`
-   In case `<AIO_version>` is empty, read versions from file `compTigerVersions.txt` of this repo

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
