### PR TITLE
BUGFIX: TNT-1877 Remove admin group when user is demoted to member

### DIFF
--- a/libs/sdk-backend-base/src/dummyBackend/index.ts
+++ b/libs/sdk-backend-base/src/dummyBackend/index.ts
@@ -741,6 +741,8 @@ class DummyOrganization implements IOrganization {
         return {
             getWorkspacePermissionsForUser: () => Promise.resolve([]),
             getWorkspacePermissionsForUserGroup: () => Promise.resolve([]),
+            getOrganizationPermissionForUser: () => Promise.resolve([]),
+            getOrganizationPermissionForUserGroup: () => Promise.resolve([]),
             updateOrganizationPermissions: () => Promise.resolve(),
             updateWorkspacePermissions: () => Promise.resolve(),
         };

--- a/libs/sdk-backend-mockingbird/src/recordedBackend/index.ts
+++ b/libs/sdk-backend-mockingbird/src/recordedBackend/index.ts
@@ -366,6 +366,8 @@ function recordedOrganization(organizationId: string, implConfig: RecordedBacken
             return {
                 getWorkspacePermissionsForUser: () => Promise.resolve([]),
                 getWorkspacePermissionsForUserGroup: () => Promise.resolve([]),
+                getOrganizationPermissionForUser: () => Promise.resolve([]),
+                getOrganizationPermissionForUserGroup: () => Promise.resolve([]),
                 updateOrganizationPermissions: () => Promise.resolve(),
                 updateWorkspacePermissions: () => Promise.resolve(),
             };

--- a/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
+++ b/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
@@ -84,6 +84,7 @@ import { IWorkspaceUser } from '@gooddata/sdk-model';
 import { IWorkspaceUserGroup } from '@gooddata/sdk-model';
 import { ObjectType } from '@gooddata/sdk-model';
 import { ObjRef } from '@gooddata/sdk-model';
+import { OrganizationPermissionAssignment } from '@gooddata/sdk-model';
 import { SortDirection } from '@gooddata/sdk-model';
 
 // @public
@@ -555,6 +556,8 @@ export interface IOrganization {
 
 // @alpha
 export interface IOrganizationPermissionService {
+    getOrganizationPermissionForUser(userId: string): Promise<OrganizationPermissionAssignment[]>;
+    getOrganizationPermissionForUserGroup(userGroupId: string): Promise<OrganizationPermissionAssignment[]>;
     getWorkspacePermissionsForUser(userId: string): Promise<IWorkspacePermissionAssignment[]>;
     getWorkspacePermissionsForUserGroup(userGroupId: string): Promise<IWorkspacePermissionAssignment[]>;
     updateOrganizationPermissions(permissionAssignments: IOrganizationPermissionAssignment[]): Promise<void>;

--- a/libs/sdk-backend-spi/src/organization/permissions/index.ts
+++ b/libs/sdk-backend-spi/src/organization/permissions/index.ts
@@ -1,6 +1,10 @@
 // (C) 2023 GoodData Corporation
 
-import { IWorkspacePermissionAssignment, IOrganizationPermissionAssignment } from "@gooddata/sdk-model";
+import {
+    IWorkspacePermissionAssignment,
+    IOrganizationPermissionAssignment,
+    OrganizationPermissionAssignment,
+} from "@gooddata/sdk-model";
 
 /**
  * This service provides access to organization permissions.
@@ -34,6 +38,24 @@ export interface IOrganizationPermissionService {
      * @returns promise
      */
     updateWorkspacePermissions(permissions: IWorkspacePermissionAssignment[]): Promise<void>;
+
+    /**
+     * Get list of organization permissions assigned to the user.
+     *
+     * @param userId - ID of the user.
+     *
+     * @returns promise
+     */
+    getOrganizationPermissionForUser(userId: string): Promise<OrganizationPermissionAssignment[]>;
+
+    /**
+     * Get list of organization permissions assigned to the user group.
+     *
+     * @param userGroupId - ID of the user.
+     *
+     * @returns promise
+     */
+    getOrganizationPermissionForUserGroup(userGroupId: string): Promise<OrganizationPermissionAssignment[]>;
 
     /**
      * Update organization permission for the user or user group.

--- a/libs/sdk-ui-ext/src/internal/components/dialogs/userManagementDialogs/Details/EditUserDetails.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/dialogs/userManagementDialogs/Details/EditUserDetails.tsx
@@ -5,10 +5,11 @@ import React, { useCallback, useEffect } from "react";
 import { IUser } from "@gooddata/sdk-model";
 import { BackButton, ConfirmDialogBase } from "@gooddata/sdk-ui-kit";
 
-import { UserDetailsView } from "./UserDetailsView.js";
-import { useUserDetails } from "./detailsHooks.js";
 import { extractUserName } from "../utils.js";
 import { messages } from "../locales.js";
+
+import { UserDetailsView } from "./UserDetailsView.js";
+import { useUserDetails } from "./detailsHooks.js";
 
 export interface IEditUserDetailsProps {
     isAdmin: boolean;
@@ -19,6 +20,7 @@ export interface IEditUserDetailsProps {
     onSubmit: (user: IUser, isAdmin: boolean) => void;
     onCancel: () => void;
     onClose: () => void;
+    removeAdminGroup: () => void;
 }
 
 export const EditUserDetails: React.FC<IEditUserDetailsProps> = ({
@@ -30,6 +32,7 @@ export const EditUserDetails: React.FC<IEditUserDetailsProps> = ({
     onSubmit,
     onCancel,
     onClose,
+    removeAdminGroup,
 }) => {
     const intl = useIntl();
     const { updatedUser, isUpdatedAdmin, onSave, onChange, isDirty } = useUserDetails(
@@ -37,6 +40,7 @@ export const EditUserDetails: React.FC<IEditUserDetailsProps> = ({
         isAdmin,
         onSubmit,
         onCancel,
+        removeAdminGroup,
     );
 
     // change user membership if dialog was opened for that reason, enable Save button, do it just once

--- a/libs/sdk-ui-ext/src/internal/components/dialogs/userManagementDialogs/Details/detailsHooks.ts
+++ b/libs/sdk-ui-ext/src/internal/components/dialogs/userManagementDialogs/Details/detailsHooks.ts
@@ -14,6 +14,7 @@ export const useUserDetails = (
     isAdmin: boolean,
     onSubmit: (user: IUser, isAdmin: boolean) => void,
     onCancel: () => void,
+    removeAdminGroup: () => void,
 ) => {
     const { addSuccess, addError } = useToastMessage();
     const [updatedUser, setUpdatedUser] = useState(user);
@@ -40,7 +41,9 @@ export const useUserDetails = (
         };
 
         Promise.all([
+            // update user details
             backend.organization(organizationId).users().updateUser(sanitizedUser),
+            // grant or remove org manage rights if they are supposed to change
             updateAdmin
                 ? backend
                       .organization(organizationId)
@@ -55,6 +58,8 @@ export const useUserDetails = (
                           },
                       ])
                 : Promise.resolve(),
+            // remove admin group if org manage rights must be removed and user is its member
+            updateAdmin && !isUpdatedAdmin ? removeAdminGroup() : Promise.resolve(),
         ])
             .then(() => {
                 addSuccess(messages.userDetailsUpdatedSuccess);

--- a/libs/sdk-ui-ext/src/internal/components/dialogs/userManagementDialogs/UserGroupEditDialog.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/dialogs/userManagementDialogs/UserGroupEditDialog.tsx
@@ -16,7 +16,7 @@ import {
     useDeleteUserGroup,
     useUserGroupDialogTabs,
     useUserGroupDialogMode,
-    useIsOrganizationBootstrapUserGroup,
+    useOrganizationDetails,
 } from "./dialogHooks.js";
 import { ViewDialog } from "./ViewDialog.js";
 import { DeleteConfirmDialog } from "./ConfirmDialogs/DeleteConfirmDialog.js";
@@ -76,7 +76,7 @@ export const UserGroupEditDialog: React.FC<IUserGroupEditDialogProps> = ({
         dialogWrapperClassNames,
     } = useDeleteDialog();
     const deleteUserGroup = useDeleteUserGroup(userGroupId, organizationId, onSuccess, onClose);
-    const isBootstrapUserGroup = useIsOrganizationBootstrapUserGroup(organizationId, userGroup);
+    const { isBootstrapUserGroup } = useOrganizationDetails(organizationId);
 
     const { editButtonText, editButtonMode, editButtonIconClassName } = useMemo(() => {
         if (selectedTabId.id === userGroupDialogTabsMessages.workspaces.id) {
@@ -125,9 +125,11 @@ export const UserGroupEditDialog: React.FC<IUserGroupEditDialogProps> = ({
                         <ViewDialog
                             dialogTitle={extractUserGroupName(userGroup)}
                             isAdmin={isAdmin}
-                            isDeleteLinkEnabled={!isBootstrapUserGroup && grantedUsers?.length === 0}
+                            isDeleteLinkEnabled={
+                                !isBootstrapUserGroup(userGroup) && grantedUsers?.length === 0
+                            }
                             deleteLinkDisabledTooltipTextId={
-                                isBootstrapUserGroup
+                                isBootstrapUserGroup(userGroup)
                                     ? messages.deleteAdminUserGroupTooltip.id
                                     : messages.deleteNonEmptyUserGroupTooltip.id
                             }


### PR DESCRIPTION
- Introduce SPI to get org permissions for user and group
- Remove admin group when user is demoted to member from admin (removal of org permission is not enough)

JIRA: TNT-1877

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |
| **Compatibility matrix test commands - TIGER Backend**  |                                                            |
| `extended test - matrix-test <AIO_version>`             | Run integrated tests against AIO versions.                 |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

`<AIO_version>` in commands is used to start test with multiple AIO instances - each instance in triggered by one jenkins build

-   To run with `master` and `stable`, execute command `extended test - matrix-test master,stable` or `extended test - matrix-test latest`
-   To run with specific version,ex: `2.3.0` and `2.3.1`, execute command `extended test - matrix-test 2.3.0,2.3.1`
-   In case `<AIO_version>` is empty, read versions from file `compTigerVersions.txt` of this repo

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
