### PR TITLE
fix: Apply toast when OpenAI-generated description is applied to widget

### DIFF
--- a/libs/sdk-ui-dashboard/src/locales.ts
+++ b/libs/sdk-ui-dashboard/src/locales.ts
@@ -55,4 +55,5 @@ export const messages: Record<string, MessageDescriptor> = defineMessages({
     scheduleDialogEmailRepeatsFrequencies_day: { id: "dialogs.schedule.email.repeats.frequencies.day" },
     scheduleDialogEmailRepeatsFrequencies_month: { id: "dialogs.schedule.email.repeats.frequencies.month" },
     scheduleDialogEmailRepeatsFrequencies_week: { id: "dialogs.schedule.email.repeats.frequencies.week" },
+    widgetDescriptionApplied: { id: "dialogs.flexai.widgetDescriptionApplied" },
 });

--- a/libs/sdk-ui-dashboard/src/presentation/localization/bundles/en-US.json
+++ b/libs/sdk-ui-dashboard/src/presentation/localization/bundles/en-US.json
@@ -2169,5 +2169,11 @@
         "value": "<b>Success.</b> You have set the alert.",
         "comment": "Will be used in sentence between two nouns. For instance 'Filter by AttributeX with data of MetricY'",
         "limit": 0
+    },
+    "dialogs.flexai.widgetDescriptionApplied": {
+        "value": "Widget description has been updated.",
+        "comment": "",
+        "translate": false,
+        "limit": 0
     }
 }

--- a/libs/sdk-ui-dashboard/src/presentation/widget/widget/InsightWidget/EditableDashboardInsightWidget.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/widget/InsightWidget/EditableDashboardInsightWidget.tsx
@@ -22,6 +22,8 @@ import { useEditableInsightMenu } from "./useEditableInsightMenu.js";
 import { IDefaultDashboardInsightWidgetProps } from "./types.js";
 import { DashboardWidgetInsightGuard } from "./DashboardWidgetInsightGuard.js";
 import { EditableDashboardInsightWidgetHeader } from "./EditableDashboardInsightWidgetHeader.js";
+import { useToastMessage } from "@gooddata/sdk-ui-kit";
+import { messages } from "../../../../locales.js";
 
 export const EditableDashboardInsightWidget: React.FC<
     Omit<IDefaultDashboardInsightWidgetProps, "insight">
@@ -55,6 +57,7 @@ const EditableDashboardInsightWidgetCore: React.FC<
     const isEditable = !isSaving;
 
     const dashboardDispatch = useDashboardDispatch();
+    const { addSuccess } = useToastMessage();
     const applyWidgetDescription = useCallback(
         (e: { detail: { insightId: string; description: string } }) => {
             const { insightId, description } = e.detail;
@@ -63,9 +66,10 @@ const EditableDashboardInsightWidgetCore: React.FC<
                 dashboardDispatch(changeInsightWidgetDescription(widgetRef(widget), { description }));
                 document.dispatchEvent(new CustomEvent("gdc-llm-chat-clear"));
                 document.dispatchEvent(new CustomEvent("gdc-llm-chat-close"));
+                addSuccess(messages.widgetDescriptionApplied);
             }
         },
-        [],
+        [addSuccess],
     );
     useEffect(() => {
         document.addEventListener("gdc-llm-chat-apply-insight-description", applyWidgetDescription);

--- a/libs/sdk-ui-dashboard/styles/scss/fast_track.scss
+++ b/libs/sdk-ui-dashboard/styles/scss/fast_track.scss
@@ -115,7 +115,7 @@
 }
 
 .type-visualization {
-     .dash-item-action-alert-wrapper + .dash-item-action-placeholder {
+    .dash-item-action-alert-wrapper + .dash-item-action-placeholder {
         margin-left: 10px;
     }
 }


### PR DESCRIPTION
<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |
| **Compatibility matrix test commands - TIGER Backend**  |                                                            |
| `extended test - matrix-test <AIO_version>`             | Run integrated tests against AIO versions.                 |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

`<AIO_version>` in commands is used to start test with multiple AIO instances - each instance in triggered by one jenkins build

-   To run with `master` and `stable`, execute command `extended test - matrix-test master,stable` or `extended test - matrix-test latest`
-   To run with specific version,ex: `2.3.0` and `2.3.1`, execute command `extended test - matrix-test 2.3.0,2.3.1`
-   In case `<AIO_version>` is empty, read versions from file `compTigerVersions.txt` of this repo

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
