### PR TITLE
RELATED: TNT-1633 Avoid js error with grand totals and measures in rows in tiger

### DIFF
--- a/libs/sdk-backend-tiger/src/convertors/fromBackend/afm/GrandTotalsConverter.ts
+++ b/libs/sdk-backend-tiger/src/convertors/fromBackend/afm/GrandTotalsConverter.ts
@@ -1,5 +1,11 @@
 // (C) 2022 GoodData Corporation
-import { DataValue, IExecutionDefinition, IResultHeader, isResultTotalHeader } from "@gooddata/sdk-model";
+import {
+    isMeasureGroupIdentifier,
+    DataValue,
+    IExecutionDefinition,
+    IResultHeader,
+    isResultTotalHeader,
+} from "@gooddata/sdk-model";
 import { DimensionHeader, ExecutionResultGrandTotal } from "@gooddata/api-client-tiger";
 import isEmpty from "lodash/isEmpty.js";
 import flatMap from "lodash/flatMap.js";
@@ -22,6 +28,11 @@ export function transformGrandTotalData(
         // SDK cannot work with explicit empty totals, undefined must be returned instead
         return undefined;
     }
+
+    const measureGroupDimension = definition.dimensions.findIndex((dim) =>
+        dim?.itemIdentifiers?.find(isMeasureGroupIdentifier),
+    );
+
     const grandTotalsData: DataValue[][][] = definition.dimensions.map((_) => []);
     const dimensionIdxByLocalId = new Map(
         definition.dimensions.map((_, idx) => [dimensionLocalIdentifier(idx), idx]),
@@ -42,7 +53,7 @@ export function transformGrandTotalData(
             definition,
         );
         transformedTotals.forEach((total, totalIdx) => {
-            if (total.dimensionIdx === 1) {
+            if (total.dimensionIdx === 1 || measureGroupDimension === 0) {
                 grandTotalsData[total.dimensionIdx] = grandTotal.data as DataValue[][];
             } else {
                 grandTotalsData[total.dimensionIdx][totalIdx] = total.data;

--- a/libs/sdk-backend-tiger/src/convertors/toBackend/afm/tests/__snapshots__/TotalsConverter.test.ts.snap
+++ b/libs/sdk-backend-tiger/src/convertors/toBackend/afm/tests/__snapshots__/TotalsConverter.test.ts.snap
@@ -132,9 +132,9 @@ exports[`convertTotals > should correctly convert multiple totals with various f
     ],
   },
   {
-    "function": "MIN",
-    "localIdentifier": "total_min_m1_by_localAttr1_0",
-    "metric": "m1",
+    "function": "MAX",
+    "localIdentifier": "total_max_m2_by_localAttr1_0",
+    "metric": "m2",
     "totalDimensions": [
       {
         "dimensionIdentifier": "dim_1",
@@ -145,9 +145,9 @@ exports[`convertTotals > should correctly convert multiple totals with various f
     ],
   },
   {
-    "function": "MAX",
-    "localIdentifier": "total_max_m2_by_localAttr1_0",
-    "metric": "m2",
+    "function": "MIN",
+    "localIdentifier": "total_min_m1_by_localAttr1_0",
+    "metric": "m1",
     "totalDimensions": [
       {
         "dimensionIdentifier": "dim_1",


### PR DESCRIPTION
Applies for tiger backend:
- send totals ordered by total function
- skip grand total transformation when measures in rows



<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |
| **Compatibility matrix test commands - TIGER Backend**  |                                                            |
| `extended test - matrix-test <AIO_version>`             | Run integrated tests against AIO versions.                 |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

`<AIO_version>` in commands is used to start test with multiple AIO instances - each instance in triggered by one jenkins build

-   To run with `master` and `stable`, execute command `extended test - matrix-test master,stable` or `extended test - matrix-test latest`
-   To run with specific version,ex: `2.3.0` and `2.3.1`, execute command `extended test - matrix-test 2.3.0,2.3.1`
-   In case `<AIO_version>` is empty, read versions from file `compTigerVersions.txt` of this repo

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)