### PR TITLE
RELATED: RAIL-5146 Do not expose npm publish token

### DIFF
--- a/common/config/rush/.npmrc-publish
+++ b/common/config/rush/.npmrc-publish
@@ -1,0 +1,5 @@
+# (C) 2019-2023 GoodData Corporation
+registry=https://registry.npmjs.org/
+always-auth=true
+
+//registry.npmjs.org/:_authToken=${NPM_PUBLISH_TOKEN}

--- a/common/scripts/ci/do_publish.sh
+++ b/common/scripts/ci/do_publish.sh
@@ -62,7 +62,7 @@ fi
 echo "Publishing to NPM"
 
 # forcing restricted access level; switch this to public
-${_RUSH} publish -n "${NPM_PUBLISH_TOKEN}" -p --include-all --tag "${TAG_NPM}" --set-access-level public
+${_RUSH} publish -p --include-all --tag "${TAG_NPM}" --set-access-level public
 publish_rc=$?
 
 if [ $publish_rc -ne 0 ]; then

--- a/common/scripts/ci/docker_rush.sh
+++ b/common/scripts/ci/docker_rush.sh
@@ -32,6 +32,7 @@ docker run \
   --env WIREMOCK_NET \
   --env HOME="/workspace" \
   --env EXAMPLES_BUILD_TYPE \
+  --env NPM_PUBLISH_TOKEN \
   --env EXAMPLE_MAPBOX_ACCESS_TOKEN \
   --env BROWSERSLIST_IGNORE_OLD_DATA=true \
   --rm \

--- a/common/scripts/ci/docker_rushx.sh
+++ b/common/scripts/ci/docker_rushx.sh
@@ -34,6 +34,7 @@ docker run \
   --env CI \
   --env WIREMOCK_NET \
   --env EXAMPLES_BUILD_TYPE \
+  --env NPM_PUBLISH_TOKEN \
   --env EXAMPLE_MAPBOX_ACCESS_TOKEN \
   --env BROWSERSLIST_IGNORE_OLD_DATA=true \
   --env HOME="/workspace" \


### PR DESCRIPTION
<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |
| **Compatibility matrix test commands - TIGER Backend**  |                                                            |
| `extended test - matrix-test <AIO_version>`             | Run integrated tests against AIO versions.                 |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

`<AIO_version>` in commands is used to start test with multiple AIO instances - each instance in triggered by one jenkins build

-   To run with `master` and `stable`, execute command `extended test - matrix-test master,stable` or `extended test - matrix-test latest`
-   To run with specific version,ex: `2.3.0` and `2.3.1`, execute command `extended test - matrix-test 2.3.0,2.3.1`
-   In case `<AIO_version>` is empty, read versions from file `compTigerVersions.txt` of this repo

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)