### PR TITLE
FEATURE: QA-17949 Replace public image by internal ecr image

### DIFF
--- a/common/scripts/ci/docker_apidocs_build.sh
+++ b/common/scripts/ci/docker_apidocs_build.sh
@@ -6,7 +6,7 @@ ROOT_DIR=$(echo $(cd $(dirname "${BASH_SOURCE[0]}")/../../.. && pwd -P))
 # go one level up to "see" the gooddata-ui-apidocs too
 ROOT_DIR="$ROOT_DIR/.."
 
-IMAGE="node:18.17.0-bullseye"
+IMAGE="020413372491.dkr.ecr.us-east-1.amazonaws.com/3rdparty/library/node:18"
 
 echo "Running apidocs build using ${IMAGE} in root directory ${ROOT_DIR}"
 

--- a/common/scripts/ci/docker_examples.sh
+++ b/common/scripts/ci/docker_examples.sh
@@ -5,7 +5,7 @@ set -o pipefail
 # Absolute root directory - for volumes
 ROOT_DIR=$(echo $(cd $(dirname "${BASH_SOURCE[0]}")/../../.. && pwd -P))
 
-IMAGE="node:18.17.0-bullseye"
+IMAGE="020413372491.dkr.ecr.us-east-1.amazonaws.com/3rdparty/library/node:18"
 
 echo "Running \"$*\" using ${IMAGE} in root directory ${ROOT_DIR}"
 

--- a/common/scripts/ci/docker_rush.sh
+++ b/common/scripts/ci/docker_rush.sh
@@ -3,7 +3,7 @@
 # Absolute root directory - for volumes
 ROOT_DIR=$(echo $(cd $(dirname "${BASH_SOURCE[0]}")/../../.. && pwd -P))
 
-IMAGE="node:18.17.0-bullseye"
+IMAGE="020413372491.dkr.ecr.us-east-1.amazonaws.com/3rdparty/library/node:18"
 
 echo "Running \"$*\" using ${IMAGE} in root directory ${ROOT_DIR}"
 

--- a/common/scripts/ci/docker_rushx.sh
+++ b/common/scripts/ci/docker_rushx.sh
@@ -3,7 +3,7 @@
 # Absolute root directory - for volumes
 ROOT_DIR=$(echo $(cd $(dirname "${BASH_SOURCE[0]}")/../../.. && pwd -P))
 
-IMAGE="node:18.17.0-bullseye"
+IMAGE="020413372491.dkr.ecr.us-east-1.amazonaws.com/3rdparty/library/node:18"
 
 echo "Running \"$*\" using ${IMAGE} in root directory ${ROOT_DIR}"
 

--- a/libs/sdk-ui-tests-e2e/docker-compose-isolated.yaml
+++ b/libs/sdk-ui-tests-e2e/docker-compose-isolated.yaml
@@ -43,7 +43,7 @@ services:
             - backend-mock
 
     backend-mock:
-        image: wiremock/wiremock:2.35.0
+        image: 020413372491.dkr.ecr.us-east-1.amazonaws.com/3rdparty/wiremock/wiremock:2.35.0
         # Use "--print-all-network-traffic --verbose" for verbose logging
         # Note that we need --preserve-host-header for BEAR backend only and it must be missing for TIGER (see run_isolated.sh)
         command: "${PRESERVE_HOST_HEADER_OPTION} --proxy-all=${HOST:-https://staging3.intgdc.com} --extensions org.gooddata.extensions.ResponseHeadersTransformer,org.gooddata.extensions.RequestHeadersTransformer"


### PR DESCRIPTION
<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |
| **Compatibility matrix test commands - TIGER Backend**  |                                                            |
| `extended test - matrix-test <AIO_version>`             | Run integrated tests against AIO versions.                 |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

`<AIO_version>` in commands is used to start test with multiple AIO instances - each instance in triggered by one jenkins build

-   To run with `master` and `stable`, execute command `extended test - matrix-test master,stable` or `extended test - matrix-test latest`
-   To run with specific version,ex: `2.3.0` and `2.3.1`, execute command `extended test - matrix-test 2.3.0,2.3.1`
-   In case `<AIO_version>` is empty, read versions from file `compTigerVersions.txt` of this repo

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
