### PR TITLE
BUGFIX: TNT-1665 Metrics in rows manual resizing column attributes

### DIFF
--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/PluggablePivotTable.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/PluggablePivotTable.tsx
@@ -36,6 +36,7 @@ import {
     IColumnSizing,
     ICorePivotTableProps,
     IPivotTableConfig,
+    MeasureGroupDimension,
     pivotTableMenuForCapabilities,
 } from "@gooddata/sdk-ui-pivot";
 import React from "react";
@@ -252,6 +253,7 @@ export class PluggablePivotTable extends AbstractPluggableVisualization {
             previousRowAttributes ? previousRowAttributes : [],
             previousColumnAttributes ? previousColumnAttributes : [],
             filters,
+            originalMeasureGroupDimension,
         );
 
         const measureGroupDimensionProp =
@@ -543,10 +545,11 @@ export class PluggablePivotTable extends AbstractPluggableVisualization {
         visualizationProperties: IVisualizationProperties,
         insight: IInsightDefinition,
     ) {
+        const measureGroupDimension = getMeasureGroupDimensionFromProperties(visualizationProperties);
         // This is sanitization of properties from KD vs current mdObject from AD
         const columnWidths = getColumnWidthsFromProperties(visualizationProperties);
         if (columnWidths) {
-            this.sanitizeColumnWidths(columnWidths, insight, visualizationProperties);
+            this.sanitizeColumnWidths(columnWidths, insight, visualizationProperties, measureGroupDimension);
         }
     }
 
@@ -554,12 +557,17 @@ export class PluggablePivotTable extends AbstractPluggableVisualization {
         columnWidths: ColumnWidthItem[],
         insight: IInsightDefinition,
         visualizationProperties: IVisualizationProperties,
+        measureGroupDimension: MeasureGroupDimension,
     ) {
         if (isEmpty(insightBuckets(insight))) {
             return;
         }
 
-        const adaptedColumnWidths = adaptMdObjectWidthItemsToPivotTable(columnWidths, insight);
+        const adaptedColumnWidths = adaptMdObjectWidthItemsToPivotTable(
+            columnWidths,
+            insight,
+            measureGroupDimension,
+        );
 
         if (!isEqual(columnWidths, adaptedColumnWidths)) {
             this.visualizationProperties.controls.columnWidths = adaptedColumnWidths;

--- a/libs/sdk-ui-pivot/src/impl/structure/colLocatorFactory.ts
+++ b/libs/sdk-ui-pivot/src/impl/structure/colLocatorFactory.ts
@@ -67,15 +67,24 @@ function createMeasureLocator(descriptor: IMeasureDescriptor): IMeasureColumnLoc
  */
 export function createColumnLocator(col: LeafDataCol): ColumnLocator[] {
     if (isScopeCol(col)) {
-        const { descriptorsToHere, headersToHere } = col;
+        const result: ColumnLocator[] = [];
+        const { descriptorsToHere, headersToHere, measureDescriptors } = col;
         const descriptorsAndHeaders = zip(descriptorsToHere, headersToHere);
         descriptorsAndHeaders.push([col.attributeDescriptor, col.header]);
 
-        return descriptorsAndHeaders.map(([descriptor, header]) =>
+        descriptorsAndHeaders.forEach(([descriptor, header]) =>
             isResultTotalHeader(header)
-                ? createTotalLocator(descriptor, header)
-                : createAttributeLocator(descriptor, header),
+                ? result.push(createTotalLocator(descriptor, header))
+                : result.push(createAttributeLocator(descriptor, header)),
         );
+
+        if (measureDescriptors) {
+            measureDescriptors.forEach((measureDescriptor) =>
+                result.push(createMeasureLocator(measureDescriptor)),
+            );
+        }
+
+        return result;
     } else {
         const result: ColumnLocator[] = [];
 

--- a/libs/sdk-ui-pivot/src/impl/structure/colLocatorMatching.ts
+++ b/libs/sdk-ui-pivot/src/impl/structure/colLocatorMatching.ts
@@ -14,7 +14,6 @@ import {
     isTotalColumnLocator,
     isAttributeColumnLocator,
     isMeasureColumnLocator,
-    IMeasureColumnLocator,
 } from "../../columnWidths.js";
 import { colMeasureLocalId } from "./colAccessors.js";
 import isEmpty from "lodash/isEmpty.js";
@@ -73,19 +72,14 @@ export function searchForLocatorMatch(
                 // When table is transposed (metrics in rows). Need to check that existing measures descriptors on data view
                 // matches the exsting ones on the resized scope column.
                 if (col.measureDescriptors) {
-                    const measureDescriptorsId = col.measureDescriptors.map(
-                        (measureDescriptor) => measureDescriptor.measureHeaderItem.localIdentifier,
-                    );
                     const measureLocators = locators.filter(isMeasureColumnLocator);
-                    const matchingMeasureLocators = measureLocators.every(
-                        (locator: IMeasureColumnLocator) => {
-                            return measureDescriptorsId.includes(
-                                locator.measureLocatorItem.measureIdentifier,
-                            );
-                        },
-                    );
 
-                    if (matchingMeasureLocators) {
+                    if (
+                        col.measureDescriptors?.length !== measureLocators.length ||
+                        !isMeasureColumnLocator(measureLocators[0])
+                    ) {
+                        return undefined;
+                    } else {
                         found = col;
                     }
                 } else if (locators.length === 1) {

--- a/libs/sdk-ui-pivot/src/impl/structure/tableDescriptorTypes.ts
+++ b/libs/sdk-ui-pivot/src/impl/structure/tableDescriptorTypes.ts
@@ -1,5 +1,10 @@
 // (C) 2007-2022 GoodData Corporation
-import { IAttributeDescriptor, IResultAttributeHeader, ITotalDescriptor } from "@gooddata/sdk-model";
+import {
+    IAttributeDescriptor,
+    IResultAttributeHeader,
+    ITotalDescriptor,
+    IMeasureDescriptor,
+} from "@gooddata/sdk-model";
 import { DataSeriesDescriptor, DataSeriesId } from "@gooddata/sdk-ui";
 import { ColDef, ColGroupDef, Column } from "@ag-grid-community/all-modules";
 
@@ -269,6 +274,11 @@ export interface ScopeCol extends TableCol {
      * Checks whether this column group is part of sub-total.
      */
     readonly isSubtotal?: boolean;
+
+    /**
+     * When table is transposed (metrics in rows). Descriptor of the measure object whose computed values are in the data series
+     */
+    readonly measureDescriptors?: IMeasureDescriptor[];
 }
 
 export function isScopeCol(obj: unknown): obj is ScopeCol {


### PR DESCRIPTION
<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |
| **Compatibility matrix test commands - TIGER Backend**  |                                                            |
| `extended test - matrix-test <AIO_version>`             | Run integrated tests against AIO versions.                 |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

`<AIO_version>` in commands is used to start test with multiple AIO instances - each instance in triggered by one jenkins build

-   To run with `master` and `stable`, execute command `extended test - matrix-test master,stable` or `extended test - matrix-test latest`
-   To run with specific version,ex: `2.3.0` and `2.3.1`, execute command `extended test - matrix-test 2.3.0,2.3.1`
-   In case `<AIO_version>` is empty, read versions from file `compTigerVersions.txt` of this repo

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
