### PR TITLE
BUGFIX: TNT-1843 limit metric bucket size

### DIFF
--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/areaChart/PluggableAreaChart.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/areaChart/PluggableAreaChart.tsx
@@ -22,6 +22,7 @@ import {
     AREA_UICONFIG_WITH_MULTIPLE_DATES,
     DEFAULT_AREA_UICONFIG,
     MAX_CATEGORIES_COUNT,
+    MAX_METRICS_COUNT,
     MAX_STACKS_COUNT,
     MAX_VIEW_COUNT,
 } from "../../../constants/uiConfig.js";
@@ -51,6 +52,7 @@ import {
     sanitizeFilters,
     getMainDateItem,
     getBucketItems,
+    limitNumberOfMeasuresInBuckets,
 } from "../../../utils/bucketHelper.js";
 import {
     getReferencePointWithSupportedProperties,
@@ -298,9 +300,9 @@ export class PluggableAreaChart extends PluggableBaseChart {
         return bucketItems.filter(isNotDateBucketItem).slice(0, MAX_STACKS_COUNT);
     }
 
-    private getBucketItems(referencePoint: IReferencePoint) {
+    private getBucketItems(referencePoint: IExtendedReferencePoint) {
         const buckets = referencePoint?.buckets ?? [];
-        const measures = getFilteredMeasuresForStackedCharts(buckets);
+        const measures = this.getBucketMeasures(referencePoint);
         const dateItems = getDateItems(buckets);
         const mainDateItem = getMainDateItem(dateItems);
 
@@ -333,9 +335,20 @@ export class PluggableAreaChart extends PluggableBaseChart {
         return referencePoint.uiConfig?.buckets?.[BucketNames.VIEW]?.itemsLimit ?? MAX_CATEGORIES_COUNT;
     }
 
+    private getMeasuresMaxItemCount(referencePoint: IExtendedReferencePoint): number {
+        return referencePoint.uiConfig?.buckets?.[BucketNames.MEASURES]?.itemsLimit ?? MAX_METRICS_COUNT;
+    }
+
+    private getBucketMeasures(extendedReferencePoint: IExtendedReferencePoint) {
+        const buckets = extendedReferencePoint?.buckets ?? [];
+        const limit = this.getMeasuresMaxItemCount(extendedReferencePoint);
+        const limitedBuckets = limitNumberOfMeasuresInBuckets(buckets, limit, true);
+        return getFilteredMeasuresForStackedCharts(limitedBuckets);
+    }
+
     private getBucketItemsWithMultipleDates(referencePoint: IExtendedReferencePoint) {
         const buckets = referencePoint?.buckets ?? [];
-        const measures = getFilteredMeasuresForStackedCharts(buckets);
+        const measures = this.getBucketMeasures(referencePoint);
         const viewByMaxItemCount = this.getViewByMaxItemCount(referencePoint);
         const stacks: IBucketItem[] = getStackItems(buckets, [ATTRIBUTE, DATE]);
 

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pieChart/PluggablePieChart.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pieChart/PluggablePieChart.tsx
@@ -15,6 +15,7 @@ import { DASHBOARDS_ENVIRONMENT } from "../../../constants/properties.js";
 import { PIECHART_SUPPORTED_PROPERTIES } from "../../../constants/supportedProperties.js";
 import {
     DEFAULT_PIE_UICONFIG,
+    MAX_METRICS_COUNT,
     PIE_UICONFIG_WITH_MULTIPLE_METRICS,
     PIE_UICONFIG_WITH_ONE_METRIC,
     UICONFIG,
@@ -113,8 +114,9 @@ export class PluggablePieChart extends PluggableBaseChart {
                 },
             ]);
         } else {
-            const measures = getMeasureItems(buckets);
-            if (measures.length > 1) {
+            const limitedBuckets = limitNumberOfMeasuresInBuckets(buckets, MAX_METRICS_COUNT, true);
+            const limitedMeasures = getMeasureItems(limitedBuckets);
+            if (limitedMeasures.length > 1) {
                 set(newReferencePoint, UICONFIG, cloneDeep(PIE_UICONFIG_WITH_MULTIPLE_METRICS));
             } else {
                 set(newReferencePoint, UICONFIG, cloneDeep(PIE_UICONFIG_WITH_ONE_METRIC));
@@ -123,7 +125,7 @@ export class PluggablePieChart extends PluggableBaseChart {
             set(newReferencePoint, BUCKETS, [
                 {
                     localIdentifier: BucketNames.MEASURES,
-                    items: measures,
+                    items: limitedMeasures,
                 },
                 {
                     localIdentifier: BucketNames.VIEW,

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/treeMap/PluggableTreemap.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/treeMap/PluggableTreemap.tsx
@@ -8,7 +8,7 @@ import { BucketNames, IDrillEvent, VisualizationTypes } from "@gooddata/sdk-ui";
 import { BUCKETS, DATE, ATTRIBUTE } from "../../../constants/bucket.js";
 import { TREEMAP_SUPPORTED_PROPERTIES } from "../../../constants/supportedProperties.js";
 
-import { getTreemapUiConfig } from "../../../constants/uiConfig.js";
+import { MAX_METRICS_COUNT, getTreemapUiConfig } from "../../../constants/uiConfig.js";
 import {
     IDrillDownContext,
     IExtendedReferencePoint,
@@ -82,9 +82,20 @@ export class PluggableTreemap extends PluggableBaseChart {
         this.initializeProperties(props.visualizationProperties);
     }
 
-    private getBucketItemsWithMultipleDates(newReferencePoint: IReferencePoint): any {
+    private getMeasuresMaxItemCount(referencePoint: IExtendedReferencePoint): number {
+        return referencePoint.uiConfig?.buckets?.[BucketNames.MEASURES]?.itemsLimit ?? MAX_METRICS_COUNT;
+    }
+
+    private getBucketMeasures(extendedReferencePoint: IExtendedReferencePoint) {
+        const buckets = extendedReferencePoint?.buckets ?? [];
+        const limit = this.getMeasuresMaxItemCount(extendedReferencePoint);
+        const limitedBuckets = limitNumberOfMeasuresInBuckets(buckets, limit, true);
+        return getMeasureItems(limitedBuckets);
+    }
+
+    private getBucketItemsWithMultipleDates(newReferencePoint: IExtendedReferencePoint): any {
         const buckets = newReferencePoint?.buckets ?? [];
-        let measures = getMeasureItems(buckets);
+        let measures = this.getBucketMeasures(newReferencePoint);
         let stacks = getStackItems(buckets, [ATTRIBUTE, DATE]);
         const nonStackAttributes = getAttributeItemsWithoutStacks(buckets, [ATTRIBUTE, DATE]);
         const view = nonStackAttributes.slice(0, 1);
@@ -102,9 +113,9 @@ export class PluggableTreemap extends PluggableBaseChart {
         return { measures, view, stacks };
     }
 
-    private getBucketItems(newReferencePoint: IReferencePoint) {
+    private getBucketItems(newReferencePoint: IExtendedReferencePoint) {
         const buckets = newReferencePoint?.buckets ?? [];
-        let measures = getMeasureItems(buckets);
+        let measures = this.getBucketMeasures(newReferencePoint);
         let stacks = getStackItems(buckets);
         const nonStackAttributes = getAttributeItemsWithoutStacks(buckets);
         const view = nonStackAttributes.slice(0, 1);

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/waterfallChart/PluggableWaterfallChart.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/waterfallChart/PluggableWaterfallChart.tsx
@@ -15,6 +15,7 @@ import {
     WATERFALL_UICONFIG_WITH_MULTIPLE_METRICS,
     UICONFIG,
     WATERFALL_UICONFIG_WITH_ONE_METRIC,
+    MAX_METRICS_COUNT,
 } from "../../../constants/uiConfig.js";
 import {
     IExtendedReferencePoint,
@@ -143,8 +144,9 @@ export class PluggableWaterfallChart extends PluggableBaseChart {
                 },
             ]);
         } else {
-            const measures = getMeasureItems(buckets);
-            if (measures.length > 1) {
+            const limitedBuckets = limitNumberOfMeasuresInBuckets(buckets, MAX_METRICS_COUNT, true);
+            const limitedMeasures = getMeasureItems(limitedBuckets);
+            if (limitedMeasures.length > 1) {
                 set(newReferencePoint, UICONFIG, cloneDeep(WATERFALL_UICONFIG_WITH_MULTIPLE_METRICS));
             } else {
                 set(newReferencePoint, UICONFIG, cloneDeep(WATERFALL_UICONFIG_WITH_ONE_METRIC));
@@ -153,7 +155,7 @@ export class PluggableWaterfallChart extends PluggableBaseChart {
             set(newReferencePoint, BUCKETS, [
                 {
                     localIdentifier: BucketNames.MEASURES,
-                    items: measures,
+                    items: limitedMeasures,
                 },
                 {
                     localIdentifier: BucketNames.VIEW,


### PR DESCRIPTION
JIRA: TNT-1843

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |
| **Compatibility matrix test commands - TIGER Backend**  |                                                            |
| `extended test - matrix-test <AIO_version>`             | Run integrated tests against AIO versions.                 |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

`<AIO_version>` in commands is used to start test with multiple AIO instances - each instance in triggered by one jenkins build

-   To run with `master` and `stable`, execute command `extended test - matrix-test master,stable` or `extended test - matrix-test latest`
-   To run with specific version,ex: `2.3.0` and `2.3.1`, execute command `extended test - matrix-test 2.3.0,2.3.1`
-   In case `<AIO_version>` is empty, read versions from file `compTigerVersions.txt` of this repo

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
