### PR TITLE
FEATURE: RAIL-5029 related to add PDM->LDM fields

### DIFF
--- a/libs/sdk-backend-tiger/api/sdk-backend-tiger.api.md
+++ b/libs/sdk-backend-tiger/api/sdk-backend-tiger.api.md
@@ -38,6 +38,7 @@ import { LayoutApiPutWorkspaceLayoutRequest } from '@gooddata/api-client-tiger';
 import { LayoutApiSetPdmLayoutRequest } from '@gooddata/api-client-tiger';
 import { NotAuthenticated } from '@gooddata/sdk-backend-spi';
 import { NotAuthenticatedHandler } from '@gooddata/sdk-backend-spi';
+import { ObjectType } from '@gooddata/sdk-model';
 import { PlatformUsage } from '@gooddata/api-client-tiger';
 import { ScanSqlResponse } from '@gooddata/api-client-tiger';
 import { TestDefinitionRequestTypeEnum } from '@gooddata/api-client-tiger';
@@ -268,6 +269,22 @@ export const isTigerType: (obj: unknown) => obj is TigerObjectType;
 // @alpha
 export type JwtIsAboutToExpireHandler = (setJwt: SetJwtCallback) => void;
 
+// @alpha (undocumented)
+export const objectTypeToTigerIdType: {
+    measure: TigerObjectType;
+    fact: TigerObjectType;
+    attribute: TigerObjectType;
+    displayForm: TigerObjectType;
+    dataSet: TigerObjectType;
+    insight: TigerObjectType;
+    variable: TigerObjectType;
+    analyticalDashboard: TigerObjectType;
+    theme: TigerObjectType;
+    colorPalette: TigerObjectType;
+    filterContext: TigerObjectType;
+    dashboardPlugin: TigerObjectType;
+};
+
 // @internal (undocumented)
 export type OrganizationPermission = JsonApiOrganizationOutMetaPermissionsEnum;
 
@@ -339,9 +356,17 @@ export abstract class TigerAuthProviderBase implements IAuthenticationProvider {
     protected principal: IAuthenticatedPrincipal | undefined;
 }
 
+// @alpha (undocumented)
+export type TigerCompatibleObjectType = Exclude<ObjectType, "tag">;
+
 // @public
 function tigerFactory(config?: IAnalyticalBackendConfig, implConfig?: any): IAnalyticalBackend;
 export default tigerFactory;
+
+// @alpha (undocumented)
+export const tigerIdTypeToObjectType: {
+    [tigerType in TigerObjectType]: TigerCompatibleObjectType;
+};
 
 // @alpha
 export class TigerJwtAuthProvider extends TigerTokenAuthProvider {

--- a/libs/sdk-backend-tiger/src/index.ts
+++ b/libs/sdk-backend-tiger/src/index.ts
@@ -107,5 +107,11 @@ export {
 } from "./backend/tigerSpecificFunctions.js";
 
 export { TigerAfmType, TigerMetadataType, TigerObjectType } from "./types/index.js";
-export { isTigerType, isTigerCompatibleType } from "./types/refTypeMapping.js";
+export {
+    isTigerType,
+    isTigerCompatibleType,
+    tigerIdTypeToObjectType,
+    objectTypeToTigerIdType,
+    TigerCompatibleObjectType,
+} from "./types/refTypeMapping.js";
 export { getIdOrigin, OriginInfoWithId } from "./convertors/fromBackend/ObjectInheritance.js";

--- a/libs/sdk-backend-tiger/src/types/refTypeMapping.ts
+++ b/libs/sdk-backend-tiger/src/types/refTypeMapping.ts
@@ -6,8 +6,14 @@ import isEmpty from "lodash/isEmpty.js";
 import values from "lodash/values.js";
 import { TigerObjectType } from "./index.js";
 
+/**
+ * @alpha
+ */
 export type TigerCompatibleObjectType = Exclude<ObjectType, "tag">;
 
+/**
+ * @alpha
+ */
 export const tigerIdTypeToObjectType: {
     [tigerType in TigerObjectType]: TigerCompatibleObjectType;
 } = {
@@ -23,6 +29,9 @@ export const tigerIdTypeToObjectType: {
     dashboardPlugin: "dashboardPlugin",
 };
 
+/**
+ * @alpha
+ */
 export const objectTypeToTigerIdType = invert(tigerIdTypeToObjectType) as {
     [objectType in TigerCompatibleObjectType]: TigerObjectType;
 };


### PR DESCRIPTION
JIRA: RAIL-5029

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |
| **Compatibility matrix test commands - TIGER Backend**  |                                                            |
| `extended test - matrix-test <AIO_version>`             | Run integrated tests against AIO versions.                 |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

`<AIO_version>` in commands is used to start test with multiple AIO instances - each instance in triggered by one jenkins build

-   To run with `master` and `stable`, execute command `extended test - matrix-test master,stable` or `extended test - matrix-test latest`
-   To run with specific version,ex: `2.3.0` and `2.3.1`, execute command `extended test - matrix-test 2.3.0,2.3.1`
-   In case `<AIO_version>` is empty, read versions from file `compTigerVersions.txt` of this repo

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
