### PR TITLE
RELATED: DP-2551 updating export_catalog protocols

### DIFF
--- a/docs/content/en/latest/learn/visualize_data/export_catalog.md
+++ b/docs/content/en/latest/learn/visualize_data/export_catalog.md
@@ -56,13 +56,16 @@ This is how it works:
 
 1.  The program searches the `package.json` file for `gooddata` entry. If found, the program reads input parameters from this file.
 
+
+    TypeScript or JavaScript output files are generated based on the filename extension specified in the output parameter.
+
     The configuration can contain some, or all, of the parameters that you would typically provide on the command line:
 
     ```json
     {
         ...
         "gooddata": {
-            "hostname": "your.gooddata.hostname.com",
+            "hostname": "https://your.gooddata.hostname.com",
             "workspaceId": "your_gooddata_workspaceid",
             "catalogOutput": "desired_file_name.ts|js",
             "backend": "tiger|bear"
@@ -70,8 +73,11 @@ This is how it works:
         ...
     }
     ```
+{{% alert title="Hostname protocol" %}}
 
-    **NOTE:** TypeScript or JavaScript output files are generated based on the filename extension specified in the output parameter.
+The hostname has to include the protocol (`http://` / `https://`), otherwise you will get a fairly generic `connection refused` error, when trying to connect.
+
+{{% /alert %}}
 
 2.  It is not possible to specify credentials (`token`, `username` and `password` parameters) in `package.json` file, as it is typically saved in VCS (e.g. Git). Instead, credentials can be specified through environmental variables. We also load `.env` file if it's present in the same folder.
     
@@ -105,7 +111,7 @@ The `@gooddata/catalog-export` tool can work on top of either the GoodData Cloud
     {
         ...
         "gooddata": {
-            "hostname": "your.gooddata.hostname.com",
+            "hostname": "https://your.gooddata.hostname.com",
             "workspaceId": "your_gooddata_workspaceid",
             "catalogOutput": "desired_file_name.ts|js",
             "backend": "bear"
@@ -113,6 +119,12 @@ The `@gooddata/catalog-export` tool can work on top of either the GoodData Cloud
         ...
     }
     ```
+  
+{{% alert title="Hostname protocol" %}}
+
+The hostname has to include the protocol (`http://` / `https://`), otherwise you will get a fairly generic `connection refused` error, when trying to connect.
+
+{{% /alert %}}
 
 The tool uses Bearer token authentication when communicating with your GoodData Cloud instance or your GoodData.CN installation. For more information about how to obtain API tokens, see the [GoodData Cloud and GoodData.CN authentication page](../../integrate_and_authenticate/cn_and_cloud_authentication/).
 


### PR DESCRIPTION
JIRA: DP-2551

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |
| **Compatibility matrix test commands - TIGER Backend**  |                                                            |
| `extended test - matrix-test <AIO_version>`             | Run integrated tests against AIO versions.                 |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

`<AIO_version>` in commands is used to start test with multiple AIO instances - each instance in triggered by one jenkins build

-   To run with `master` and `stable`, execute command `extended test - matrix-test master,stable` or `extended test - matrix-test latest`
-   To run with specific version,ex: `2.3.0` and `2.3.1`, execute command `extended test - matrix-test 2.3.0,2.3.1`
-   In case `<AIO_version>` is empty, read versions from file `compTigerVersions.txt` of this repo

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
