### PR TITLE
BUGFIX: TNT-1665 New width selected columns

### DIFF
--- a/docs/content/en/latest/references/visual_components/pivot_table.md
+++ b/docs/content/en/latest/references/visual_components/pivot_table.md
@@ -179,7 +179,7 @@ You can create these items using the following factory functions:
 -  `newWidthForAttributeColumn` sets the width of a row attribute column.
 -  `newWidthForAllMeasureColumns` sets the width of all measure columns.
 -  `newWidthForAllColumnsForMeasure` sets the width of all columns for a particular measure.
--  `newWidthForSelectedColumns` sets the width for one or more columns specified by the locators.
+-  `setNewWidthForSelectedColumns` sets the width for one or more columns specified by the locators.
 
 The factory functions are exported from the `@gooddata/sdk-ui-pivot` package.
 
@@ -188,7 +188,7 @@ const config = {
     columnSizing: {
        columnWidths: [
             newWidthForAttributeColumn(Md.Date, 100),
-            newWidthForSelectedColumns(Md.$FranchiseFees, [newAttributeColumnLocator(Md.DateMonth.Short, monthDateJanuaryUri)], 200)
+            setNewWidthForSelectedColumns(Md.$FranchiseFees, [newAttributeColumnLocator(Md.DateMonth.Short, monthDateJanuaryUri)], 200)
        ]
     }
 }
@@ -238,7 +238,7 @@ const config = {
 
 ### Priorities of column width definitions
 
-`newWidthForSelectedColumns` defined for a specific column overrides the value set by `newWidthForAllColumnsForMeasure` or `newWidthForAllMeasureColumns`.
+`setNewWidthForSelectedColumns` defined for a specific column overrides the value set by `newWidthForAllColumnsForMeasure` or `newWidthForAllMeasureColumns`.
 
 ### Combining auto resizing and manual resizing
 
@@ -254,7 +254,7 @@ const config = {
         defaultWidth: "autoresizeAll",
         columnWidths: [
             newWidthForAttributeColumn(Md.Date, 100),
-            newWidthForSelectedColumns(Md.$FranchiseFees, [newAttributeColumnLocator(Md.DateMonth.Short, monthDateJanuaryUri)], 200),
+            setNewWidthForSelectedColumns(Md.$FranchiseFees, [newAttributeColumnLocator(Md.DateMonth.Short, monthDateJanuaryUri)], 200),
         ]
     }
 }
