### PR TITLE
RELATED: TNT-1815 Allow null in insight filters

### DIFF
--- a/libs/sdk-backend-bear/api/sdk-backend-bear.api.md
+++ b/libs/sdk-backend-bear/api/sdk-backend-bear.api.md
@@ -139,10 +139,10 @@ export const convertFilterContextItem: (filterContextItem: FilterContextItem) =>
 export const convertFilterReference: (filterReference: IDateFilterReference | IAttributeFilterReference) => IDashboardFilterReference;
 
 // @internal (undocumented)
-export const convertInsight: (insight: IInsight) => IVisualizationObject;
+export const convertInsight: (insight: IInsight, options?: IConvertInsightOptions) => IVisualizationObject;
 
 // @internal (undocumented)
-export const convertInsightDefinition: (insight: IInsightDefinition) => IVisualizationObject;
+export const convertInsightDefinition: (insight: IInsightDefinition, options?: IConvertInsightOptions) => IVisualizationObject;
 
 // @internal (undocumented)
 export const convertKpiDrill: (kpi: IWrappedKPI) => IDrillToLegacyDashboard;
@@ -196,6 +196,11 @@ export interface IConversionData {
     properties: VisualizationProperties;
     // (undocumented)
     references: IReferenceItems;
+}
+
+// @internal (undocumented)
+export interface IConvertInsightOptions {
+    allowNullValuesInAttributeFilters?: boolean;
 }
 
 // @internal (undocumented)

--- a/libs/sdk-backend-bear/src/convertors/toBackend/FilterConverter.ts
+++ b/libs/sdk-backend-bear/src/convertors/toBackend/FilterConverter.ts
@@ -89,11 +89,27 @@ const convertAbsoluteDateFilter = (filter: IAbsoluteDateFilter): IVisualizationO
     };
 };
 
