### PR TITLE
BUGFIX: EGL-232 keep dependencies of arithmetic metric in primary bucket

### DIFF
--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/headline/PluggableHeadline.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/headline/PluggableHeadline.tsx
@@ -38,6 +38,7 @@ import {
     findDerivedBucketItem,
     getAllItemsByType,
     hasDerivedBucketItems,
+    isArithmeticBucketItem,
     isDerivedBucketItem,
     limitNumberOfMeasuresInBuckets,
     removeAllArithmeticMeasuresFromDerived,
@@ -144,7 +145,11 @@ export class PluggableHeadline extends AbstractPluggableVisualization {
                 allMeasures.length > 1 ? allMeasures.slice(1, numberOfSecondaryMeasure + 1) : null;
 
             const primaryDerivedMeasure = findDerivedBucketItem(primaryMeasure, allMeasures);
-            if (this.keepPrimaryDerivedMeasureOnly && primaryDerivedMeasure) {
+            if (
+                this.keepPrimaryDerivedMeasureOnly &&
+                primaryDerivedMeasure &&
+                !isArithmeticBucketItem(primaryMeasure)
+            ) {
                 secondaryMeasures = [primaryDerivedMeasure];
             }
             this.keepPrimaryDerivedMeasureOnly = !primaryDerivedMeasure;

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/headline/tests/PluggableHeadline2.test.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/headline/tests/PluggableHeadline2.test.tsx
@@ -1257,6 +1257,61 @@ describe("PluggableHeadline2", () => {
                         },
                     ]);
                 });
+
+                it("should pick first arithmetic to primary and its derived and dependencies to secondary bucket when adding derived measure in the first time", async () => {
+                    const headline = createComponent();
+                    const referencePoint = createReferencePointWithDateFilter([
+                        {
+                            localIdentifier: "measures",
+                            items: [
+                                referencePointMocks.masterMeasureItems[0],
+                                referencePointMocks.masterMeasureItems[1],
+                            ],
+                        },
+                    ]);
+                    const extendedReferencePoint = await headline.getExtendedReferencePoint(referencePoint);
+
+                    expect(extendedReferencePoint.buckets).toEqual([
+                        {
+                            localIdentifier: "measures",
+                            items: [referencePointMocks.masterMeasureItems[0]],
+                        },
+                        {
+                            localIdentifier: "secondary_measures",
+                            items: [referencePointMocks.masterMeasureItems[1]],
+                        },
+                    ]);
+
+                    const referencePoint2 = createReferencePointWithDateFilter([
+                        {
+                            localIdentifier: "measures",
+                            items: [
+                                referencePointMocks.arithmeticMeasureItems[2],
+                                referencePointMocks.derivedMeasureItems[5],
+                            ],
+                        },
+                        {
+                            localIdentifier: "secondary_measures",
+                            items: [referencePointMocks.masterMeasureItems[0]],
+                        },
+                    ]);
+
+                    const extendedReferencePoint2 = await headline.getExtendedReferencePoint(referencePoint2);
+
+                    expect(extendedReferencePoint2.buckets).toEqual([
+                        {
+                            localIdentifier: "measures",
+                            items: [referencePointMocks.arithmeticMeasureItems[2]],
+                        },
+                        {
+                            localIdentifier: "secondary_measures",
+                            items: [
+                                referencePointMocks.derivedMeasureItems[5],
+                                referencePointMocks.masterMeasureItems[0],
+                            ],
+                        },
+                    ]);
+                });
             });
 
             describe("mixed known and unknown buckets", () => {

--- a/libs/sdk-ui-ext/src/internal/tests/mocks/referencePointMocks.ts
+++ b/libs/sdk-ui-ext/src/internal/tests/mocks/referencePointMocks.ts
@@ -102,6 +102,16 @@ export const derivedMeasureItems: IBucketItem[] = [
         masterLocalIdentifier: "m4",
         overTimeComparisonType: OverTimeComparisonTypes.SAME_PERIOD_PREVIOUS_YEAR,
     },
+    {
+        localIdentifier: "m6_pop",
+        type: "metric",
+        aggregation: null,
+        attribute: "acfWntEMcom0",
+        showInPercent: null,
+        showOnSecondaryAxis: null,
+        masterLocalIdentifier: "am3",
+        overTimeComparisonType: OverTimeComparisonTypes.SAME_PERIOD_PREVIOUS_YEAR,
+    },
 ];
 
 export const arithmeticMeasureItems: IBucketItem[] = [

--- a/libs/sdk-ui-ext/src/internal/utils/bucketHelper.ts
+++ b/libs/sdk-ui-ext/src/internal/utils/bucketHelper.ts
@@ -150,7 +150,7 @@ export function isDerivedBucketItem(measureItem: IBucketItem): boolean {
     return !!measureItem.masterLocalIdentifier;
 }
 
-function isArithmeticBucketItem(bucketItem: IBucketItem): boolean {
+export function isArithmeticBucketItem(bucketItem: IBucketItem): boolean {
     return !!bucketItem.operandLocalIdentifiers;
 }
 


### PR DESCRIPTION
JIRA: EGL-232

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |
| **Compatibility matrix test commands - TIGER Backend**  |                                                            |
| `extended test - matrix-test <AIO_version>`             | Run integrated tests against AIO versions.                 |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

`<AIO_version>` in commands is used to start test with multiple AIO instances - each instance in triggered by one jenkins build

-   To run with `master` and `stable`, execute command `extended test - matrix-test master,stable` or `extended test - matrix-test latest`
-   To run with specific version,ex: `2.3.0` and `2.3.1`, execute command `extended test - matrix-test 2.3.0,2.3.1`
-   In case `<AIO_version>` is empty, read versions from file `compTigerVersions.txt` of this repo

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