@@ -262,7 +262,7 @@ const config = {
 
 **Example 2:** In the following code sample:
 * The width of all the measure columns is set to the value of the `width` prop passed to `newWidthForAllMeasureColumns` (see [Manual resizing](#manual-resizing)).
-* However, the `newWidthForSelectedColumns` prop overrides the value set by `newWidthForAllMeasureColumns` for the measure columns that are defined in the call to `newWidthForSelectedColumns`. Notice that the `width` prop passed to `newWidthForSelectedColumns` is set to `"auto"` and not to a number as in **Example 1**. This means that at the initial rendering these measure columns will be resized to fit the content (see [Auto resizing](#auto-resizing)), while all the other measure columns will be set to the width defined by `newWidthForAllMeasureColumns`.
+* However, the `setNewWidthForSelectedColumns` prop overrides the value set by `newWidthForAllMeasureColumns` for the measure columns that are defined in the call to `setNewWidthForSelectedColumns`. Notice that the `width` prop passed to `setNewWidthForSelectedColumns` is set to `"auto"` and not to a number as in **Example 1**. This means that at the initial rendering these measure columns will be resized to fit the content (see [Auto resizing](#auto-resizing)), while all the other measure columns will be set to the width defined by `newWidthForAllMeasureColumns`.
 * All the attribute columns, if any, are resized to fit the content (see [Auto resizing](#auto-resizing)).
 
 ```jsx
@@ -271,7 +271,7 @@ const config = {
         defaultWidth: "autoresizeAll",
         columnWidths: [
             newWidthForAllMeasureColumns(200),
-            newWidthForSelectedColumns(Md.$FranchiseFees, [newAttributeColumnLocator(Md.DateMonth.Short, monthDateJanuaryUri)], "auto"),
+            setNewWidthForSelectedColumns(Md.$FranchiseFees, [newAttributeColumnLocator(Md.DateMonth.Short, monthDateJanuaryUri)], "auto"),
         ]
     }
 }
@@ -280,7 +280,7 @@ const config = {
 **Example 3:** In the following code sample:
 * The width of all the measure columns is set to the value of the `width` prop passed to `allMeasureColumnWidthItem` (see [Manual resizing](#manual-resizing)).
 * The width of all columns of the selected measure is set to the value of the `width` prop passed to `newWidthForAllColumnsForMeasure` and overrides the value from `newWidthForAllMeasureColumns` (see [Manual resizing](#manual-resizing)).
-* However, the `newWidthForSelectedColumns`prop overrides the value set by `newWidthForAllMeasureColumns` and `newWidthForAllColumnsForMeasure` for the measure column that is defined under `newWidthForSelectedColumns`. Notice that the `width` prop passed to `newWidthForSelectedColumns` is set to `"auto"` and not to a number as in **Example 1**. This means that at the initial rendering this measure column will be resized to fit the content (see [Auto resizing](#auto-resizing)), while all the other measure columns will be set to the width defined by `newWidthForAllMeasureColumns` or `newWidthForAllColumnsForMeasure`.
+* However, the `setNewWidthForSelectedColumns`prop overrides the value set by `newWidthForAllMeasureColumns` and `newWidthForAllColumnsForMeasure` for the measure column that is defined under `setNewWidthForSelectedColumns`. Notice that the `width` prop passed to `setNewWidthForSelectedColumns` is set to `"auto"` and not to a number as in **Example 1**. This means that at the initial rendering this measure column will be resized to fit the content (see [Auto resizing](#auto-resizing)), while all the other measure columns will be set to the width defined by `newWidthForAllMeasureColumns` or `newWidthForAllColumnsForMeasure`.
 * All the attribute columns, if any, are resized to fit the content (see [Auto resizing](#auto-resizing)).
 
 ```jsx
@@ -290,7 +290,7 @@ const config = {
         columnWidths: [
             newWidthForAllMeasureColumns(200),
             newWidthForAllColumnsForMeasure(Md.$TotalSales, 200),
-            newWidthForSelectedColumns(Md.$FranchiseFees, [newAttributeColumnLocator(Md.DateMonth.Short, monthDateJanuaryUri)], "auto"),
+            setNewWidthForSelectedColumns(Md.$FranchiseFees, [newAttributeColumnLocator(Md.DateMonth.Short, monthDateJanuaryUri)], "auto"),
         ]
     }
 }
@@ -329,7 +329,7 @@ const config = {
 
     All the measures columns are resized to the set width.
 
-    The new column widths are propagated via the `onColumnResized` callback array. All the `newWidthForSelectedColumns` items are removed. The `newWidthForAllMeasureColumns` item is added.
+    The new column widths are propagated via the `onColumnResized` callback array. All the `setNewWidthForSelectedColumns` items are removed. The `newWidthForAllMeasureColumns` item is added.
 
 ### Resizing all columns of a specific measure at once to a custom width
 
@@ -338,7 +338,7 @@ const config = {
 
     All columns of the corresponding measure are resized to the set width.
 
-    The new column widths are propagated via the `onColumnResized` callback array. All the `newWidthForSelectedColumns` items for the corresponding measure are removed. The `newWidthForAllColumnsForMeasure` item is added.
+    The new column widths are propagated via the `onColumnResized` callback array. All the `setNewWidthForSelectedColumns` items for the corresponding measure are removed. The `newWidthForAllColumnsForMeasure` item is added.
 
 ### Resizing a column to fit its content
 
@@ -351,7 +351,7 @@ const config = {
 
 **NOTES:**
 * This behavior is not applied if [auto resizing](#auto-resizing) is enabled and you double-click a column that was auto-resized at the initial rendering and then its width was manually adjusted in the UI. Such column is removed from the `onColumnResized` callback array.
-* If [auto resizing](#auto-resizing) is enabled, and `columnWidths` includes the `newWidthForAllMeasureColumns` or `newWidthForAllColumnsForMeasure` items, and you double-click a measure column, the `newWidthForSelectedColumns` item with `width` set to `"auto"` is added to the `onColumnResized` callback array.
+* If [auto resizing](#auto-resizing) is enabled, and `columnWidths` includes the `newWidthForAllMeasureColumns` or `newWidthForAllColumnsForMeasure` items, and you double-click a measure column, the `setNewWidthForSelectedColumns` item with `width` set to `"auto"` is added to the `onColumnResized` callback array.
 
 ### Resizing all measure columns at once to fit their content
 
@@ -409,7 +409,7 @@ const config = {
         defaultWidth: "autoresizeAll",
         columnWidths: [
             newWidthForAttributeColumn(Md.Date, 100),
-            newWidthForSelectedColumns(Md.$FranchiseFees, [newAttributeColumnLocator(Md.DateMonth.Short, monthDateJanuaryUri)], 200),
+            setNewWidthForSelectedColumns(Md.$FranchiseFees, [newAttributeColumnLocator(Md.DateMonth.Short, monthDateJanuaryUri)], 200),
         ]
     }
 };

--- a/examples/sdk-examples/src/examples/pivotTable/PivotTableManualResizingExample.tsx
+++ b/examples/sdk-examples/src/examples/pivotTable/PivotTableManualResizingExample.tsx
@@ -3,7 +3,7 @@ import React, { useState } from "react";
 import {
     PivotTable,
     newWidthForAttributeColumn,
-    newWidthForSelectedColumns,
+    setNewWidthForSelectedColumns,
     newAttributeColumnLocator,
     ColumnWidthItem,
 } from "@gooddata/sdk-ui-pivot";
@@ -22,7 +22,7 @@ const columns = [Md.DateDatasets.Date.Quarter.Default];
 const attributeWidth = (width: number) => newWidthForAttributeColumn(attributes[0], width);
 
 const measureWidth = (width: number) =>
-    newWidthForSelectedColumns(
+    setNewWidthForSelectedColumns(
         FranchiseFees,
         [
             newAttributeColumnLocator(

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/tests/__snapshots__/pivotTableAdditionalFactories.test.ts.snap
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/tests/__snapshots__/pivotTableAdditionalFactories.test.ts.snap
@@ -12,13 +12,21 @@ exports[`pivotTableAdditionalFactories > factoryNotationForAttributeColumnWidthI
 
 exports[`pivotTableAdditionalFactories > factoryNotationForAttributeColumnWidthItem > should handle item without grow to fit 1`] = `"newWidthForAttributeColumn(\\"some-id\\", 123)"`;
 
-exports[`pivotTableAdditionalFactories > factoryNotationForMeasureColumnWidthItem > with numeric width value > should handle item with grow to fit 1`] = `"newWidthForSelectedColumns(\\"some-id\\", [newAttributeColumnLocator(\\"attr-id\\")], 123, true)"`;
+exports[`pivotTableAdditionalFactories > factoryNotationForMeasureColumnWidthItem > with numeric width value > should handle item with grow to fit 1`] = `"setNewWidthForSelectedColumns([\\"some-id\\"], [newAttributeColumnLocator(\\"attr-id\\")], 123, true)"`;
 
-exports[`pivotTableAdditionalFactories > factoryNotationForMeasureColumnWidthItem > with numeric width value > should handle item without grow to fit 1`] = `"newWidthForSelectedColumns(\\"some-id\\", [newAttributeColumnLocator(\\"attr-id\\")], 123)"`;
+exports[`pivotTableAdditionalFactories > factoryNotationForMeasureColumnWidthItem > with numeric width value > should handle item with transposed metrics and with grow to fit 1`] = `"setNewWidthForSelectedColumns([\\"measure-1\\",\\"measure-2\\"], [newAttributeColumnLocator(\\"attr-id\\"), newTotalColumnLocator(\\"attr-id\\", \\"max\\")], 123, true)"`;
 
-exports[`pivotTableAdditionalFactories > factoryNotationForMeasureColumnWidthItem > with string width value > should handle item with grow to fit 1`] = `"newWidthForSelectedColumns(\\"some-id\\", [newAttributeColumnLocator(\\"attr-id\\")], \\"auto\\")"`;
+exports[`pivotTableAdditionalFactories > factoryNotationForMeasureColumnWidthItem > with numeric width value > should handle item with transposed metrics and without grow to fit 1`] = `"setNewWidthForSelectedColumns([\\"measure-1\\",\\"measure-2\\",\\"measure-3\\"], [newAttributeColumnLocator(\\"attr-id\\"), newTotalColumnLocator(\\"attr-id\\", \\"max\\")], 123, true)"`;
 
-exports[`pivotTableAdditionalFactories > factoryNotationForMeasureColumnWidthItem > with string width value > should handle item without grow to fit 1`] = `"newWidthForSelectedColumns(\\"some-id\\", [newAttributeColumnLocator(\\"attr-id\\")], \\"auto\\")"`;
+exports[`pivotTableAdditionalFactories > factoryNotationForMeasureColumnWidthItem > with numeric width value > should handle item without grow to fit 1`] = `"setNewWidthForSelectedColumns([\\"some-id\\"], [newAttributeColumnLocator(\\"attr-id\\")], 123)"`;
+
+exports[`pivotTableAdditionalFactories > factoryNotationForMeasureColumnWidthItem > with string width value > should handle item with grow to fit 1`] = `"setNewWidthForSelectedColumns([\\"some-id\\"], [newAttributeColumnLocator(\\"attr-id\\")], \\"auto\\")"`;
+
+exports[`pivotTableAdditionalFactories > factoryNotationForMeasureColumnWidthItem > with string width value > should handle item with transposed metrics and with grow to fit 1`] = `"setNewWidthForSelectedColumns([\\"measure-1\\",\\"measure-2\\"], [newAttributeColumnLocator(\\"attr-id\\"), newTotalColumnLocator(\\"attr-id\\", \\"max\\")], \\"auto\\")"`;
+
+exports[`pivotTableAdditionalFactories > factoryNotationForMeasureColumnWidthItem > with string width value > should handle item with transposed metrics and without grow to fit 1`] = `"setNewWidthForSelectedColumns([\\"measure-1\\",\\"measure-2\\",\\"measure-3\\"], [newAttributeColumnLocator(\\"attr-id\\"), newTotalColumnLocator(\\"attr-id\\", \\"max\\")], \\"auto\\")"`;
+
+exports[`pivotTableAdditionalFactories > factoryNotationForMeasureColumnWidthItem > with string width value > should handle item without grow to fit 1`] = `"setNewWidthForSelectedColumns([\\"some-id\\"], [newAttributeColumnLocator(\\"attr-id\\")], \\"auto\\")"`;
 
 exports[`pivotTableAdditionalFactories > factoryNotationForWeakMeasureColumnWidthItem > should handle item with grow to fit 1`] = `"newWidthForAllColumnsForMeasure(\\"some-id\\", 123, true)"`;
 

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/tests/pivotTableAdditionalFactories.test.ts
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/tests/pivotTableAdditionalFactories.test.ts
@@ -1,10 +1,11 @@
 // (C) 2022 GoodData Corporation
 import {
     newAttributeColumnLocator,
+    newTotalColumnLocator,
     newWidthForAllColumnsForMeasure,
     newWidthForAllMeasureColumns,
     newWidthForAttributeColumn,
-    newWidthForSelectedColumns,
+    setNewWidthForSelectedColumns,
 } from "@gooddata/sdk-ui-pivot";
 import {
     factoryNotationForAllMeasureColumnWidthItem,
@@ -13,6 +14,7 @@ import {
     factoryNotationForMeasureColumnWidthItem,
     factoryNotationForWeakMeasureColumnWidthItem,
 } from "../pivotTableAdditionalFactories.js";
+
 import { describe, it, expect } from "vitest";
 
 describe("pivotTableAdditionalFactories", () => {
@@ -31,18 +33,39 @@ describe("pivotTableAdditionalFactories", () => {
 
     describe("factoryNotationForMeasureColumnWidthItem", () => {
         const attributeLocators = [newAttributeColumnLocator("attr-id")];
+        const totalLocators = [newTotalColumnLocator("attr-id", "max")];
 
         describe.each([
             ["numeric", 123],
             ["string", "auto"],
         ] as const)("with %s width value", (_, width) => {
             it("should handle item without grow to fit", () => {
-                const input = newWidthForSelectedColumns("some-id", attributeLocators, width);
+                const input = setNewWidthForSelectedColumns("some-id", attributeLocators, width);
                 const actual = factoryNotationForMeasureColumnWidthItem(input);
                 expect(actual).toMatchSnapshot();
             });
             it("should handle item with grow to fit", () => {
-                const input = newWidthForSelectedColumns("some-id", attributeLocators, width, true);
+                const input = setNewWidthForSelectedColumns("some-id", attributeLocators, width, true);
+                const actual = factoryNotationForMeasureColumnWidthItem(input);
+                expect(actual).toMatchSnapshot();
+            });
+            it("should handle item with transposed metrics and without grow to fit", () => {
+                const input = setNewWidthForSelectedColumns(
+                    ["measure-1", "measure-2", "measure-3"],
+                    [...attributeLocators, ...totalLocators],
+                    width,
+                    true,
+                );
+                const actual = factoryNotationForMeasureColumnWidthItem(input);
+                expect(actual).toMatchSnapshot();
+            });
+            it("should handle item with transposed metrics and with grow to fit", () => {
+                const input = setNewWidthForSelectedColumns(
+                    ["measure-1", "measure-2"],
+                    [...attributeLocators, ...totalLocators],
+                    width,
+                    true,
+                );
                 const actual = factoryNotationForMeasureColumnWidthItem(input);
                 expect(actual).toMatchSnapshot();
             });

--- a/libs/sdk-ui-ext/src/internal/components/tests/__snapshots__/VisualizationCatalog.test.ts.snap
+++ b/libs/sdk-ui-ext/src/internal/components/tests/__snapshots__/VisualizationCatalog.test.ts.snap
@@ -38721,7 +38721,7 @@ export function MyComponent() {
 exports[`getEmbeddingCode functionality > should generate code for PivotTable - simple table with attribute and metric column size 1`] = `
 "import React from \\"react\\";
 import { IAttribute, IAttributeOrMeasure, idRef, newAttribute, newMeasure } from \\"@gooddata/sdk-model\\";
-import { IPivotTableConfig, newWidthForAttributeColumn, newWidthForSelectedColumns, PivotTable } from \\"@gooddata/sdk-ui-pivot\\";
+import { IPivotTableConfig, newWidthForAttributeColumn, PivotTable, setNewWidthForSelectedColumns } from \\"@gooddata/sdk-ui-pivot\\";
 
 const measures: IAttributeOrMeasure[] = [
     newMeasure(idRef(\\"aangOxLSeztu\\", \\"measure\\"), m => m.localId(\\"m_aangOxLSeztu\\")),
@@ -38735,7 +38735,7 @@ const config: IPivotTableConfig = {
         defaultWidth: \\"autoresizeAll\\",
         columnWidths: [
             newWidthForAttributeColumn(\\"a_label.product.id.name\\", 400),
-            newWidthForSelectedColumns(\\"m_aangOxLSeztu\\", [], 60)
+            setNewWidthForSelectedColumns([\\"m_aangOxLSeztu\\"], [], 60)
         ]
     },
     menu: {
@@ -38764,7 +38764,7 @@ export function MyComponent() {
 exports[`getEmbeddingCode functionality > should generate code for PivotTable - simple table with attribute and metric column size 2`] = `
 "import React from \\"react\\";
 import { IAttribute, IAttributeOrMeasure, idRef, newAttribute, newMeasure } from \\"@gooddata/sdk-model\\";
-import { IPivotTableConfig, newWidthForAttributeColumn, newWidthForSelectedColumns, PivotTable } from \\"@gooddata/sdk-ui-pivot\\";
+import { IPivotTableConfig, newWidthForAttributeColumn, PivotTable, setNewWidthForSelectedColumns } from \\"@gooddata/sdk-ui-pivot\\";
 
 const measures: IAttributeOrMeasure[] = [
     newMeasure(idRef(\\"aangOxLSeztu\\", \\"measure\\"), m => m.localId(\\"m_aangOxLSeztu\\")),
@@ -38778,7 +38778,7 @@ const config: IPivotTableConfig = {
         defaultWidth: \\"autoresizeAll\\",
         columnWidths: [
             newWidthForAttributeColumn(\\"a_label.product.id.name\\", 400),
-            newWidthForSelectedColumns(\\"m_aangOxLSeztu\\", [], 60)
+            setNewWidthForSelectedColumns([\\"m_aangOxLSeztu\\"], [], 60)
         ]
     },
     menu: {
@@ -38807,7 +38807,7 @@ export function MyComponent() {
 exports[`getEmbeddingCode functionality > should generate code for PivotTable - simple table with attribute and metric column size 3`] = `
 "import React from \\"react\\";
 import { IAttribute, IAttributeOrMeasure, idRef, newAttribute, newMeasure } from \\"@gooddata/sdk-model\\";
-import { IPivotTableConfig, newWidthForAttributeColumn, newWidthForSelectedColumns, PivotTable } from \\"@gooddata/sdk-ui-pivot\\";
+import { IPivotTableConfig, newWidthForAttributeColumn, PivotTable, setNewWidthForSelectedColumns } from \\"@gooddata/sdk-ui-pivot\\";
 
 const measures: IAttributeOrMeasure[] = [
     newMeasure(idRef(\\"aangOxLSeztu\\", \\"measure\\"), m => m.localId(\\"m_aangOxLSeztu\\")),
@@ -38821,7 +38821,7 @@ const config: IPivotTableConfig = {
         defaultWidth: \\"autoresizeAll\\",
         columnWidths: [
             newWidthForAttributeColumn(\\"a_label.product.id.name\\", 400),
-            newWidthForSelectedColumns(\\"m_aangOxLSeztu\\", [], 60)
+            setNewWidthForSelectedColumns([\\"m_aangOxLSeztu\\"], [], 60)
         ]
     },
     menu: {
@@ -38850,7 +38850,7 @@ export function MyComponent() {
 exports[`getEmbeddingCode functionality > should generate code for PivotTable - simple table with attribute and metric column size 4`] = `
 "import React from \\"react\\";
 import { IAttribute, IAttributeOrMeasure, idRef, newAttribute, newMeasure } from \\"@gooddata/sdk-model\\";
-import { IPivotTableConfig, newWidthForAttributeColumn, newWidthForSelectedColumns, PivotTable } from \\"@gooddata/sdk-ui-pivot\\";
+import { IPivotTableConfig, newWidthForAttributeColumn, PivotTable, setNewWidthForSelectedColumns } from \\"@gooddata/sdk-ui-pivot\\";
 
 const measures: IAttributeOrMeasure[] = [
     newMeasure(idRef(\\"aangOxLSeztu\\", \\"measure\\"), m => m.localId(\\"m_aangOxLSeztu\\")),
@@ -38864,7 +38864,7 @@ const config: IPivotTableConfig = {
         defaultWidth: \\"autoresizeAll\\",
         columnWidths: [
             newWidthForAttributeColumn(\\"a_label.product.id.name\\", 400),
-            newWidthForSelectedColumns(\\"m_aangOxLSeztu\\", [], 60)
+            setNewWidthForSelectedColumns([\\"m_aangOxLSeztu\\"], [], 60)
         ]
     },
     menu: {
@@ -39061,7 +39061,7 @@ export function MyComponent() {
 exports[`getEmbeddingCode functionality > should generate code for PivotTable - simple table with custom metric column size 1`] = `
 "import React from \\"react\\";
 import { IAttribute, IAttributeOrMeasure, idRef, newAttribute, newMeasure } from \\"@gooddata/sdk-model\\";
-import { IPivotTableConfig, newWidthForSelectedColumns, PivotTable } from \\"@gooddata/sdk-ui-pivot\\";
+import { IPivotTableConfig, PivotTable, setNewWidthForSelectedColumns } from \\"@gooddata/sdk-ui-pivot\\";
 
 const measures: IAttributeOrMeasure[] = [
     newMeasure(idRef(\\"aangOxLSeztu\\", \\"measure\\"), m => m.localId(\\"m_aangOxLSeztu\\")),
@@ -39074,7 +39074,7 @@ const config: IPivotTableConfig = {
     columnSizing: {
         defaultWidth: \\"autoresizeAll\\",
         columnWidths: [
-            newWidthForSelectedColumns(\\"m_aangOxLSeztu\\", [], 60)
+            setNewWidthForSelectedColumns([\\"m_aangOxLSeztu\\"], [], 60)
         ]
     },
     menu: {
@@ -39103,7 +39103,7 @@ export function MyComponent() {
 exports[`getEmbeddingCode functionality > should generate code for PivotTable - simple table with custom metric column size 2`] = `
 "import React from \\"react\\";
 import { IAttribute, IAttributeOrMeasure, idRef, newAttribute, newMeasure } from \\"@gooddata/sdk-model\\";
-import { IPivotTableConfig, newWidthForSelectedColumns, PivotTable } from \\"@gooddata/sdk-ui-pivot\\";
+import { IPivotTableConfig, PivotTable, setNewWidthForSelectedColumns } from \\"@gooddata/sdk-ui-pivot\\";
 
 const measures: IAttributeOrMeasure[] = [
     newMeasure(idRef(\\"aangOxLSeztu\\", \\"measure\\"), m => m.localId(\\"m_aangOxLSeztu\\")),
@@ -39116,7 +39116,7 @@ const config: IPivotTableConfig = {
     columnSizing: {
         defaultWidth: \\"autoresizeAll\\",
         columnWidths: [
-            newWidthForSelectedColumns(\\"m_aangOxLSeztu\\", [], 60)
+            setNewWidthForSelectedColumns([\\"m_aangOxLSeztu\\"], [], 60)
         ]
     },
     menu: {
@@ -39145,7 +39145,7 @@ export function MyComponent() {
 exports[`getEmbeddingCode functionality > should generate code for PivotTable - simple table with custom metric column size 3`] = `
 "import React from \\"react\\";
 import { IAttribute, IAttributeOrMeasure, idRef, newAttribute, newMeasure } from \\"@gooddata/sdk-model\\";
-import { IPivotTableConfig, newWidthForSelectedColumns, PivotTable } from \\"@gooddata/sdk-ui-pivot\\";
+import { IPivotTableConfig, PivotTable, setNewWidthForSelectedColumns } from \\"@gooddata/sdk-ui-pivot\\";
 
 const measures: IAttributeOrMeasure[] = [
     newMeasure(idRef(\\"aangOxLSeztu\\", \\"measure\\"), m => m.localId(\\"m_aangOxLSeztu\\")),
@@ -39158,7 +39158,7 @@ const config: IPivotTableConfig = {
     columnSizing: {
         defaultWidth: \\"autoresizeAll\\",
         columnWidths: [
-            newWidthForSelectedColumns(\\"m_aangOxLSeztu\\", [], 60)
+            setNewWidthForSelectedColumns([\\"m_aangOxLSeztu\\"], [], 60)
         ]
     },
     menu: {
@@ -39187,7 +39187,7 @@ export function MyComponent() {
 exports[`getEmbeddingCode functionality > should generate code for PivotTable - simple table with custom metric column size 4`] = `
 "import React from \\"react\\";
 import { IAttribute, IAttributeOrMeasure, idRef, newAttribute, newMeasure } from \\"@gooddata/sdk-model\\";
-import { IPivotTableConfig, newWidthForSelectedColumns, PivotTable } from \\"@gooddata/sdk-ui-pivot\\";
+import { IPivotTableConfig, PivotTable, setNewWidthForSelectedColumns } from \\"@gooddata/sdk-ui-pivot\\";
 
 const measures: IAttributeOrMeasure[] = [
     newMeasure(idRef(\\"aangOxLSeztu\\", \\"measure\\"), m => m.localId(\\"m_aangOxLSeztu\\")),
@@ -39200,7 +39200,7 @@ const config: IPivotTableConfig = {
     columnSizing: {
         defaultWidth: \\"autoresizeAll\\",
         columnWidths: [
-            newWidthForSelectedColumns(\\"m_aangOxLSeztu\\", [], 60)
+            setNewWidthForSelectedColumns([\\"m_aangOxLSeztu\\"], [], 60)
         ]
     },
     menu: {

--- a/libs/sdk-ui-pivot/api/sdk-ui-pivot.api.md
+++ b/libs/sdk-ui-pivot/api/sdk-ui-pivot.api.md
@@ -243,6 +243,9 @@ export function isMixedValuesColumnWidthItem(obj: unknown): obj is IMixedValuesC
 export function isSliceMeasureColumnWidthItem(obj: unknown): obj is ISliceMeasureColumnWidthItem;
 
 // @public
+export function isTotalColumnLocator(obj: unknown): obj is ITotalColumnLocator;
+
+// @public
 export function isWeakMeasureColumnWidthItem(obj: unknown): obj is IWeakMeasureColumnWidthItem;
 
 // @public
@@ -277,6 +280,9 @@ export type MeasureGroupDimension = "columns" | "rows";
 // @public
 export function newAttributeColumnLocator(attributeOrId: IAttribute | string, element?: string): IAttributeColumnLocator;
 
+// @alpha
+export function newTotalColumnLocator(attributeOrId: IAttribute | string, totalFunction: string): ITotalColumnLocator;
+
 // @public
 export function newWidthForAllColumnsForMeasure(measureOrId: IMeasure | string, width: number, allowGrowToFit?: boolean): IWeakMeasureColumnWidthItem;
 
@@ -286,13 +292,16 @@ export function newWidthForAllMeasureColumns(width: number, allowGrowToFit?: boo
 // @public
 export function newWidthForAttributeColumn(attributeOrId: IAttribute | string, width: number, allowGrowToFit?: boolean): IAttributeColumnWidthItem;
 
-// @public
-export function newWidthForSelectedColumns(measureOrId: IMeasure | string | null, locators: IAttributeColumnLocator[], width: number | "auto", allowGrowToFit?: boolean): IMeasureColumnWidthItem;
+// @public @deprecated
+export function newWidthForSelectedColumns(measureOrId: IMeasure | string, locators: (IAttributeColumnLocator | ITotalColumnLocator)[], width: number | "auto", allowGrowToFit?: boolean): IMeasureColumnWidthItem;
 
 // @public
 export const PivotTable: (props: IPivotTableProps) => JSX.Element;
 
 // @public
 export function pivotTableMenuForCapabilities(capabilities: IBackendCapabilities, desiredMenu?: IMenu): IMenu;
+
+// @public
+export function setNewWidthForSelectedColumns(measuresOrIds: IMeasure | string | IMeasure[] | string[] | null, locators: (IAttributeColumnLocator | ITotalColumnLocator)[], width: number | "auto", allowGrowToFit?: boolean): IMeasureColumnWidthItem;
 
 ```

--- a/libs/sdk-ui-pivot/src/columnWidths.ts
+++ b/libs/sdk-ui-pivot/src/columnWidths.ts
@@ -463,15 +463,45 @@ export function newWidthForAllColumnsForMeasure(
  * @param locators - Attribute locators to narrow down selection
  * @param width - Width in pixels
  * @param allowGrowToFit - indicates whether the column is allowed to grow if the table's growToFit is enabled
+   @deprecated this method is deprecated, please use {@link setNewWidthForSelectedColumns} instead.
  * @public
  */
 export function newWidthForSelectedColumns(
-    measureOrId: IMeasure | string | null,
-    locators: IAttributeColumnLocator[],
+    measureOrId: IMeasure | string,
+    locators: (IAttributeColumnLocator | ITotalColumnLocator)[],
     width: number | "auto",
     allowGrowToFit?: boolean,
 ): IMeasureColumnWidthItem {
-    const measureLocator = measureOrId ? [newMeasureColumnLocator(measureOrId)] : [];
+    return setNewWidthForSelectedColumns(measureOrId, locators, width, allowGrowToFit);
+}
+
+/**
+ * Creates width item that will set width for all columns containing values of the provided measure.
+ * To prepare width items for columns in tables without measures, pass measureOrId as `null`.
+ *
+ * @remarks
+ * See also {@link newAttributeColumnLocator} to learn more about the attribute column locators.
+ *
+ * @param measuresOrIds - Measures specified either by value or by localId reference
+ * @param locators - Attribute locators to narrow down selection
+ * @param width - Width in pixels
+ * @param allowGrowToFit - indicates whether the column is allowed to grow if the table's growToFit is enabled
+ * @public
+ */
+export function setNewWidthForSelectedColumns(
+    measuresOrIds: IMeasure | string | IMeasure[] | string[] | null,
+    locators: (IAttributeColumnLocator | ITotalColumnLocator)[],
+    width: number | "auto",
+    allowGrowToFit?: boolean,
+): IMeasureColumnWidthItem {
+    let measureLocators: IMeasureColumnLocator[] = [];
+
+    if (Array.isArray(measuresOrIds)) {
+        measureLocators = measuresOrIds.map(newMeasureColumnLocator);
+    } else if (measuresOrIds) {
+        measureLocators.push(newMeasureColumnLocator(measuresOrIds));
+    }
+
     const growToFitProp = allowGrowToFit !== undefined && width !== "auto" ? { allowGrowToFit } : {};
 
     // Note: beware here. The attribute locators _must_ come first for some obscure, impl dependent reason
@@ -481,7 +511,7 @@ export function newWidthForSelectedColumns(
                 value: width,
                 ...growToFitProp,
             },
-            locators: [...locators, ...measureLocator],
+            locators: [...locators, ...measureLocators],
         },
     };
 }

--- a/libs/sdk-ui-pivot/src/columnWidths.ts
+++ b/libs/sdk-ui-pivot/src/columnWidths.ts
@@ -271,7 +271,7 @@ export function isAttributeColumnLocator(obj: unknown): obj is IAttributeColumnL
 }
 
 /**
- * Tests whether object is an instance of {@link TotalColumnLocator}
+ * Tests whether object is an instance of {@link ITotalColumnLocator}
  *
  * @public
  */
@@ -372,6 +372,25 @@ export function newMeasureColumnLocator(measureOrId: IMeasure | string): IMeasur
     return {
         measureLocatorItem: {
             measureIdentifier,
+        },
+    };
+}
+
+/**
+ * Creates a new total column locator
+ *
+ * @param attributeOrId - Column attribute specified by either value or by localId reference
+ * @param totalFunction - Function for the total, such as sum, max, min...
+ * @alpha
+ */
+export function newTotalColumnLocator(
+    attributeOrId: IAttribute | string,
+    totalFunction: string,
+): ITotalColumnLocator {
+    return {
+        totalLocatorItem: {
+            attributeIdentifier: attributeLocalId(attributeOrId),
+            totalFunction,
         },
     };
 }

--- a/libs/sdk-ui-pivot/src/impl/resizing/tests/columnSizing.test.ts
+++ b/libs/sdk-ui-pivot/src/impl/resizing/tests/columnSizing.test.ts
@@ -8,7 +8,7 @@ import {
     newWidthForAllColumnsForMeasure,
     newWidthForAllMeasureColumns,
     newWidthForAttributeColumn,
-    newWidthForSelectedColumns,
+    setNewWidthForSelectedColumns,
 } from "../../../columnWidths.js";
 import {
     getMaxWidth,
@@ -74,26 +74,26 @@ describe("ResizedColumnStore", () => {
         [
             "for first measure column on non-pivoted table with two measures",
             TwoMeasuresWithRowAttributeDescriptor,
-            [newWidthForSelectedColumns(ReferenceMd.Amount, [], 100)],
+            [setNewWidthForSelectedColumns(ReferenceMd.Amount, [], 100)],
         ],
         [
             "for second measure column on non-pivoted table with two measures",
             TwoMeasuresWithRowAttributeDescriptor,
-            [newWidthForSelectedColumns(ReferenceMd.Won, [], 100)],
+            [setNewWidthForSelectedColumns(ReferenceMd.Won, [], 100)],
         ],
         [
             "for both measure columns on non-pivoted table with two measures",
             TwoMeasuresWithRowAttributeDescriptor,
             [
-                newWidthForSelectedColumns(ReferenceMd.Amount, [], 100),
-                newWidthForSelectedColumns(ReferenceMd.Won, [], 200),
+                setNewWidthForSelectedColumns(ReferenceMd.Amount, [], 100),
+                setNewWidthForSelectedColumns(ReferenceMd.Won, [], 200),
             ],
         ],
         [
             "for exactly one measure column on pivoted table",
             TwoMeasuresWithTwoRowAndTwoColumnAttributesDescriptor,
             [
-                newWidthForSelectedColumns(
+                setNewWidthForSelectedColumns(
                     ReferenceMd.Amount,
                     [
                         newAttributeColumnLocator(
@@ -110,7 +110,7 @@ describe("ResizedColumnStore", () => {
             "for auto-sizing exactly one measure column on pivoted table",
             TwoMeasuresWithTwoRowAndTwoColumnAttributesDescriptor,
             [
-                newWidthForSelectedColumns(
+                setNewWidthForSelectedColumns(
                     ReferenceMd.Amount,
                     [
                         newAttributeColumnLocator(
@@ -127,7 +127,7 @@ describe("ResizedColumnStore", () => {
             "for exactly two measure columns of same measure on pivoted table",
             TwoMeasuresWithTwoRowAndTwoColumnAttributesDescriptor,
             [
-                newWidthForSelectedColumns(
+                setNewWidthForSelectedColumns(
                     ReferenceMd.Amount,
                     [
                         newAttributeColumnLocator(
@@ -138,7 +138,7 @@ describe("ResizedColumnStore", () => {
                     ],
                     100,
                 ),
-                newWidthForSelectedColumns(
+                setNewWidthForSelectedColumns(
                     ReferenceMd.Amount,
                     [
                         newAttributeColumnLocator(
@@ -155,7 +155,7 @@ describe("ResizedColumnStore", () => {
             "for exactly two measure columns of two different measures on pivoted table",
             TwoMeasuresWithTwoRowAndTwoColumnAttributesDescriptor,
             [
-                newWidthForSelectedColumns(
+                setNewWidthForSelectedColumns(
                     ReferenceMd.Amount,
                     [
                         newAttributeColumnLocator(
@@ -166,7 +166,7 @@ describe("ResizedColumnStore", () => {
                     ],
                     100,
                 ),
-                newWidthForSelectedColumns(
+                setNewWidthForSelectedColumns(
                     ReferenceMd.Won,
                     [
                         newAttributeColumnLocator(
@@ -183,7 +183,7 @@ describe("ResizedColumnStore", () => {
             "for auto-sizing exactly two measure columns of two different measures on pivoted table",
             TwoMeasuresWithTwoRowAndTwoColumnAttributesDescriptor,
             [
-                newWidthForSelectedColumns(
+                setNewWidthForSelectedColumns(
                     ReferenceMd.Amount,
                     [
                         newAttributeColumnLocator(
@@ -194,7 +194,7 @@ describe("ResizedColumnStore", () => {
                     ],
                     "auto",
                 ),
-                newWidthForSelectedColumns(
+                setNewWidthForSelectedColumns(
                     ReferenceMd.Won,
                     [
                         newAttributeColumnLocator(
@@ -226,7 +226,7 @@ describe("ResizedColumnStore", () => {
             "for combination of single measure and all measure widths on pivoted table",
             TwoMeasuresWithTwoRowAndTwoColumnAttributesDescriptor,
             [
-                newWidthForSelectedColumns(
+                setNewWidthForSelectedColumns(
                     ReferenceMd.Amount,
                     [
                         newAttributeColumnLocator(
@@ -244,7 +244,7 @@ describe("ResizedColumnStore", () => {
             "for combination of attribute, single measure and all measure widths on pivoted table",
             TwoMeasuresWithTwoRowAndTwoColumnAttributesDescriptor,
             [
-                newWidthForSelectedColumns(
+                setNewWidthForSelectedColumns(
                     ReferenceMd.Amount,
                     [
                         newAttributeColumnLocator(
@@ -325,7 +325,7 @@ describe("ResizedColumnStore", () => {
         it("should remove measure from manual resizing", () => {
             const store = testStore(
                 TwoMeasuresWithRowAttributeDescriptor,
-                newWidthForSelectedColumns(ReferenceMd.Amount, [], 100),
+                setNewWidthForSelectedColumns(ReferenceMd.Amount, [], 100),
             );
 
             const column = getFakeColumn({
@@ -390,7 +390,7 @@ describe("ResizedColumnStore", () => {
             const store = testStore(
                 TwoMeasuresWithRowAttributeDescriptor,
                 newWidthForAllMeasureColumns(155),
-                newWidthForSelectedColumns(ReferenceMd.Amount, [], 175),
+                setNewWidthForSelectedColumns(ReferenceMd.Amount, [], 175),
             );
 
             const column = getFakeColumn({
@@ -408,13 +408,13 @@ describe("ResizedColumnStore", () => {
             [
                 "keep fixed-size single measure column setting",
                 TwoMeasuresWithRowAttributeDescriptor,
-                [newWidthForSelectedColumns(ReferenceMd.Amount, [], 100)],
+                [setNewWidthForSelectedColumns(ReferenceMd.Amount, [], 100)],
                 100,
             ],
             [
                 "remove measure column settings when using auto-size",
                 TwoMeasuresWithRowAttributeDescriptor,
-                [newWidthForSelectedColumns(ReferenceMd.Amount, [], "auto")],
+                [setNewWidthForSelectedColumns(ReferenceMd.Amount, [], "auto")],
                 undefined,
             ],
             [
@@ -459,7 +459,7 @@ describe("ResizedColumnStore", () => {
             const store = testStore(
                 TwoMeasuresWithRowAttributeDescriptor,
                 newWidthForAllColumnsForMeasure(ReferenceMd.Amount, 100),
-                newWidthForSelectedColumns(ReferenceMd.Amount, [], 175),
+                setNewWidthForSelectedColumns(ReferenceMd.Amount, [], 175),
             );
 
             const column = getFakeColumn({
@@ -507,7 +507,7 @@ describe("ResizedColumnStore", () => {
         it("should replace single row measure width with weak column", () => {
             const store = testStore(
                 TwoMeasuresWithTwoRowAndTwoColumnAttributesDescriptor,
-                newWidthForSelectedColumns(
+                setNewWidthForSelectedColumns(
                     ReferenceMd.Amount,
                     [
                         newAttributeColumnLocator(
@@ -714,7 +714,7 @@ describe("ResizedColumnStore", () => {
         it("should return explicit measure column width", () => {
             const store = testStore(
                 TestTable,
-                newWidthForSelectedColumns(
+                setNewWidthForSelectedColumns(
                     ReferenceMd.Amount,
                     [
                         newAttributeColumnLocator(

--- a/libs/sdk-ui-pivot/src/impl/resizing/tests/updateColDefs.test.ts
+++ b/libs/sdk-ui-pivot/src/impl/resizing/tests/updateColDefs.test.ts
@@ -6,7 +6,7 @@ import {
     newWidthForAllColumnsForMeasure,
     newWidthForAllMeasureColumns,
     newWidthForAttributeColumn,
-    newWidthForSelectedColumns,
+    setNewWidthForSelectedColumns,
 } from "../../../columnWidths.js";
 import { TableDescriptor } from "../../structure/tableDescriptor.js";
 import {
@@ -24,7 +24,7 @@ describe("updateColumnDefinitionsWithWidths", () => {
     it("should enrich colDefs based on column width items", () => {
         const table = TableDescriptor.for(TwoMeasuresWithTwoRowAndTwoColumnAttributes, "empty value");
         const widths: ColumnWidthItem[] = [
-            newWidthForSelectedColumns(
+            setNewWidthForSelectedColumns(
                 ReferenceMd.Amount,
                 [
                     newAttributeColumnLocator(
@@ -67,7 +67,7 @@ describe("updateColumnDefinitionsWithWidths", () => {
 
     it("should enrich colDefs when mix of manual and auto-resizing and grow-to-fit on", () => {
         const table = TableDescriptor.for(TwoMeasuresWithRowAttribute, "empty value");
-        const store = testStore(table, newWidthForSelectedColumns(ReferenceMd.Won, [], 200));
+        const store = testStore(table, setNewWidthForSelectedColumns(ReferenceMd.Won, [], 200));
 
         updateColumnDefinitionsWithWidths(table, store, { r_0: { width: 100 } }, 666, true, {
             c_0: { width: 500 },

--- a/libs/sdk-ui-pivot/src/index.ts
+++ b/libs/sdk-ui-pivot/src/index.ts
@@ -57,6 +57,7 @@ export {
     IMeasureColumnLocatorBody,
     isMeasureColumnLocator,
     isAttributeColumnLocator,
+    isTotalColumnLocator,
     newAttributeColumnLocator,
     newWidthForAllColumnsForMeasure,
     newWidthForAllMeasureColumns,

--- a/libs/sdk-ui-pivot/src/index.ts
+++ b/libs/sdk-ui-pivot/src/index.ts
@@ -62,4 +62,6 @@ export {
     newWidthForAllMeasureColumns,
     newWidthForAttributeColumn,
     newWidthForSelectedColumns,
+    setNewWidthForSelectedColumns,
+    newTotalColumnLocator,
 } from "./columnWidths.js";

--- a/libs/sdk-ui-pivot/src/tests/__snapshots__/columnWidths.test.ts.snap
+++ b/libs/sdk-ui-pivot/src/tests/__snapshots__/columnWidths.test.ts.snap
@@ -118,7 +118,7 @@ exports[`newWidthForAttributeColumn > should create width item with grow to fit 
 }
 `;
 
-exports[`newWidthForSelectedColumns > should create width item when measure as localId and without grow to fit prop 1`] = `
+exports[`setNewWidthForSelectedColumns > should create width item when measure as localId and without grow to fit prop 1`] = `
 {
   "measureColumnWidthItem": {
     "locators": [
@@ -135,7 +135,7 @@ exports[`newWidthForSelectedColumns > should create width item when measure as l
 }
 `;
 
-exports[`newWidthForSelectedColumns > should create width item when measure as value and without grow to fit prop 1`] = `
+exports[`setNewWidthForSelectedColumns > should create width item when measure as value and without grow to fit prop 1`] = `
 {
   "measureColumnWidthItem": {
     "locators": [
@@ -152,7 +152,7 @@ exports[`newWidthForSelectedColumns > should create width item when measure as v
 }
 `;
 
-exports[`newWidthForSelectedColumns > should create width item with attr locators in front of measure locator 1`] = `
+exports[`setNewWidthForSelectedColumns > should create width item with attr locators in front of measure locator 1`] = `
 {
   "measureColumnWidthItem": {
     "locators": [
@@ -175,7 +175,7 @@ exports[`newWidthForSelectedColumns > should create width item with attr locator
 }
 `;
 
-exports[`newWidthForSelectedColumns > should create width item with grow to fit prop false 1`] = `
+exports[`setNewWidthForSelectedColumns > should create width item with grow to fit prop false 1`] = `
 {
   "measureColumnWidthItem": {
     "locators": [
@@ -193,7 +193,7 @@ exports[`newWidthForSelectedColumns > should create width item with grow to fit 
 }
 `;
 
-exports[`newWidthForSelectedColumns > should create width item with grow to fit prop true 1`] = `
+exports[`setNewWidthForSelectedColumns > should create width item with grow to fit prop true 1`] = `
 {
   "measureColumnWidthItem": {
     "locators": [

--- a/libs/sdk-ui-pivot/src/tests/columnWidths.test.ts
+++ b/libs/sdk-ui-pivot/src/tests/columnWidths.test.ts
@@ -6,7 +6,7 @@ import {
     newWidthForAllColumnsForMeasure,
     newWidthForAllMeasureColumns,
     newWidthForAttributeColumn,
-    newWidthForSelectedColumns,
+    setNewWidthForSelectedColumns,
 } from "../columnWidths.js";
 import { IAttribute, IMeasure } from "@gooddata/sdk-model";
 import { ReferenceMd } from "@gooddata/reference-workspace";
@@ -44,7 +44,7 @@ describe("newWidthForAttributeColumn", () => {
     });
 });
 
-describe("newWidthForSelectedColumns", () => {
+describe("setNewWidthForSelectedColumns", () => {
     const Scenarios: Array<
         [string, IMeasure | string, IAttributeColumnLocator[], number, boolean | undefined]
     > = [
@@ -62,6 +62,6 @@ describe("newWidthForSelectedColumns", () => {
     ];
 
     it.each(Scenarios)("should create width item %s", (_desc, measureOrId, locators, width, grow) => {
-        expect(newWidthForSelectedColumns(measureOrId, locators, width, grow)).toMatchSnapshot();
+        expect(setNewWidthForSelectedColumns(measureOrId, locators, width, grow)).toMatchSnapshot();
     });
 });

--- a/libs/sdk-ui-tests/scenarios/pivotTable/manualSizing.tsx
+++ b/libs/sdk-ui-tests/scenarios/pivotTable/manualSizing.tsx
@@ -5,7 +5,7 @@ import {
     IPivotTableProps,
     newWidthForAllColumnsForMeasure,
     newWidthForAttributeColumn,
-    newWidthForSelectedColumns,
+    setNewWidthForSelectedColumns,
     PivotTable,
 } from "@gooddata/sdk-ui-pivot";
 import {
@@ -18,7 +18,7 @@ const ATTRIBUTE_WIDTH = 400;
 const MEASURE_WIDTH = 60;
 
 const attributeColumnWidthItem = newWidthForAttributeColumn(ReferenceMd.Product.Name, ATTRIBUTE_WIDTH);
-const measureColumnWidthItemSimple = newWidthForSelectedColumns(ReferenceMd.Amount, [], MEASURE_WIDTH);
+const measureColumnWidthItemSimple = setNewWidthForSelectedColumns(ReferenceMd.Amount, [], MEASURE_WIDTH);
 const weakMeasureColumnWidthItem = newWidthForAllColumnsForMeasure(ReferenceMd.Amount, MEASURE_WIDTH);
 
 const justManualResizing = scenariosFor<IPivotTableProps>("PivotTable", PivotTable)


### PR DESCRIPTION
Update `newWidhtForSelectedColumns` to accept an array of measure so columnmanual resizing works properly on new table transposition.

Also add missing `newTotalColumnLocator` to pivot table factories.

JIRA: TNT-1665

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |
| **Compatibility matrix test commands - TIGER Backend**  |                                                            |
| `extended test - matrix-test <AIO_version>`             | Run integrated tests against AIO versions.                 |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

`<AIO_version>` in commands is used to start test with multiple AIO instances - each instance in triggered by one jenkins build

-   To run with `master` and `stable`, execute command `extended test - matrix-test master,stable` or `extended test - matrix-test latest`
-   To run with specific version,ex: `2.3.0` and `2.3.1`, execute command `extended test - matrix-test 2.3.0,2.3.1`
-   In case `<AIO_version>` is empty, read versions from file `compTigerVersions.txt` of this repo

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
