### PR TITLE
BUGFIX: TNT-1716 Reuse KPI execution for new alerts

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/widget/kpi/ViewModeDashboardKpi/KpiExecutor.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/kpi/ViewModeDashboardKpi/KpiExecutor.tsx
@@ -127,19 +127,6 @@ const KpiExecutorCore: React.FC<IKpiExecutorProps> = (props) => {
     });
     const isLoading = status === "loading" || status === "pending";
 
-    const {
-        error: alertExecutionError,
-        result: alertExecutionResult,
-        status: alertExecutionStatus,
-    } = useKpiExecutionDataView({
-        backend,
-        workspace,
-        primaryMeasure,
-        effectiveFilters,
-        shouldLoad: true,
-    });
-    const isAlertExecutionLoading = alertExecutionStatus === "loading" || alertExecutionStatus === "pending";
-
     const currentUser = useDashboardSelector(selectCurrentUser);
     const canCreateScheduledMail = useDashboardSelector(selectCanCreateScheduledMail);
     const settings = useDashboardSelector(selectSettings);
@@ -166,7 +153,7 @@ const KpiExecutorCore: React.FC<IKpiExecutorProps> = (props) => {
     const executionsHandler = useWidgetExecutionsHandler(widgetRef(kpiWidget));
 
     useEffect(() => {
-        const err = error ?? alertExecutionError;
+        const err = error;
         if (err) {
             onError?.(err);
         }
@@ -174,7 +161,7 @@ const KpiExecutorCore: React.FC<IKpiExecutorProps> = (props) => {
         if (error) {
             executionsHandler.onError(error);
         }
-    }, [error, alertExecutionError]);
+    }, [error]);
 
     useEffect(() => {
         if (result) {
@@ -222,7 +209,13 @@ const KpiExecutorCore: React.FC<IKpiExecutorProps> = (props) => {
     const { kpiAlertDialogClosed, kpiAlertDialogOpened } = useDashboardUserInteraction();
 
     const kpiResult = getKpiResult(result, primaryMeasure, secondaryMeasure, separators);
-    const kpiAlertResult = getKpiAlertResult(alertExecutionResult, primaryMeasure, separators);
+    // Alert does not require its own execution.
+    // isTriggered status is computed on BE for existing alerts.
+    // For new/updated alerts in this moment it is the same as KPI's execution -> reuse it
+    const kpiAlertResult = getKpiAlertResult(result, primaryMeasure, separators);
+    const isAlertExecutionLoading = isLoading;
+    const alertExecutionError = error;
+
     const { isThresholdRepresentingPercent, thresholdPlaceholder } = useMemo(
         () => getAlertThresholdInfo(kpiResult, intl),
         [kpiResult, intl],


### PR DESCRIPTION
Execution done just for Alert is exactly the same as for KPI itself, only omits secondary metric.
It was probably meant as optimization,
but it caused cache miss and
one redundant execution for every KPI.
Even for ones which dont have alert at all.
For evaluation of new/updated alert KPI's execution is enough as they share filters and secondary metric is ignored anyway. JIRA: TNT-1716

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |
| **Compatibility matrix test commands - TIGER Backend**  |                                                            |
| `extended test - matrix-test <AIO_version>`             | Run integrated tests against AIO versions.                 |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

`<AIO_version>` in commands is used to start test with multiple AIO instances - each instance in triggered by one jenkins build

-   To run with `master` and `stable`, execute command `extended test - matrix-test master,stable` or `extended test - matrix-test latest`
-   To run with specific version,ex: `2.3.0` and `2.3.1`, execute command `extended test - matrix-test 2.3.0,2.3.1`
-   In case `<AIO_version>` is empty, read versions from file `compTigerVersions.txt` of this repo

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
