### PR TITLE
BUGFIX: TNT-1738 Bar chart totals labels when stacked by one value

### DIFF
--- a/libs/sdk-ui-charts/src/highcharts/adapter/plugins/autohideLabels/autohideBarLabels.ts
+++ b/libs/sdk-ui-charts/src/highcharts/adapter/plugins/autohideLabels/autohideBarLabels.ts
@@ -1,5 +1,6 @@
 // (C) 2007-2022 GoodData Corporation
 import sortBy from "lodash/sortBy.js";
+import { VisualizationTypes } from "@gooddata/sdk-ui";
 
 import {
     isStacked,
@@ -167,6 +168,7 @@ export function toggleStackedLabelsForAxis() {
         const areOverlapping = areLabelsOverlappingColumns(
             getStackedLabels(stacks),
             getDataPointsOfVisibleSeries(this),
+            VisualizationTypes.BAR,
         );
 
         stackTotalGroups.forEach((stackTotalGroup: Highcharts.SVGAttributes) =>

--- a/libs/sdk-ui-charts/src/highcharts/adapter/plugins/autohideLabels/autohideColumnLabels.ts
+++ b/libs/sdk-ui-charts/src/highcharts/adapter/plugins/autohideLabels/autohideColumnLabels.ts
@@ -170,6 +170,7 @@ export function areNeighborsOverlapping(neighbors: IUnsafeDataLabels[][]): boole
 export function areLabelsOverlappingColumns(
     labels: Highcharts.Point[],
     visiblePoints: Highcharts.Point[],
+    chartType?: string,
 ): boolean {
     return labels.some((label: UnsafeInternals) => {
         if (isEmpty(label)) {
@@ -192,7 +193,8 @@ export function areLabelsOverlappingColumns(
                 // supportedDualAxesChartTypes is including AREA and LINE
                 // won't hide the stacked label if it overlaps with points of AREA and LINE
                 seriesType === VisualizationTypes.AREA ||
-                seriesType === VisualizationTypes.LINE
+                seriesType === VisualizationTypes.LINE ||
+                (chartType === VisualizationTypes.BAR && labelAttr.width === 0)
             ) {
                 return false;
             }


### PR DESCRIPTION
When filtering by legend values if the bar chart is only stacked by one value it makes whole totals labels disappear.

JIRA: TNT-1738


---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |
| **Compatibility matrix test commands - TIGER Backend**  |                                                            |
| `extended test - matrix-test <AIO_version>`             | Run integrated tests against AIO versions.                 |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

`<AIO_version>` in commands is used to start test with multiple AIO instances - each instance in triggered by one jenkins build

-   To run with `master` and `stable`, execute command `extended test - matrix-test master,stable` or `extended test - matrix-test latest`
-   To run with specific version,ex: `2.3.0` and `2.3.1`, execute command `extended test - matrix-test 2.3.0,2.3.1`
-   In case `<AIO_version>` is empty, read versions from file `compTigerVersions.txt` of this repo

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
