### PR TITLE
BUGFIX: TNT-1439 Save stackMeasures on MD properties when is enabled by default

### DIFF
--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/areaChart/PluggableAreaChart.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/areaChart/PluggableAreaChart.tsx
@@ -55,6 +55,7 @@ import {
 import {
     getReferencePointWithSupportedProperties,
     removeImmutableOptionalStackingProperties,
+    setAreaChartDefaultStackMeasuresValue,
 } from "../../../utils/propertiesHelper.js";
 import { removeSort, getCustomSortDisabledExplanation } from "../../../utils/sort.js";
 import { setAreaChartUiConfig } from "../../../utils/uiConfigHelpers/areaChartUiConfigHelper.js";
@@ -149,6 +150,9 @@ export class PluggableAreaChart extends PluggableBaseChart {
         if (!this.featureFlags.enableChartsSorting) {
             newReferencePoint = removeSort(newReferencePoint);
         }
+
+        newReferencePoint.properties = setAreaChartDefaultStackMeasuresValue(newReferencePoint);
+
         return Promise.resolve(sanitizeFilters(newReferencePoint));
     }
 

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/areaChart/tests/PluggableAreaChart.test.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/areaChart/tests/PluggableAreaChart.test.tsx
@@ -58,6 +58,7 @@ describe("PluggableAreaChart", () => {
         backend: dummyBackend(),
         visualizationProperties: {},
         renderFun: mockRenderFun,
+        unmountFun: vi.fn(),
     };
 
     const executionFactory = dummyBackend().workspace("PROJECTID").execution();

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/areaChart/tests/__snapshots__/PluggableAreaChart.test.tsx.snap
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/areaChart/tests/__snapshots__/PluggableAreaChart.test.tsx.snap
@@ -487,7 +487,11 @@ exports[`PluggableAreaChart > optional stacking > should reuse all measures, onl
     ],
     "localIdentifier": "filters",
   },
-  "properties": {},
+  "properties": {
+    "controls": {
+      "stackMeasures": true,
+    },
+  },
   "uiConfig": {
     "buckets": {
       "filters": {

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/comboChart/PluggableComboChart.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/comboChart/PluggableComboChart.tsx
@@ -53,6 +53,7 @@ import { getMasterMeasuresCount } from "../../../utils/bucketRules.js";
 import {
     getReferencePointWithSupportedProperties,
     isDualAxisOrSomeSecondaryAxisMeasure,
+    setComboChartDefaultStackMeasuresValue,
     setSecondaryMeasures,
 } from "../../../utils/propertiesHelper.js";
 import { setComboChartUiConfig } from "../../../utils/uiConfigHelpers/comboChartUiConfigHelper.js";
@@ -265,6 +266,11 @@ export class PluggableComboChart extends PluggableBaseChart {
                 ...referencePoint.properties,
                 controls: {
                     ...controls,
+                    ...setComboChartDefaultStackMeasuresValue(
+                        buckets,
+                        primaryChartType,
+                        controls.stackMeasures,
+                    ),
                     primaryChartType,
                     secondaryChartType,
                 },

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/comboChart/tests/PluggableComboChart.test.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/comboChart/tests/PluggableComboChart.test.tsx
@@ -36,6 +36,7 @@ describe("PluggableComboChart", () => {
         backend: dummyBackend(),
         visualizationProperties: {},
         renderFun: mockRenderFun,
+        unmountFun: vi.fn(),
     };
     const primaryMeasureBucketProps: IBucketOfFun = {
         localIdentifier: "measures",

--- a/libs/sdk-ui-ext/src/internal/utils/propertiesHelper.ts
+++ b/libs/sdk-ui-ext/src/internal/utils/propertiesHelper.ts
@@ -13,8 +13,9 @@ import {
     IVisualizationProperties,
     IBucketItem,
     IVisProps,
+    IBucketOfFun,
 } from "../interfaces/Visualization.js";
-import { BucketNames } from "@gooddata/sdk-ui";
+import { BucketNames, VisualizationTypes } from "@gooddata/sdk-ui";
 import { AXIS } from "../constants/axis.js";
 import {
     getItemsCount,
@@ -389,5 +390,38 @@ export function getPivotTableProperties(settings: ISettings, properties: IVisual
                   columnHeadersPosition: getColumnHeadersPositionFromProperties(properties),
               }
             : {}),
+    };
+}
+
+export function setComboChartDefaultStackMeasuresValue(
+    buckets: IBucketOfFun[],
+    primaryChartType: string,
+    stackMeasures?: boolean,
+) {
+    const measuresCount = getItemsCount(buckets, BucketNames.MEASURES);
+
+    return {
+        ...(measuresCount > 1 && primaryChartType === VisualizationTypes.AREA && stackMeasures === undefined
+            ? {
+                  stackMeasures: true,
+              }
+            : {}),
+    };
+}
+
+export function setAreaChartDefaultStackMeasuresValue(referencePoint: IExtendedReferencePoint) {
+    const measuresCount = getItemsCount(referencePoint.buckets, BucketNames.MEASURES);
+    const propertiesControlStackMeasures = referencePoint.properties?.controls?.stackMeasures;
+
+    return {
+        ...(measuresCount > 1 && propertiesControlStackMeasures === undefined
+            ? {
+                  ...referencePoint.properties,
+                  controls: {
+                      ...referencePoint.properties?.controls,
+                      stackMeasures: true,
+                  },
+              }
+            : referencePoint.properties),
     };
 }


### PR DESCRIPTION
Update Area and Combo chart properties to contain stackMeasures when is enabled by default.

JIRA: TNT-1439

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |
| **Compatibility matrix test commands - TIGER Backend**  |                                                            |
| `extended test - matrix-test <AIO_version>`             | Run integrated tests against AIO versions.                 |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

`<AIO_version>` in commands is used to start test with multiple AIO instances - each instance in triggered by one jenkins build

-   To run with `master` and `stable`, execute command `extended test - matrix-test master,stable` or `extended test - matrix-test latest`
-   To run with specific version,ex: `2.3.0` and `2.3.1`, execute command `extended test - matrix-test 2.3.0,2.3.1`
-   In case `<AIO_version>` is empty, read versions from file `compTigerVersions.txt` of this repo

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
