### PR TITLE
test: use auto-width for table totals screenshots

### DIFF
--- a/libs/sdk-ui-tests/scenarios/pivotTable/base.tsx
+++ b/libs/sdk-ui-tests/scenarios/pivotTable/base.tsx
@@ -6,23 +6,15 @@ import {
     IPivotTableProps,
     PivotTable,
     IPivotTableConfig,
-    newWidthForAttributeColumn,
-    newWidthForAllColumnsForMeasure,
 } from "@gooddata/sdk-ui-pivot";
 import { ScenarioGroupNames } from "../charts/_infra/groupNames.js";
 import { requestPages } from "@gooddata/mock-handling";
 import { IAttribute, modifyAttribute, newAbsoluteDateFilter } from "@gooddata/sdk-model";
 
-export function getCommonPivotTableSizingConfig(attributesUsed: IAttribute[] = []): IPivotTableConfig {
+export function getCommonPivotTableSizingConfig(): IPivotTableConfig {
     return {
         columnSizing: {
-            columnWidths: [
-                newWidthForAllColumnsForMeasure(ReferenceMd.Amount, 100),
-                newWidthForAllColumnsForMeasure(ReferenceMd.Probability, 100),
-                newWidthForAllColumnsForMeasure(ReferenceMd.Won, 100),
-                ...attributesUsed.map((attribute) => newWidthForAttributeColumn(attribute, 120)),
-            ],
-            defaultWidth: "unset",
+            defaultWidth: "autoresizeAll",
             growToFit: false,
         },
     };

--- a/libs/sdk-ui-tests/scenarios/pivotTable/totals.tsx
+++ b/libs/sdk-ui-tests/scenarios/pivotTable/totals.tsx
@@ -24,7 +24,7 @@ export const PivotTableWithTwoMeasuresAndTotals = {
         newTotal("sum", ReferenceMd.Amount, ReferenceMd.Product.Name),
         newTotal("sum", ReferenceMd.Won, ReferenceMd.Product.Name),
     ],
-    config: getCommonPivotTableSizingConfig([ReferenceMd.Product.Name]),
+    config: getCommonPivotTableSizingConfig(),
 };
 
 export const PivotTableWithTwoMeasuresGrandTotalsAndSubtotals = {
@@ -39,7 +39,7 @@ export const PivotTableWithTwoMeasuresGrandTotalsAndSubtotals = {
         newTotal("med", ReferenceMd.Won, ReferenceMd.Department),
         newTotal("nat", ReferenceMd.Won, ReferenceMd.Department),
     ],
-    config: getCommonPivotTableSizingConfig([ReferenceMd.Product.Name, ReferenceMd.Department]),
+    config: getCommonPivotTableSizingConfig(),
 };
 
 export const PivotTableWithTwoMeasuresColumnGrandTotalsAndSubtotals = {
@@ -187,7 +187,7 @@ const totalsForColumns = scenariosFor<IPivotTableProps>("PivotTable", PivotTable
     .withVisualTestConfig({ screenshotSize: { width: 1000, height: 600 } })
     .addScenario("single measure and single column grand total", {
         ...PivotTableWithSingleMeasureAndColumnGrandTotal,
-        config: getCommonPivotTableSizingConfig([ReferenceMd.SalesRep.Owner]),
+        config: getCommonPivotTableSizingConfig(),
     })
     .addScenario("single measure and multiple column grand totals", {
         ...PivotTableWighSingleMeasureAndSingleRowColAttr,
@@ -221,12 +221,12 @@ const totalsForColumns = scenariosFor<IPivotTableProps>("PivotTable", PivotTable
             newTotal("max", ReferenceMd.Probability, ReferenceMd.ForecastCategory),
             newTotal("nat", ReferenceMd.Probability, ReferenceMd.ForecastCategory),
         ],
-        config: getCommonPivotTableSizingConfig([ReferenceMd.SalesRep.Owner]),
+        config: getCommonPivotTableSizingConfig(),
     })
     .addScenario("two measures and one column subtotal", {
         ...PivotTableWithTwoMeasuresAndTwoRowsAndCols,
         totals: [newTotal("sum", ReferenceMd.Amount, ReferenceMd.Region)],
-        config: getCommonPivotTableSizingConfig([ReferenceMd.Product.Name, ReferenceMd.Department]),
+        config: getCommonPivotTableSizingConfig(),
     })
     .addScenario("two measures and multiple column subtotals", {
         ...PivotTableWithTwoMeasuresAndTwoRowsAndCols,
@@ -237,19 +237,19 @@ const totalsForColumns = scenariosFor<IPivotTableProps>("PivotTable", PivotTable
             newTotal("nat", ReferenceMd.Won, ReferenceMd.Region),
         ],
         filters: [newPositiveAttributeFilter(ReferenceMd.Region, ["West Coast"])],
-        config: getCommonPivotTableSizingConfig([ReferenceMd.Product.Name, ReferenceMd.Department]),
+        config: getCommonPivotTableSizingConfig(),
     })
     .addScenario("two measures and column grand totals and multiple subtotals", {
         ...PivotTableWithTwoMeasuresColumnGrandTotalsAndSubtotals,
         filters: [newPositiveAttributeFilter(ReferenceMd.Region, ["West Coast"])],
-        config: getCommonPivotTableSizingConfig([ReferenceMd.Product.Name, ReferenceMd.Department]),
+        config: getCommonPivotTableSizingConfig(),
     })
     .addScenario("two measures and column single grand total sorted by second attribute", {
         ...PivotTableWithTwoMeasuresAndTwoRowsAndCols,
         totals: [newTotal("sum", ReferenceMd.Amount, ReferenceMd.ForecastCategory)],
         sortBy: [newAttributeSort(ReferenceMd.Department, "desc")],
         filters: [newPositiveAttributeFilter(ReferenceMd.Region, ["West Coast"])],
-        config: getCommonPivotTableSizingConfig([ReferenceMd.Product.Name, ReferenceMd.Department]),
+        config: getCommonPivotTableSizingConfig(),
     })
     .addScenario(
         "two measures and single column grand total and single subtotal sorted by second attribute",
@@ -264,7 +264,7 @@ const totalsForColumns = scenariosFor<IPivotTableProps>("PivotTable", PivotTable
             ],
             sortBy: [newAttributeSort(ReferenceMd.Department, "desc")],
             filters: [newPositiveAttributeFilter(ReferenceMd.Region, ["West Coast"])],
-            config: getCommonPivotTableSizingConfig([ReferenceMd.Product.Name, ReferenceMd.Department]),
+            config: getCommonPivotTableSizingConfig(),
         },
     );
 
@@ -315,7 +315,7 @@ const totalsForRowsAndColumns = scenariosFor<IPivotTableProps>("PivotTable", Piv
             newTotal("max", ReferenceMd.Probability, ReferenceMd.ForecastCategory),
             newTotal("nat", ReferenceMd.Probability, ReferenceMd.ForecastCategory),
         ],
-        config: getCommonPivotTableSizingConfig([ReferenceMd.SalesRep.Owner]),
+        config: getCommonPivotTableSizingConfig(),
     })
     .addScenario("two measures and one column/row subtotal", {
         ...PivotTableWithTwoMeasuresAndTwoRowsAndCols,
@@ -323,7 +323,7 @@ const totalsForRowsAndColumns = scenariosFor<IPivotTableProps>("PivotTable", Piv
             newTotal("sum", ReferenceMd.Amount, ReferenceMd.Department),
             newTotal("sum", ReferenceMd.Amount, ReferenceMd.Region),
         ],
-        config: getCommonPivotTableSizingConfig([ReferenceMd.Product.Name, ReferenceMd.Department]),
+        config: getCommonPivotTableSizingConfig(),
     })
     .addScenario("two measures and multiple column/row subtotals", {
         ...PivotTableWithTwoMeasuresAndTwoRowsAndCols,
@@ -337,11 +337,11 @@ const totalsForRowsAndColumns = scenariosFor<IPivotTableProps>("PivotTable", Piv
             newTotal("med", ReferenceMd.Won, ReferenceMd.Region),
             newTotal("nat", ReferenceMd.Won, ReferenceMd.Region),
         ],
-        config: getCommonPivotTableSizingConfig([ReferenceMd.Product.Name, ReferenceMd.Department]),
+        config: getCommonPivotTableSizingConfig(),
     })
     .addScenario("two measures and column/row grand totals and multiple subtotals", {
         ...PivotTableWithTwoMeasuresRowColumnGrandTotalsAndSubtotals,
-        config: getCommonPivotTableSizingConfig([ReferenceMd.Product.Name, ReferenceMd.Department]),
+        config: getCommonPivotTableSizingConfig(),
     });
 
 export default [totalsForRows, totalsForColumns, totalsForRowsAndColumns];

