### PR TITLE
FEATURE: EGL-247 - allow to show unrelated date items on KD

### DIFF
--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -6159,6 +6159,9 @@ export const selectEnableRenamingMeasureToMetric: DashboardSelector<boolean>;
 export const selectEnableRenamingProjectToWorkspace: DashboardSelector<boolean>;
 
 // @internal
+export const selectEnableUnavailableItemsVisibility: DashboardSelector<boolean>;
+
+// @internal
 export const selectEnableWidgetCustomHeight: DashboardSelector<boolean>;
 
 // @alpha (undocumented)

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/validation/filterValidation.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/validation/filterValidation.ts
@@ -26,6 +26,8 @@ import { resolveDisplayFormMetadata } from "../../../utils/displayFormResolver.j
 import isEmpty from "lodash/isEmpty.js";
 import { selectFilterContextAttributeFilters } from "../../../store/filterContext/filterContextSelectors.js";
 import { IDashboardCommand } from "../../../commands/index.js";
+import { selectEnableUnavailableItemsVisibility } from "../../../store/config/configSelectors.js";
+import { selectCatalogDateDatasets } from "../../../store/catalog/catalogSelectors.js";
 
 /**
  * This generator validates that a date dataset with the provided ref can be used for date filtering of insight in
@@ -60,9 +62,11 @@ export function* validateDatasetForInsightWidgetDateFilter(
         query,
         queryDateDatasetsForInsight(resolvedInsight ? resolvedInsight : widget.insight),
     );
-    const catalogDataSet = newCatalogDateDatasetMap(insightDateDatasets.allAvailableDateDatasets).get(
-        dateDataSet,
-    );
+    const enableUnavailableItemsVisible = yield select(selectEnableUnavailableItemsVisibility);
+    const dateDataSetsToValidate = enableUnavailableItemsVisible
+        ? yield select(selectCatalogDateDatasets)
+        : insightDateDatasets.allAvailableDateDatasets;
+    const catalogDataSet = newCatalogDateDatasetMap(dateDataSetsToValidate).get(dateDataSet);
 
     if (!catalogDataSet) {
         throw invalidArgumentsProvided(

--- a/libs/sdk-ui-dashboard/src/model/store/config/configSelectors.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/config/configSelectors.ts
@@ -563,3 +563,15 @@ export const selectIsDrillDownEnabled: DashboardSelector<boolean> = createSelect
         return isKPIDashboardImplicitDrillDownEnabled || isAttribueHierarchiesEnabled;
     },
 );
+
+/**
+ * Returns whether the unrelated data datasets are shown.
+ *
+ * @internal
+ */
+export const selectEnableUnavailableItemsVisibility: DashboardSelector<boolean> = createSelector(
+    selectConfig,
+    (state) => {
+        return state.settings?.enableUnavailableItemsVisible ?? false;
+    },
+);

--- a/libs/sdk-ui-dashboard/src/model/store/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/index.ts
@@ -63,6 +63,7 @@ export {
     selectWeekStart,
     selectEnableAttributeHierarchies,
     selectIsDrillDownEnabled,
+    selectEnableUnavailableItemsVisibility,
 } from "./config/configSelectors.js";
 export { EntitlementsState } from "./entitlements/entitlementsState.js";
 export { selectEntitlementExportPdf } from "./entitlements/entitlementsSelectors.js";

--- a/libs/sdk-ui-dashboard/src/presentation/localization/bundles/en-US.json
+++ b/libs/sdk-ui-dashboard/src/presentation/localization/bundles/en-US.json
@@ -2058,6 +2058,21 @@
         "comment": "",
         "limit": 0
     },
