### PR TITLE
FEATURE: EGL-339 - remove attribute filter config when attribute filter has removed

### DIFF
--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/filterContext/attributeFilter/removeAttributeFiltersHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/filterContext/attributeFilter/removeAttributeFiltersHandler.ts
@@ -9,6 +9,7 @@ import { RemoveAttributeFilters } from "../../../commands/filters.js";
 import { invalidArgumentsProvided } from "../../../events/general.js";
 import { attributeFilterRemoved } from "../../../events/filters.js";
 import { filterContextActions } from "../../../store/filterContext/index.js";
+import { attributeFilterConfigsActions } from "../../../store/attributeFilterConfigs/index.js";
 import { selectFilterContextAttributeFilters } from "../../../store/filterContext/filterContextSelectors.js";
 import { DashboardContext } from "../../../types/commonTypes.js";
 import { dispatchFilterContextChanged } from "../common.js";
@@ -66,6 +67,10 @@ export function* removeAttributeFiltersHandler(
             }),
             // remove filter's display form metadata object
             filterContextActions.removeAttributeFilterDisplayForms(removedFilter.attributeFilter.displayForm),
+            // remove reflect dashboard attribute filter config
+            attributeFilterConfigsActions.removeAttributeFilterConfig(
+                removedFilter.attributeFilter.localIdentifier!,
+            ),
             // house-keeping: ensure the removed attribute filter disappears from widget ignore lists
             layoutActions.removeIgnoredAttributeFilter({
                 displayFormRefs: [removedFilter.attributeFilter.displayForm],

--- a/libs/sdk-ui-dashboard/src/model/store/attributeFilterConfigs/attributeFilterConfigsReducers.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/attributeFilterConfigs/attributeFilterConfigsReducers.ts
@@ -35,7 +35,14 @@ const setAttributeFilterConfigs: AttributeFilterConfigReducer<PayloadAction<Attr
     state.attributeFilterConfigs = attributeFilterConfigs;
 };
 
+const removeAttributeFilterConfig: AttributeFilterConfigReducer<PayloadAction<string>> = (state, action) => {
+    state.attributeFilterConfigs = state.attributeFilterConfigs?.filter(
+        (attributeFilterConfig) => attributeFilterConfig.localIdentifier !== action.payload,
+    );
+};
+
 export const attributeFilterConfigsReducers = {
     changeMode,
     setAttributeFilterConfigs,
+    removeAttributeFilterConfig,
 };


### PR DESCRIPTION
JIRA: EGL-330

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |
| **Compatibility matrix test commands - TIGER Backend**  |                                                            |
| `extended test - matrix-test <AIO_version>`             | Run integrated tests against AIO versions.                 |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

`<AIO_version>` in commands is used to start test with multiple AIO instances - each instance in triggered by one jenkins build

-   To run with `master` and `stable`, execute command `extended test - matrix-test master,stable` or `extended test - matrix-test latest`
-   To run with specific version,ex: `2.3.0` and `2.3.1`, execute command `extended test - matrix-test 2.3.0,2.3.1`
-   In case `<AIO_version>` is empty, read versions from file `compTigerVersions.txt` of this repo

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
