### PR TITLE
BUGFIX: RAIL-5042 Dashboard plugins built as ESM

### DIFF
--- a/libs/sdk-ui-loaders/src/dashboard/dashboardLoader.tsx
+++ b/libs/sdk-ui-loaders/src/dashboard/dashboardLoader.tsx
@@ -241,6 +241,7 @@ export class DashboardLoader implements IDashboardLoader {
                 plugins = resolvedPlugins;
             }
         } catch (err) {
+            console.error(err);
             console.error(
                 "Dashboard plugins load failed. Loader is falling back to the statically linked dashboard without any external plugins.",
             );

--- a/libs/sdk-ui-loaders/src/dashboard/loadingStrategies/dynamicComponentLoaders.ts
+++ b/libs/sdk-ui-loaders/src/dashboard/loadingStrategies/dynamicComponentLoaders.ts
@@ -126,7 +126,7 @@ export async function dynamicDashboardBeforeLoad(
 }
 
 function moduleNameFromUrl(url: string): string {
-    const moduleName = /.*\/([^/]+)\.js$/.exec(url)?.[1];
+    const moduleName = /.*\/([^/]+)\.(?:js|mjs)$/.exec(url)?.[1];
     invariant(moduleName, "Invalid plugin URL provided, it must point to the root .js file");
     return moduleName;
 }
@@ -138,6 +138,9 @@ function addScriptTag(url: string): { element: HTMLScriptElement; promise: Promi
         element.src = url;
         element.type = "text/javascript";
         element.async = true;
+        if (url.match(/.mjs$/)) {
+            element.type = "module";
+        }
 
         element.onload = () => {
             // eslint-disable-next-line no-console

--- a/tools/dashboard-plugin-template/README.template.md
+++ b/tools/dashboard-plugin-template/README.template.md
@@ -62,13 +62,13 @@ Building a new plugin is easy. Before you start, ensure that your `.env` and `.e
 
 3.  Build the plugin: `{{packageManager}} run build-plugin`
 
-    This will build plugin artifacts under `dist/dashboardPlugin`.
+    This will build plugin artifacts under `esm/dashboardPlugin`.
 
 4.  Upload plugin artifacts to your hosting
 
-    It is paramount that you upload all files from the `dist/dashboardPlugin`.
+    It is paramount that you upload all files from the `esm/dashboardPlugin`.
 
-    _IMPORTANT_: your hosting must support https and your GoodData domain must include the hosting location in the list
+    _IMPORTANT_: your hosting must support https, allow CORS to your GoodData domain and your GoodData domain must include the hosting location in the list
     of allowed hosts from where GoodData will load plugins. You should create a [support ticket](https://support.gooddata.com/hc/en-us/requests/new?ticket_form_id=582387) to explicitly allow the hosting
     location before we will load any plugins from it. You may host multiple plugins in separate directories within
     the allowed hosting location.

--- a/tools/dashboard-plugin-template/webpack.config.cjs
+++ b/tools/dashboard-plugin-template/webpack.config.cjs
@@ -64,8 +64,7 @@ module.exports = (_env, argv) => {
         },
         output: {
             path: path.resolve("./esm"),
-            // Force .js extension instead of .mjs
-            filename: "[name].js",
+            filename: "[name].mjs",
             library: {
                 type: "module",
             },
@@ -189,6 +188,7 @@ module.exports = (_env, argv) => {
             plugins: [
                 ...commonConfig.plugins,
                 new ModuleFederationPlugin({
+                    library: { type: "window", name: MODULE_FEDERATION_NAME },
                     name: MODULE_FEDERATION_NAME, // this is used to put the plugin on the target window scope by default
                     exposes: {
                         /**

--- a/tools/plugin-toolkit/src/_base/utils.ts
+++ b/tools/plugin-toolkit/src/_base/utils.ts
@@ -69,7 +69,7 @@ export function convertToPluginDirectory(name: string): string {
  * Converts plugin identifier to entry point file name
  */
 export function convertToPluginEntrypoint(pluginIdentifier: string): string {
-    return `${pluginIdentifier}.js`;
+    return `${pluginIdentifier}.mjs`;
 }
 
 /**

--- a/tools/plugin-toolkit/src/addPluginCmd/actionConfig.ts
+++ b/tools/plugin-toolkit/src/addPluginCmd/actionConfig.ts
@@ -51,7 +51,7 @@ async function doAsyncValidations(config: AddCmdActionConfig) {
  * @param url - the URL of the plugin being added
  */
 function pluginUrlToPluginName(url: string): string {
-    const match = /dp_([^/]+).js$/i.exec(url);
+    const match = /dp_([^/]+).mjs$/i.exec(url);
     return match?.[1] ?? "";
 }
 


### PR DESCRIPTION
SDK v9 builds plugin as ECMAScript module, it needs to be loaded with `type="module"` script attribute. Use `.mjs` extension to distinguish type of the dashboard plugin build.

Reflect these changes in webpack config and plugin-toolkit.

Update dashboard plugin readme, because with `type="module"`, you need to allow CORS from GoodData domain on plugin hosting.

Also improve error reporting when plugin,
engine or entry point load fails.

JIRA: RAIL-5042

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |
| **Compatibility matrix test commands - TIGER Backend**  |                                                            |
| `extended test - matrix-test <AIO_version>`             | Run integrated tests against AIO versions.                 |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

`<AIO_version>` in commands is used to start test with multiple AIO instances - each instance in triggered by one jenkins build

-   To run with `master` and `stable`, execute command `extended test - matrix-test master,stable` or `extended test - matrix-test latest`
-   To run with specific version,ex: `2.3.0` and `2.3.1`, execute command `extended test - matrix-test 2.3.0,2.3.1`
-   In case `<AIO_version>` is empty, read versions from file `compTigerVersions.txt` of this repo

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
