### PR TITLE
FEATURE: QA-19951 UI-SDK tiger-backend sanitize field created

### DIFF
--- a/libs/sdk-backend-tiger/tests/integrated/__snapshots__/catalog.test.ts.snap
+++ b/libs/sdk-backend-tiger/tests/integrated/__snapshots__/catalog.test.ts.snap
@@ -6,7 +6,7 @@ exports[`tiger catalog > should correctly get catalog availability when derived 
     {
       "groups": [],
       "measure": {
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "description": "",
         "expression": "SELECT COUNT({label/f_activity.id})",
         "format": "#,##0",
@@ -25,7 +25,7 @@ exports[`tiger catalog > should correctly get catalog availability when derived 
     {
       "groups": [],
       "measure": {
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "description": "",
         "expression": "SELECT {metric/768414e1-4bbe-4f01-b125-0cdc6305dc76}
   WHERE {label/f_stage.status_id} = \\"Lost\\"",
@@ -45,7 +45,7 @@ exports[`tiger catalog > should correctly get catalog availability when derived 
     {
       "groups": [],
       "measure": {
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "description": "",
         "expression": "SELECT COUNT({attribute/f_opportunity.id}, {label/f_opportunitysnapshot.id}) WHERE {fact/fact.f_opportunitysnapshot.oppsnapshotdate} = {metric/c5ee7836-126c-41aa-bd69-1873d379a065}",
         "format": "#,##0.00",
@@ -64,7 +64,7 @@ exports[`tiger catalog > should correctly get catalog availability when derived 
     {
       "groups": [],
       "measure": {
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "description": "",
         "expression": "SELECT {metric/768414e1-4bbe-4f01-b125-0cdc6305dc76} WHERE {label/f_stage.status_id} = \\"Won\\"",
         "format": "#,##0.00",
@@ -83,7 +83,7 @@ exports[`tiger catalog > should correctly get catalog availability when derived 
     {
       "groups": [],
       "measure": {
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "description": "",
         "expression": "select {metric/768414e1-4bbe-4f01-b125-0cdc6305dc76} where {label/f_stage.status_id} = \\"Won\\"",
         "format": "#,##0",
@@ -122,7 +122,7 @@ exports[`tiger catalog > should correctly get catalog availability when derived 
     {
       "groups": [],
       "measure": {
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "description": "Amount metric description",
         "expression": "SELECT SUM({fact/f_opportunitysnapshot.f_amount}) WHERE {fact/fact.f_opportunitysnapshot.oppsnapshotdate} = {metric/c5ee7836-126c-41aa-bd69-1873d379a065}",
         "format": "$#,##0.00",
@@ -161,7 +161,7 @@ exports[`tiger catalog > should correctly get catalog availability when derived 
     {
       "groups": [],
       "measure": {
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "description": "",
         "expression": "SELECT SUM({fact/f_opportunitysnapshot.f_amount}) WHERE {fact/fact.f_opportunitysnapshot.oppsnapshotdate} = {metric/snapshot_bop}",
         "format": "$#,##0.00",
@@ -180,7 +180,7 @@ exports[`tiger catalog > should correctly get catalog availability when derived 
     {
       "groups": [],
       "measure": {
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "description": "",
         "expression": "SELECT AVG({fact/f_opportunitysnapshot.f_amount})
   WHERE {fact/fact.f_opportunitysnapshot.oppsnapshotdate} = {metric/c5ee7836-126c-41aa-bd69-1873d379a065}",
@@ -200,7 +200,7 @@ exports[`tiger catalog > should correctly get catalog availability when derived 
     {
       "groups": [],
       "measure": {
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "description": "",
         "expression": "SELECT SUM(
     SELECT {metric/87a053b0-3947-49f3-b0c5-de53fd01f050}
@@ -281,7 +281,7 @@ exports[`tiger catalog > should correctly get catalog availability when derived 
     {
       "groups": [],
       "measure": {
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "description": "Metric with long name",
         "expression": "SELECT SUM({fact/f_opportunitysnapshot.f_amount}) WHERE {fact/fact.f_opportunitysnapshot.oppsnapshotdate} = {metric/c5ee7836-126c-41aa-bd69-1873d379a065}",
         "format": "$#,##0.00",
@@ -300,7 +300,7 @@ exports[`tiger catalog > should correctly get catalog availability when derived 
     {
       "groups": [],
       "measure": {
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "description": "Metric has null value",
         "expression": "SELECT SUM({fact/f_opportunitysnapshot.f_amount}) where {label/f_owner.region_id} IN (\\"\\", NULL, \\"East Coast\\", \\"West Coast\\" )",
         "format": "#,##0",
@@ -319,7 +319,7 @@ exports[`tiger catalog > should correctly get catalog availability when derived 
     {
       "groups": [],
       "measure": {
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "description": "",
         "expression": "SELECT SUM({metric/amount_bop} * -1 )",
         "format": "#,##0.00",
@@ -398,7 +398,7 @@ exports[`tiger catalog > should correctly get catalog availability when derived 
     {
       "groups": [],
       "measure": {
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "description": "",
         "expression": "SELECT SUM({fact/f_opportunitysnapshot.f_amount})",
         "format": "#,##0",
@@ -437,7 +437,7 @@ exports[`tiger catalog > should correctly get catalog availability when derived 
     {
       "groups": [],
       "measure": {
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "description": "",
         "expression": "SELECT AVG({fact/f_opportunitysnapshot.f_probability}) WHERE {fact/fact.f_opportunitysnapshot.oppsnapshotdate} = {metric/c5ee7836-126c-41aa-bd69-1873d379a065}",
         "format": "#,##0.0%",
@@ -516,7 +516,7 @@ exports[`tiger catalog > should correctly get catalog availability when derived 
     {
       "groups": [],
       "measure": {
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "description": "",
         "expression": "SELECT {metric/8d33a0b1-cfdf-4074-a26a-4c4357774967} / {metric/768414e1-4bbe-4f01-b125-0cdc6305dc76}",
         "format": "#,##0.0%",
@@ -535,7 +535,7 @@ exports[`tiger catalog > should correctly get catalog availability when derived 
     {
       "groups": [],
       "measure": {
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "description": "",
         "expression": "SELECT {metric/87a053b0-3947-49f3-b0c5-de53fd01f050}
   WHERE {label/f_stage.status_id} = \\"Won\\"",
@@ -555,7 +555,7 @@ exports[`tiger catalog > should correctly get catalog availability when derived 
     {
       "groups": [],
       "measure": {
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "description": "",
         "expression": "SELECT MAX({fact/fact.f_opportunitysnapshot.oppclosedate})
   WHERE {fact/fact.f_opportunitysnapshot.oppsnapshotdate} = {metric/snapshot_bop}",
@@ -575,7 +575,7 @@ exports[`tiger catalog > should correctly get catalog availability when derived 
     {
       "groups": [],
       "measure": {
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "description": "",
         "expression": "SELECT MAX({fact/fact.f_opportunitysnapshot.oppclosedate}) where {fact/fact.f_opportunitysnapshot.oppsnapshotdate} = {metric/c5ee7836-126c-41aa-bd69-1873d379a065}",
         "format": "#,##0.00",
@@ -594,7 +594,7 @@ exports[`tiger catalog > should correctly get catalog availability when derived 
     {
       "groups": [],
       "measure": {
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "description": "",
         "expression": "select min({fact/fact.f_opportunitysnapshot.oppsnapshotdate}) by all in all other dimensions except {attribute/f_opportunity.id}",
         "format": "#,##0.00",
@@ -613,7 +613,7 @@ exports[`tiger catalog > should correctly get catalog availability when derived 
     {
       "groups": [],
       "measure": {
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "description": "",
         "expression": "SELECT MIN({fact/fact.f_opportunitysnapshot.oppsnapshotdate})
   BY ALL IN ALL OTHER DIMENSIONS EXCEPT {attribute/dt_snapshotdate_timestamp.day}
@@ -634,7 +634,7 @@ exports[`tiger catalog > should correctly get catalog availability when derived 
     {
       "groups": [],
       "measure": {
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "description": "",
         "expression": "SELECT MAX({fact/fact.f_opportunitysnapshot.oppsnapshotdate}) BY ALL IN ALL OTHER DIMENSIONS EXCEPT {attribute/dt_snapshotdate_timestamp.day} WHERE {fact/fact.f_opportunitysnapshot.oppsnapshotdate} <= {metric/6b1411d5-e253-418e-8fd3-137a9f56ea92}",
         "format": "#,##0.00",
@@ -653,7 +653,7 @@ exports[`tiger catalog > should correctly get catalog availability when derived 
     {
       "groups": [],
       "measure": {
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "description": "",
         "expression": "SELECT MIN({fact/fact.f_timeline.timelinedate})
   BY ALL IN ALL OTHER DIMENSIONS EXCEPT {attribute/dt_timeline_timestamp.day}",
@@ -673,7 +673,7 @@ exports[`tiger catalog > should correctly get catalog availability when derived 
     {
       "groups": [],
       "measure": {
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "description": "",
         "expression": "SELECT MAX({fact/fact.f_timeline.timelinedate}) BY ALL IN ALL OTHER DIMENSIONS EXCEPT {attribute/dt_timeline_timestamp.day}",
         "format": "#,##0",
@@ -766,7 +766,7 @@ exports[`tiger catalog > should correctly get catalog availability when derived 
     {
       "groups": [],
       "measure": {
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "description": "",
         "expression": "SELECT COUNT({label/f_activity.id})",
         "format": "#,##0",
@@ -785,7 +785,7 @@ exports[`tiger catalog > should correctly get catalog availability when derived 
     {
       "groups": [],
       "measure": {
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "description": "",
         "expression": "SELECT {metric/768414e1-4bbe-4f01-b125-0cdc6305dc76}
   WHERE {label/f_stage.status_id} = \\"Lost\\"",
@@ -805,7 +805,7 @@ exports[`tiger catalog > should correctly get catalog availability when derived 
     {
       "groups": [],
       "measure": {
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "description": "",
         "expression": "SELECT COUNT({attribute/f_opportunity.id}, {label/f_opportunitysnapshot.id}) WHERE {fact/fact.f_opportunitysnapshot.oppsnapshotdate} = {metric/c5ee7836-126c-41aa-bd69-1873d379a065}",
         "format": "#,##0.00",
@@ -824,7 +824,7 @@ exports[`tiger catalog > should correctly get catalog availability when derived 
     {
       "groups": [],
       "measure": {
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "description": "",
         "expression": "SELECT {metric/768414e1-4bbe-4f01-b125-0cdc6305dc76} WHERE {label/f_stage.status_id} = \\"Won\\"",
         "format": "#,##0.00",
@@ -843,7 +843,7 @@ exports[`tiger catalog > should correctly get catalog availability when derived 
     {
       "groups": [],
       "measure": {
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "description": "",
         "expression": "select {metric/768414e1-4bbe-4f01-b125-0cdc6305dc76} where {label/f_stage.status_id} = \\"Won\\"",
         "format": "#,##0",
@@ -1292,7 +1292,7 @@ exports[`tiger catalog > should correctly get catalog availability when derived 
     {
       "groups": [],
       "measure": {
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "description": "Amount metric description",
         "expression": "SELECT SUM({fact/f_opportunitysnapshot.f_amount}) WHERE {fact/fact.f_opportunitysnapshot.oppsnapshotdate} = {metric/c5ee7836-126c-41aa-bd69-1873d379a065}",
         "format": "$#,##0.00",
@@ -1331,7 +1331,7 @@ exports[`tiger catalog > should correctly get catalog availability when derived 
     {
       "groups": [],
       "measure": {
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "description": "",
         "expression": "SELECT SUM({fact/f_opportunitysnapshot.f_amount}) WHERE {fact/fact.f_opportunitysnapshot.oppsnapshotdate} = {metric/snapshot_bop}",
         "format": "$#,##0.00",
@@ -1350,7 +1350,7 @@ exports[`tiger catalog > should correctly get catalog availability when derived 
     {
       "groups": [],
       "measure": {
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "description": "",
         "expression": "SELECT AVG({fact/f_opportunitysnapshot.f_amount})
   WHERE {fact/fact.f_opportunitysnapshot.oppsnapshotdate} = {metric/c5ee7836-126c-41aa-bd69-1873d379a065}",
@@ -1370,7 +1370,7 @@ exports[`tiger catalog > should correctly get catalog availability when derived 
     {
       "groups": [],
       "measure": {
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "description": "",
         "expression": "SELECT SUM(
     SELECT {metric/87a053b0-3947-49f3-b0c5-de53fd01f050}
@@ -2298,7 +2298,7 @@ exports[`tiger catalog > should correctly get catalog availability when derived 
     {
       "groups": [],
       "measure": {
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "description": "Metric with long name",
         "expression": "SELECT SUM({fact/f_opportunitysnapshot.f_amount}) WHERE {fact/fact.f_opportunitysnapshot.oppsnapshotdate} = {metric/c5ee7836-126c-41aa-bd69-1873d379a065}",
         "format": "$#,##0.00",
@@ -2317,7 +2317,7 @@ exports[`tiger catalog > should correctly get catalog availability when derived 
     {
       "groups": [],
       "measure": {
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "description": "Metric has null value",
         "expression": "SELECT SUM({fact/f_opportunitysnapshot.f_amount}) where {label/f_owner.region_id} IN (\\"\\", NULL, \\"East Coast\\", \\"West Coast\\" )",
         "format": "#,##0",
@@ -2336,7 +2336,7 @@ exports[`tiger catalog > should correctly get catalog availability when derived 
     {
       "groups": [],
       "measure": {
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "description": "",
         "expression": "SELECT SUM({metric/amount_bop} * -1 )",
         "format": "#,##0.00",
@@ -2827,7 +2827,7 @@ exports[`tiger catalog > should correctly get catalog availability when derived 
     {
       "groups": [],
       "measure": {
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "description": "",
         "expression": "SELECT SUM({fact/f_opportunitysnapshot.f_amount})",
         "format": "#,##0",
@@ -2936,7 +2936,7 @@ exports[`tiger catalog > should correctly get catalog availability when derived 
     {
       "groups": [],
       "measure": {
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "description": "",
         "expression": "SELECT AVG({fact/f_opportunitysnapshot.f_probability}) WHERE {fact/fact.f_opportunitysnapshot.oppsnapshotdate} = {metric/c5ee7836-126c-41aa-bd69-1873d379a065}",
         "format": "#,##0.0%",
@@ -4005,7 +4005,7 @@ exports[`tiger catalog > should correctly get catalog availability when derived 
     {
       "groups": [],
       "measure": {
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "description": "",
         "expression": "SELECT {metric/8d33a0b1-cfdf-4074-a26a-4c4357774967} / {metric/768414e1-4bbe-4f01-b125-0cdc6305dc76}",
         "format": "#,##0.0%",
@@ -4024,7 +4024,7 @@ exports[`tiger catalog > should correctly get catalog availability when derived 
     {
       "groups": [],
       "measure": {
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "description": "",
         "expression": "SELECT {metric/87a053b0-3947-49f3-b0c5-de53fd01f050}
   WHERE {label/f_stage.status_id} = \\"Won\\"",
@@ -4044,7 +4044,7 @@ exports[`tiger catalog > should correctly get catalog availability when derived 
     {
       "groups": [],
       "measure": {
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "description": "",
         "expression": "SELECT MAX({fact/fact.f_opportunitysnapshot.oppclosedate})
   WHERE {fact/fact.f_opportunitysnapshot.oppsnapshotdate} = {metric/snapshot_bop}",
@@ -4064,7 +4064,7 @@ exports[`tiger catalog > should correctly get catalog availability when derived 
     {
       "groups": [],
       "measure": {
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "description": "",
         "expression": "SELECT MAX({fact/fact.f_opportunitysnapshot.oppclosedate}) where {fact/fact.f_opportunitysnapshot.oppsnapshotdate} = {metric/c5ee7836-126c-41aa-bd69-1873d379a065}",
         "format": "#,##0.00",
@@ -4083,7 +4083,7 @@ exports[`tiger catalog > should correctly get catalog availability when derived 
     {
       "groups": [],
       "measure": {
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "description": "",
         "expression": "select min({fact/fact.f_opportunitysnapshot.oppsnapshotdate}) by all in all other dimensions except {attribute/f_opportunity.id}",
         "format": "#,##0.00",
@@ -4102,7 +4102,7 @@ exports[`tiger catalog > should correctly get catalog availability when derived 
     {
       "groups": [],
       "measure": {
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "description": "",
         "expression": "SELECT MIN({fact/fact.f_opportunitysnapshot.oppsnapshotdate})
   BY ALL IN ALL OTHER DIMENSIONS EXCEPT {attribute/dt_snapshotdate_timestamp.day}
@@ -4123,7 +4123,7 @@ exports[`tiger catalog > should correctly get catalog availability when derived 
     {
       "groups": [],
       "measure": {
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "description": "",
         "expression": "SELECT MAX({fact/fact.f_opportunitysnapshot.oppsnapshotdate}) BY ALL IN ALL OTHER DIMENSIONS EXCEPT {attribute/dt_snapshotdate_timestamp.day} WHERE {fact/fact.f_opportunitysnapshot.oppsnapshotdate} <= {metric/6b1411d5-e253-418e-8fd3-137a9f56ea92}",
         "format": "#,##0.00",
@@ -4142,7 +4142,7 @@ exports[`tiger catalog > should correctly get catalog availability when derived 
     {
       "groups": [],
       "measure": {
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "description": "",
         "expression": "SELECT MIN({fact/fact.f_timeline.timelinedate})
   BY ALL IN ALL OTHER DIMENSIONS EXCEPT {attribute/dt_timeline_timestamp.day}",
@@ -4162,7 +4162,7 @@ exports[`tiger catalog > should correctly get catalog availability when derived 
     {
       "groups": [],
       "measure": {
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "description": "",
         "expression": "SELECT MAX({fact/fact.f_timeline.timelinedate}) BY ALL IN ALL OTHER DIMENSIONS EXCEPT {attribute/dt_timeline_timestamp.day}",
         "format": "#,##0",
@@ -7876,7 +7876,7 @@ exports[`tiger catalog > should read catalog for reference workspace 1`] = `
     {
       "groups": [],
       "measure": {
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "description": "",
         "expression": "SELECT COUNT({label/f_activity.id})",
         "format": "#,##0",
@@ -7895,7 +7895,7 @@ exports[`tiger catalog > should read catalog for reference workspace 1`] = `
     {
       "groups": [],
       "measure": {
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "description": "",
         "expression": "SELECT {metric/768414e1-4bbe-4f01-b125-0cdc6305dc76}
   WHERE {label/f_stage.status_id} = \\"Lost\\"",
@@ -7915,7 +7915,7 @@ exports[`tiger catalog > should read catalog for reference workspace 1`] = `
     {
       "groups": [],
       "measure": {
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "description": "",
         "expression": "SELECT COUNT({attribute/f_opportunity.id}, {label/f_opportunitysnapshot.id}) WHERE {fact/fact.f_opportunitysnapshot.oppsnapshotdate} = {metric/c5ee7836-126c-41aa-bd69-1873d379a065}",
         "format": "#,##0.00",
@@ -7934,7 +7934,7 @@ exports[`tiger catalog > should read catalog for reference workspace 1`] = `
     {
       "groups": [],
       "measure": {
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "description": "",
         "expression": "SELECT {metric/768414e1-4bbe-4f01-b125-0cdc6305dc76} WHERE {label/f_stage.status_id} = \\"Won\\"",
         "format": "#,##0.00",
@@ -7953,7 +7953,7 @@ exports[`tiger catalog > should read catalog for reference workspace 1`] = `
     {
       "groups": [],
       "measure": {
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "description": "",
         "expression": "select {metric/768414e1-4bbe-4f01-b125-0cdc6305dc76} where {label/f_stage.status_id} = \\"Won\\"",
         "format": "#,##0",
@@ -8402,7 +8402,7 @@ exports[`tiger catalog > should read catalog for reference workspace 1`] = `
     {
       "groups": [],
       "measure": {
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "description": "Amount metric description",
         "expression": "SELECT SUM({fact/f_opportunitysnapshot.f_amount}) WHERE {fact/fact.f_opportunitysnapshot.oppsnapshotdate} = {metric/c5ee7836-126c-41aa-bd69-1873d379a065}",
         "format": "$#,##0.00",
@@ -8441,7 +8441,7 @@ exports[`tiger catalog > should read catalog for reference workspace 1`] = `
     {
       "groups": [],
       "measure": {
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "description": "",
         "expression": "SELECT SUM({fact/f_opportunitysnapshot.f_amount}) WHERE {fact/fact.f_opportunitysnapshot.oppsnapshotdate} = {metric/snapshot_bop}",
         "format": "$#,##0.00",
@@ -8460,7 +8460,7 @@ exports[`tiger catalog > should read catalog for reference workspace 1`] = `
     {
       "groups": [],
       "measure": {
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "description": "",
         "expression": "SELECT AVG({fact/f_opportunitysnapshot.f_amount})
   WHERE {fact/fact.f_opportunitysnapshot.oppsnapshotdate} = {metric/c5ee7836-126c-41aa-bd69-1873d379a065}",
@@ -8480,7 +8480,7 @@ exports[`tiger catalog > should read catalog for reference workspace 1`] = `
     {
       "groups": [],
       "measure": {
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "description": "",
         "expression": "SELECT SUM(
     SELECT {metric/87a053b0-3947-49f3-b0c5-de53fd01f050}
@@ -9408,7 +9408,7 @@ exports[`tiger catalog > should read catalog for reference workspace 1`] = `
     {
       "groups": [],
       "measure": {
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "description": "Metric with long name",
         "expression": "SELECT SUM({fact/f_opportunitysnapshot.f_amount}) WHERE {fact/fact.f_opportunitysnapshot.oppsnapshotdate} = {metric/c5ee7836-126c-41aa-bd69-1873d379a065}",
         "format": "$#,##0.00",
@@ -9427,7 +9427,7 @@ exports[`tiger catalog > should read catalog for reference workspace 1`] = `
     {
       "groups": [],
       "measure": {
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "description": "Metric has null value",
         "expression": "SELECT SUM({fact/f_opportunitysnapshot.f_amount}) where {label/f_owner.region_id} IN (\\"\\", NULL, \\"East Coast\\", \\"West Coast\\" )",
         "format": "#,##0",
@@ -9446,7 +9446,7 @@ exports[`tiger catalog > should read catalog for reference workspace 1`] = `
     {
       "groups": [],
       "measure": {
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "description": "",
         "expression": "SELECT SUM({metric/amount_bop} * -1 )",
         "format": "#,##0.00",
@@ -9937,7 +9937,7 @@ exports[`tiger catalog > should read catalog for reference workspace 1`] = `
     {
       "groups": [],
       "measure": {
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "description": "",
         "expression": "SELECT SUM({fact/f_opportunitysnapshot.f_amount})",
         "format": "#,##0",
@@ -10046,7 +10046,7 @@ exports[`tiger catalog > should read catalog for reference workspace 1`] = `
     {
       "groups": [],
       "measure": {
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "description": "",
         "expression": "SELECT AVG({fact/f_opportunitysnapshot.f_probability}) WHERE {fact/fact.f_opportunitysnapshot.oppsnapshotdate} = {metric/c5ee7836-126c-41aa-bd69-1873d379a065}",
         "format": "#,##0.0%",
@@ -11115,7 +11115,7 @@ exports[`tiger catalog > should read catalog for reference workspace 1`] = `
     {
       "groups": [],
       "measure": {
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "description": "",
         "expression": "SELECT {metric/8d33a0b1-cfdf-4074-a26a-4c4357774967} / {metric/768414e1-4bbe-4f01-b125-0cdc6305dc76}",
         "format": "#,##0.0%",
@@ -11134,7 +11134,7 @@ exports[`tiger catalog > should read catalog for reference workspace 1`] = `
     {
       "groups": [],
       "measure": {
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "description": "",
         "expression": "SELECT {metric/87a053b0-3947-49f3-b0c5-de53fd01f050}
   WHERE {label/f_stage.status_id} = \\"Won\\"",
@@ -11154,7 +11154,7 @@ exports[`tiger catalog > should read catalog for reference workspace 1`] = `
     {
       "groups": [],
       "measure": {
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "description": "",
         "expression": "SELECT MAX({fact/fact.f_opportunitysnapshot.oppclosedate})
   WHERE {fact/fact.f_opportunitysnapshot.oppsnapshotdate} = {metric/snapshot_bop}",
@@ -11174,7 +11174,7 @@ exports[`tiger catalog > should read catalog for reference workspace 1`] = `
     {
       "groups": [],
       "measure": {
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "description": "",
         "expression": "SELECT MAX({fact/fact.f_opportunitysnapshot.oppclosedate}) where {fact/fact.f_opportunitysnapshot.oppsnapshotdate} = {metric/c5ee7836-126c-41aa-bd69-1873d379a065}",
         "format": "#,##0.00",
@@ -11193,7 +11193,7 @@ exports[`tiger catalog > should read catalog for reference workspace 1`] = `
     {
       "groups": [],
       "measure": {
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "description": "",
         "expression": "select min({fact/fact.f_opportunitysnapshot.oppsnapshotdate}) by all in all other dimensions except {attribute/f_opportunity.id}",
         "format": "#,##0.00",
@@ -11212,7 +11212,7 @@ exports[`tiger catalog > should read catalog for reference workspace 1`] = `
     {
       "groups": [],
       "measure": {
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "description": "",
         "expression": "SELECT MIN({fact/fact.f_opportunitysnapshot.oppsnapshotdate})
   BY ALL IN ALL OTHER DIMENSIONS EXCEPT {attribute/dt_snapshotdate_timestamp.day}
@@ -11233,7 +11233,7 @@ exports[`tiger catalog > should read catalog for reference workspace 1`] = `
     {
       "groups": [],
       "measure": {
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "description": "",
         "expression": "SELECT MAX({fact/fact.f_opportunitysnapshot.oppsnapshotdate}) BY ALL IN ALL OTHER DIMENSIONS EXCEPT {attribute/dt_snapshotdate_timestamp.day} WHERE {fact/fact.f_opportunitysnapshot.oppsnapshotdate} <= {metric/6b1411d5-e253-418e-8fd3-137a9f56ea92}",
         "format": "#,##0.00",
@@ -11252,7 +11252,7 @@ exports[`tiger catalog > should read catalog for reference workspace 1`] = `
     {
       "groups": [],
       "measure": {
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "description": "",
         "expression": "SELECT MIN({fact/fact.f_timeline.timelinedate})
   BY ALL IN ALL OTHER DIMENSIONS EXCEPT {attribute/dt_timeline_timestamp.day}",
@@ -11272,7 +11272,7 @@ exports[`tiger catalog > should read catalog for reference workspace 1`] = `
     {
       "groups": [],
       "measure": {
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "description": "",
         "expression": "SELECT MAX({fact/fact.f_timeline.timelinedate}) BY ALL IN ALL OTHER DIMENSIONS EXCEPT {attribute/dt_timeline_timestamp.day}",
         "format": "#,##0",

--- a/libs/sdk-backend-tiger/tests/integrated/__snapshots__/insights.test.ts.snap
+++ b/libs/sdk-backend-tiger/tests/integrated/__snapshots__/insights.test.ts.snap
@@ -85,7 +85,7 @@ exports[`tiger insights > should load empty insights for out-of-range page 1`] =
             "localIdentifier": "columns",
           },
         ],
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "filters": [
           {
             "positiveAttributeFilter": {
@@ -219,7 +219,7 @@ exports[`tiger insights > should load empty insights for out-of-range page 1`] =
             "localIdentifier": "attribute",
           },
         ],
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "filters": [],
         "identifier": "5517045e-661f-4d6b-b0b0-98030ab9f68c",
         "isLocked": false,
@@ -304,7 +304,7 @@ exports[`tiger insights > should load empty insights for out-of-range page 1`] =
             "localIdentifier": "view",
           },
         ],
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "filters": [
           {
             "positiveAttributeFilter": {
@@ -463,7 +463,7 @@ exports[`tiger insights > should load empty insights for out-of-range page 1`] =
             "localIdentifier": "view",
           },
         ],
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "filters": [
           {
             "measureValueFilter": {
@@ -532,7 +532,7 @@ exports[`tiger insights > should load empty insights for out-of-range page 1`] =
             "localIdentifier": "attribute",
           },
         ],
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "filters": [
           {
             "relativeDateFilter": {
@@ -623,7 +623,7 @@ exports[`tiger insights > should load empty insights for out-of-range page 1`] =
             "localIdentifier": "view",
           },
         ],
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "filters": [],
         "identifier": "dcce2234-9097-47e7-a165-36cdbaa2e134",
         "isLocked": false,
@@ -688,7 +688,7 @@ exports[`tiger insights > should load empty insights for out-of-range page 1`] =
             "localIdentifier": "attribute",
           },
         ],
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "filters": [
           {
             "negativeAttributeFilter": {
@@ -760,7 +760,7 @@ exports[`tiger insights > should load empty insights for out-of-range page 1`] =
             "localIdentifier": "measures",
           },
         ],
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "filters": [],
         "identifier": "c1f236a4-b48a-4bf6-a94f-a89d5bde2fe9",
         "isLocked": false,
@@ -816,7 +816,7 @@ exports[`tiger insights > should load empty insights for out-of-range page 1`] =
             "localIdentifier": "attribute",
           },
         ],
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "filters": [
           {
             "absoluteDateFilter": {
@@ -897,7 +897,7 @@ exports[`tiger insights > should load empty insights for out-of-range page 1`] =
             "localIdentifier": "attribute",
           },
         ],
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "filters": [],
         "identifier": "b3b665b7-bca2-4462-82f1-b0e01dff8afe",
         "isLocked": false,
@@ -1042,7 +1042,7 @@ exports[`tiger insights > should load empty insights for out-of-range page 1`] =
             ],
           },
         ],
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "filters": [
           {
             "absoluteDateFilter": {
@@ -1529,7 +1529,7 @@ exports[`tiger insights > should load empty insights for out-of-range page 1`] =
             ],
           },
         ],
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "filters": [],
         "identifier": "6d236ec6-5cf7-493e-8285-6613fde4ce18",
         "isLocked": false,
@@ -1585,7 +1585,7 @@ exports[`tiger insights > should load empty insights for out-of-range page 1`] =
             "localIdentifier": "measures",
           },
         ],
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "filters": [],
         "identifier": "1e17f8cf-aa34-4474-8dd5-c1249c688225",
         "isLocked": false,
@@ -1650,7 +1650,7 @@ exports[`tiger insights > should load empty insights for out-of-range page 1`] =
             "localIdentifier": "attribute",
           },
         ],
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "filters": [
           {
             "negativeAttributeFilter": {
@@ -1791,7 +1791,7 @@ exports[`tiger insights > should load insights 1`] = `
             "localIdentifier": "columns",
           },
         ],
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "filters": [
           {
             "positiveAttributeFilter": {
@@ -1925,7 +1925,7 @@ exports[`tiger insights > should load insights 1`] = `
             "localIdentifier": "attribute",
           },
         ],
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "filters": [],
         "identifier": "5517045e-661f-4d6b-b0b0-98030ab9f68c",
         "isLocked": false,
@@ -2010,7 +2010,7 @@ exports[`tiger insights > should load insights 1`] = `
             "localIdentifier": "view",
           },
         ],
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "filters": [
           {
             "positiveAttributeFilter": {
@@ -2169,7 +2169,7 @@ exports[`tiger insights > should load insights 1`] = `
             "localIdentifier": "view",
           },
         ],
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "filters": [
           {
             "measureValueFilter": {
@@ -2238,7 +2238,7 @@ exports[`tiger insights > should load insights 1`] = `
             "localIdentifier": "attribute",
           },
         ],
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "filters": [
           {
             "relativeDateFilter": {
@@ -2329,7 +2329,7 @@ exports[`tiger insights > should load insights 1`] = `
             "localIdentifier": "view",
           },
         ],
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "filters": [],
         "identifier": "dcce2234-9097-47e7-a165-36cdbaa2e134",
         "isLocked": false,
@@ -2394,7 +2394,7 @@ exports[`tiger insights > should load insights 1`] = `
             "localIdentifier": "attribute",
           },
         ],
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "filters": [
           {
             "negativeAttributeFilter": {
@@ -2466,7 +2466,7 @@ exports[`tiger insights > should load insights 1`] = `
             "localIdentifier": "measures",
           },
         ],
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "filters": [],
         "identifier": "c1f236a4-b48a-4bf6-a94f-a89d5bde2fe9",
         "isLocked": false,
@@ -2522,7 +2522,7 @@ exports[`tiger insights > should load insights 1`] = `
             "localIdentifier": "attribute",
           },
         ],
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "filters": [
           {
             "absoluteDateFilter": {
@@ -2603,7 +2603,7 @@ exports[`tiger insights > should load insights 1`] = `
             "localIdentifier": "attribute",
           },
         ],
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "filters": [],
         "identifier": "b3b665b7-bca2-4462-82f1-b0e01dff8afe",
         "isLocked": false,
@@ -2748,7 +2748,7 @@ exports[`tiger insights > should load insights 1`] = `
             ],
           },
         ],
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "filters": [
           {
             "absoluteDateFilter": {
@@ -3235,7 +3235,7 @@ exports[`tiger insights > should load insights 1`] = `
             ],
           },
         ],
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "filters": [],
         "identifier": "6d236ec6-5cf7-493e-8285-6613fde4ce18",
         "isLocked": false,
@@ -3291,7 +3291,7 @@ exports[`tiger insights > should load insights 1`] = `
             "localIdentifier": "measures",
           },
         ],
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "filters": [],
         "identifier": "1e17f8cf-aa34-4474-8dd5-c1249c688225",
         "isLocked": false,
@@ -3356,7 +3356,7 @@ exports[`tiger insights > should load insights 1`] = `
             "localIdentifier": "attribute",
           },
         ],
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "filters": [
           {
             "negativeAttributeFilter": {
@@ -3488,7 +3488,7 @@ exports[`tiger insights > should load insights 1`] = `
             "localIdentifier": "columns",
           },
         ],
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "filters": [
           {
             "positiveAttributeFilter": {
@@ -3622,7 +3622,7 @@ exports[`tiger insights > should load insights 1`] = `
             "localIdentifier": "attribute",
           },
         ],
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "filters": [],
         "identifier": "5517045e-661f-4d6b-b0b0-98030ab9f68c",
         "isLocked": false,
@@ -3707,7 +3707,7 @@ exports[`tiger insights > should load insights 1`] = `
             "localIdentifier": "view",
           },
         ],
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "filters": [
           {
             "positiveAttributeFilter": {
@@ -3866,7 +3866,7 @@ exports[`tiger insights > should load insights 1`] = `
             "localIdentifier": "view",
           },
         ],
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "filters": [
           {
             "measureValueFilter": {
@@ -3935,7 +3935,7 @@ exports[`tiger insights > should load insights 1`] = `
             "localIdentifier": "attribute",
           },
         ],
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "filters": [
           {
             "relativeDateFilter": {
@@ -4026,7 +4026,7 @@ exports[`tiger insights > should load insights 1`] = `
             "localIdentifier": "view",
           },
         ],
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "filters": [],
         "identifier": "dcce2234-9097-47e7-a165-36cdbaa2e134",
         "isLocked": false,
@@ -4091,7 +4091,7 @@ exports[`tiger insights > should load insights 1`] = `
             "localIdentifier": "attribute",
           },
         ],
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "filters": [
           {
             "negativeAttributeFilter": {
@@ -4163,7 +4163,7 @@ exports[`tiger insights > should load insights 1`] = `
             "localIdentifier": "measures",
           },
         ],
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "filters": [],
         "identifier": "c1f236a4-b48a-4bf6-a94f-a89d5bde2fe9",
         "isLocked": false,
@@ -4219,7 +4219,7 @@ exports[`tiger insights > should load insights 1`] = `
             "localIdentifier": "attribute",
           },
         ],
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "filters": [
           {
             "absoluteDateFilter": {
@@ -4300,7 +4300,7 @@ exports[`tiger insights > should load insights 1`] = `
             "localIdentifier": "attribute",
           },
         ],
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "filters": [],
         "identifier": "b3b665b7-bca2-4462-82f1-b0e01dff8afe",
         "isLocked": false,
@@ -4445,7 +4445,7 @@ exports[`tiger insights > should load insights 1`] = `
             ],
           },
         ],
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "filters": [
           {
             "absoluteDateFilter": {
@@ -4932,7 +4932,7 @@ exports[`tiger insights > should load insights 1`] = `
             ],
           },
         ],
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "filters": [],
         "identifier": "6d236ec6-5cf7-493e-8285-6613fde4ce18",
         "isLocked": false,
@@ -4988,7 +4988,7 @@ exports[`tiger insights > should load insights 1`] = `
             "localIdentifier": "measures",
           },
         ],
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "filters": [],
         "identifier": "1e17f8cf-aa34-4474-8dd5-c1249c688225",
         "isLocked": false,
@@ -5053,7 +5053,7 @@ exports[`tiger insights > should load insights 1`] = `
             "localIdentifier": "attribute",
           },
         ],
-        "created": "2023-08-31 10:37",
+        "created": "sanitize_created",
         "filters": [
           {
             "negativeAttributeFilter": {

--- a/libs/sdk-backend-tiger/tests/integrated/backend.ts
+++ b/libs/sdk-backend-tiger/tests/integrated/backend.ts
@@ -97,9 +97,15 @@ function sanitizeWorkspaceId(result: object) {
     return result;
 }
 
-export function sanitizeWorkspace(result: object, key: string, newValue: string) {
-    const newResult = sanitizeKeyWithNewValue(result, key, newValue);
-    return sanitizeWorkspaceId(newResult);
+export function sanitizeWorkspace(result: object) {
+    const commonResult = doSanitizeCommon(result);
+    return sanitizeWorkspaceId(commonResult);
+}
+
+export function doSanitizeCommon(result: object) {
+    const newURIResult = sanitizeKeyWithNewValue(result, "uri", "sanitize_uri");
+    const newCreatedResult = sanitizeKeyWithNewValue(newURIResult, "created", "sanitize_created");
+    return newCreatedResult;
 }
 
 export function sortToOrder(json: any) {

--- a/libs/sdk-backend-tiger/tests/integrated/catalog.test.ts
+++ b/libs/sdk-backend-tiger/tests/integrated/catalog.test.ts
@@ -14,7 +14,7 @@ beforeAll(async () => {
 describe("tiger catalog", () => {
     it("should read catalog for reference workspace", async () => {
         const result = await backend.workspace(testWorkspace()).catalog().load();
-        const sanitizedResult = sanitizeWorkspace(result, "uri", "sanitize_uri");
+        const sanitizedResult = sanitizeWorkspace(result);
         expect(sortToOrder(sanitizedResult)).toMatchSnapshot();
     });
 
@@ -39,7 +39,7 @@ describe("tiger catalog", () => {
             })
             .load();
 
-        const sanitizedResult = sanitizeWorkspace(result, "uri", "sanitize_uri");
+        const sanitizedResult = sanitizeWorkspace(result);
         expect(sortToOrder(sanitizedResult)).toMatchSnapshot();
     });
 
@@ -68,7 +68,7 @@ describe("tiger catalog", () => {
             ])
             .load();
 
-        const sanitizedResult = sanitizeWorkspace(availability, "uri", "sanitize_uri");
+        const sanitizedResult = sanitizeWorkspace(availability);
         expect(sortToOrder(sanitizedResult)).toMatchSnapshot();
     });
 });

--- a/libs/sdk-backend-tiger/tests/integrated/insights.test.ts
+++ b/libs/sdk-backend-tiger/tests/integrated/insights.test.ts
@@ -1,6 +1,6 @@
 // (C) 2022 GoodData Corporation
 import { describe, beforeAll, expect, it } from "vitest";
-import { testBackend, testWorkspace, sanitizeKeyWithNewValue } from "./backend.js";
+import { testBackend, testWorkspace, doSanitizeCommon } from "./backend.js";
 const backend = testBackend();
 
 beforeAll(async () => {
@@ -10,14 +10,14 @@ beforeAll(async () => {
 describe("tiger insights", () => {
     it("should load insights", async () => {
         const result = await backend.workspace(testWorkspace()).insights().getInsights();
-        const sanitizeResult = sanitizeKeyWithNewValue(result, "uri", "sanitize_uri");
+        const sanitizeResult = doSanitizeCommon(result);
         expect(sanitizeResult).toMatchSnapshot();
     });
 
     it("should load empty insights for out-of-range page", async () => {
         const result = await backend.workspace(testWorkspace()).insights().getInsights();
         const page = await result.goTo(4);
-        const sanitizeResult = sanitizeKeyWithNewValue(page, "uri", "sanitize_uri");
+        const sanitizeResult = doSanitizeCommon(page);
         expect(sanitizeResult).toMatchSnapshot();
     });
 });


### PR DESCRIPTION
JIRA: QA-19951

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |
| **Compatibility matrix test commands - TIGER Backend**  |                                                            |
| `extended test - matrix-test <AIO_version>`             | Run integrated tests against AIO versions.                 |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

`<AIO_version>` in commands is used to start test with multiple AIO instances - each instance in triggered by one jenkins build

-   To run with `master` and `stable`, execute command `extended test - matrix-test master,stable` or `extended test - matrix-test latest`
-   To run with specific version,ex: `2.3.0` and `2.3.1`, execute command `extended test - matrix-test 2.3.0,2.3.1`
-   In case `<AIO_version>` is empty, read versions from file `compTigerVersions.txt` of this repo

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
