### PR TITLE
RELATED: TNT-1664 Do not require measure locators for column widths

### DIFF
--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/pivotTableAdditionalFactories.ts
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/pivotTableAdditionalFactories.ts
@@ -49,8 +49,9 @@ export function factoryNotationForMeasureColumnWidthItem(obj: IMeasureColumnWidt
     );
 
     // cannot use lodash compact, that would remove 0 values which we want to keep here
+    const measureLocatorIdentifier = measureLocator?.measureLocatorItem?.measureIdentifier;
     const params = [
-        `"${measureLocator.measureLocatorItem.measureIdentifier}"`,
+        measureLocatorIdentifier ? `"${measureLocatorIdentifier}"` : "null",
         `[${attributeLocatorFactories.join(", ")}]`,
         isString(width.value) ? `"${width.value}"` : width.value,
         allowGrowToFit && "true",

--- a/libs/sdk-ui-pivot/api/sdk-ui-pivot.api.md
+++ b/libs/sdk-ui-pivot/api/sdk-ui-pivot.api.md
@@ -287,7 +287,7 @@ export function newWidthForAllMeasureColumns(width: number, allowGrowToFit?: boo
 export function newWidthForAttributeColumn(attributeOrId: IAttribute | string, width: number, allowGrowToFit?: boolean): IAttributeColumnWidthItem;
 
 // @public
-export function newWidthForSelectedColumns(measureOrId: IMeasure | string, locators: IAttributeColumnLocator[], width: number | "auto", allowGrowToFit?: boolean): IMeasureColumnWidthItem;
+export function newWidthForSelectedColumns(measureOrId: IMeasure | string | null, locators: IAttributeColumnLocator[], width: number | "auto", allowGrowToFit?: boolean): IMeasureColumnWidthItem;
 
 // @public
 export const PivotTable: (props: IPivotTableProps) => JSX.Element;

--- a/libs/sdk-ui-pivot/src/columnWidths.ts
+++ b/libs/sdk-ui-pivot/src/columnWidths.ts
@@ -454,6 +454,7 @@ export function newWidthForAllColumnsForMeasure(
 
 /**
  * Creates width item that will set width for all columns containing values of the provided measure.
+ * To prepare width items for columns in tables without measures, pass measureOrId as `null`.
  *
  * @remarks
  * See also {@link newAttributeColumnLocator} to learn more about the attribute column locators.
@@ -465,12 +466,12 @@ export function newWidthForAllColumnsForMeasure(
  * @public
  */
 export function newWidthForSelectedColumns(
-    measureOrId: IMeasure | string,
+    measureOrId: IMeasure | string | null,
     locators: IAttributeColumnLocator[],
     width: number | "auto",
     allowGrowToFit?: boolean,
 ): IMeasureColumnWidthItem {
-    const measureLocator = newMeasureColumnLocator(measureOrId);
+    const measureLocator = measureOrId ? [newMeasureColumnLocator(measureOrId)] : [];
     const growToFitProp = allowGrowToFit !== undefined && width !== "auto" ? { allowGrowToFit } : {};
 
     // Note: beware here. The attribute locators _must_ come first for some obscure, impl dependent reason
@@ -480,7 +481,7 @@ export function newWidthForSelectedColumns(
                 value: width,
                 ...growToFitProp,
             },
-            locators: [...locators, measureLocator],
+            locators: [...locators, ...measureLocator],
         },
     };
 }


### PR DESCRIPTION
Applies for table insights without measures where columns still can
be resized.


<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |
| **Compatibility matrix test commands - TIGER Backend**  |                                                            |
| `extended test - matrix-test <AIO_version>`             | Run integrated tests against AIO versions.                 |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

`<AIO_version>` in commands is used to start test with multiple AIO instances - each instance in triggered by one jenkins build

-   To run with `master` and `stable`, execute command `extended test - matrix-test master,stable` or `extended test - matrix-test latest`
-   To run with specific version,ex: `2.3.0` and `2.3.1`, execute command `extended test - matrix-test 2.3.0,2.3.1`
-   In case `<AIO_version>` is empty, read versions from file `compTigerVersions.txt` of this repo

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)