### PR TITLE
BUGFIX: RAIL-5108 Convert JSON files to TS to work on node runtime

### DIFF
--- a/libs/sdk-ui-dashboard/.gitignore
+++ b/libs/sdk-ui-dashboard/.gitignore
@@ -1,5 +1,7 @@
 styles/css
 # ignore the auxiliary file created during build to extract package version
 src/__version.ts
+# ignore localisations TS files, used to avoid ESM errors on node runtime
+src/presentation/localization/bundles/*.ts
 # ignore the NOTICE that gets copied here on publish, the source of truth is the root of the repo
 NOTICE

--- a/libs/sdk-ui-dashboard/.prettierignore
+++ b/libs/sdk-ui-dashboard/.prettierignore
@@ -1,0 +1,1 @@
+src/presentation/localization/bundles/*.ts

--- a/libs/sdk-ui-dashboard/scripts/build.sh
+++ b/libs/sdk-ui-dashboard/scripts/build.sh
@@ -18,8 +18,7 @@ _common-build() {
 
     _build_styles
 
-    mkdir -p esm/presentation/localization/bundles
-    cp -rf src/presentation/localization/bundles esm/presentation/localization
+    node scripts/convertJsonToTS.mjs
 
     # prepare the auxiliary __version.ts file so that the code can read the package version as a constant
     echo '// (C) 2021 GoodData Corporation' >src/__version.ts

--- a/libs/sdk-ui-dashboard/scripts/convertJsonToTS.mjs
+++ b/libs/sdk-ui-dashboard/scripts/convertJsonToTS.mjs
@@ -1,0 +1,28 @@
+// (C) 2007-2022 GoodData Corporation
+
+import fs from "fs/promises";
+import path from "path";
+
+const __dirname = path.dirname(new URL(import.meta.url).pathname);
+
+const BUNDLES_DIR = path.join(__dirname, "../", "src/presentation/localization/bundles");
+
+async function convertJsonToTS() {
+    const bundleFiles = await fs.readdir(BUNDLES_DIR);
+
+    for (const bundleFile of bundleFiles) {
+        if (bundleFile.endsWith(".json")) {
+            const jsonPath = path.resolve(BUNDLES_DIR, bundleFile);
+            const tsPath = path.resolve(BUNDLES_DIR, bundleFile.replace(".json", ".ts"));
+
+            const jsonData = await fs.readFile(jsonPath, "utf-8");
+            let tsData =
+                "// (C) 2023 GoodData Corporation\n// DO NOT CHANGE THIS FILE, IT IS RE-GENERATED ON EVERY BUILD\nexport default " +
+                JSON.stringify(JSON.parse(jsonData), null, 2);
+
+            await fs.writeFile(tsPath, tsData);
+        }
+    }
+}
+
+convertJsonToTS();

--- a/libs/sdk-ui-dashboard/src/presentation/localization/translations.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/localization/translations.ts
@@ -3,16 +3,16 @@ import merge from "lodash/merge.js";
 import { messagesMap as sdkUiTranslations } from "@gooddata/sdk-ui";
 import { translationUtils } from "@gooddata/util";
 
-import enUS from "./bundles/en-US.json";
-import deDE from "./bundles/de-DE.json";
-import esES from "./bundles/es-ES.json";
-import frFR from "./bundles/fr-FR.json";
-import jaJP from "./bundles/ja-JP.json";
-import nlNL from "./bundles/nl-NL.json";
-import ptBR from "./bundles/pt-BR.json";
-import ptPT from "./bundles/pt-PT.json";
-import zhHans from "./bundles/zh-Hans.json";
-import ruRU from "./bundles/ru-RU.json";
+import enUS from "./bundles/en-US.js";
+import deDE from "./bundles/de-DE.js";
+import esES from "./bundles/es-ES.js";
+import frFR from "./bundles/fr-FR.js";
+import jaJP from "./bundles/ja-JP.js";
+import nlNL from "./bundles/nl-NL.js";
+import ptBR from "./bundles/pt-BR.js";
+import ptPT from "./bundles/pt-PT.js";
+import zhHans from "./bundles/zh-Hans.js";
+import ruRU from "./bundles/ru-RU.js";
 
 const sdkUiDashboardTranslations: { [locale: string]: Record<string, string> } = {
     "en-US": translationUtils.removeMetadata(enUS),

--- a/libs/sdk-ui-ext/.gitignore
+++ b/libs/sdk-ui-ext/.gitignore
@@ -1,4 +1,6 @@
 styles/css
 styles/internal/css
+# ignore localisations TS files, used to avoid ESM errors on node runtime
+src/internal/translations/*.ts
 # ignore the NOTICE that gets copied here on publish, the source of truth is the root of the repo
 NOTICE

--- a/libs/sdk-ui-ext/.prettierignore
+++ b/libs/sdk-ui-ext/.prettierignore
@@ -1,0 +1,1 @@
+src/internal/translations/*.ts

--- a/libs/sdk-ui-ext/scripts/build.sh
+++ b/libs/sdk-ui-ext/scripts/build.sh
@@ -17,7 +17,8 @@ _common-build() {
     cp -rf src/internal/assets esm/internal/
     # then use svgo to optimize all the SVGs there
     svgo -rqf src/internal/assets esm/internal/assets
-    cp -rf src/internal/translations esm/internal/
+
+    node scripts/convertJsonToTS.mjs
 
     _build_styles
 }

--- a/libs/sdk-ui-ext/scripts/convertJsonToTS.mjs
+++ b/libs/sdk-ui-ext/scripts/convertJsonToTS.mjs
@@ -1,0 +1,28 @@
+// (C) 2007-2022 GoodData Corporation
+
+import fs from "fs/promises";
+import path from "path";
+
+const __dirname = path.dirname(new URL(import.meta.url).pathname);
+
+const TRANSLATIONS_DIR = path.join(__dirname, "../", "src/internal/translations");
+
+async function convertJsonToTS() {
+    const translationFiles = await fs.readdir(TRANSLATIONS_DIR);
+
+    for (const translationFile of translationFiles) {
+        if (translationFile.endsWith(".json")) {
+            const jsonPath = path.resolve(TRANSLATIONS_DIR, translationFile);
+            const tsPath = path.resolve(TRANSLATIONS_DIR, translationFile.replace(".json", ".ts"));
+
+            const jsonData = await fs.readFile(jsonPath, "utf-8");
+            let tsData =
+                "// (C) 2023 GoodData Corporation\n// DO NOT CHANGE THIS FILE, IT IS RE-GENERATED ON EVERY BUILD\nexport default " +
+                JSON.stringify(JSON.parse(jsonData), null, 2);
+
+            await fs.writeFile(tsPath, tsData);
+        }
+    }
+}
+
+convertJsonToTS();

--- a/libs/sdk-ui-ext/src/internal/utils/translations.ts
+++ b/libs/sdk-ui-ext/src/internal/utils/translations.ts
@@ -4,16 +4,16 @@ import merge from "lodash/merge.js";
 import { translationUtils } from "@gooddata/util";
 import { messagesMap as sdkUiTranslations } from "@gooddata/sdk-ui";
 
-import enUS from "../translations/en-US.json";
-import deDE from "../translations/de-DE.json";
-import esES from "../translations/es-ES.json";
-import frFR from "../translations/fr-FR.json";
-import jaJP from "../translations/ja-JP.json";
-import nlNL from "../translations/nl-NL.json";
-import ptBR from "../translations/pt-BR.json";
-import ptPT from "../translations/pt-PT.json";
-import zhHans from "../translations/zh-Hans.json";
-import ruRU from "../translations/ru-RU.json";
+import enUS from "../translations/en-US.js";
+import deDE from "../translations/de-DE.js";
+import esES from "../translations/es-ES.js";
+import frFR from "../translations/fr-FR.js";
+import jaJP from "../translations/ja-JP.js";
+import nlNL from "../translations/nl-NL.js";
+import ptBR from "../translations/pt-BR.js";
+import ptPT from "../translations/pt-PT.js";
+import zhHans from "../translations/zh-Hans.js";
+import ruRU from "../translations/ru-RU.js";
 import { IDropdownItem } from "../interfaces/Dropdown.js";
 
 export function getTranslation(

--- a/libs/sdk-ui/.gitignore
+++ b/libs/sdk-ui/.gitignore
@@ -1,2 +1,4 @@
 styles/css
 styles/internal/css
+# ignore localisations TS files, used to avoid ESM errors on node runtime
+src/base/localization/bundles/*.ts

--- a/libs/sdk-ui/.prettierignore
+++ b/libs/sdk-ui/.prettierignore
@@ -1,0 +1,1 @@
+src/base/localization/bundles/*.ts

--- a/libs/sdk-ui/scripts/build.sh
+++ b/libs/sdk-ui/scripts/build.sh
@@ -7,7 +7,8 @@ _clean() {
 
 _common-build() {
     mkdir -p esm/base/localization/bundles
-    cp -rf src/base/localization/bundles esm/base/localization
+
+    node scripts/convertJsonToTS.mjs
 }
 
 build() {

--- a/libs/sdk-ui/scripts/convertJsonToTS.mjs
+++ b/libs/sdk-ui/scripts/convertJsonToTS.mjs
@@ -1,0 +1,28 @@
+// (C) 2007-2022 GoodData Corporation
+
+import fs from "fs/promises";
+import path from "path";
+
+const __dirname = path.dirname(new URL(import.meta.url).pathname);
+
+const BUNDLES_DIR = path.join(__dirname, "../", "src/base/localization/bundles");
+
+async function convertJsonToTS() {
+    const bundleFiles = await fs.readdir(BUNDLES_DIR);
+
+    for (const bundleFile of bundleFiles) {
+        if (bundleFile.endsWith(".json")) {
+            const jsonPath = path.resolve(BUNDLES_DIR, bundleFile);
+            const tsPath = path.resolve(BUNDLES_DIR, bundleFile.replace(".json", ".ts"));
+
+            const jsonData = await fs.readFile(jsonPath, "utf-8");
+            let tsData =
+                "// (C) 2023 GoodData Corporation\n// DO NOT CHANGE THIS FILE, IT IS RE-GENERATED ON EVERY BUILD\nexport default " +
+                JSON.stringify(JSON.parse(jsonData), null, 2);
+
+            await fs.writeFile(tsPath, tsData);
+        }
+    }
+}
+
+convertJsonToTS();

--- a/libs/sdk-ui/src/base/localization/messagesMap.ts
+++ b/libs/sdk-ui/src/base/localization/messagesMap.ts
@@ -1,16 +1,16 @@
 // (C) 2007-2022 GoodData Corporation
 import { translationUtils } from "@gooddata/util";
 
-import enUS from "./bundles/en-US.json";
-import deDE from "./bundles/de-DE.json";
-import esES from "./bundles/es-ES.json";
-import frFR from "./bundles/fr-FR.json";
-import jaJP from "./bundles/ja-JP.json";
-import nlNL from "./bundles/nl-NL.json";
-import ptBR from "./bundles/pt-BR.json";
-import ptPT from "./bundles/pt-PT.json";
-import zhHans from "./bundles/zh-Hans.json";
-import ruRU from "./bundles/ru-RU.json";
+import enUS from "./bundles/en-US.js";
+import deDE from "./bundles/de-DE.js";
+import esES from "./bundles/es-ES.js";
+import frFR from "./bundles/fr-FR.js";
+import jaJP from "./bundles/ja-JP.js";
+import nlNL from "./bundles/nl-NL.js";
+import ptBR from "./bundles/pt-BR.js";
+import ptPT from "./bundles/pt-PT.js";
+import zhHans from "./bundles/zh-Hans.js";
+import ruRU from "./bundles/ru-RU.js";
 
 /**
  * @internal


### PR DESCRIPTION
<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |
| **Compatibility matrix test commands - TIGER Backend**  |                                                            |
| `extended test - matrix-test <AIO_version>`             | Run integrated tests against AIO versions.                 |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

`<AIO_version>` in commands is used to start test with multiple AIO instances - each instance in triggered by one jenkins build

-   To run with `master` and `stable`, execute command `extended test - matrix-test master,stable` or `extended test - matrix-test latest`
-   To run with specific version,ex: `2.3.0` and `2.3.1`, execute command `extended test - matrix-test 2.3.0,2.3.1`
-   In case `<AIO_version>` is empty, read versions from file `compTigerVersions.txt` of this repo

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
