### PR TITLE
BUGFIX: TNT-1847 Revert removed LDM related tiger specific function

### DIFF
--- a/libs/sdk-backend-tiger/api/sdk-backend-tiger.api.md
+++ b/libs/sdk-backend-tiger/api/sdk-backend-tiger.api.md
@@ -41,6 +41,7 @@ import { NotAuthenticated } from '@gooddata/sdk-backend-spi';
 import { NotAuthenticatedHandler } from '@gooddata/sdk-backend-spi';
 import { ObjectType } from '@gooddata/sdk-model';
 import { PlatformUsage } from '@gooddata/api-client-tiger';
+import { ScanResultPdm } from '@gooddata/api-client-tiger';
 import { ScanSqlResponse } from '@gooddata/api-client-tiger';
 import { TestDefinitionRequestTypeEnum } from '@gooddata/api-client-tiger';
 
@@ -294,6 +295,25 @@ export type PutWorkspaceLayoutRequest = LayoutApiPutWorkspaceLayoutRequest;
 export function redirectToTigerAuthentication(context: IAuthenticationContext, error: NotAuthenticated): void;
 
 // @internal (undocumented)
+export interface ScanRequest {
+    // (undocumented)
+    scanTables: boolean;
+    // (undocumented)
+    scanViews: boolean;
+    // (undocumented)
+    schemata: string[];
+    // (undocumented)
+    separator: string;
+    // (undocumented)
+    tablePrefix: string;
+    // (undocumented)
+    viewPrefix: string;
+}
+
+// @internal (undocumented)
+export type ScanResult = ScanResultPdm;
+
+// @internal (undocumented)
 export type ScanSqlResult = ScanSqlResponse;
 
 // @alpha
@@ -356,6 +376,7 @@ export type TigerSpecificFunctions = {
     deleteApiToken?: (userId: string, tokenId: string) => Promise<void>;
     someDataSourcesExists?: (filter?: string) => Promise<boolean>;
     generateLogicalModel?: (dataSourceId: string, generateLogicalModelRequest: GenerateLogicalModelRequest) => Promise<DeclarativeLogicalModel>;
+    scanDataSource?: (dataSourceId: string, scanRequest: ScanRequest) => Promise<ScanResult>;
     createDemoWorkspace?: (sampleWorkspace: WorkspaceDefinition) => Promise<string>;
     createDemoDataSource?: (sampleDataSource: DataSourceDefinition) => Promise<string>;
     createWorkspace?: (id: string, name: string) => Promise<string>;

--- a/libs/sdk-backend-tiger/src/backend/tigerSpecificFunctions.ts
+++ b/libs/sdk-backend-tiger/src/backend/tigerSpecificFunctions.ts
@@ -42,6 +42,7 @@ import {
     JsonApiWorkspaceDataFilterOutDocument,
     JsonApiWorkspaceDataFilterSettingOutDocument,
     JsonApiWorkspaceDataFilterSettingInDocument,
+    ScanResultPdm,
 } from "@gooddata/api-client-tiger";
 import { convertApiError } from "../utils/errorHandling.js";
 import uniq from "lodash/uniq.js";
@@ -65,6 +66,23 @@ export interface IApiToken {
 export interface IApiTokenExtended extends IApiToken {
     bearerToken: string | undefined;
 }
+
+/**
+ * @internal
+ */
+export interface ScanRequest {
+    scanTables: boolean;
+    scanViews: boolean;
+    separator: string;
+    tablePrefix: string;
+    viewPrefix: string;
+    schemata: string[];
+}
+
+/**
+ * @internal
+ */
+export type ScanResult = ScanResultPdm;
 
 /**
  * @internal
@@ -313,6 +331,7 @@ export type TigerSpecificFunctions = {
         dataSourceId: string,
         generateLogicalModelRequest: GenerateLogicalModelRequest,
     ) => Promise<DeclarativeLogicalModel>;
+    scanDataSource?: (dataSourceId: string, scanRequest: ScanRequest) => Promise<ScanResult>;
     createDemoWorkspace?: (sampleWorkspace: WorkspaceDefinition) => Promise<string>;
     createDemoDataSource?: (sampleDataSource: DataSourceDefinition) => Promise<string>;
     createWorkspace?: (id: string, name: string) => Promise<string>;
@@ -713,6 +732,22 @@ export const buildTigerSpecificFunctions = (
                         generateLdmRequest,
                     })
                     .then((axiosResponse) => axiosResponse.data);
+            });
+        } catch (error: any) {
+            throw convertApiError(error);
+        }
+    },
+    scanDataSource: async (dataSourceId: string, scanRequest: ScanRequest) => {
+        try {
+            return await authApiCall(async (sdk) => {
+                return await sdk.scanModel
+                    .scanDataSource({
+                        dataSourceId,
+                        scanRequest,
+                    })
+                    .then((res) => {
+                        return res?.data;
+                    });
             });
         } catch (error: any) {
             throw convertApiError(error);

--- a/libs/sdk-backend-tiger/src/index.ts
+++ b/libs/sdk-backend-tiger/src/index.ts
@@ -101,6 +101,8 @@ export {
     ICustomApplicationSetting,
     ScanSqlResult,
     WorkspaceEntitiesDatasets,
+    ScanRequest,
+    ScanResult,
 } from "./backend/tigerSpecificFunctions.js";
 
 export { TigerAfmType, TigerMetadataType, TigerObjectType } from "./types/index.js";


### PR DESCRIPTION
JIRA: TNT-1847

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |
| **Compatibility matrix test commands - TIGER Backend**  |                                                            |
| `extended test - matrix-test <AIO_version>`             | Run integrated tests against AIO versions.                 |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

`<AIO_version>` in commands is used to start test with multiple AIO instances - each instance in triggered by one jenkins build

-   To run with `master` and `stable`, execute command `extended test - matrix-test master,stable` or `extended test - matrix-test latest`
-   To run with specific version,ex: `2.3.0` and `2.3.1`, execute command `extended test - matrix-test 2.3.0,2.3.1`
-   In case `<AIO_version>` is empty, read versions from file `compTigerVersions.txt` of this repo

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