--- a/libs/sdk-ui-tests/scenarios/pivotTable/transposition.tsx
+++ b/libs/sdk-ui-tests/scenarios/pivotTable/transposition.tsx
@@ -48,7 +48,7 @@ export default scenariosFor<IPivotTableProps>("PivotTable", PivotTable)
             newTotal("nat", ReferenceMd.Won, ReferenceMd.Region),
         ],
         config: {
-            ...getCommonPivotTableSizingConfig([ReferenceMd.Product.Name, ReferenceMd.Department]),
+            ...getCommonPivotTableSizingConfig(),
             measureGroupDimension: "rows",
         },
     })
@@ -63,7 +63,7 @@ export default scenariosFor<IPivotTableProps>("PivotTable", PivotTable)
             newTotal("nat", ReferenceMd.Won, ReferenceMd.Region),
         ],
         config: {
-            ...getCommonPivotTableSizingConfig([ReferenceMd.Region, ReferenceMd.Department]),
+            ...getCommonPivotTableSizingConfig(),
             measureGroupDimension: "rows",
         },
     })


### PR DESCRIPTION
<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |
| **Compatibility matrix test commands - TIGER Backend**  |                                                            |
| `extended test - matrix-test <AIO_version>`             | Run integrated tests against AIO versions.                 |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

`<AIO_version>` in commands is used to start test with multiple AIO instances - each instance in triggered by one jenkins build

-   To run with `master` and `stable`, execute command `extended test - matrix-test master,stable` or `extended test - matrix-test latest`
-   To run with specific version,ex: `2.3.0` and `2.3.1`, execute command `extended test - matrix-test 2.3.0,2.3.1`
-   In case `<AIO_version>` is empty, read versions from file `compTigerVersions.txt` of this repo

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)