### PR TITLE
BUGFIX: TNT-1667 Display time of insight creation/update in local time on Tiger

### DIFF
--- a/libs/sdk-backend-bear/src/backend/user/settings.ts
+++ b/libs/sdk-backend-bear/src/backend/user/settings.ts
@@ -3,6 +3,7 @@ import { IUserSettingsService, IUserSettings, NotSupported } from "@gooddata/sdk
 import { userLoginMd5FromAuthenticatedPrincipalWithAnonymous } from "../../utils/api.js";
 import { BearAuthenticatedCallGuard } from "../../types/auth.js";
 import { ANONYMOUS_USER_SETTINGS } from "../constants.js";
+import { DefaultUiSettings } from "../../uiSettings.js";
 
 export class BearUserSettingsService implements IUserSettingsService {
     constructor(private readonly authCall: BearAuthenticatedCallGuard) {}
@@ -25,6 +26,7 @@ export class BearUserSettingsService implements IUserSettingsService {
             const { language } = currentProfile;
 
             return {
+                ...DefaultUiSettings,
                 userId: userLoginMd5,
                 locale: language!,
                 separators,

--- a/libs/sdk-backend-bear/src/backend/workspace/settings/settings.ts
+++ b/libs/sdk-backend-bear/src/backend/workspace/settings/settings.ts
@@ -10,6 +10,7 @@ import { IFeatureFlags } from "@gooddata/api-client-bear";
 import { BearAuthenticatedCallGuard } from "../../../types/auth.js";
 import { userLoginMd5FromAuthenticatedPrincipalWithAnonymous } from "../../../utils/api.js";
 import { ANONYMOUS_USER_SETTINGS } from "../../constants.js";
+import { DefaultUiSettings } from "../../../uiSettings.js";
 
 // settings which are ignored from user level as they can be set up only for project and above levels
 // no explicit type as every string is valid key from IUserWorkspaceSettings
@@ -45,6 +46,7 @@ export class BearWorkspaceSettings implements IWorkspaceSettingsService {
             const flags = await sdk.project.getProjectFeatureFlags(this.workspace);
 
             return {
+                ...DefaultUiSettings,
                 workspace: this.workspace,
                 ...flags,
             };
@@ -59,6 +61,7 @@ export class BearWorkspaceSettings implements IWorkspaceSettingsService {
             if (!userLoginMd5) {
                 const workspaceSettings = await this.getSettings();
                 return {
+                    ...DefaultUiSettings,
                     // the order is important here, we want workspace settings to overwrite anonymous user settings
                     ...ANONYMOUS_USER_SETTINGS,
                     ...workspaceSettings,
@@ -76,6 +79,7 @@ export class BearWorkspaceSettings implements IWorkspaceSettingsService {
 
             const { language } = currentProfile;
             return {
+                ...DefaultUiSettings,
                 userId: userLoginMd5,
                 workspace: this.workspace,
                 locale: language!,

--- a/libs/sdk-backend-bear/src/uiSettings.ts
+++ b/libs/sdk-backend-bear/src/uiSettings.ts
@@ -1,0 +1,10 @@
+// (C) 2023 GoodData Corporation
+
+import { ISettings } from "@gooddata/sdk-model";
+
+/**
+ * Hardcoded UI settings that are configurable on Tiger or hardcoded on both backends.
+ */
+export const DefaultUiSettings: ISettings = {
+    metadataTimeZone: "Europe/Prague", // Bear metadata are always stored in Prague time zone
+};

--- a/libs/sdk-backend-tiger/src/backend/uiSettings.ts
+++ b/libs/sdk-backend-tiger/src/backend/uiSettings.ts
@@ -85,6 +85,7 @@ export const DefaultUiSettings: ISettings = {
 
     enablePushpinGeoChart: true,
     tableSortingCheckDisabled: true,
+    metadataTimeZone: "UTC", // Panther/Tiger metadata are always stored in UTC time zone
     ...DefaultFeatureFlags,
 };
 

--- a/libs/sdk-model/api/sdk-model.api.md
+++ b/libs/sdk-model/api/sdk-model.api.md
@@ -2281,6 +2281,7 @@ export interface ISettings {
     enableWeekFilters?: boolean;
     formatLocale?: string;
     hideKpiDrillInEmbedded?: boolean;
+    metadataTimeZone?: string;
     platformEdition?: PlatformEdition;
     responsiveUiDateFormat?: string;
     weekStart?: WeekStart;

--- a/libs/sdk-model/src/settings/index.ts
+++ b/libs/sdk-model/src/settings/index.ts
@@ -289,6 +289,11 @@ export interface ISettings {
      */
     enableColumnHeadersPosition?: boolean;
 
+    /**
+     * IANA identifier of time zone in which the platform metadata are stored.
+     */
+    metadataTimeZone?: string;
+
     [key: string]: number | boolean | string | object | undefined;
 }
 

--- a/libs/sdk-ui-dashboard/src/presentation/insightList/InsightList.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/insightList/InsightList.tsx
@@ -223,6 +223,7 @@ export const InsightList: React.FC<IInsightListProps> = ({
                             }
                             isLocked={insightIsLocked(insightListSourceItem.insight)}
                             onClick={() => onSelect?.(insight)}
+                            metadataTimeZone={settings?.metadataTimeZone}
                         />
                     );
                 })

--- a/libs/sdk-ui-kit/api/sdk-ui-kit.api.md
+++ b/libs/sdk-ui-kit/api/sdk-ui-kit.api.md
@@ -2061,6 +2061,8 @@ export interface IInsightListItemProps {
     // (undocumented)
     isSelected?: boolean;
     // (undocumented)
+    metadataTimeZone?: string;
+    // (undocumented)
     onClick?: () => void;
     // (undocumented)
     onDelete?: () => void;

--- a/libs/sdk-ui-kit/src/List/InsightListItem.tsx
+++ b/libs/sdk-ui-kit/src/List/InsightListItem.tsx
@@ -52,6 +52,7 @@ export interface IInsightListItemProps {
     onDescriptionPanelOpen?: () => void;
 
     showDescriptionPanel?: boolean;
+    metadataTimeZone?: string;
 }
 
 /**
@@ -144,7 +145,7 @@ export class InsightListItemCore extends Component<IInsightListItemProps & Wrapp
     };
 
     private renderUpdatedDateTime = (date: any) => {
-        const { type } = this.props;
+        const { type, metadataTimeZone } = this.props;
 
         if (!date) {
             return false;
@@ -154,7 +155,8 @@ export class InsightListItemCore extends Component<IInsightListItemProps & Wrapp
             return <span />;
         }
 
-        return <InsightListItemDate config={getDateTimeConfig(date)} />;
+        const dateTimeConfig = getDateTimeConfig(date, { dateTimezone: metadataTimeZone });
+        return <InsightListItemDate config={dateTimeConfig} />;
     };
 
     private shouldRenderActions = () => !!this.props.onDelete;


### PR DESCRIPTION
Bear has always metadata stored in Prague time zone. Tiger has them 
always stored in UTC. The current insight list code counts with Prague
timezone, i.e., insight creation/update date for Tiger is shifted by
two hours. New hardcoded setting is introduced for both backends to
provide information about metadata timezone. The commit fixes insight
list for KD. The settings must be also applied to the component in AD
to fix it there. 

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |
| **Compatibility matrix test commands - TIGER Backend**  |                                                            |
| `extended test - matrix-test <AIO_version>`             | Run integrated tests against AIO versions.                 |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

`<AIO_version>` in commands is used to start test with multiple AIO instances - each instance in triggered by one jenkins build

-   To run with `master` and `stable`, execute command `extended test - matrix-test master,stable` or `extended test - matrix-test latest`
-   To run with specific version,ex: `2.3.0` and `2.3.1`, execute command `extended test - matrix-test 2.3.0,2.3.1`
-   In case `<AIO_version>` is empty, read versions from file `compTigerVersions.txt` of this repo

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
