### PR TITLE
FEATURE: RAIL-5029 related to add PDM->LDM fields that are planned to be deprecated

### DIFF
--- a/libs/sdk-backend-tiger/api/sdk-backend-tiger.api.md
+++ b/libs/sdk-backend-tiger/api/sdk-backend-tiger.api.md
@@ -259,6 +259,12 @@ export interface IInvitationUserResponse {
     successful?: boolean;
 }
 
+// @alpha (undocumented)
+export const isTigerCompatibleType: (obj: unknown) => obj is TigerObjectType;
+
+// @alpha (undocumented)
+export const isTigerType: (obj: unknown) => obj is TigerObjectType;
+
 // @alpha
 export type JwtIsAboutToExpireHandler = (setJwt: SetJwtCallback) => void;
 
@@ -317,6 +323,9 @@ export type SetJwtCallback = (jwt: string, secondsBeforeTokenExpirationToCallRem
 export type SetPdmLayoutRequest = LayoutApiSetPdmLayoutRequest;
 
 // @public
+export type TigerAfmType = "label" | "metric" | "dataset" | "fact" | "attribute" | "prompt";
+
+// @public
 export abstract class TigerAuthProviderBase implements IAuthenticationProvider {
     // (undocumented)
     abstract authenticate(context: IAuthenticationContext): Promise<IAuthenticatedPrincipal>;
@@ -341,6 +350,12 @@ export class TigerJwtAuthProvider extends TigerTokenAuthProvider {
     initializeClient(client: ITigerClient): void;
     updateJwt: (jwt: string, secondsBeforeTokenExpirationToCallReminder?: number) => void;
 }
+
+// @public
+export type TigerMetadataType = "analyticalDashboard" | "visualizationObject" | "filterContext" | "dashboardPlugin";
+
+// @public
+export type TigerObjectType = TigerAfmType | TigerMetadataType;
 
 // @internal
 export type TigerSpecificFunctions = {

--- a/libs/sdk-backend-tiger/src/index.ts
+++ b/libs/sdk-backend-tiger/src/index.ts
@@ -106,4 +106,6 @@ export {
     WorkspaceEntitiesDatasets,
 } from "./backend/tigerSpecificFunctions.js";
 
+export { TigerAfmType, TigerMetadataType, TigerObjectType } from "./types/index.js";
+export { isTigerType, isTigerCompatibleType } from "./types/refTypeMapping.js";
 export { getIdOrigin, OriginInfoWithId } from "./convertors/fromBackend/ObjectInheritance.js";

--- a/libs/sdk-backend-tiger/src/types/refTypeMapping.ts
+++ b/libs/sdk-backend-tiger/src/types/refTypeMapping.ts
@@ -30,10 +30,16 @@ export const objectTypeToTigerIdType = invert(tigerIdTypeToObjectType) as {
 const validTigerTypes = Object.keys(tigerIdTypeToObjectType);
 const validCompatibleTypes = values(tigerIdTypeToObjectType);
 
+/**
+ * @alpha
+ */
 export const isTigerCompatibleType = (obj: unknown): obj is TigerObjectType => {
     return !isEmpty(obj) && validCompatibleTypes.some((type) => type === obj);
 };
 
+/**
+ * @alpha
+ */
 export const isTigerType = (obj: unknown): obj is TigerObjectType => {
     return !isEmpty(obj) && validTigerTypes.some((type) => type === obj);
 };


### PR DESCRIPTION
JIRA: RAIL-5029


---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |
| **Compatibility matrix test commands - TIGER Backend**  |                                                            |
| `extended test - matrix-test <AIO_version>`             | Run integrated tests against AIO versions.                 |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

`<AIO_version>` in commands is used to start test with multiple AIO instances - each instance in triggered by one jenkins build

-   To run with `master` and `stable`, execute command `extended test - matrix-test master,stable` or `extended test - matrix-test latest`
-   To run with specific version,ex: `2.3.0` and `2.3.1`, execute command `extended test - matrix-test 2.3.0,2.3.1`
-   In case `<AIO_version>` is empty, read versions from file `compTigerVersions.txt` of this repo

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