+    "gs.date.date-dataset.unrelated_hidden": {
+        "value": "{count} unrelated {count, plural, one {date} other {dates}} {isShow, select, true {visible} other {hidden}}.",
+        "comment": "Don't translate placeholder '{count}'. In '{count, plural, one {DATE} other {DATES}} and {isShow, select, true {VISIBLE} other {HIDDEN}}' translate only uppercase words.",
+        "limit": 0
+    },
+    "gs.date.date-dataset.unrelated.show": {
+        "value": "Show",
+        "comment": "The unrelated items button",
+        "limit": 0
+    },
+    "gs.date.date-dataset.unrelated.hide": {
+        "value": "Hide",
+        "comment": "The unrelated items button",
+        "limit": 0
+    },
     "layout.widget.width.min": {
         "value": "Widget is at the minimal width",
         "comment": "Shown as red text inside of widget if resized under min limit.",

--- a/libs/sdk-ui-dashboard/src/presentation/widget/common/configuration/DateDatasetPicker.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/common/configuration/DateDatasetPicker.tsx
@@ -24,6 +24,8 @@ export interface IDateDatasetPickerProps {
     onDateDatasetChange: (id: string) => void;
     className?: string;
     isLoading?: boolean;
+    enableUnrelatedItemsVisibility?: boolean;
+    unrelatedDateDatasets: readonly ICatalogDateDataset[] | undefined;
 }
 
 export const DateDatasetPicker: React.FC<IDateDatasetPickerProps> = (props) => {
@@ -35,6 +37,8 @@ export const DateDatasetPicker: React.FC<IDateDatasetPickerProps> = (props) => {
         dateFromVisualization,
         autoOpen,
         isLoading,
+        enableUnrelatedItemsVisibility,
+        unrelatedDateDatasets,
 
         onDateDatasetChange,
     } = props;
@@ -56,6 +60,8 @@ export const DateDatasetPicker: React.FC<IDateDatasetPickerProps> = (props) => {
                 onDateDatasetChange={onDateDatasetChange}
                 isLoading={isLoading}
                 width={width}
+                enableUnrelatedItemsVisibility={enableUnrelatedItemsVisibility}
+                unrelatedDateDatasets={unrelatedDateDatasets}
             />
         </div>
     );

--- a/libs/sdk-ui-dashboard/src/presentation/widget/common/configuration/DateFilterCheckbox.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/common/configuration/DateFilterCheckbox.tsx
@@ -15,6 +15,7 @@ interface IDateFilterCheckboxProps {
     selectedDateDatasetHidden?: boolean;
     dateFilterCheckboxDisabled?: boolean;
     onDateDatasetFilterEnabled: (enabled: boolean, dateDatasetRef: ObjRef | undefined) => void;
+    enableUnrelatedItemsVisibility?: boolean;
 }
 
 export const DateFilterCheckbox: React.FC<IDateFilterCheckboxProps> = (props) => {
@@ -28,6 +29,7 @@ export const DateFilterCheckbox: React.FC<IDateFilterCheckboxProps> = (props) =>
         relatedDateDatasets,
         widget,
         onDateDatasetFilterEnabled,
+        enableUnrelatedItemsVisibility,
     } = props;
 
     const unrelatedDateDataset =
@@ -41,7 +43,8 @@ export const DateFilterCheckbox: React.FC<IDateFilterCheckboxProps> = (props) =>
         !selectedDateDatasetHidden &&
         dateFilterEnabled &&
         !isDropdownLoading &&
-        !dateFilterCheckboxDisabled;
+        !dateFilterCheckboxDisabled &&
+        !enableUnrelatedItemsVisibility;
 
     const showError =
         (!!unrelatedDateDataset || showNoRelatedDate) &&

--- a/libs/sdk-ui-dashboard/src/presentation/widget/common/configuration/utils.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/common/configuration/utils.ts
@@ -12,6 +12,12 @@ import {
     IAttributeMetadataObject,
     ObjRef,
 } from "@gooddata/sdk-model";
+import { sortDateDatasets, IDateDataset, unrelatedHeader, IDateDatasetHeader } from "@gooddata/sdk-ui-kit";
+
+const DATE_DROPDOWN_BODY_MARGIN = 6;
+const UNRELATED_HEIGHT = 37;
+const PADDING = 10;
+const DROPDOWN_MAX_HEIGHT = 400;
 
 export function getUnrelatedDateDataset(
     relatedDateDataSets: readonly ICatalogDateDataset[],
@@ -46,4 +52,71 @@ export function removeDateFromTitle(title: string): string {
 
 export function getAttributeByDisplayForm(attributes: IAttributeMetadataObject[], displayForm: ObjRef) {
     return attributes.find((attribute) => areObjRefsEqual(attribute.ref, displayForm));
+}
+
+export function getUnrelatedDateDatasets(
+    allDateDataSets: readonly ICatalogDateDataset[],
+    relatedDateDataSets?: readonly ICatalogDateDataset[],
+): readonly ICatalogDateDataset[] {
+    if (!relatedDateDataSets) {
+        return allDateDataSets;
+    }
+    return allDateDataSets.filter(
+        (unrelatedItem) =>
+            !relatedDateDataSets.some((relatedItem) =>
+                areObjRefsEqual(relatedItem.dataSet.ref, unrelatedItem.dataSet.ref),
+            ),
+    );
+}
+
+export function getDateConfigurationDropdownHeight(
+    dropdownButtonTop: number,
+    dropdownButtonHeight: number,
+    dropdownBodyHeight: number,
+    hasFooter = false,
+) {
+    const footerHeight = hasFooter ? UNRELATED_HEIGHT : 0;
+    const dropdownHeight = 2 * DATE_DROPDOWN_BODY_MARGIN + PADDING + footerHeight;
+    const nodeAboveHeight = dropdownButtonTop - dropdownHeight;
+    const nodeBelowHeight = window.innerHeight - (dropdownButtonTop + dropdownButtonHeight + dropdownHeight);
+    const maxHeight = Math.max(nodeAboveHeight, nodeBelowHeight);
+
+    return Math.min(dropdownBodyHeight, maxHeight, DROPDOWN_MAX_HEIGHT);
+}
+
+function catalogDateDatasetToDateDataset(ds: ICatalogDateDataset): IDateDataset {
+    return {
+        id: ds.dataSet.id,
+        title: ds.dataSet.title,
+        relevance: ds.relevance,
+    };
+}
+
+export function getSortedDateDatasetsItems(
+    relatedDateDatasets: readonly ICatalogDateDataset[],
+    recommendedDateDataSet: ICatalogDateDataset | undefined,
+    unrelatedDateDataset: ICatalogDateDataset | undefined,
+    unrelatedDateDatasets: readonly ICatalogDateDataset[] | undefined,
+    shouldDisplayUnrelatedDatasets = false,
+): (IDateDataset | IDateDatasetHeader)[] {
+    const sortedUnrelatedDateDataset = sortDateDatasets(
+        (unrelatedDateDatasets || []).map(catalogDateDatasetToDateDataset),
+    );
+    const withUnrelatedHeader = [unrelatedHeader, ...sortedUnrelatedDateDataset];
+
+    if (shouldDisplayUnrelatedDatasets) {
+        return [
+            ...sortDateDatasets(
+                relatedDateDatasets.map(catalogDateDatasetToDateDataset),
+                recommendedDateDataSet ? catalogDateDatasetToDateDataset(recommendedDateDataSet) : undefined,
+            ),
+            ...withUnrelatedHeader,
+        ];
+    }
+
+    return sortDateDatasets(
+        relatedDateDatasets.map(catalogDateDatasetToDateDataset),
+        recommendedDateDataSet ? catalogDateDatasetToDateDataset(recommendedDateDataSet) : undefined,
+        unrelatedDateDataset ? catalogDateDatasetToDateDataset(unrelatedDateDataset) : undefined,
+    );
 }

--- a/libs/sdk-ui-dashboard/styles/scss/attributeFilterConfig.scss
+++ b/libs/sdk-ui-dashboard/styles/scss/attributeFilterConfig.scss
@@ -165,6 +165,18 @@
     }
 }
 
+.dropdown-body {
+    .gd-list-footer {
+        .unrelated-date-button {
+            font-size: 12px;
+            line-height: 16px;
+            padding-left: 2px;
+            padding-right: 0;
+            margin-top: -3px;
+        }
+    }
+}
+
 .gd-attribute-filter-dropdown-bubble {
     max-width: 200px;
 }


### PR DESCRIPTION
feat: allow to show unrelated date items on KD
JIRA: EGL-247

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |
| **Compatibility matrix test commands - TIGER Backend**  |                                                            |
| `extended test - matrix-test <AIO_version>`             | Run integrated tests against AIO versions.                 |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

`<AIO_version>` in commands is used to start test with multiple AIO instances - each instance in triggered by one jenkins build

-   To run with `master` and `stable`, execute command `extended test - matrix-test master,stable` or `extended test - matrix-test latest`
-   To run with specific version,ex: `2.3.0` and `2.3.1`, execute command `extended test - matrix-test 2.3.0,2.3.1`
-   In case `<AIO_version>` is empty, read versions from file `compTigerVersions.txt` of this repo

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