+/**
+ * @internal
+ */
+export interface IConvertInsightOptions {
+    /**
+     * Disables prohibition of null values in elements of the attribute filter.
+     * In most use-cases, it is false/undefined, such as metadata conversion,
+     * but in some specific instances, where the same conversion is needed
+     * without a strict rule for nulls, it can be disabled.
+     */
+    allowNullValuesInAttributeFilters?: boolean;
+}
+
 const convertNegativeAttributeFilter = (
     filter: INegativeAttributeFilter,
+    options?: IConvertInsightOptions,
 ): IVisualizationObjectNegativeAttributeFilter => {
     const elements = filterAttributeElements(filter);
-    assertNoNulls(elements);
+    if (!options?.allowNullValuesInAttributeFilters) {
+        assertNoNulls(elements);
+    }
     return {
         negativeAttributeFilter: {
             displayForm: toBearRef(filterObjRef(filter)),
@@ -104,9 +120,12 @@ const convertNegativeAttributeFilter = (
 
 const convertPositiveAttributeFilter = (
     filter: IPositiveAttributeFilter,
+    options?: IConvertInsightOptions,
 ): IVisualizationObjectPositiveAttributeFilter => {
     const elements = filterAttributeElements(filter);
-    assertNoNulls(elements);
+    if (!options?.allowNullValuesInAttributeFilters) {
+        assertNoNulls(elements);
+    }
     return {
         positiveAttributeFilter: {
             displayForm: toBearRef(filterObjRef(filter)),
@@ -115,21 +134,27 @@ const convertPositiveAttributeFilter = (
     };
 };
 
-export const convertExtendedFilter = (filter: IFilter): VisualizationObjectExtendedFilter => {
+export const convertExtendedFilter = (
+    filter: IFilter,
+    options?: IConvertInsightOptions,
+): VisualizationObjectExtendedFilter => {
     if (isMeasureValueFilter(filter)) {
         return convertMeasureValueFilter(filter);
     } else if (isRankingFilter(filter)) {
         return convertRankingFilter(filter);
     } else {
-        return convertFilter(filter);
+        return convertFilter(filter, options);
     }
 };
 
-export const convertFilter = (filter: IMeasureFilter): VisualizationObjectFilter => {
+export const convertFilter = (
+    filter: IMeasureFilter,
+    options?: IConvertInsightOptions,
+): VisualizationObjectFilter => {
     if (isPositiveAttributeFilter(filter)) {
-        return convertPositiveAttributeFilter(filter);
+        return convertPositiveAttributeFilter(filter, options);
     } else if (isNegativeAttributeFilter(filter)) {
-        return convertNegativeAttributeFilter(filter);
+        return convertNegativeAttributeFilter(filter, options);
     } else if (isAbsoluteDateFilter(filter)) {
         return convertAbsoluteDateFilter(filter);
     } else {

--- a/libs/sdk-backend-bear/src/convertors/toBackend/InsightConverter.ts
+++ b/libs/sdk-backend-bear/src/convertors/toBackend/InsightConverter.ts
@@ -33,7 +33,7 @@ import isEmpty from "lodash/isEmpty.js";
 import omitBy from "lodash/omitBy.js";
 import { convertUrisToReferences } from "../fromBackend/ReferenceConverter.js";
 import { serializeProperties } from "../fromBackend/PropertiesConverter.js";
-import { convertExtendedFilter } from "./FilterConverter.js";
+import { convertExtendedFilter, IConvertInsightOptions } from "./FilterConverter.js";
 import { convertMeasure } from "./MeasureConverter.js";
 
 const convertAttribute = (attribute: IAttribute): IVisualizationObjectAttribute => {
@@ -64,7 +64,10 @@ const convertBucket = (bucket: IBucket): IBearBucket => {
 /**
  * @internal
  */
-export const convertInsightContent = (insight: IInsightDefinition): IVisualizationObjectContent => {
+export const convertInsightContent = (
+    insight: IInsightDefinition,
+    options?: IConvertInsightOptions,
+): IVisualizationObjectContent => {
     const { properties, references } = convertUrisToReferences({
         properties: insightProperties(insight),
         references: {},
@@ -72,7 +75,7 @@ export const convertInsightContent = (insight: IInsightDefinition): IVisualizati
 
     const nonEmptyProperties = omitBy(properties, (value, key) => key !== "controls" && isEmpty(value));
 
-    const filters = insightFilters(insight).map(convertExtendedFilter);
+    const filters = insightFilters(insight).map((filter) => convertExtendedFilter(filter, options));
 
     return {
         buckets: insightBuckets(insight).map(convertBucket),
@@ -88,9 +91,12 @@ export const convertInsightContent = (insight: IInsightDefinition): IVisualizati
 /**
  * @internal
  */
-export const convertInsightDefinition = (insight: IInsightDefinition): IVisualizationObject => {
+export const convertInsightDefinition = (
+    insight: IInsightDefinition,
+    options?: IConvertInsightOptions,
+): IVisualizationObject => {
     return {
-        content: convertInsightContent(insight),
+        content: convertInsightContent(insight, options),
         meta: {
             title: insightTitle(insight),
             category: "visualizationObject",
@@ -102,8 +108,8 @@ export const convertInsightDefinition = (insight: IInsightDefinition): IVisualiz
 /**
  * @internal
  */
-export const convertInsight = (insight: IInsight): IVisualizationObject => {
-    const convertedDefinition = convertInsightDefinition(insight);
+export const convertInsight = (insight: IInsight, options?: IConvertInsightOptions): IVisualizationObject => {
+    const convertedDefinition = convertInsightDefinition(insight, options);
     const locked = insightIsLocked(insight);
 
     return {

--- a/libs/sdk-backend-bear/src/convertors/toBackend/MeasureConverter.ts
+++ b/libs/sdk-backend-bear/src/convertors/toBackend/MeasureConverter.ts
@@ -95,7 +95,7 @@ const convertSimpleMeasureDefinition = (
 
     const aggregation = convertAggregation(measureAggregation(measure));
     const computeRatio = measureDoesComputeRatio(measure);
-    const filters = (measureFilters(measure) || []).map(convertFilter);
+    const filters = (measureFilters(measure) || []).map((filter) => convertFilter(filter));
 
     return {
         measureDefinition: {

--- a/libs/sdk-backend-bear/src/index.ts
+++ b/libs/sdk-backend-bear/src/index.ts
@@ -69,6 +69,11 @@ export {
 };
 
 /**
+ * @internal
+ */
+export { IConvertInsightOptions } from "./convertors/toBackend/FilterConverter.js";
+
+/**
  * Some of the convertors from bear types are exported through this so that they can be used by our
  * applications that were using bear-specific types in their state.
  *


### PR DESCRIPTION
This is a backport of TNT-1815 fix to older
revision for the hotfix, see TNT-1893.

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |
| **Compatibility matrix test commands - TIGER Backend**  |                                                            |
| `extended test - matrix-test <AIO_version>`             | Run integrated tests against AIO versions.                 |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

`<AIO_version>` in commands is used to start test with multiple AIO instances - each instance in triggered by one jenkins build

-   To run with `master` and `stable`, execute command `extended test - matrix-test master,stable` or `extended test - matrix-test latest`
-   To run with specific version,ex: `2.3.0` and `2.3.1`, execute command `extended test - matrix-test 2.3.0,2.3.1`
-   In case `<AIO_version>` is empty, read versions from file `compTigerVersions.txt` of this repo

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)