### PR TITLE
FEATURE: TNT-1817 Introduce dependent filters on Panther

### DIFF
--- a/libs/api-client-tiger/api/api-client-tiger.api.md
+++ b/libs/api-client-tiger/api/api-client-tiger.api.md
@@ -574,7 +574,6 @@ export const AfmValidObjectsQueryTypesEnum: {
     readonly FACTS: "facts";
     readonly ATTRIBUTES: "attributes";
     readonly MEASURES: "measures";
-    readonly UNRECOGNIZED: "UNRECOGNIZED";
 };
 
 // @public (undocumented)
@@ -674,6 +673,7 @@ export const ApiEntitlementNameEnum: {
     readonly UNLIMITED_WORKSPACES: "UnlimitedWorkspaces";
     readonly WHITE_LABELING: "WhiteLabeling";
     readonly WORKSPACE_COUNT: "WorkspaceCount";
+    readonly USER_TELEMETRY_DISABLED: "UserTelemetryDisabled";
 };
 
 // @public (undocumented)
@@ -685,7 +685,6 @@ export class APITokensApi extends MetadataBaseApi implements APITokensApiInterfa
     deleteEntityApiTokens(requestParameters: APITokensApiDeleteEntityApiTokensRequest, options?: AxiosRequestConfig): Promise<AxiosResponse<void, any>>;
     getAllEntitiesApiTokens(requestParameters: APITokensApiGetAllEntitiesApiTokensRequest, options?: AxiosRequestConfig): Promise<AxiosResponse<JsonApiApiTokenOutList, any>>;
     getEntityApiTokens(requestParameters: APITokensApiGetEntityApiTokensRequest, options?: AxiosRequestConfig): Promise<AxiosResponse<JsonApiApiTokenOutDocument, any>>;
-    updateEntityApiTokens(requestParameters: APITokensApiUpdateEntityApiTokensRequest, options?: AxiosRequestConfig): Promise<AxiosResponse<JsonApiApiTokenOutDocument, any>>;
 }
 
 // @public
@@ -694,7 +693,6 @@ export const APITokensApiAxiosParamCreator: (configuration?: MetadataConfigurati
     deleteEntityApiTokens: (userId: string, id: string, filter?: string, options?: AxiosRequestConfig) => Promise<MetadataRequestArgs>;
     getAllEntitiesApiTokens: (userId: string, filter?: string, page?: number, size?: number, sort?: Array<string>, options?: AxiosRequestConfig) => Promise<MetadataRequestArgs>;
     getEntityApiTokens: (userId: string, id: string, filter?: string, options?: AxiosRequestConfig) => Promise<MetadataRequestArgs>;
-    updateEntityApiTokens: (userId: string, id: string, jsonApiApiTokenInDocument: JsonApiApiTokenInDocument, filter?: string, options?: AxiosRequestConfig) => Promise<MetadataRequestArgs>;
 };
 
 // @public
@@ -716,7 +714,6 @@ export const APITokensApiFactory: (configuration?: MetadataConfiguration, basePa
     deleteEntityApiTokens(requestParameters: APITokensApiDeleteEntityApiTokensRequest, options?: AxiosRequestConfig): AxiosPromise<void>;
     getAllEntitiesApiTokens(requestParameters: APITokensApiGetAllEntitiesApiTokensRequest, options?: AxiosRequestConfig): AxiosPromise<JsonApiApiTokenOutList>;
     getEntityApiTokens(requestParameters: APITokensApiGetEntityApiTokensRequest, options?: AxiosRequestConfig): AxiosPromise<JsonApiApiTokenOutDocument>;
-    updateEntityApiTokens(requestParameters: APITokensApiUpdateEntityApiTokensRequest, options?: AxiosRequestConfig): AxiosPromise<JsonApiApiTokenOutDocument>;
 };
 
 // @public
@@ -725,7 +722,6 @@ export const APITokensApiFp: (configuration?: MetadataConfiguration) => {
     deleteEntityApiTokens(userId: string, id: string, filter?: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>>;
     getAllEntitiesApiTokens(userId: string, filter?: string, page?: number, size?: number, sort?: Array<string>, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiApiTokenOutList>>;
     getEntityApiTokens(userId: string, id: string, filter?: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiApiTokenOutDocument>>;
-    updateEntityApiTokens(userId: string, id: string, jsonApiApiTokenInDocument: JsonApiApiTokenInDocument, filter?: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiApiTokenOutDocument>>;
 };
 
 // @public
@@ -750,15 +746,6 @@ export interface APITokensApiInterface {
     deleteEntityApiTokens(requestParameters: APITokensApiDeleteEntityApiTokensRequest, options?: AxiosRequestConfig): AxiosPromise<void>;
     getAllEntitiesApiTokens(requestParameters: APITokensApiGetAllEntitiesApiTokensRequest, options?: AxiosRequestConfig): AxiosPromise<JsonApiApiTokenOutList>;
     getEntityApiTokens(requestParameters: APITokensApiGetEntityApiTokensRequest, options?: AxiosRequestConfig): AxiosPromise<JsonApiApiTokenOutDocument>;
-    updateEntityApiTokens(requestParameters: APITokensApiUpdateEntityApiTokensRequest, options?: AxiosRequestConfig): AxiosPromise<JsonApiApiTokenOutDocument>;
-}
-
-// @public
-export interface APITokensApiUpdateEntityApiTokensRequest {
-    readonly filter?: string;
-    readonly id: string;
-    readonly jsonApiApiTokenInDocument: JsonApiApiTokenInDocument;
-    readonly userId: string;
 }
 
 // @public
@@ -2835,8 +2822,18 @@ export interface DeclarativePdm {
 export interface DeclarativeReference {
     identifier: ReferenceIdentifier;
     multivalue: boolean;
+    // @deprecated
     sourceColumnDataTypes?: Array<DeclarativeReferenceSourceColumnDataTypesEnum>;
-    sourceColumns: Array<string>;
+    // @deprecated
+    sourceColumns?: Array<string>;
+    sources?: Array<DeclarativeReferenceSource>;
+}
+
+// @public
+export interface DeclarativeReferenceSource {
+    column: string;
+    dataType?: DeclarativeReferenceSourceDataTypeEnum;
+    target: GrainIdentifier;
 }
 
 // @public (undocumented)
@@ -2852,6 +2849,20 @@ export const DeclarativeReferenceSourceColumnDataTypesEnum: {
 
 // @public (undocumented)
 export type DeclarativeReferenceSourceColumnDataTypesEnum = typeof DeclarativeReferenceSourceColumnDataTypesEnum[keyof typeof DeclarativeReferenceSourceColumnDataTypesEnum];
+
+// @public (undocumented)
+export const DeclarativeReferenceSourceDataTypeEnum: {
+    readonly INT: "INT";
+    readonly STRING: "STRING";
+    readonly DATE: "DATE";
+    readonly NUMERIC: "NUMERIC";
+    readonly TIMESTAMP: "TIMESTAMP";
+    readonly TIMESTAMP_TZ: "TIMESTAMP_TZ";
+    readonly BOOLEAN: "BOOLEAN";
+};
+
+// @public (undocumented)
+export type DeclarativeReferenceSourceDataTypeEnum = typeof DeclarativeReferenceSourceDataTypeEnum[keyof typeof DeclarativeReferenceSourceDataTypeEnum];
 
 // @public
 export interface DeclarativeRsaSpecification {
@@ -3276,6 +3287,13 @@ export interface DependentEntitiesResponse {
 }
 
 // @public
+export interface DependsOn {
+    complementFilter?: boolean;
+    label: string;
+    values: Array<string>;
+}
+
+// @public
 export interface Dimension {
     itemIdentifiers: Array<string>;
     localIdentifier?: string;
@@ -3299,6 +3317,7 @@ export interface ElementsRequest {
     complementFilter?: boolean;
     // @deprecated
     dataSamplingPercentage?: number;
+    dependsOn?: Array<DependsOn>;
     exactFilter?: Array<string>;
     excludePrimaryLabel?: boolean;
     filterBy?: FilterBy;
@@ -3485,7 +3504,6 @@ export class EntitiesApi extends MetadataBaseApi implements EntitiesApiInterface
     patchEntityWorkspaces(requestParameters: EntitiesApiPatchEntityWorkspacesRequest, options?: AxiosRequestConfig): Promise<AxiosResponse<JsonApiWorkspaceOutDocument, any>>;
     patchEntityWorkspaceSettings(requestParameters: EntitiesApiPatchEntityWorkspaceSettingsRequest, options?: AxiosRequestConfig): Promise<AxiosResponse<JsonApiWorkspaceSettingOutDocument, any>>;
     updateEntityAnalyticalDashboards(requestParameters: EntitiesApiUpdateEntityAnalyticalDashboardsRequest, options?: AxiosRequestConfig): Promise<AxiosResponse<JsonApiAnalyticalDashboardOutDocument, any>>;
-    updateEntityApiTokens(requestParameters: EntitiesApiUpdateEntityApiTokensRequest, options?: AxiosRequestConfig): Promise<AxiosResponse<JsonApiApiTokenOutDocument, any>>;
     updateEntityAttributeHierarchies(requestParameters: EntitiesApiUpdateEntityAttributeHierarchiesRequest, options?: AxiosRequestConfig): Promise<AxiosResponse<JsonApiAttributeHierarchyOutDocument, any>>;
     updateEntityColorPalettes(requestParameters: EntitiesApiUpdateEntityColorPalettesRequest, options?: AxiosRequestConfig): Promise<AxiosResponse<JsonApiColorPaletteOutDocument, any>>;
     updateEntityCookieSecurityConfigurations(requestParameters: EntitiesApiUpdateEntityCookieSecurityConfigurationsRequest, options?: AxiosRequestConfig): Promise<AxiosResponse<JsonApiCookieSecurityConfigurationOutDocument, any>>;
@@ -3644,7 +3662,6 @@ export const EntitiesApiAxiosParamCreator: (configuration?: MetadataConfiguratio
     patchEntityWorkspaceSettings: (workspaceId: string, objectId: string, jsonApiWorkspaceSettingPatchDocument: JsonApiWorkspaceSettingPatchDocument, filter?: string, options?: AxiosRequestConfig) => Promise<MetadataRequestArgs>;
     patchEntityWorkspaces: (id: string, jsonApiWorkspacePatchDocument: JsonApiWorkspacePatchDocument, filter?: string, include?: Array<"workspaces" | "parent" | "ALL">, options?: AxiosRequestConfig) => Promise<MetadataRequestArgs>;
     updateEntityAnalyticalDashboards: (workspaceId: string, objectId: string, jsonApiAnalyticalDashboardInDocument: JsonApiAnalyticalDashboardInDocument, filter?: string, include?: Array<"userIdentifiers" | "visualizationObjects" | "analyticalDashboards" | "labels" | "metrics" | "datasets" | "filterContexts" | "dashboardPlugins" | "createdBy" | "modifiedBy" | "ALL">, options?: AxiosRequestConfig) => Promise<MetadataRequestArgs>;
-    updateEntityApiTokens: (userId: string, id: string, jsonApiApiTokenInDocument: JsonApiApiTokenInDocument, filter?: string, options?: AxiosRequestConfig) => Promise<MetadataRequestArgs>;
     updateEntityAttributeHierarchies: (workspaceId: string, objectId: string, jsonApiAttributeHierarchyInDocument: JsonApiAttributeHierarchyInDocument, filter?: string, include?: Array<"userIdentifiers" | "attributes" | "createdBy" | "modifiedBy" | "ALL">, options?: AxiosRequestConfig) => Promise<MetadataRequestArgs>;
     updateEntityColorPalettes: (id: string, jsonApiColorPaletteInDocument: JsonApiColorPaletteInDocument, filter?: string, options?: AxiosRequestConfig) => Promise<MetadataRequestArgs>;
     updateEntityCookieSecurityConfigurations: (id: string, jsonApiCookieSecurityConfigurationInDocument: JsonApiCookieSecurityConfigurationInDocument, filter?: string, options?: AxiosRequestConfig) => Promise<MetadataRequestArgs>;
@@ -4096,7 +4113,6 @@ export const EntitiesApiFactory: (configuration?: MetadataConfiguration, basePat
     patchEntityWorkspaceSettings(requestParameters: EntitiesApiPatchEntityWorkspaceSettingsRequest, options?: AxiosRequestConfig): AxiosPromise<JsonApiWorkspaceSettingOutDocument>;
     patchEntityWorkspaces(requestParameters: EntitiesApiPatchEntityWorkspacesRequest, options?: AxiosRequestConfig): AxiosPromise<JsonApiWorkspaceOutDocument>;
     updateEntityAnalyticalDashboards(requestParameters: EntitiesApiUpdateEntityAnalyticalDashboardsRequest, options?: AxiosRequestConfig): AxiosPromise<JsonApiAnalyticalDashboardOutDocument>;
-    updateEntityApiTokens(requestParameters: EntitiesApiUpdateEntityApiTokensRequest, options?: AxiosRequestConfig): AxiosPromise<JsonApiApiTokenOutDocument>;
     updateEntityAttributeHierarchies(requestParameters: EntitiesApiUpdateEntityAttributeHierarchiesRequest, options?: AxiosRequestConfig): AxiosPromise<JsonApiAttributeHierarchyOutDocument>;
     updateEntityColorPalettes(requestParameters: EntitiesApiUpdateEntityColorPalettesRequest, options?: AxiosRequestConfig): AxiosPromise<JsonApiColorPaletteOutDocument>;
     updateEntityCookieSecurityConfigurations(requestParameters: EntitiesApiUpdateEntityCookieSecurityConfigurationsRequest, options?: AxiosRequestConfig): AxiosPromise<JsonApiCookieSecurityConfigurationOutDocument>;
@@ -4257,7 +4273,6 @@ export const EntitiesApiFp: (configuration?: MetadataConfiguration) => {
     patchEntityWorkspaceSettings(workspaceId: string, objectId: string, jsonApiWorkspaceSettingPatchDocument: JsonApiWorkspaceSettingPatchDocument, filter?: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiWorkspaceSettingOutDocument>>;
     patchEntityWorkspaces(id: string, jsonApiWorkspacePatchDocument: JsonApiWorkspacePatchDocument, filter?: string, include?: Array<"workspaces" | "parent" | "ALL">, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiWorkspaceOutDocument>>;
     updateEntityAnalyticalDashboards(workspaceId: string, objectId: string, jsonApiAnalyticalDashboardInDocument: JsonApiAnalyticalDashboardInDocument, filter?: string, include?: Array<"userIdentifiers" | "visualizationObjects" | "analyticalDashboards" | "labels" | "metrics" | "datasets" | "filterContexts" | "dashboardPlugins" | "createdBy" | "modifiedBy" | "ALL">, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiAnalyticalDashboardOutDocument>>;
-    updateEntityApiTokens(userId: string, id: string, jsonApiApiTokenInDocument: JsonApiApiTokenInDocument, filter?: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiApiTokenOutDocument>>;
     updateEntityAttributeHierarchies(workspaceId: string, objectId: string, jsonApiAttributeHierarchyInDocument: JsonApiAttributeHierarchyInDocument, filter?: string, include?: Array<"userIdentifiers" | "attributes" | "createdBy" | "modifiedBy" | "ALL">, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiAttributeHierarchyOutDocument>>;
     updateEntityColorPalettes(id: string, jsonApiColorPaletteInDocument: JsonApiColorPaletteInDocument, filter?: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiColorPaletteOutDocument>>;
     updateEntityCookieSecurityConfigurations(id: string, jsonApiCookieSecurityConfigurationInDocument: JsonApiCookieSecurityConfigurationInDocument, filter?: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiCookieSecurityConfigurationOutDocument>>;
@@ -5004,7 +5019,6 @@ export interface EntitiesApiInterface {
     patchEntityWorkspaces(requestParameters: EntitiesApiPatchEntityWorkspacesRequest, options?: AxiosRequestConfig): AxiosPromise<JsonApiWorkspaceOutDocument>;
     patchEntityWorkspaceSettings(requestParameters: EntitiesApiPatchEntityWorkspaceSettingsRequest, options?: AxiosRequestConfig): AxiosPromise<JsonApiWorkspaceSettingOutDocument>;
     updateEntityAnalyticalDashboards(requestParameters: EntitiesApiUpdateEntityAnalyticalDashboardsRequest, options?: AxiosRequestConfig): AxiosPromise<JsonApiAnalyticalDashboardOutDocument>;
-    updateEntityApiTokens(requestParameters: EntitiesApiUpdateEntityApiTokensRequest, options?: AxiosRequestConfig): AxiosPromise<JsonApiApiTokenOutDocument>;
     updateEntityAttributeHierarchies(requestParameters: EntitiesApiUpdateEntityAttributeHierarchiesRequest, options?: AxiosRequestConfig): AxiosPromise<JsonApiAttributeHierarchyOutDocument>;
     updateEntityColorPalettes(requestParameters: EntitiesApiUpdateEntityColorPalettesRequest, options?: AxiosRequestConfig): AxiosPromise<JsonApiColorPaletteOutDocument>;
     updateEntityCookieSecurityConfigurations(requestParameters: EntitiesApiUpdateEntityCookieSecurityConfigurationsRequest, options?: AxiosRequestConfig): AxiosPromise<JsonApiCookieSecurityConfigurationOutDocument>;
@@ -5214,14 +5228,6 @@ export interface EntitiesApiUpdateEntityAnalyticalDashboardsRequest {
     readonly jsonApiAnalyticalDashboardInDocument: JsonApiAnalyticalDashboardInDocument;
     readonly objectId: string;
     readonly workspaceId: string;
-}
-
-// @public
-export interface EntitiesApiUpdateEntityApiTokensRequest {
-    readonly filter?: string;
-    readonly id: string;
-    readonly jsonApiApiTokenInDocument: JsonApiApiTokenInDocument;
-    readonly userId: string;
 }
 
 // @public
@@ -5481,6 +5487,7 @@ export const EntitlementsRequestEntitlementsNameEnum: {
     readonly UNLIMITED_WORKSPACES: "UnlimitedWorkspaces";
     readonly WHITE_LABELING: "WhiteLabeling";
     readonly WORKSPACE_COUNT: "WorkspaceCount";
+    readonly USER_TELEMETRY_DISABLED: "UserTelemetryDisabled";
 };
 
 // @public (undocumented)
@@ -6097,7 +6104,7 @@ export const JSON_API_HEADER_VALUE = "application/vnd.gooddata.api+json";
 
 // @public
 export interface JsonApiAnalyticalDashboardIn {
-    attributes?: JsonApiAnalyticalDashboardPatchAttributes;
+    attributes: JsonApiFilterContextOutAttributes;
     id: string;
     type: JsonApiAnalyticalDashboardInTypeEnum;
 }
@@ -6131,7 +6138,7 @@ export type JsonApiAnalyticalDashboardLinkageTypeEnum = typeof JsonApiAnalytical
 
 // @public
 export interface JsonApiAnalyticalDashboardOut {
-    attributes?: JsonApiAnalyticalDashboardOutAttributes;
+    attributes: JsonApiAnalyticalDashboardOutAttributes;
     id: string;
     meta?: JsonApiAnalyticalDashboardOutMeta;
     relationships?: JsonApiAnalyticalDashboardOutRelationships;
@@ -6141,7 +6148,7 @@ export interface JsonApiAnalyticalDashboardOut {
 // @public
 export interface JsonApiAnalyticalDashboardOutAttributes {
     areRelationsValid?: boolean;
-    content?: object;
+    content: object;
     createdAt?: string;
     description?: string;
     modifiedAt?: string;
@@ -6266,7 +6273,7 @@ export type JsonApiAnalyticalDashboardOutTypeEnum = typeof JsonApiAnalyticalDash
 
 // @public
 export interface JsonApiAnalyticalDashboardOutWithLinks {
-    attributes?: JsonApiAnalyticalDashboardOutAttributes;
+    attributes: JsonApiAnalyticalDashboardOutAttributes;
     id: string;
     links?: ObjectLinks;
     meta?: JsonApiAnalyticalDashboardOutMeta;
@@ -6284,7 +6291,7 @@ export type JsonApiAnalyticalDashboardOutWithLinksTypeEnum = typeof JsonApiAnaly
 
 // @public
 export interface JsonApiAnalyticalDashboardPatch {
-    attributes?: JsonApiAnalyticalDashboardPatchAttributes;
+    attributes: JsonApiAnalyticalDashboardPatchAttributes;
     id: string;
     type: JsonApiAnalyticalDashboardPatchTypeEnum;
 }
@@ -6313,7 +6320,7 @@ export type JsonApiAnalyticalDashboardPatchTypeEnum = typeof JsonApiAnalyticalDa
 
 // @public
 export interface JsonApiAnalyticalDashboardPostOptionalId {
-    attributes?: JsonApiAnalyticalDashboardPatchAttributes;
+    attributes: JsonApiFilterContextOutAttributes;
     id?: string;
     type: JsonApiAnalyticalDashboardPostOptionalIdTypeEnum;
 }
@@ -7912,7 +7919,7 @@ export type JsonApiFactOutWithLinksTypeEnum = typeof JsonApiFactOutWithLinksType
 
 // @public
 export interface JsonApiFilterContextIn {
-    attributes?: JsonApiAnalyticalDashboardPatchAttributes;
+    attributes: JsonApiFilterContextOutAttributes;
     id: string;
     type: JsonApiFilterContextInTypeEnum;
 }
@@ -7946,11 +7953,20 @@ export type JsonApiFilterContextLinkageTypeEnum = typeof JsonApiFilterContextLin
 
 // @public
 export interface JsonApiFilterContextOut {
-    attributes?: JsonApiAnalyticalDashboardPatchAttributes;
+    attributes: JsonApiFilterContextOutAttributes;
     id: string;
     meta?: JsonApiAttributeHierarchyOutMeta;
     relationships?: JsonApiFilterContextOutRelationships;
     type: JsonApiFilterContextOutTypeEnum;
+}
+
+// @public
+export interface JsonApiFilterContextOutAttributes {
+    areRelationsValid?: boolean;
+    content: object;
+    description?: string;
+    tags?: Array<string>;
+    title?: string;
 }
 
 // @public
@@ -7987,7 +8003,7 @@ export type JsonApiFilterContextOutTypeEnum = typeof JsonApiFilterContextOutType
 
 // @public
 export interface JsonApiFilterContextOutWithLinks {
-    attributes?: JsonApiAnalyticalDashboardPatchAttributes;
+    attributes: JsonApiFilterContextOutAttributes;
     id: string;
     links?: ObjectLinks;
     meta?: JsonApiAttributeHierarchyOutMeta;
@@ -8005,7 +8021,7 @@ export type JsonApiFilterContextOutWithLinksTypeEnum = typeof JsonApiFilterConte
 
 // @public
 export interface JsonApiFilterContextPatch {
-    attributes?: JsonApiAnalyticalDashboardPatchAttributes;
+    attributes: JsonApiAnalyticalDashboardPatchAttributes;
     id: string;
     type: JsonApiFilterContextPatchTypeEnum;
 }
@@ -8025,7 +8041,7 @@ export type JsonApiFilterContextPatchTypeEnum = typeof JsonApiFilterContextPatch
 
 // @public
 export interface JsonApiFilterContextPostOptionalId {
-    attributes?: JsonApiAnalyticalDashboardPatchAttributes;
+    attributes: JsonApiFilterContextOutAttributes;
     id?: string;
     type: JsonApiFilterContextPostOptionalIdTypeEnum;
 }
@@ -9275,7 +9291,7 @@ export type JsonApiUserToOneLinkage = JsonApiUserLinkage;
 
 // @public
 export interface JsonApiVisualizationObjectIn {
-    attributes?: JsonApiAnalyticalDashboardPatchAttributes;
+    attributes: JsonApiFilterContextOutAttributes;
     id: string;
     type: JsonApiVisualizationObjectInTypeEnum;
 }
@@ -9309,7 +9325,7 @@ export type JsonApiVisualizationObjectLinkageTypeEnum = typeof JsonApiVisualizat
 
 // @public
 export interface JsonApiVisualizationObjectOut {
-    attributes?: JsonApiAnalyticalDashboardOutAttributes;
+    attributes: JsonApiAnalyticalDashboardOutAttributes;
     id: string;
     meta?: JsonApiAttributeHierarchyOutMeta;
     relationships?: JsonApiMetricOutRelationships;
@@ -9340,7 +9356,7 @@ export type JsonApiVisualizationObjectOutTypeEnum = typeof JsonApiVisualizationO
 
 // @public
 export interface JsonApiVisualizationObjectOutWithLinks {
-    attributes?: JsonApiAnalyticalDashboardOutAttributes;
+    attributes: JsonApiAnalyticalDashboardOutAttributes;
     id: string;
     links?: ObjectLinks;
     meta?: JsonApiAttributeHierarchyOutMeta;
@@ -9358,7 +9374,7 @@ export type JsonApiVisualizationObjectOutWithLinksTypeEnum = typeof JsonApiVisua
 
 // @public
 export interface JsonApiVisualizationObjectPatch {
-    attributes?: JsonApiAnalyticalDashboardPatchAttributes;
+    attributes: JsonApiAnalyticalDashboardPatchAttributes;
     id: string;
     type: JsonApiVisualizationObjectPatchTypeEnum;
 }
@@ -9378,7 +9394,7 @@ export type JsonApiVisualizationObjectPatchTypeEnum = typeof JsonApiVisualizatio
 
 // @public
 export interface JsonApiVisualizationObjectPostOptionalId {
-    attributes?: JsonApiAnalyticalDashboardPatchAttributes;
+    attributes: JsonApiFilterContextOutAttributes;
     id?: string;
     type: JsonApiVisualizationObjectPostOptionalIdTypeEnum;
 }
@@ -13090,7 +13106,6 @@ export class UserModelControllerApi extends MetadataBaseApi implements UserModel
     getAllEntitiesUserSettings(requestParameters: UserModelControllerApiGetAllEntitiesUserSettingsRequest, options?: AxiosRequestConfig): Promise<AxiosResponse<JsonApiUserSettingOutList, any>>;
     getEntityApiTokens(requestParameters: UserModelControllerApiGetEntityApiTokensRequest, options?: AxiosRequestConfig): Promise<AxiosResponse<JsonApiApiTokenOutDocument, any>>;
     getEntityUserSettings(requestParameters: UserModelControllerApiGetEntityUserSettingsRequest, options?: AxiosRequestConfig): Promise<AxiosResponse<JsonApiUserSettingOutDocument, any>>;
-    updateEntityApiTokens(requestParameters: UserModelControllerApiUpdateEntityApiTokensRequest, options?: AxiosRequestConfig): Promise<AxiosResponse<JsonApiApiTokenOutDocument, any>>;
     updateEntityUserSettings(requestParameters: UserModelControllerApiUpdateEntityUserSettingsRequest, options?: AxiosRequestConfig): Promise<AxiosResponse<JsonApiUserSettingOutDocument, any>>;
 }
 
@@ -13104,7 +13119,6 @@ export const UserModelControllerApiAxiosParamCreator: (configuration?: MetadataC
     getAllEntitiesUserSettings: (userId: string, filter?: string, page?: number, size?: number, sort?: Array<string>, options?: AxiosRequestConfig) => Promise<MetadataRequestArgs>;
     getEntityApiTokens: (userId: string, id: string, filter?: string, options?: AxiosRequestConfig) => Promise<MetadataRequestArgs>;
     getEntityUserSettings: (userId: string, id: string, filter?: string, options?: AxiosRequestConfig) => Promise<MetadataRequestArgs>;
-    updateEntityApiTokens: (userId: string, id: string, jsonApiApiTokenInDocument: JsonApiApiTokenInDocument, filter?: string, options?: AxiosRequestConfig) => Promise<MetadataRequestArgs>;
     updateEntityUserSettings: (userId: string, id: string, jsonApiUserSettingInDocument: JsonApiUserSettingInDocument, filter?: string, options?: AxiosRequestConfig) => Promise<MetadataRequestArgs>;
 };
 
@@ -13144,7 +13158,6 @@ export const UserModelControllerApiFactory: (configuration?: MetadataConfigurati
     getAllEntitiesUserSettings(requestParameters: UserModelControllerApiGetAllEntitiesUserSettingsRequest, options?: AxiosRequestConfig): AxiosPromise<JsonApiUserSettingOutList>;
     getEntityApiTokens(requestParameters: UserModelControllerApiGetEntityApiTokensRequest, options?: AxiosRequestConfig): AxiosPromise<JsonApiApiTokenOutDocument>;
     getEntityUserSettings(requestParameters: UserModelControllerApiGetEntityUserSettingsRequest, options?: AxiosRequestConfig): AxiosPromise<JsonApiUserSettingOutDocument>;
-    updateEntityApiTokens(requestParameters: UserModelControllerApiUpdateEntityApiTokensRequest, options?: AxiosRequestConfig): AxiosPromise<JsonApiApiTokenOutDocument>;
     updateEntityUserSettings(requestParameters: UserModelControllerApiUpdateEntityUserSettingsRequest, options?: AxiosRequestConfig): AxiosPromise<JsonApiUserSettingOutDocument>;
 };
 
@@ -13158,7 +13171,6 @@ export const UserModelControllerApiFp: (configuration?: MetadataConfiguration) =
     getAllEntitiesUserSettings(userId: string, filter?: string, page?: number, size?: number, sort?: Array<string>, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiUserSettingOutList>>;
     getEntityApiTokens(userId: string, id: string, filter?: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiApiTokenOutDocument>>;
     getEntityUserSettings(userId: string, id: string, filter?: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiUserSettingOutDocument>>;
-    updateEntityApiTokens(userId: string, id: string, jsonApiApiTokenInDocument: JsonApiApiTokenInDocument, filter?: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiApiTokenOutDocument>>;
     updateEntityUserSettings(userId: string, id: string, jsonApiUserSettingInDocument: JsonApiUserSettingInDocument, filter?: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiUserSettingOutDocument>>;
 };
 
@@ -13204,16 +13216,7 @@ export interface UserModelControllerApiInterface {
     getAllEntitiesUserSettings(requestParameters: UserModelControllerApiGetAllEntitiesUserSettingsRequest, options?: AxiosRequestConfig): AxiosPromise<JsonApiUserSettingOutList>;
     getEntityApiTokens(requestParameters: UserModelControllerApiGetEntityApiTokensRequest, options?: AxiosRequestConfig): AxiosPromise<JsonApiApiTokenOutDocument>;
     getEntityUserSettings(requestParameters: UserModelControllerApiGetEntityUserSettingsRequest, options?: AxiosRequestConfig): AxiosPromise<JsonApiUserSettingOutDocument>;
-    updateEntityApiTokens(requestParameters: UserModelControllerApiUpdateEntityApiTokensRequest, options?: AxiosRequestConfig): AxiosPromise<JsonApiApiTokenOutDocument>;
     updateEntityUserSettings(requestParameters: UserModelControllerApiUpdateEntityUserSettingsRequest, options?: AxiosRequestConfig): AxiosPromise<JsonApiUserSettingOutDocument>;
-}
-
-// @public
-export interface UserModelControllerApiUpdateEntityApiTokensRequest {
-    readonly filter?: string;
-    readonly id: string;
-    readonly jsonApiApiTokenInDocument: JsonApiApiTokenInDocument;
-    readonly userId: string;
 }
 
 // @public

--- a/libs/api-client-tiger/src/generated/afm-rest-api/api.ts
+++ b/libs/api-client-tiger/src/generated/afm-rest-api/api.ts
@@ -425,7 +425,6 @@ export const AfmValidObjectsQueryTypesEnum = {
     FACTS: "facts",
     ATTRIBUTES: "attributes",
     MEASURES: "measures",
-    UNRECOGNIZED: "UNRECOGNIZED",
 } as const;
 
 export type AfmValidObjectsQueryTypesEnum =
@@ -771,6 +770,31 @@ export interface DataColumnLocators {
 export type DateFilter = AbsoluteDateFilter | RelativeDateFilter;
 
 /**
+ *
+ * @export
+ * @interface DependsOn
+ */
+export interface DependsOn {
+    /**
+     * Specifies on which label the filter depends on.
+     * @type {string}
+     * @memberof DependsOn
+     */
+    label: string;
+    /**
+     * Specifies values of the label for element filtering.
+     * @type {Array<string>}
+     * @memberof DependsOn
+     */
+    values: Array<string>;
+    /**
+     * Inverse filtering mode.
+     * @type {boolean}
+     * @memberof DependsOn
+     */
+    complementFilter?: boolean;
+}
+/**
  * Single dimension description.
  * @export
  * @interface Dimension
@@ -875,6 +899,12 @@ export interface ElementsRequest {
      * @memberof ElementsRequest
      */
     exactFilter?: Array<string>;
+    /**
+     * Return only items, whose are not filtered out by the parent filters.
+     * @type {Array<DependsOn>}
+     * @memberof ElementsRequest
+     */
+    dependsOn?: Array<DependsOn>;
     /**
      * Specifies percentage of source table data scanned during the computation. This field is deprecated and is no longer used during the elements computation.
      * @type {number}

--- a/libs/api-client-tiger/src/generated/afm-rest-api/openapi-spec.json
+++ b/libs/api-client-tiger/src/generated/afm-rest-api/openapi-spec.json
@@ -595,6 +595,32 @@
                 },
                 "description": "Object identifier."
             },
+            "DependsOn": {
+                "required": ["label", "values"],
+                "type": "object",
+                "properties": {
+                    "label": {
+                        "type": "string",
+                        "description": "Specifies on which label the filter depends on.",
+                        "default": "null"
+                    },
+                    "values": {
+                        "type": "array",
+                        "description": "Specifies values of the label for element filtering.",
+                        "items": {
+                            "type": "string",
+                            "description": "Specifies values of the label for element filtering.",
+                            "default": "null"
+                        }
+                    },
+                    "complementFilter": {
+                        "type": "boolean",
+                        "description": "Inverse filtering mode.",
+                        "default": false
+                    }
+                },
+                "nullable": true
+            },
             "ElementsRequest": {
                 "required": ["label"],
                 "type": "object",
@@ -633,6 +659,13 @@
                         "items": {
                             "type": "string",
                             "nullable": true
+                        }
+                    },
+                    "dependsOn": {
+                        "type": "array",
+                        "description": "Return only items, whose are not filtered out by the parent filters.",
+                        "items": {
+                            "$ref": "#/components/schemas/DependsOn"
                         }
                     },
                     "dataSamplingPercentage": {
@@ -1823,7 +1856,7 @@
                         "items": {
                             "type": "string",
                             "example": "facts",
-                            "enum": ["facts", "attributes", "measures", "UNRECOGNIZED"]
+                            "enum": ["facts", "attributes", "measures"]
                         }
                     },
                     "afm": {

--- a/libs/api-client-tiger/src/generated/metadata-json-api/openapi-spec.json
+++ b/libs/api-client-tiger/src/generated/metadata-json-api/openapi-spec.json
@@ -2817,55 +2817,6 @@
                     }
                 }
             },
-            "put": {
-                "tags": ["API tokens", "entities", "user-model-controller"],
-                "summary": "Put new API token for the user",
-                "operationId": "updateEntity@ApiTokens",
-                "parameters": [
-                    {
-                        "name": "userId",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "$ref": "#/components/parameters/idPathParameter"
-                    },
-                    {
-                        "name": "filter",
-                        "in": "query",
-                        "description": "Filtering parameter in RSQL. See https://github.com/jirutka/rsql-parser. You can specify any object parameter and parameter of related entity (for example title=='Some Title';description=='desc'). Additionally, if the entity relationship represents a polymorphic entity type, it can be casted to its subtypes (for example relatedEntity::subtype.subtypeProperty=='Value 123').",
-                        "schema": {
-                            "type": "string"
-                        },
-                        "example": "filter=bearerToken==someString"
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/vnd.gooddata.api+json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/JsonApiApiTokenInDocument"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "responses": {
-                    "200": {
-                        "description": "Request successfully processed",
-                        "content": {
-                            "application/vnd.gooddata.api+json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/JsonApiApiTokenOutDocument"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
             "delete": {
                 "tags": ["API tokens", "entities", "user-model-controller"],
                 "summary": "Delete an API Token for a user",
@@ -12514,73 +12465,6 @@
                     }
                 ]
             },
-            "JsonApiApiTokenInDocument": {
-                "required": ["data"],
-                "type": "object",
-                "properties": {
-                    "data": {
-                        "$ref": "#/components/schemas/JsonApiApiTokenIn"
-                    }
-                }
-            },
-            "JsonApiApiTokenIn": {
-                "required": ["id", "type"],
-                "type": "object",
-                "properties": {
-                    "type": {
-                        "type": "string",
-                        "description": "Object type",
-                        "example": "apiToken",
-                        "enum": ["apiToken"]
-                    },
-                    "id": {
-                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
-                        "type": "string",
-                        "description": "API identifier of an object",
-                        "example": "id1"
-                    }
-                },
-                "description": "JSON:API representation of apiToken entity."
-            },
-            "JsonApiApiTokenOutDocument": {
-                "required": ["data"],
-                "type": "object",
-                "properties": {
-                    "data": {
-                        "$ref": "#/components/schemas/JsonApiApiTokenOut"
-                    },
-                    "links": {
-                        "$ref": "#/components/schemas/ObjectLinks"
-                    }
-                }
-            },
-            "JsonApiApiTokenOut": {
-                "required": ["id", "type"],
-                "type": "object",
-                "properties": {
-                    "type": {
-                        "type": "string",
-                        "description": "Object type",
-                        "example": "apiToken",
-                        "enum": ["apiToken"]
-                    },
-                    "id": {
-                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
-                        "type": "string",
-                        "description": "API identifier of an object",
-                        "example": "id1"
-                    },
-                    "attributes": {
-                        "type": "object",
-                        "properties": {
-                            "bearerToken": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "description": "JSON:API representation of apiToken entity."
-            },
             "JsonApiUserSettingInDocument": {
                 "required": ["data"],
                 "type": "object",
@@ -13850,7 +13734,7 @@
                 }
             },
             "JsonApiAnalyticalDashboardPatch": {
-                "required": ["id", "type"],
+                "required": ["attributes", "id", "type"],
                 "type": "object",
                 "properties": {
                     "type": {
@@ -13950,7 +13834,7 @@
                 }
             },
             "JsonApiAnalyticalDashboardOut": {
-                "required": ["id", "type"],
+                "required": ["attributes", "id", "type"],
                 "type": "object",
                 "properties": {
                     "type": {
@@ -14004,6 +13888,7 @@
                         }
                     },
                     "attributes": {
+                        "required": ["content"],
                         "type": "object",
                         "properties": {
                             "title": {
@@ -14839,7 +14724,7 @@
                 }
             },
             "JsonApiFilterContextPatch": {
-                "required": ["id", "type"],
+                "required": ["attributes", "id", "type"],
                 "type": "object",
                 "properties": {
                     "type": {
@@ -14924,7 +14809,7 @@
                 }
             },
             "JsonApiFilterContextOut": {
-                "required": ["id", "type"],
+                "required": ["attributes", "id", "type"],
                 "type": "object",
                 "properties": {
                     "type": {
@@ -14960,6 +14845,7 @@
                         }
                     },
                     "attributes": {
+                        "required": ["content"],
                         "type": "object",
                         "properties": {
                             "title": {
@@ -15572,7 +15458,7 @@
                 }
             },
             "JsonApiVisualizationObjectPatch": {
-                "required": ["id", "type"],
+                "required": ["attributes", "id", "type"],
                 "type": "object",
                 "properties": {
                     "type": {
@@ -15644,7 +15530,7 @@
                 }
             },
             "JsonApiVisualizationObjectOut": {
-                "required": ["id", "type"],
+                "required": ["attributes", "id", "type"],
                 "type": "object",
                 "properties": {
                     "type": {
@@ -15680,6 +15566,7 @@
                         }
                     },
                     "attributes": {
+                        "required": ["content"],
                         "type": "object",
                         "properties": {
                             "title": {
@@ -16248,6 +16135,33 @@
                     }
                 },
                 "description": "A JSON:API document with a list of resources"
+            },
+            "JsonApiApiTokenOut": {
+                "required": ["id", "type"],
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "description": "Object type",
+                        "example": "apiToken",
+                        "enum": ["apiToken"]
+                    },
+                    "id": {
+                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
+                        "type": "string",
+                        "description": "API identifier of an object",
+                        "example": "id1"
+                    },
+                    "attributes": {
+                        "type": "object",
+                        "properties": {
+                            "bearerToken": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "description": "JSON:API representation of apiToken entity."
             },
             "JsonApiUserSettingOutWithLinks": {
                 "allOf": [
@@ -17231,6 +17145,18 @@
                     }
                 ]
             },
+            "JsonApiApiTokenOutDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiApiTokenOut"
+                    },
+                    "links": {
+                        "$ref": "#/components/schemas/ObjectLinks"
+                    }
+                }
+            },
             "JsonApiAnalyticalDashboardPostOptionalIdDocument": {
                 "required": ["data"],
                 "type": "object",
@@ -17241,7 +17167,7 @@
                 }
             },
             "JsonApiAnalyticalDashboardPostOptionalId": {
-                "required": ["type"],
+                "required": ["attributes", "type"],
                 "type": "object",
                 "properties": {
                     "type": {
@@ -17257,6 +17183,7 @@
                         "example": "id1"
                     },
                     "attributes": {
+                        "required": ["content"],
                         "type": "object",
                         "properties": {
                             "title": {
@@ -17472,7 +17399,7 @@
                 }
             },
             "JsonApiFilterContextPostOptionalId": {
-                "required": ["type"],
+                "required": ["attributes", "type"],
                 "type": "object",
                 "properties": {
                     "type": {
@@ -17488,6 +17415,7 @@
                         "example": "id1"
                     },
                     "attributes": {
+                        "required": ["content"],
                         "type": "object",
                         "properties": {
                             "title": {
@@ -17676,7 +17604,7 @@
                 }
             },
             "JsonApiVisualizationObjectPostOptionalId": {
-                "required": ["type"],
+                "required": ["attributes", "type"],
                 "type": "object",
                 "properties": {
                     "type": {
@@ -17692,6 +17620,7 @@
                         "example": "id1"
                     },
                     "attributes": {
+                        "required": ["content"],
                         "type": "object",
                         "properties": {
                             "title": {
@@ -17988,6 +17917,34 @@
                     }
                 },
                 "description": "Tables in data source"
+            },
+            "JsonApiApiTokenInDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiApiTokenIn"
+                    }
+                }
+            },
+            "JsonApiApiTokenIn": {
+                "required": ["id", "type"],
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "description": "Object type",
+                        "example": "apiToken",
+                        "enum": ["apiToken"]
+                    },
+                    "id": {
+                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
+                        "type": "string",
+                        "description": "API identifier of an object",
+                        "example": "id1"
+                    }
+                },
+                "description": "JSON:API representation of apiToken entity."
             },
             "JsonApiDataSourceTableOutWithLinks": {
                 "allOf": [
@@ -18535,7 +18492,7 @@
                 }
             },
             "JsonApiAnalyticalDashboardIn": {
-                "required": ["id", "type"],
+                "required": ["attributes", "id", "type"],
                 "type": "object",
                 "properties": {
                     "type": {
@@ -18551,6 +18508,7 @@
                         "example": "id1"
                     },
                     "attributes": {
+                        "required": ["content"],
                         "type": "object",
                         "properties": {
                             "title": {
@@ -18696,7 +18654,7 @@
                 }
             },
             "JsonApiFilterContextIn": {
-                "required": ["id", "type"],
+                "required": ["attributes", "id", "type"],
                 "type": "object",
                 "properties": {
                     "type": {
@@ -18712,6 +18670,7 @@
                         "example": "id1"
                     },
                     "attributes": {
+                        "required": ["content"],
                         "type": "object",
                         "properties": {
                             "title": {
@@ -18900,7 +18859,7 @@
                 }
             },
             "JsonApiVisualizationObjectIn": {
-                "required": ["id", "type"],
+                "required": ["attributes", "id", "type"],
                 "type": "object",
                 "properties": {
                     "type": {
@@ -18916,6 +18875,7 @@
                         "example": "id1"
                     },
                     "attributes": {
+                        "required": ["content"],
                         "type": "object",
                         "properties": {
                             "title": {
@@ -19609,7 +19569,7 @@
                 "description": "A data model structured as a set of its attributes."
             },
             "DeclarativeReference": {
-                "required": ["identifier", "multivalue", "sourceColumns"],
+                "required": ["identifier", "multivalue"],
                 "type": "object",
                 "properties": {
                     "identifier": {
@@ -19622,15 +19582,17 @@
                     },
                     "sourceColumns": {
                         "type": "array",
-                        "description": "An array of source column names for a given reference.",
+                        "description": "An array of source column names for a given reference. Deprecated, use 'sources' instead.",
                         "example": ["customer_id"],
+                        "deprecated": true,
                         "items": {
                             "type": "string"
                         }
                     },
                     "sourceColumnDataTypes": {
                         "type": "array",
-                        "description": "An array of source column data types for a given reference.",
+                        "description": "An array of source column data types for a given reference. Deprecated, use 'sources' instead.",
+                        "deprecated": true,
                         "items": {
                             "type": "string",
                             "enum": [
@@ -19643,9 +19605,39 @@
                                 "BOOLEAN"
                             ]
                         }
+                    },
+                    "sources": {
+                        "type": "array",
+                        "description": "An array of source columns for a given reference.",
+                        "items": {
+                            "$ref": "#/components/schemas/DeclarativeReferenceSource"
+                        }
                     }
                 },
                 "description": "A dataset reference."
+            },
+            "DeclarativeReferenceSource": {
+                "required": ["column", "target"],
+                "type": "object",
+                "properties": {
+                    "column": {
+                        "maxLength": 255,
+                        "type": "string",
+                        "description": "A name of the source column in the table.",
+                        "example": "customer_id"
+                    },
+                    "dataType": {
+                        "maxLength": 255,
+                        "type": "string",
+                        "description": "A type of the source column.",
+                        "example": "STRING",
+                        "enum": ["INT", "STRING", "DATE", "NUMERIC", "TIMESTAMP", "TIMESTAMP_TZ", "BOOLEAN"]
+                    },
+                    "target": {
+                        "$ref": "#/components/schemas/GrainIdentifier"
+                    }
+                },
+                "description": "A dataset reference source column description."
             },
             "DeclarativeWorkspaceDataFilterColumn": {
                 "required": ["dataType", "name"],
@@ -19685,6 +19677,7 @@
                 }
             },
             "GrainIdentifier": {
+                "maxLength": 255,
                 "required": ["id", "type"],
                 "type": "object",
                 "properties": {
@@ -19701,7 +19694,11 @@
                         "enum": ["attribute", "date"]
                     }
                 },
-                "description": "A grain identifier."
+                "description": "A grain identifier.",
+                "example": {
+                    "id": "customer_id",
+                    "type": "attribute"
+                }
             },
             "GranularitiesFormatting": {
                 "required": ["titleBase", "titlePattern"],
@@ -21452,7 +21449,8 @@
                                 "UnlimitedUsers",
                                 "UnlimitedWorkspaces",
                                 "WhiteLabeling",
-                                "WorkspaceCount"
+                                "WorkspaceCount",
+                                "UserTelemetryDisabled"
                             ]
                         }
                     }
@@ -21478,7 +21476,8 @@
                             "UnlimitedUsers",
                             "UnlimitedWorkspaces",
                             "WhiteLabeling",
-                            "WorkspaceCount"
+                            "WorkspaceCount",
+                            "UserTelemetryDisabled"
                         ]
                     },
                     "value": {

--- a/libs/api-client-tiger/src/index.ts
+++ b/libs/api-client-tiger/src/index.ts
@@ -168,6 +168,7 @@ export {
     ActionsApiComputeValidDescendantsRequest,
     AfmValidDescendantsQuery,
     AfmValidDescendantsResponse,
+    DependsOn,
 } from "./generated/afm-rest-api/api.js";
 export {
     ActionsApiFactory as AuthActionsApiFactory,

--- a/libs/sdk-backend-base/src/decoratedBackend/attributes.ts
+++ b/libs/sdk-backend-base/src/decoratedBackend/attributes.ts
@@ -49,4 +49,8 @@ export abstract class DecoratedWorkspaceAttributesService implements IWorkspaceA
     public getAttributeDatasetMeta(ref: ObjRef): Promise<IMetadataObject> {
         return this.decorated.getAttributeDatasetMeta(ref);
     }
+
+    public getConnectedAttributesByDisplayForm(ref: ObjRef): Promise<ObjRef[]> {
+        return this.decorated.getConnectedAttributesByDisplayForm(ref);
+    }
 }

--- a/libs/sdk-backend-base/src/dummyBackend/index.ts
+++ b/libs/sdk-backend-base/src/dummyBackend/index.ts
@@ -918,6 +918,9 @@ class DummyWorkspaceAttributesService implements IWorkspaceAttributesService {
     getAttributeDatasetMeta(_ref: ObjRef): Promise<IMetadataObject> {
         throw new NotSupported("not supported");
     }
+    getConnectedAttributesByDisplayForm(_ref: ObjRef): Promise<ObjRef[]> {
+        throw new NotSupported("Not supported");
+    }
 }
 
 class DummyWorkspaceMeasuresService implements IWorkspaceMeasuresService {

--- a/libs/sdk-backend-bear/src/backend/index.ts
+++ b/libs/sdk-backend-bear/src/backend/index.ts
@@ -91,6 +91,8 @@ const CAPABILITIES: IBackendCapabilities = {
     supportsSeparateLatitudeLongitudeLabels: false,
     supportsEnumeratingDatetimeAttributes: true,
     supportsHiddenAndLockedFiltersOnUI: false,
+    supportsSettingConnectingAttributes: true,
+    supportsKeepingDependentFiltersSelection: false,
 };
 
 /**

--- a/libs/sdk-backend-bear/src/backend/workspace/attributes/elements/limitingAfmFactory.ts
+++ b/libs/sdk-backend-bear/src/backend/workspace/attributes/elements/limitingAfmFactory.ts
@@ -105,7 +105,9 @@ export class LimitingAfmFactory {
 
         const attributeRefUri = getDisplayFormAttributeUri(this.displayFormRef);
 
-        const groupsByOverAttribute = groupBy(filters, (filter) => getUriForIdentifier(filter.overAttribute));
+        const groupsByOverAttribute = groupBy(filters, (filter) =>
+            getUriForIdentifier(filter.overAttribute!),
+        );
 
         const expressionsByOverAttribute = Object.keys(groupsByOverAttribute).map((overAttribute) => {
             const filterGroupExpression = groupsByOverAttribute[overAttribute]

--- a/libs/sdk-backend-bear/src/backend/workspace/attributes/elements/limitingAfmFactory.ts
+++ b/libs/sdk-backend-bear/src/backend/workspace/attributes/elements/limitingAfmFactory.ts
@@ -105,9 +105,7 @@ export class LimitingAfmFactory {
 
         const attributeRefUri = getDisplayFormAttributeUri(this.displayFormRef);
 
-        const groupsByOverAttribute = groupBy(filters, (filter) =>
-            getUriForIdentifier(filter.overAttribute!),
-        );
+        const groupsByOverAttribute = groupBy(filters, (filter) => getUriForIdentifier(filter.overAttribute));
 
         const expressionsByOverAttribute = Object.keys(groupsByOverAttribute).map((overAttribute) => {
             const filterGroupExpression = groupsByOverAttribute[overAttribute]

--- a/libs/sdk-backend-bear/src/backend/workspace/attributes/index.ts
+++ b/libs/sdk-backend-bear/src/backend/workspace/attributes/index.ts
@@ -21,6 +21,7 @@ import { BearWorkspaceElements } from "./elements/index.js";
 import {
     IElementsQueryFactory,
     IWorkspaceAttributesService,
+    NotSupported,
     UnexpectedError,
 } from "@gooddata/sdk-backend-spi";
 import {
@@ -185,5 +186,9 @@ export class BearWorkspaceAttributes implements IWorkspaceAttributesService {
 
             return convertMetadataObjectXrefEntry("dataSet", usedBy.entries[0]);
         });
+    }
+
+    public async getConnectedAttributesByDisplayForm(_ref: ObjRef): Promise<ObjRef[]> {
+        throw new NotSupported("Not supported");
     }
 }

--- a/libs/sdk-backend-bear/src/backend/workspace/dashboards/filterContexts.ts
+++ b/libs/sdk-backend-bear/src/backend/workspace/dashboards/filterContexts.ts
@@ -35,7 +35,7 @@ export async function sanitizeFilterContext<T extends IFilterContextDefinition>(
             const ref = getDashboardFilterRef(filter);
 
             const overRefs = isDashboardAttributeFilter(filter)
-                ? flatMap(filter.attributeFilter.filterElementsBy ?? [], (item) => item.over.attributes)
+                ? flatMap(filter.attributeFilter.filterElementsBy ?? [], (item) => item.over!.attributes)
                 : [];
 
             return [ref, ...overRefs];
@@ -66,7 +66,7 @@ export async function sanitizeFilterContext<T extends IFilterContextDefinition>(
                     ...item,
                     over: {
                         ...item.over,
-                        attributes: item.over.attributes.map((attrRef) => {
+                        attributes: item.over!.attributes.map((attrRef) => {
                             // we can use referential comparison here, the objects are the same
                             const attrMatch = refUriPairs.find(([ref]) => ref === attrRef);
 

--- a/libs/sdk-backend-bear/src/convertors/toBackend/DashboardConverter.ts
+++ b/libs/sdk-backend-bear/src/convertors/toBackend/DashboardConverter.ts
@@ -251,7 +251,7 @@ export const convertFilterContextItem = (
         return {
             filterLocalIdentifier: filterElementsByItem.filterLocalIdentifier,
             over: {
-                attributes: filterElementsByItem.over.attributes.map(refToUri),
+                attributes: filterElementsByItem.over!.attributes.map(refToUri),
             },
         };
     });

--- a/libs/sdk-backend-mockingbird/src/recordedBackend/attributes.ts
+++ b/libs/sdk-backend-mockingbird/src/recordedBackend/attributes.ts
@@ -142,4 +142,8 @@ export class RecordedAttributes implements IWorkspaceAttributesService {
 
         return obj.id === ref.identifier;
     }
+
+    public getConnectedAttributesByDisplayForm(_ref: ObjRef): Promise<ObjRef[]> {
+        throw new NotSupported("Not supported");
+    }
 }

--- a/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
+++ b/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
@@ -342,7 +342,7 @@ export interface IElementsQueryAttributeFilter {
     // (undocumented)
     attributeFilter: IAttributeFilter;
     // (undocumented)
-    overAttribute?: ObjRef;
+    overAttribute: ObjRef;
 }
 
 // @public

--- a/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
+++ b/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
@@ -251,6 +251,7 @@ export interface IBackendCapabilities {
     supportsHierarchicalWorkspaces?: boolean;
     supportsHyperlinkAttributeLabels?: boolean;
     supportsInlineMeasures?: boolean;
+    supportsKeepingDependentFiltersSelection?: boolean;
     supportsKpiWidget?: boolean;
     supportsMetadataObjectLocking?: boolean;
     supportsNonProductionDatasets?: boolean;
@@ -260,6 +261,7 @@ export interface IBackendCapabilities {
     supportsRankingFilter?: boolean;
     supportsRankingFilterWithMeasureValueFilter?: boolean;
     supportsSeparateLatitudeLongitudeLabels?: boolean;
+    supportsSettingConnectingAttributes?: boolean;
     supportsShowAllAttributeValues?: boolean;
     supportsTimeGranularities?: boolean;
     supportsWidgetEntity?: boolean;
@@ -340,7 +342,7 @@ export interface IElementsQueryAttributeFilter {
     // (undocumented)
     attributeFilter: IAttributeFilter;
     // (undocumented)
-    overAttribute: ObjRef;
+    overAttribute?: ObjRef;
 }
 
 // @public
@@ -723,6 +725,7 @@ export interface IWorkspaceAttributesService {
     getAttributes(refs: ObjRef[]): Promise<IAttributeMetadataObject[]>;
     getCommonAttributes(attributeRefs: ObjRef[]): Promise<ObjRef[]>;
     getCommonAttributesBatch(attributesRefsBatch: ObjRef[][]): Promise<ObjRef[][]>;
+    getConnectedAttributesByDisplayForm(ref: ObjRef): Promise<ObjRef[]>;
 }
 
 // @public

--- a/libs/sdk-backend-spi/src/backend/capabilities.ts
+++ b/libs/sdk-backend-spi/src/backend/capabilities.ts
@@ -231,6 +231,16 @@ export interface IBackendCapabilities {
     supportsHiddenAndLockedFiltersOnUI?: boolean;
 
     /**
+     * Indicates whether backend supports setting connecting attribute in dependent filters.
+     */
+    supportsSettingConnectingAttributes?: boolean;
+
+    /**
+     * Indicates whether backend supports to keep selection of dependent filters.
+     */
+    supportsKeepingDependentFiltersSelection?: boolean;
+
+    /**
      * Catchall for additional capabilities
      */
     [key: string]: undefined | boolean | number | string;

--- a/libs/sdk-backend-spi/src/workspace/attributes/elements/index.ts
+++ b/libs/sdk-backend-spi/src/workspace/attributes/elements/index.ts
@@ -168,7 +168,7 @@ export interface IElementsQueryOptions {
 
 export interface IElementsQueryAttributeFilter {
     attributeFilter: IAttributeFilter;
-    overAttribute?: ObjRef;
+    overAttribute: ObjRef;
 }
 
 /**

--- a/libs/sdk-backend-spi/src/workspace/attributes/elements/index.ts
+++ b/libs/sdk-backend-spi/src/workspace/attributes/elements/index.ts
@@ -157,14 +157,18 @@ export interface IElementsQueryOptions {
  * and the filter attribute must be connected in the data model. The property `overAttribute` identifies
  * the connecting table in the logical data model.
  *
+ * Not all backends support overAttribute prop.
+ *
  * For method providing all possible connecting attributes see {@link IWorkspaceAttributesService.getCommonAttributes}.
+ * For method providing whether attributes have some connection in model
+ * see {@link IWorkspaceAttributesService.getConnectedAttributesByDisplayForm}.
  *
  * @public
  */
 
 export interface IElementsQueryAttributeFilter {
     attributeFilter: IAttributeFilter;
-    overAttribute: ObjRef;
+    overAttribute?: ObjRef;
 }
 
 /**

--- a/libs/sdk-backend-spi/src/workspace/attributes/index.ts
+++ b/libs/sdk-backend-spi/src/workspace/attributes/index.ts
@@ -96,4 +96,12 @@ export interface IWorkspaceAttributesService {
      * @returns promise of metadata object
      */
     getAttributeDatasetMeta(ref: ObjRef): Promise<IMetadataObject>;
+
+    /**
+     * Request list of attributes that have a connection with specified display form in the data model.
+     *
+     * @param ref - attribute display form reference whose connections we need to find
+     * @returns promise of array of connected attribute references
+     */
+    getConnectedAttributesByDisplayForm(ref: ObjRef): Promise<ObjRef[]>;
 }

--- a/libs/sdk-backend-tiger/src/backend/features/feature.ts
+++ b/libs/sdk-backend-tiger/src/backend/features/feature.ts
@@ -184,6 +184,13 @@ export function mapFeatures(features: FeaturesMap): Partial<ITigerFeatureFlags> 
             "BOOLEAN",
             FeatureFlagsValues.enableUserManagement,
         ),
+        ...loadFeature(
+            features,
+            TigerFeaturesNames.EnableKDDependentFilters,
+            "enableKDDependentFilters",
+            "BOOLEAN",
+            FeatureFlagsValues.enableKDDependentFilters,
+        ),
     };
 }
 

--- a/libs/sdk-backend-tiger/src/backend/index.ts
+++ b/libs/sdk-backend-tiger/src/backend/index.ts
@@ -88,6 +88,8 @@ const CAPABILITIES: IBackendCapabilities = {
     supportsSeparateLatitudeLongitudeLabels: true,
     supportsEnumeratingDatetimeAttributes: false,
     supportsHiddenAndLockedFiltersOnUI: true,
+    supportsSettingConnectingAttributes: false,
+    supportsKeepingDependentFiltersSelection: true,
 };
 
 /**

--- a/libs/sdk-backend-tiger/src/backend/index.ts
+++ b/libs/sdk-backend-tiger/src/backend/index.ts
@@ -64,7 +64,7 @@ const CAPABILITIES: IBackendCapabilities = {
     supportsCsvUploader: false,
     supportsRankingFilter: true,
     supportsRankingFilterWithMeasureValueFilter: false,
-    supportsElementsQueryParentFiltering: false,
+    supportsElementsQueryParentFiltering: true,
     supportsKpiWidget: false,
     supportsWidgetEntity: false,
     supportsHyperlinkAttributeLabels: true,

--- a/libs/sdk-backend-tiger/src/backend/uiFeatures.ts
+++ b/libs/sdk-backend-tiger/src/backend/uiFeatures.ts
@@ -55,6 +55,8 @@ export enum TigerFeaturesNames {
     EnablePivotTableIncreaseBucketSize = "enablePivotTableIncreaseBucketSize",
     // boolean + possible values: enabled, disabled
     EnableUserManagement = "enableUserManagement",
+    //boolean + possible values: enabled, disabled
+    EnableKDDependentFilters = "enableKDDependentFilters",
 }
 
 export type ITigerFeatureFlags = {
@@ -82,6 +84,7 @@ export type ITigerFeatureFlags = {
     enableUnavailableItemsVisible: typeof FeatureFlagsValues["enableUnavailableItemsVisible"][number];
     enablePivotTableIncreaseBucketSize: typeof FeatureFlagsValues["enablePivotTableIncreaseBucketSize"][number];
     enableUserManagement: typeof FeatureFlagsValues["enableUserManagement"][number];
+    enableKDDependentFilters: typeof FeatureFlagsValues["enableKDDependentFilters"][number];
 };
 
 export const DefaultFeatureFlags: ITigerFeatureFlags = {
@@ -109,6 +112,7 @@ export const DefaultFeatureFlags: ITigerFeatureFlags = {
     enableUnavailableItemsVisible: false,
     enablePivotTableIncreaseBucketSize: true,
     enableUserManagement: false,
+    enableKDDependentFilters: false,
 };
 
 export const FeatureFlagsValues = {
@@ -140,4 +144,5 @@ export const FeatureFlagsValues = {
     enableUnavailableItemsVisible: [true, false] as const,
     enablePivotTableIncreaseBucketSize: [true, false] as const,
     enableUserManagement: [true, false] as const,
+    enableKDDependentFilters: [true, false] as const,
 };

--- a/libs/sdk-backend-tiger/src/backend/workspace/catalog/availableItemsFactory.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/catalog/availableItemsFactory.ts
@@ -33,6 +33,7 @@ import { convertAttribute } from "../../../convertors/toBackend/afm/AttributeCon
 import { jsonApiIdToObjRef } from "../../../convertors/fromBackend/ObjRefConverter.js";
 import { InvariantError } from "ts-invariant";
 import { convertAfmFilters } from "../../../convertors/toBackend/afm/AfmFiltersConverter.js";
+import compact from "lodash/compact.js";
 
 const typesMatching: Partial<{ [T in CatalogItemType]: AfmValidObjectsQueryTypesEnum }> = {
     attribute: AfmValidObjectsQueryTypesEnum.ATTRIBUTES,
@@ -41,8 +42,8 @@ const typesMatching: Partial<{ [T in CatalogItemType]: AfmValidObjectsQueryTypes
     // dateDatasets are not supported by tiger in this context
 };
 
-const mapToTigerType = (type: CatalogItemType): AfmValidObjectsQueryTypesEnum => {
-    return typesMatching[type] ?? AfmValidObjectsQueryTypesEnum.UNRECOGNIZED;
+const mapToTigerType = (type: CatalogItemType): AfmValidObjectsQueryTypesEnum | undefined => {
+    return typesMatching[type];
 };
 
 /**
@@ -155,7 +156,7 @@ export class TigerWorkspaceCatalogAvailableItemsFactory implements IWorkspaceCat
         const { filters: afmFilters, auxMeasures } = convertAfmFilters(measures, filters);
 
         const afmValidObjectsQuery: AfmValidObjectsQuery = {
-            types: relevantRestrictingTypes.map(mapToTigerType),
+            types: compact(relevantRestrictingTypes.map(mapToTigerType)),
             afm: {
                 attributes: attributes.map(convertAttribute),
                 measures: measures.map(convertMeasure),

--- a/libs/sdk-backend-tiger/src/convertors/fromBackend/analyticalDashboards/AnalyticalDashboardConverter.ts
+++ b/libs/sdk-backend-tiger/src/convertors/fromBackend/analyticalDashboards/AnalyticalDashboardConverter.ts
@@ -43,7 +43,7 @@ export const convertAnalyticalDashboard = (
     analyticalDashboard: JsonApiAnalyticalDashboardOutWithLinks,
     included?: JsonApiAnalyticalDashboardOutIncludes[],
 ): IListedDashboard => {
-    const { id, links, attributes = {}, meta, relationships = {} } = analyticalDashboard;
+    const { id, links, attributes, meta, relationships = {} } = analyticalDashboard;
     const { createdBy, modifiedBy } = relationships;
     const { createdAt, modifiedAt } = attributes;
     const isPrivate = meta?.accessInfo?.private ?? false;

--- a/libs/sdk-backend-tiger/src/convertors/fromBackend/analyticalDashboards/v1/AnalyticalDashboardConverter.ts
+++ b/libs/sdk-backend-tiger/src/convertors/fromBackend/analyticalDashboards/v1/AnalyticalDashboardConverter.ts
@@ -73,7 +73,7 @@ export function convertDashboard(
     filterContext?: IFilterContext,
 ): IDashboard {
     const { data, links, included } = analyticalDashboard;
-    const { id, attributes = {}, meta = {}, relationships = {} } = data;
+    const { id, attributes, meta = {}, relationships = {} } = data;
     const { createdBy, modifiedBy } = relationships;
     const { title = "", description = "", content, createdAt = "", modifiedAt = "" } = attributes;
     const isPrivate = meta.accessInfo?.private ?? false;

--- a/libs/sdk-backend-tiger/src/convertors/fromBackend/analyticalDashboards/v2/AnalyticalDashboardConverter.ts
+++ b/libs/sdk-backend-tiger/src/convertors/fromBackend/analyticalDashboards/v2/AnalyticalDashboardConverter.ts
@@ -94,7 +94,7 @@ export function convertDashboard(
     filterContext?: IFilterContext,
 ): IDashboard {
     const { data, links, included } = analyticalDashboard;
-    const { id, attributes = {}, meta = {}, relationships = {} } = data;
+    const { id, attributes, meta = {}, relationships = {} } = data;
     const { createdBy, modifiedBy } = relationships;
     const { title = "", description = "", content, createdAt = "", modifiedAt = "" } = attributes;
     const isPrivate = meta.accessInfo?.private ?? false;

--- a/libs/sdk-model/api/sdk-model.api.md
+++ b/libs/sdk-model/api/sdk-model.api.md
@@ -2313,6 +2313,7 @@ export interface ISettings {
     enableHidingOfWidgetTitle?: boolean;
     enableInsightExportScheduling?: boolean;
     enableInsightToReport?: boolean;
+    enableKDDependentFilters?: boolean;
     enableKDWidgetCustomHeight?: boolean;
     enableKDZooming?: boolean;
     enableKPIDashboardDrillFromAttribute?: boolean;

--- a/libs/sdk-model/api/sdk-model.api.md
+++ b/libs/sdk-model/api/sdk-model.api.md
@@ -868,7 +868,7 @@ export interface IDashboardAttributeFilterConfig {
 // @beta
 export interface IDashboardAttributeFilterParent {
     filterLocalIdentifier: string;
-    over: {
+    over?: {
         attributes: ObjRef[];
     };
 }

--- a/libs/sdk-model/api/sdk-model.api.md
+++ b/libs/sdk-model/api/sdk-model.api.md
@@ -1245,7 +1245,7 @@ export interface IEntitlementDescriptor {
 }
 
 // @public
-export type IEntitlementsName = "CacheStrategy" | "Contract" | "CustomTheming" | "ExtraCache" | "ManagedOIDC" | "UiLocalization" | "Tier" | "UserCount" | "PdfExports" | "UnlimitedUsers" | "UnlimitedWorkspaces" | "WhiteLabeling" | "WorkspaceCount" | "Hipaa";
+export type IEntitlementsName = "CacheStrategy" | "Contract" | "CustomTheming" | "ExtraCache" | "ManagedOIDC" | "UiLocalization" | "Tier" | "UserCount" | "PdfExports" | "UnlimitedUsers" | "UnlimitedWorkspaces" | "WhiteLabeling" | "WorkspaceCount" | "Hipaa" | "UserTelemetryDisabled";
 
 // @public
 export interface IExecutionConfig {

--- a/libs/sdk-model/src/dashboard/filterContext.ts
+++ b/libs/sdk-model/src/dashboard/filterContext.ts
@@ -36,7 +36,7 @@ export interface IDashboardAttributeFilterParent {
     /**
      * Specification of the connection point(s) between the parent and child filter in the data model
      */
-    over: {
+    over?: {
         attributes: ObjRef[];
     };
 }

--- a/libs/sdk-model/src/entitlements/index.ts
+++ b/libs/sdk-model/src/entitlements/index.ts
@@ -19,7 +19,8 @@ export type IEntitlementsName =
     | "UnlimitedWorkspaces"
     | "WhiteLabeling"
     | "WorkspaceCount"
-    | "Hipaa";
+    | "Hipaa"
+    | "UserTelemetryDisabled";
 
 /**
  * Entitlement descriptor

--- a/libs/sdk-model/src/settings/index.ts
+++ b/libs/sdk-model/src/settings/index.ts
@@ -314,6 +314,11 @@ export interface ISettings {
      */
     enableUserManagement?: boolean;
 
+    /**
+     * Enable new dependent filters in KD
+     */
+    enableKDDependentFilters?: boolean;
+
     [key: string]: number | boolean | string | object | undefined;
 }
 

--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -2179,7 +2179,7 @@ export abstract class DashboardPluginV1 implements IDashboardPluginContract_V1 {
 }
 
 // @alpha (undocumented)
-export type DashboardQueries = QueryInsightDateDatasets | QueryMeasureDateDatasets | QueryInsightAttributesMeta | QueryWidgetFilters | QueryWidgetBrokenAlerts | QueryWidgetAlertCount | QueryConnectingAttributes | QueryAttributeByDisplayForm | QueryAttributeDataSet | QueryAttributeElements;
+export type DashboardQueries = QueryInsightDateDatasets | QueryMeasureDateDatasets | QueryInsightAttributesMeta | QueryWidgetFilters | QueryWidgetBrokenAlerts | QueryWidgetAlertCount | QueryConnectingAttributes | QueryAttributeByDisplayForm | QueryAttributeDataSet | QueryAttributeElements | QueryConnectedAttributes;
 
 // @beta
 export interface DashboardQueryCompleted<TQuery extends IDashboardQuery, TResult> extends IDashboardEvent {
@@ -2230,7 +2230,7 @@ export interface DashboardQueryStartedPayload {
 }
 
 // @beta (undocumented)
-export type DashboardQueryType = "GDC.DASH/QUERY.INSIGHT.DATE.DATASETS" | "GDC.DASH/QUERY.INSIGHT.ATTRIBUTE.META" | "GDC.DASH/QUERY.MEASURE.DATE.DATASETS" | "GDC.DASH/QUERY.WIDGET.FILTERS" | "GDC.DASH/QUERY.WIDGET.BROKEN_ALERTS" | "GDC.DASH/QUERY.WIDGET.ALERT_COUNT" | "GDC.DASH/QUERY.CONNECTING.ATTRIBUTES" | "GDC.DASH/QUERY.DISPLAY.FORM.ATTRIBUTE" | "GDC.DASH/QUERY.DATA.SET.ATTRIBUTE" | "GDC.DASH/QUERY.ELEMENTS.ATTRIBUTE";
+export type DashboardQueryType = "GDC.DASH/QUERY.INSIGHT.DATE.DATASETS" | "GDC.DASH/QUERY.INSIGHT.ATTRIBUTE.META" | "GDC.DASH/QUERY.MEASURE.DATE.DATASETS" | "GDC.DASH/QUERY.WIDGET.FILTERS" | "GDC.DASH/QUERY.WIDGET.BROKEN_ALERTS" | "GDC.DASH/QUERY.WIDGET.ALERT_COUNT" | "GDC.DASH/QUERY.CONNECTING.ATTRIBUTES" | "GDC.DASH/QUERY.DISPLAY.FORM.ATTRIBUTE" | "GDC.DASH/QUERY.DATA.SET.ATTRIBUTE" | "GDC.DASH/QUERY.ELEMENTS.ATTRIBUTE" | "GDC.DASH/QUERY.CONNECTED.ATTRIBUTES";
 
 // @beta
 export interface DashboardRenamed extends IDashboardEvent {
@@ -5285,6 +5285,19 @@ export type QueryCacheEntryResult<TResult> = {
 export type QueryCacheReducer<TQuery extends IDashboardQuery, TResult, TPayload> = CaseReducer<EntityState<QueryCacheEntry<TQuery, TResult>>, PayloadAction<TPayload>>;
 
 // @alpha (undocumented)
+export interface QueryConnectedAttributes extends IDashboardQuery {
+    // (undocumented)
+    payload: {
+        readonly ref: ObjRef;
+    };
+    // (undocumented)
+    type: "GDC.DASH/QUERY.CONNECTED.ATTRIBUTES";
+}
+
+// @alpha
+export function queryConnectedAttributes(ref: ObjRef, correlationId?: string): QueryConnectedAttributes;
+
+// @alpha (undocumented)
 export interface QueryConnectingAttributes extends IDashboardQuery {
     // (undocumented)
     payload: {
@@ -6508,10 +6521,16 @@ export const selectSupportsElementUris: DashboardSelector<boolean>;
 export const selectSupportsHierarchicalWorkspacesCapability: DashboardSelector<boolean>;
 
 // @internal
+export const selectSupportsKeepingDependentFiltersSelection: DashboardSelector<boolean>;
+
+// @internal
 export const selectSupportsKpiWidgetCapability: DashboardSelector<boolean>;
 
 // @internal
 export const selectSupportsObjectUris: DashboardSelector<boolean>;
+
+// @internal
+export const selectSupportsSettingConnectingAttributes: DashboardSelector<boolean>;
 
 // @internal (undocumented)
 export const selectValidConfiguredDrillsByWidgetRef: (ref: ObjRef) => DashboardSelector<IImplicitDrillWithPredicates[]>;

--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -6162,6 +6162,9 @@ export const selectEnableFilterValuesResolutionInDrillEvents: DashboardSelector<
 // @public
 export const selectEnableInsightExportScheduling: DashboardSelector<boolean>;
 
+// @internal
+export const selectEnableKDDependentFilters: DashboardSelector<boolean>;
+
 // @public
 export const selectEnableKPIDashboardDrillFromAttribute: DashboardSelector<boolean>;
 
@@ -6356,6 +6359,9 @@ export const selectIsInEditMode: DashboardSelector<boolean>;
 
 // @internal (undocumented)
 export const selectIsInViewMode: DashboardSelector<boolean>;
+
+// @internal
+export const selectIsKDDependentFiltersEnabled: DashboardSelector<boolean>;
 
 // @alpha (undocumented)
 export const selectIsKpiAlertHighlightedByWidgetRef: (ref: ObjRef | undefined) => (state: DashboardState) => boolean;

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/filterContext/attributeFilter/changeAttributeFilterSelectionHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/filterContext/attributeFilter/changeAttributeFilterSelectionHandler.ts
@@ -42,23 +42,25 @@ export function* changeAttributeFilterSelectionHandler(
 
     invariant(changedFilter, "Inconsistent state in attributeFilterChangeSelectionCommandHandler");
 
-    const childFiltersIds: ReturnType<ReturnType<typeof selectAttributeFilterDescendants>> = yield select(
-        selectAttributeFilterDescendants(changedFilter.attributeFilter.localIdentifier!),
-    );
+    if (!ctx.backend.capabilities.supportsKeepingDependentFiltersSelection) {
+        const childFiltersIds: ReturnType<ReturnType<typeof selectAttributeFilterDescendants>> = yield select(
+            selectAttributeFilterDescendants(changedFilter.attributeFilter.localIdentifier!),
+        );
 
-    yield all(
-        childFiltersIds.map((childFilterId) =>
-            put(
-                filterContextActions.updateAttributeFilterSelection({
-                    filterLocalId: childFilterId,
-                    elements: {
-                        uris: [],
-                    },
-                    negativeSelection: true,
-                }),
+        yield all(
+            childFiltersIds.map((childFilterId) =>
+                put(
+                    filterContextActions.updateAttributeFilterSelection({
+                        filterLocalId: childFilterId,
+                        elements: {
+                            uris: [],
+                        },
+                        negativeSelection: true,
+                    }),
+                ),
             ),
-        ),
-    );
+        );
+    }
 
     yield dispatchDashboardEvent(attributeFilterSelectionChanged(ctx, changedFilter, cmd.correlationId));
     yield call(dispatchFilterContextChanged, ctx, cmd);

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/filterContext/attributeFilter/tests/changeAttributeFilterSelectionHandler.test.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/filterContext/attributeFilter/tests/changeAttributeFilterSelectionHandler.test.ts
@@ -1,6 +1,6 @@
 // (C) 2021-2022 GoodData Corporation
 import { beforeEach, describe, it, expect } from "vitest";
-import { changeAttributeFilterSelection } from "../../../../commands/index.js";
+import { changeAttributeFilterSelection, setAttributeFilterParents } from "../../../../commands/index.js";
 import { DashboardTester, preloadedTesterFactory } from "../../../../tests/DashboardTester.js";
 import { selectFilterContextAttributeFilters } from "../../../../store/filterContext/filterContextSelectors.js";
 import { SimpleDashboardIdentifier } from "../../../../tests/fixtures/SimpleDashboard.fixtures.js";
@@ -85,5 +85,103 @@ describe("changeAttributeFilterSelectionHandler.test", () => {
         await Tester.waitFor("GDC.DASH/EVT.COMMAND.FAILED");
 
         expect(selectFilterContextAttributeFilters(Tester.state())).toEqual(originalFilters);
+    });
+
+    describe("with dependent filters set up", () => {
+        it("should reset child filter selection on parent change when backend DOES NOT support keeping dependent filters selection", async () => {
+            await preloadedTesterFactory(
+                (tester) => {
+                    Tester = tester;
+                },
+                SimpleDashboardIdentifier,
+                { customCapabilities: { supportsKeepingDependentFiltersSelection: false } },
+            );
+
+            const firstFilterLocalId = selectFilterContextAttributeFilters(Tester.state())[0].attributeFilter
+                .localIdentifier!;
+            const secondFilterLocalId = selectFilterContextAttributeFilters(Tester.state())[1].attributeFilter
+                .localIdentifier!;
+
+            Tester.dispatch(
+                changeAttributeFilterSelection(
+                    secondFilterLocalId,
+                    { uris: ["testing/uri1", "testing/uri2"] },
+                    "IN",
+                    TestCorrelation,
+                ),
+            );
+
+            Tester.dispatch(
+                setAttributeFilterParents(secondFilterLocalId, [
+                    { filterLocalIdentifier: firstFilterLocalId },
+                ]),
+            );
+
+            Tester.dispatch(
+                changeAttributeFilterSelection(
+                    firstFilterLocalId,
+                    { uris: ["testing/uri"] },
+                    "NOT_IN",
+                    TestCorrelation,
+                ),
+            );
+
+            await Tester.waitFor("GDC.DASH/EVT.FILTER_CONTEXT.CHANGED");
+
+            expect(
+                selectFilterContextAttributeFilters(Tester.state())[0].attributeFilter.attributeElements,
+            ).toEqual({ uris: ["testing/uri"] });
+            expect(
+                selectFilterContextAttributeFilters(Tester.state())[1].attributeFilter.attributeElements,
+            ).toEqual({ uris: [] });
+        });
+
+        it("should NOT reset child filter selection on parent change when backend DOES support keeping dependent filters selection", async () => {
+            await preloadedTesterFactory(
+                (tester) => {
+                    Tester = tester;
+                },
+                SimpleDashboardIdentifier,
+                { customCapabilities: { supportsKeepingDependentFiltersSelection: true } },
+            );
+
+            const firstFilterLocalId = selectFilterContextAttributeFilters(Tester.state())[0].attributeFilter
+                .localIdentifier!;
+            const secondFilterLocalId = selectFilterContextAttributeFilters(Tester.state())[1].attributeFilter
+                .localIdentifier!;
+
+            Tester.dispatch(
+                changeAttributeFilterSelection(
+                    secondFilterLocalId,
+                    { uris: ["testing/uri1", "testing/uri2"] },
+                    "IN",
+                    TestCorrelation,
+                ),
+            );
+
+            Tester.dispatch(
+                setAttributeFilterParents(secondFilterLocalId, [
+                    { filterLocalIdentifier: firstFilterLocalId },
+                ]),
+            );
+
+            Tester.dispatch(
+                changeAttributeFilterSelection(
+                    firstFilterLocalId,
+                    { uris: ["testing/uri"] },
+                    "NOT_IN",
+                    TestCorrelation,
+                ),
+            );
+
+            await Tester.waitFor("GDC.DASH/EVT.FILTER_CONTEXT.CHANGED");
+
+            expect(
+                selectFilterContextAttributeFilters(Tester.state())[0].attributeFilter.attributeElements,
+            ).toEqual({ uris: ["testing/uri"] });
+            expect(
+                selectFilterContextAttributeFilters(Tester.state())[1].attributeFilter.attributeElements,
+            ).toEqual({ uris: ["testing/uri1", "testing/uri2"] });
+        });
     });
 });

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/filterContext/attributeFilter/validation/tests/parentFiltersValidation.test.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/filterContext/attributeFilter/validation/tests/parentFiltersValidation.test.ts
@@ -95,11 +95,15 @@ describe("validateAttributeFilterParents", () => {
 
     it("should reject when there are parents that are NOT valid as ancestors", async () => {
         const ctx: DashboardContext = {
-            backend: recordedBackend(ReferenceRecordings.Recordings, {
-                getCommonAttributesResponses: {
-                    [objRefsToStringKey([idRef("df1"), idRef("df2")])]: [idRef("parent")],
+            backend: recordedBackend(
+                ReferenceRecordings.Recordings,
+                {
+                    getCommonAttributesResponses: {
+                        [objRefsToStringKey([idRef("df1"), idRef("df2")])]: [idRef("parent")],
+                    },
                 },
-            }),
+                { supportsSettingConnectingAttributes: true },
+            ),
             dashboardRef: idRef(SimpleDashboardIdentifier),
             workspace: "referenceworkspace",
         };
@@ -117,6 +121,37 @@ describe("validateAttributeFilterParents", () => {
         const allFilters = [getAttributeFilter("df1"), getAttributeFilter("df2")];
 
         const expected: AttributeFilterParentsValidationResult = "INVALID_CONNECTION";
+        const actual = await validateAttributeFilterParents(
+            ctx,
+            changingFilter,
+            parents,
+            allFilters,
+            getDisplayFormsMap(),
+        );
+        expect(actual).toBe(expected);
+    });
+
+    it("should allow when backend does not support setting connecting attributes", async () => {
+        const ctx: DashboardContext = {
+            backend: recordedBackend(
+                ReferenceRecordings.Recordings,
+                {},
+                { supportsSettingConnectingAttributes: false },
+            ),
+            dashboardRef: idRef(SimpleDashboardIdentifier),
+            workspace: "referenceworkspace",
+        };
+
+        const changingFilter = getAttributeFilter("df1");
+        const parents: IDashboardAttributeFilterParent[] = [
+            {
+                filterLocalIdentifier: "df2",
+            },
+        ];
+
+        const allFilters = [getAttributeFilter("df1"), getAttributeFilter("df2")];
+
+        const expected: AttributeFilterParentsValidationResult = "VALID";
         const actual = await validateAttributeFilterParents(
             ctx,
             changingFilter,

--- a/libs/sdk-ui-dashboard/src/model/queries/base.ts
+++ b/libs/sdk-ui-dashboard/src/model/queries/base.ts
@@ -13,7 +13,8 @@ export type DashboardQueryType =
     | "GDC.DASH/QUERY.CONNECTING.ATTRIBUTES"
     | "GDC.DASH/QUERY.DISPLAY.FORM.ATTRIBUTE"
     | "GDC.DASH/QUERY.DATA.SET.ATTRIBUTE"
-    | "GDC.DASH/QUERY.ELEMENTS.ATTRIBUTE";
+    | "GDC.DASH/QUERY.ELEMENTS.ATTRIBUTE"
+    | "GDC.DASH/QUERY.CONNECTED.ATTRIBUTES";
 
 /**
  * Base type for all dashboard queries. A dashboard query encapsulates how complex, read-only dashboard-specific logic

--- a/libs/sdk-ui-dashboard/src/model/queries/connectedAttributes.ts
+++ b/libs/sdk-ui-dashboard/src/model/queries/connectedAttributes.ts
@@ -1,0 +1,36 @@
+// (C) 2023 GoodData Corporation
+
+import { ObjRef } from "@gooddata/sdk-model";
+import { IDashboardQuery } from "./base.js";
+
+/**
+ * @alpha
+ */
+export interface QueryConnectedAttributes extends IDashboardQuery {
+    type: "GDC.DASH/QUERY.CONNECTED.ATTRIBUTES";
+    payload: {
+        readonly ref: ObjRef;
+    };
+}
+
+/**
+ * Creates action through which you can query connected attributes for the information about
+ * possibility of parent-child attribute filter relationship as only connected attributes may
+ * be dependent on each other.
+ *
+ * @param ref - reference of the attribute filter display form
+ * @param correlationId - specify correlation id to use for this command. this will be included in all
+ *  events that will be emitted during the command processing
+ * @returns array of connected attributes for given reference
+ *
+ * @alpha
+ */
+export function queryConnectedAttributes(ref: ObjRef, correlationId?: string): QueryConnectedAttributes {
+    return {
+        type: "GDC.DASH/QUERY.CONNECTED.ATTRIBUTES",
+        correlationId,
+        payload: {
+            ref,
+        },
+    };
+}

--- a/libs/sdk-ui-dashboard/src/model/queries/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/queries/index.ts
@@ -7,6 +7,7 @@ import { QueryConnectingAttributes } from "./connectingAttributes.js";
 import { QueryAttributeByDisplayForm } from "./attributes.js";
 import { QueryAttributeDataSet } from "./attributeDataSet.js";
 import { QueryAttributeElements } from "./attributeElements.js";
+import { QueryConnectedAttributes } from "./connectedAttributes.js";
 
 export { IDashboardQuery, DashboardQueryType } from "./base.js";
 export {
@@ -28,6 +29,7 @@ export {
     queryWidgetAlertCount,
 } from "./widgets.js";
 export { QueryConnectingAttributes, queryConnectingAttributes } from "./connectingAttributes.js";
+export { QueryConnectedAttributes, queryConnectedAttributes } from "./connectedAttributes.js";
 export { QueryAttributeByDisplayForm, queryAttributeByDisplayForm } from "./attributes.js";
 export { QueryAttributeDataSet, queryAttributeDataSet } from "./attributeDataSet.js";
 export { QueryAttributeElements, queryAttributeElements } from "./attributeElements.js";
@@ -45,4 +47,5 @@ export type DashboardQueries =
     | QueryConnectingAttributes
     | QueryAttributeByDisplayForm
     | QueryAttributeDataSet
-    | QueryAttributeElements;
+    | QueryAttributeElements
+    | QueryConnectedAttributes;

--- a/libs/sdk-ui-dashboard/src/model/queryServices/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/queryServices/index.ts
@@ -9,6 +9,7 @@ import { QueryConnectingAttributesService } from "./queryConnectingAttributes.js
 import { QueryAttributeByDisplayFormService } from "./queryAttributeByDisplayForm.js";
 import { QueryAttributeDataSetService } from "./queryAttributeDataset.js";
 import { QueryAttributeElementsService } from "./queryAttributeElements.js";
+import { QueryConnectedAttributesService } from "./queryConnectedAttributes.js";
 
 export const AllQueryServices = [
     QueryDateDatasetsForInsightService,
@@ -21,4 +22,5 @@ export const AllQueryServices = [
     QueryAttributeByDisplayFormService,
     QueryAttributeDataSetService,
     QueryAttributeElementsService,
+    QueryConnectedAttributesService,
 ];

--- a/libs/sdk-ui-dashboard/src/model/queryServices/queryAttributeByDisplayForm.ts
+++ b/libs/sdk-ui-dashboard/src/model/queryServices/queryAttributeByDisplayForm.ts
@@ -35,18 +35,18 @@ export const QueryAttributeByDisplayFormService = createCachedQueryService(
 async function loadAttributeByDisplayForm(
     ctx: DashboardContext,
     catalogAttributes: ICatalogAttribute[],
-    displayForm: ObjRef,
+    displayFormRef: ObjRef,
 ): Promise<IAttributeMetadataObject> {
     const { backend, workspace } = ctx;
     const attribute = catalogAttributes.find((catalogAttribute) =>
-        catalogAttribute.displayForms.some((df) => areObjRefsEqual(df, displayForm)),
+        catalogAttribute.displayForms.some((df) => areObjRefsEqual(df.ref, displayFormRef)),
     );
 
     if (attribute) {
         return attribute.attribute;
     }
 
-    return backend.workspace(workspace).attributes().getAttributeByDisplayForm(displayForm);
+    return backend.workspace(workspace).attributes().getAttributeByDisplayForm(displayFormRef);
 }
 
 async function loadAttributes(

--- a/libs/sdk-ui-dashboard/src/model/queryServices/queryConnectedAttributes.ts
+++ b/libs/sdk-ui-dashboard/src/model/queryServices/queryConnectedAttributes.ts
@@ -1,0 +1,40 @@
+// (C) 2022 GoodData Corporation
+
+import { ObjRef, serializeObjRef } from "@gooddata/sdk-model";
+import { SagaIterator } from "redux-saga";
+import { call, SagaReturnType } from "redux-saga/effects";
+import { createCachedQueryService } from "../store/_infra/queryService.js";
+import { DashboardContext } from "../types/commonTypes.js";
+import { QueryConnectedAttributes } from "../queries/connectedAttributes.js";
+
+export const QueryConnectedAttributesService = createCachedQueryService(
+    "GDC.DASH/QUERY.CONNECTED.ATTRIBUTES",
+    queryService,
+    (query: QueryConnectedAttributes) => {
+        const {
+            payload: { ref },
+        } = query;
+
+        return serializeObjRef(ref);
+    },
+);
+
+async function loadConnectedAttributes(ctx: DashboardContext, ref: ObjRef): Promise<ObjRef[]> {
+    const { backend, workspace } = ctx;
+
+    return await backend.workspace(workspace).attributes().getConnectedAttributesByDisplayForm(ref);
+}
+
+function* queryService(ctx: DashboardContext, query: QueryConnectedAttributes): SagaIterator<ObjRef[]> {
+    const {
+        payload: { ref },
+    } = query;
+
+    const connectedAttributes: SagaReturnType<typeof loadConnectedAttributes> = yield call(
+        loadConnectedAttributes,
+        ctx,
+        ref,
+    );
+
+    return connectedAttributes;
+}

--- a/libs/sdk-ui-dashboard/src/model/store/backendCapabilities/backendCapabilitiesSelectors.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/backendCapabilities/backendCapabilitiesSelectors.ts
@@ -102,3 +102,23 @@ export const selectSupportsObjectUris: DashboardSelector<boolean> = createSelect
     selectBackendCapabilities,
     (capabilities) => capabilities.supportsObjectUris ?? false,
 );
+
+/**
+ * Selector for {@link @gooddata/sdk-backend-spi#IBackendCapabilities.supportsSettingConnectingAttributes}
+ *
+ * @internal
+ */
+export const selectSupportsSettingConnectingAttributes: DashboardSelector<boolean> = createSelector(
+    selectBackendCapabilities,
+    (capabilities) => capabilities.supportsSettingConnectingAttributes ?? false,
+);
+
+/**
+ * Selector for {@link @gooddata/sdk-backend-spi#IBackendCapabilities.supportsKeepingDependentFiltersSelection}
+ *
+ * @internal
+ */
+export const selectSupportsKeepingDependentFiltersSelection: DashboardSelector<boolean> = createSelector(
+    selectBackendCapabilities,
+    (capabilities) => capabilities.supportsKeepingDependentFiltersSelection ?? false,
+);

--- a/libs/sdk-ui-dashboard/src/model/store/config/configSelectors.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/config/configSelectors.ts
@@ -575,3 +575,30 @@ export const selectEnableUnavailableItemsVisibility: DashboardSelector<boolean> 
         return state.settings?.enableUnavailableItemsVisible ?? false;
     },
 );
+
+/**
+ * Returns whether new KD dependent filters are enabled.
+ *
+ * @internal
+ */
+export const selectEnableKDDependentFilters: DashboardSelector<boolean> = createSelector(
+    selectConfig,
+    (state) => {
+        return state.settings?.enableKDDependentFilters ?? false;
+    },
+);
+
+/**
+ * Returns whether KD dependent filters are enabled.
+ * On Bear, this is driven by enableKPIDashboardDependentFilters.
+ * On Tiger, it is driven by enableKDDependentFilters.
+ *
+ * @internal
+ */
+export const selectIsKDDependentFiltersEnabled: DashboardSelector<boolean> = createSelector(
+    selectEnableKDDependentFilters,
+    selectIsKPIDashboardDependentFiltersEnabled,
+    (enableKDDependentFilters, isKPIDashboardDependentFiltersEnabled) => {
+        return enableKDDependentFilters || isKPIDashboardDependentFiltersEnabled;
+    },
+);

--- a/libs/sdk-ui-dashboard/src/model/store/filterContext/filterContextSelectors.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/filterContext/filterContextSelectors.ts
@@ -267,6 +267,8 @@ export const selectFilterContextAttributeFilterIndexByLocalId: (
  *
  * @remarks
  * Invocations before initialization lead to invariant errors.
+ * This selector should only be used when circular filter dependencies are not allowed,
+ * otherwise loops may occur.
  *
  * @public
  */

--- a/libs/sdk-ui-dashboard/src/model/store/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/index.ts
@@ -64,6 +64,8 @@ export {
     selectEnableAttributeHierarchies,
     selectIsDrillDownEnabled,
     selectEnableUnavailableItemsVisibility,
+    selectEnableKDDependentFilters,
+    selectIsKDDependentFiltersEnabled,
 } from "./config/configSelectors.js";
 export { EntitlementsState } from "./entitlements/entitlementsState.js";
 export { selectEntitlementExportPdf } from "./entitlements/entitlementsSelectors.js";

--- a/libs/sdk-ui-dashboard/src/model/store/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/index.ts
@@ -14,6 +14,8 @@ export {
     selectSupportsAccessControlCapability,
     selectSupportsHierarchicalWorkspacesCapability,
     selectSupportsObjectUris,
+    selectSupportsSettingConnectingAttributes,
+    selectSupportsKeepingDependentFiltersSelection,
 } from "./backendCapabilities/backendCapabilitiesSelectors.js";
 export { ConfigState } from "./config/configState.js";
 export {

--- a/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/dashboardDropdownBody/configuration/hooks/useOriginalConfigurationState.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/dashboardDropdownBody/configuration/hooks/useOriginalConfigurationState.ts
@@ -22,7 +22,7 @@ export function useOriginalConfigurationState(
 
             const overAttributes = filterElementsBy?.find(
                 (by) => by.filterLocalIdentifier === neighborFilterLocalId,
-            )?.over.attributes;
+            )?.over?.attributes;
 
             invariant(
                 neighborFilterLocalId,

--- a/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/dashboardDropdownBody/configuration/hooks/useParentsConfiguration.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/dashboardDropdownBody/configuration/hooks/useParentsConfiguration.ts
@@ -1,5 +1,6 @@
 // (C) 2022 GoodData Corporation
 import { IDashboardAttributeFilter, IDashboardAttributeFilterParent, ObjRef } from "@gooddata/sdk-model";
+import { useBackend } from "@gooddata/sdk-ui";
 import { useState, useMemo, useCallback } from "react";
 import { invariant } from "ts-invariant";
 import isEqual from "lodash/isEqual.js";
@@ -22,12 +23,18 @@ export function useParentsConfiguration(
     );
 
     const saveParentFilterCommand = useDispatchDashboardCommand(setAttributeFilterParents);
+    const backend = useBackend();
+    const supportsSettingConnectingAttributes = !!backend?.capabilities.supportsSettingConnectingAttributes;
 
     const originalState = useOriginalConfigurationState(neighborFilters, filterElementsBy);
 
     const [parents, setParents] = useState<IDashboardAttributeFilterParentItem[]>(originalState);
 
-    function onParentSelect(localIdentifier: string, isSelected: boolean, overAttributes: ObjRef[]) {
+    function onParentSelect(
+        localIdentifier: string,
+        isSelected: boolean,
+        overAttributes: ObjRef[] | undefined,
+    ) {
         const changedParentIndex = parents.findIndex((parent) => parent.localIdentifier === localIdentifier);
         const changedItem = { ...parents[changedParentIndex] };
 
@@ -35,7 +42,7 @@ export function useParentsConfiguration(
         changedItem.overAttributes = overAttributes;
 
         if (isSelected) {
-            changedItem.selectedConnectingAttribute = overAttributes[0];
+            changedItem.selectedConnectingAttribute = overAttributes?.[0];
         } else {
             // set connecting attributes to undefined to properly check for
             // state updates
@@ -70,7 +77,18 @@ export function useParentsConfiguration(
         if (configurationChanged) {
             const parentFilters: IDashboardAttributeFilterParent[] = [];
             parents.forEach((parentItem) => {
-                if (parentItem.isSelected && parentItem.overAttributes?.length) {
+                if (!parentItem.isSelected) {
+                    return;
+                }
+
+                if (!supportsSettingConnectingAttributes) {
+                    parentFilters.push({
+                        filterLocalIdentifier: parentItem.localIdentifier,
+                    });
+                    return;
+                }
+
+                if (parentItem.overAttributes?.length) {
                     const overAttribute =
                         parentItem.selectedConnectingAttribute || parentItem.overAttributes[0];
                     parentFilters.push({
@@ -83,7 +101,13 @@ export function useParentsConfiguration(
             });
             saveParentFilterCommand(currentFilter.attributeFilter.localIdentifier!, parentFilters);
         }
-    }, [parents, configurationChanged, currentFilter, saveParentFilterCommand]);
+    }, [
+        parents,
+        configurationChanged,
+        currentFilter,
+        saveParentFilterCommand,
+        supportsSettingConnectingAttributes,
+    ]);
 
     const onConfigurationClose = useCallback(() => {
         setParents(originalState);

--- a/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/dashboardDropdownBody/configuration/hooks/useValidNeighbourAttributes.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/dashboardDropdownBody/configuration/hooks/useValidNeighbourAttributes.ts
@@ -1,0 +1,92 @@
+// (C) 2023 GoodData Corporation
+
+import { useEffect, useMemo } from "react";
+import { ObjRef, areObjRefsEqual } from "@gooddata/sdk-model";
+import { GoodDataSdkError } from "@gooddata/sdk-ui";
+import {
+    selectAttributeFilterDisplayFormsMap,
+    selectSupportsElementsQueryParentFiltering,
+    selectSupportsSettingConnectingAttributes,
+    useDashboardQueryProcessing,
+    useDashboardSelector,
+    QueryConnectedAttributes,
+    queryConnectedAttributes,
+    selectIsKDDependentFiltersEnabled,
+} from "../../../../../../model/index.js";
+
+interface IUseValidNeighbourAttributesResult {
+    validNeighbourAttributes: ObjRef[];
+    validNeighbourAttributesLoading: boolean;
+    validNeighbourAttributesError: GoodDataSdkError | undefined;
+}
+
+/**
+ * Returns neighbor attribute filter display forms that have a valid connection in model with provided attribute display form.
+ * This should only be used when we don't need to look for connecting attributes and just need the information whether
+ * some connection exists.
+ */
+export const useValidNeighbourAttributes = (
+    attributeFilterDisplayForm: ObjRef,
+    neighbourFilterDisplayForms: ObjRef[],
+): IUseValidNeighbourAttributesResult => {
+    const isDependentFiltersEnabled = useDashboardSelector(selectIsKDDependentFiltersEnabled);
+    const supportsDependentFilters = useDashboardSelector(selectSupportsElementsQueryParentFiltering);
+    const supportsSettingConnectingAttributes = useDashboardSelector(
+        selectSupportsSettingConnectingAttributes,
+    );
+    const shouldValidateNeighbourAttributes =
+        isDependentFiltersEnabled && supportsDependentFilters && !supportsSettingConnectingAttributes;
+    const neighbourFilterDisplayFormsMap = useDashboardSelector(selectAttributeFilterDisplayFormsMap);
+
+    const {
+        run: getValidAttributes,
+        result: validAttributes,
+        status: validAttributesStatus,
+        error: validAttributesError,
+    } = useDashboardQueryProcessing<
+        QueryConnectedAttributes,
+        ObjRef[],
+        Parameters<typeof queryConnectedAttributes>
+    >({
+        queryCreator: queryConnectedAttributes,
+    });
+
+    useEffect(() => {
+        if (shouldValidateNeighbourAttributes) {
+            getValidAttributes(attributeFilterDisplayForm);
+        }
+    }, [attributeFilterDisplayForm, getValidAttributes, shouldValidateNeighbourAttributes]);
+
+    const validAttributesLoading = useMemo(() => {
+        return validAttributesStatus === "pending" || validAttributesStatus === "running";
+    }, [validAttributesStatus]);
+
+    if (!shouldValidateNeighbourAttributes) {
+        return {
+            validNeighbourAttributes: [],
+            validNeighbourAttributesLoading: false,
+            validNeighbourAttributesError: undefined,
+        };
+    }
+
+    /**
+     * Filter out attributes that are not in the list of valid attributes.
+     * At the beginning we have only display forms, so we need to get the attribute ref from the display form.
+     * Then compare the attribute ref with the list of valid attributes.
+     */
+    const validNeighbourAttributes = neighbourFilterDisplayForms.filter((neighbourFilterDisplayForm) => {
+        const neighbourAttribute = neighbourFilterDisplayFormsMap.get(neighbourFilterDisplayForm)?.attribute;
+
+        return (
+            validAttributes?.some((validAttributeRef) =>
+                areObjRefsEqual(neighbourAttribute, validAttributeRef),
+            ) ?? false
+        );
+    });
+
+    return {
+        validNeighbourAttributes: validNeighbourAttributes,
+        validNeighbourAttributesLoading: validAttributesLoading,
+        validNeighbourAttributesError: validAttributesError,
+    };
+};

--- a/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/dashboardDropdownBody/configuration/parentFilters/ParentFiltersListItemWithoutConnectingAttributes.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/dashboardDropdownBody/configuration/parentFilters/ParentFiltersListItemWithoutConnectingAttributes.tsx
@@ -1,0 +1,69 @@
+// (C) 2022-2023 GoodData Corporation
+import React, { useCallback, useMemo } from "react";
+import cx from "classnames";
+
+import { ObjRef } from "@gooddata/sdk-model";
+import { ParentFiltersDisabledItem } from "./ParentFiltersDisabledItem.js";
+import { stringUtils } from "@gooddata/util";
+import { IDashboardAttributeFilterParentItem } from "../../../../../../model/index.js";
+
+interface IConfigurationParentItemProps {
+    currentFilterLocalId: string;
+    item: IDashboardAttributeFilterParentItem;
+    onClick: (localId: string, isSelected: boolean, overAttributes?: ObjRef[]) => void;
+    title: string;
+    disabled: boolean;
+    isValid: boolean;
+}
+
+export const ParentFiltersListItemWithoutConnectingAttributes: React.FC<IConfigurationParentItemProps> = (
+    props,
+) => {
+    const {
+        item: { isSelected, localIdentifier },
+        onClick,
+        currentFilterLocalId,
+        title,
+        disabled,
+        isValid,
+    } = props;
+
+    const activeItemClasses = useMemo(() => {
+        return cx(
+            "gd-list-item attribute-filter-item s-attribute-filter-dropdown-configuration-item",
+            `s-${stringUtils.simplifyText(title)}`,
+            {
+                "is-selected": isSelected,
+            },
+        );
+    }, [isSelected, title]);
+
+    const onSelect = useCallback(() => {
+        onClick(localIdentifier, !isSelected);
+    }, [onClick, localIdentifier, isSelected]);
+
+    if (!isValid) {
+        return (
+            <ParentFiltersDisabledItem
+                hasConnectingAttributes={false}
+                itemTitle={title}
+                itemLocalId={currentFilterLocalId}
+            />
+        );
+    }
+
+    return (
+        <div className={activeItemClasses} onClick={() => !disabled && onSelect()} title={title}>
+            <label className="input-checkbox-label configuration-item-title">
+                <input
+                    type="checkbox"
+                    className="input-checkbox s-checkbox"
+                    checked={isSelected}
+                    disabled={disabled}
+                    readOnly
+                />
+                <span className="input-label-text">{title}</span>
+            </label>
+        </div>
+    );
+};

--- a/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/useParentFilters.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/useParentFilters.ts
@@ -4,7 +4,11 @@ import { invariant } from "ts-invariant";
 import { IAttributeFilter, ObjRef, IDashboardAttributeFilter } from "@gooddata/sdk-model";
 
 import { dashboardAttributeFilterToAttributeFilter } from "../../../_staging/dashboard/dashboardFilterConverter.js";
-import { selectFilterContextAttributeFilters, useDashboardSelector } from "../../../model/index.js";
+import {
+    selectFilterContextAttributeFilters,
+    selectSupportsSettingConnectingAttributes,
+    useDashboardSelector,
+} from "../../../model/index.js";
 import { IAttributeFilterBaseProps } from "@gooddata/sdk-ui-filters";
 
 /**
@@ -26,6 +30,9 @@ export type UseParentFiltersResult = Pick<
  */
 export const useParentFilters = (filter: IDashboardAttributeFilter): UseParentFiltersResult => {
     const allAttributeFilters = useDashboardSelector(selectFilterContextAttributeFilters);
+    const supportsSettingConnectingAttributes = useDashboardSelector(
+        selectSupportsSettingConnectingAttributes,
+    );
 
     const parentFiltersData = useMemo(() => {
         return filter.attributeFilter.filterElementsBy?.map((parent) => {
@@ -35,7 +42,7 @@ export const useParentFilters = (filter: IDashboardAttributeFilter): UseParentFi
 
             invariant(matchingFilter); // if this blows up, the state is inconsistent
 
-            return { filter: matchingFilter, over: parent.over.attributes[0] };
+            return { filter: matchingFilter, over: parent.over?.attributes[0] };
         });
     }, [allAttributeFilters, filter.attributeFilter.filterElementsBy]);
 
@@ -45,12 +52,13 @@ export const useParentFilters = (filter: IDashboardAttributeFilter): UseParentFi
 
     const parentOverLookup = useMemo(() => {
         // no parents -> no need for the lookup function
-        if (!parentFiltersData) {
+        // no support for connecting attributes -> no need for the lookup function
+        if (!parentFiltersData || !supportsSettingConnectingAttributes) {
             return undefined;
         }
 
-        return (_parentFilter: IAttributeFilter, index: number): ObjRef => parentFiltersData[index].over;
-    }, [parentFiltersData]);
+        return (_parentFilter: IAttributeFilter, index: number): ObjRef => parentFiltersData[index].over!;
+    }, [parentFiltersData, supportsSettingConnectingAttributes]);
 
     return {
         parentFilters,

--- a/libs/sdk-ui-filters/api/sdk-ui-filters.api.md
+++ b/libs/sdk-ui-filters/api/sdk-ui-filters.api.md
@@ -90,6 +90,7 @@ export type AttributeFilterControllerCallbacks = {
     onSearch: (search: string) => void;
     onSelect: (selectedItems: IAttributeElement[], isInverted: boolean) => void;
     onReset: () => void;
+    onOpen: () => void;
 };
 
 // @public
@@ -303,6 +304,7 @@ export interface IAttributeElementLoader {
     getOffset(): number;
     getOrder(): SortDirection;
     getSearch(): string;
+    getShouldReloadElements(): boolean;
     getTotalElementsCount(): number;
     getTotalElementsCountWithCurrentSettings(): number;
     initTotalCount(correlation?: Correlation): void;
@@ -331,6 +333,7 @@ export interface IAttributeElementLoader {
     setLimitingMeasures(measures: IMeasure[]): void;
     setOrder(order: SortDirection): void;
     setSearch(search: string): void;
+    setShouldReloadElements(shouldReloadElements: boolean): void;
 }
 
 // @beta

--- a/libs/sdk-ui-filters/src/AttributeFilter/Components/Dropdown/AttributeFilterDropdown.tsx
+++ b/libs/sdk-ui-filters/src/AttributeFilter/Components/Dropdown/AttributeFilterDropdown.tsx
@@ -38,6 +38,7 @@ export const AttributeFilterDropdown: React.VFC = () => {
         committedSelectionElements,
         onReset,
         onApply,
+        onOpen,
         fullscreenOnMobile,
         isCommittedSelectionInverted,
         selectionMode,
@@ -96,6 +97,8 @@ export const AttributeFilterDropdown: React.VFC = () => {
             onOpenStateChanged={(isOpen) => {
                 if (!isOpen) {
                     onReset();
+                } else {
+                    onOpen();
                 }
             }}
             renderBody={({ closeDropdown }) => (

--- a/libs/sdk-ui-filters/src/AttributeFilter/hooks/types.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilter/hooks/types.ts
@@ -165,6 +165,11 @@ export type AttributeFilterControllerCallbacks = {
      * Reset working selection.
      */
     onReset: () => void;
+
+    /**
+     * Filter open callback.
+     */
+    onOpen: () => void;
 };
 
 /**

--- a/libs/sdk-ui-filters/src/AttributeFilter/hooks/useResolveParentFiltersInput.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilter/hooks/useResolveParentFiltersInput.ts
@@ -18,19 +18,21 @@ export const useResolveParentFiltersInput = (
 
     return useMemo(() => {
         if (!supportsSettingConnectingAttributes) {
-            return getParentFilters(resolvedParentFilters);
+            return getParentFiltersWithoutOverAttribute(resolvedParentFilters);
         }
 
         return getParentFiltersWithOverAttribute(resolvedParentFilters, overAttribute);
     }, [supportsSettingConnectingAttributes, resolvedParentFilters, overAttribute]);
 };
 
-const getParentFilters = (parentFilters: IAttributeFilter[]) => {
+const getParentFiltersWithoutOverAttribute = (
+    parentFilters: IAttributeFilter[],
+): IElementsQueryAttributeFilter[] => {
     if (!parentFilters) {
         return [];
     }
 
-    return parentFilters.map((attributeFilter) => ({ attributeFilter }));
+    return parentFilters.map((attributeFilter) => ({ attributeFilter, overAttribute: null }));
 };
 
 const getParentFiltersWithOverAttribute = (

--- a/libs/sdk-ui-filters/src/AttributeFilter/hooks/useResolveParentFiltersInput.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilter/hooks/useResolveParentFiltersInput.ts
@@ -12,12 +12,25 @@ import { ParentFilterOverAttributeType } from "../types.js";
 export const useResolveParentFiltersInput = (
     parentFilters?: AttributeFiltersOrPlaceholders,
     overAttribute?: ParentFilterOverAttributeType,
-) => {
+    supportsSettingConnectingAttributes?: boolean,
+): IElementsQueryAttributeFilter[] => {
     const resolvedParentFilters = useResolveValueWithPlaceholders(parentFilters);
 
     return useMemo(() => {
+        if (!supportsSettingConnectingAttributes) {
+            return getParentFilters(resolvedParentFilters);
+        }
+
         return getParentFiltersWithOverAttribute(resolvedParentFilters, overAttribute);
-    }, [resolvedParentFilters, overAttribute]);
+    }, [supportsSettingConnectingAttributes, resolvedParentFilters, overAttribute]);
+};
+
+const getParentFilters = (parentFilters: IAttributeFilter[]) => {
+    if (!parentFilters) {
+        return [];
+    }
+
+    return parentFilters.map((attributeFilter) => ({ attributeFilter }));
 };
 
 const getParentFiltersWithOverAttribute = (

--- a/libs/sdk-ui-filters/src/AttributeFilterHandler/internal/bridge.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilterHandler/internal/bridge.ts
@@ -81,6 +81,7 @@ import {
     selectLimitingAttributeFiltersAttributes,
     selectInitTotalCountStatus,
     selectInitTotalCountError,
+    selectShouldReloadElements,
 } from "./redux/index.js";
 import { newAttributeFilterCallbacks } from "./callbacks.js";
 import { AttributeFilterHandlerConfig } from "./types.js";
@@ -415,6 +416,14 @@ export class AttributeFilterReduxBridge {
 
     getLimitingAttributeFiltersAttributes = (): IAttributeMetadataObject[] => {
         return this.redux.select(selectLimitingAttributeFiltersAttributes);
+    };
+
+    getShouldReloadElements = (): boolean => {
+        return this.redux.select(selectShouldReloadElements);
+    };
+
+    setShouldReloadElements = (shouldReloadElements: boolean): void => {
+        this.redux.dispatch(actions.setShouldReloadElements({ shouldReloadElements }));
     };
 
     //

--- a/libs/sdk-ui-filters/src/AttributeFilterHandler/internal/loader.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilterHandler/internal/loader.ts
@@ -385,4 +385,12 @@ export class AttributeFilterLoader implements IAttributeFilterLoader {
     onUpdate: CallbackRegistration<void> = (cb) => {
         return this.bridge.onUpdate(cb);
     };
+
+    getShouldReloadElements(): boolean {
+        return this.bridge.getShouldReloadElements();
+    }
+
+    setShouldReloadElements(shouldReloadElements: boolean): void {
+        this.bridge.setShouldReloadElements(shouldReloadElements);
+    }
 }

--- a/libs/sdk-ui-filters/src/AttributeFilterHandler/internal/redux/elements/elementsReducers.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilterHandler/internal/redux/elements/elementsReducers.ts
@@ -89,6 +89,13 @@ const setLimitingDateFilters: AttributeFilterReducer<PayloadAction<{ filters: IR
     state.elements.currentOptions.limitingDateFilters = action.payload.filters;
 };
 
+const setShouldReloadElements: AttributeFilterReducer<PayloadAction<{ shouldReloadElements: boolean }>> = (
+    state,
+    action,
+) => {
+    state.elements.shouldReloadElements = action.payload.shouldReloadElements;
+};
+
 /**
  * @internal
  */
@@ -108,4 +115,5 @@ export const elementsReducers = {
     setLimitingMeasures,
     setLimitingDateFilters,
     setLimitingAttributeFiltersAttributes,
+    setShouldReloadElements,
 };

--- a/libs/sdk-ui-filters/src/AttributeFilterHandler/internal/redux/elements/elementsSelectors.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilterHandler/internal/redux/elements/elementsSelectors.ts
@@ -198,3 +198,11 @@ export const selectLastLoadedElementsOptions: FilterSelector<ILoadElementsOption
  */
 export const selectLimitingAttributeFiltersAttributes: FilterSelector<IAttributeMetadataObject[]> =
     createSelector(selectState, (state) => state.elements.limitingAttributeFiltersAttributes);
+
+/**
+ * @internal
+ */
+export const selectShouldReloadElements: FilterSelector<boolean> = createSelector(
+    selectState,
+    (state) => state.elements.shouldReloadElements,
+);

--- a/libs/sdk-ui-filters/src/AttributeFilterHandler/internal/redux/store/state.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilterHandler/internal/redux/store/state.ts
@@ -40,6 +40,7 @@ export interface AttributeFilterState {
         lastLoadedOptions?: ILoadElementsOptions;
         currentOptions: ILoadElementsOptions;
         limitingAttributeFiltersAttributes: IAttributeMetadataObject[];
+        shouldReloadElements: boolean;
     };
     selection: {
         commited: {
@@ -88,6 +89,7 @@ export const initialState: Omit<AttributeFilterState, "displayFormRef" | "elemen
         totalCountInitialization: {
             status: "pending",
         },
+        shouldReloadElements: false,
     },
     config: {},
     selection: {

--- a/libs/sdk-ui-filters/src/AttributeFilterHandler/types/elementsLoader.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilterHandler/types/elementsLoader.ts
@@ -453,6 +453,17 @@ export interface IAttributeElementLoader {
      * @param callback - callback to run
      */
     onLoadCustomElementsCancel: CallbackRegistration<OnLoadCustomElementsCancelCallbackPayload>;
+
+    /**
+     * Sets information whether elements should be reinitialized for example
+     * in case when limiting attributes changed.
+     */
+    setShouldReloadElements(shouldReloadElements: boolean): void;
+
+    /**
+     * Returns the information whether elements should reload whenever possible.
+     */
+    getShouldReloadElements(): boolean;
 }
 
 /**


### PR DESCRIPTION
- pass dependsOn property to collectLabelElements endpoint
- introduce supportsSettingConnectingAttributes capability
- do not allow setting connecting attributes
- avoid using "over" attribute in filter context
- introduce supportsKeepingDependentFiltersSelection capability
- do not reset linked attributes on parent change
- reload elements on linked attribute dropdown open when parent changes

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |
| **Compatibility matrix test commands - TIGER Backend**  |                                                            |
| `extended test - matrix-test <AIO_version>`             | Run integrated tests against AIO versions.                 |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

`<AIO_version>` in commands is used to start test with multiple AIO instances - each instance in triggered by one jenkins build

-   To run with `master` and `stable`, execute command `extended test - matrix-test master,stable` or `extended test - matrix-test latest`
-   To run with specific version,ex: `2.3.0` and `2.3.1`, execute command `extended test - matrix-test 2.3.0,2.3.1`
-   In case `<AIO_version>` is empty, read versions from file `compTigerVersions.txt` of this repo

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
