### PR TITLE
RELATED: TNT-1886 Unify pivot table warning messages

### DIFF
--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/tests/__snapshots__/PluggablePivotTable.test.tsx.snap
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/tests/__snapshots__/PluggablePivotTable.test.tsx.snap
@@ -1772,7 +1772,7 @@ exports[`PluggablePivotTable > getExtendedReferencePoint > given simpleStackedRe
           "date": 1,
         },
         "title": "Columns",
-        "warningMessage": "To add columns, total count of items from measures or rows should not be higher than 20",
+        "warningMessage": "Cannot add columns: limit is 40 measures and 20 rows. Follow the limits to add more",
       },
       "filters": {
         "accepts": [

--- a/libs/sdk-ui-ext/src/internal/translations/en-US.json
+++ b/libs/sdk-ui-ext/src/internal/translations/en-US.json
@@ -577,13 +577,13 @@
         "translate": false
     },
     "dashboard.bucket.category_columns_warning._measure": {
-        "value": "To add columns, total count of items from measures or rows should not be higher than {oldLimit}",
-        "comment": "Do not translate {oldLimit}.",
+        "value": "Cannot add columns: limit is {oldLimit} measures and {oldRowsLimit} rows. Follow the limits to add more",
+        "comment": "Do not translate {oldLimit} and {oldRowsLimit}.",
         "limit": 0
     },
     "dashboard.bucket.category_columns_warning._metric": {
-        "value": "To add columns, total count of items from metrics or rows should not be higher than {oldLimit}",
-        "comment": "Do not translate {oldLimit}.",
+        "value": "Cannot add columns: limit is {oldLimit} metrics and {oldRowsLimit} rows. Follow the limits to add more",
+        "comment": "Do not translate {oldLimit} and {oldRowsLimit}.",
         "limit": 0
     },
     "dashboard.bucket.category_measures_rows_warning": {

--- a/libs/sdk-ui-ext/src/internal/utils/uiConfigHelpers/pivotTableUiConfigHelper.ts
+++ b/libs/sdk-ui-ext/src/internal/utils/uiConfigHelpers/pivotTableUiConfigHelper.ts
@@ -55,7 +55,8 @@ function setPivotTableBucketWarningMessages(referencePoint: IExtendedReferencePo
             if (bucket.localIdentifier === BucketNames.COLUMNS) {
                 warningMessageId = messages.columns.id;
                 warningMessageValues = {
-                    oldLimit: MAX_TABLE_CATEGORIES_COUNT,
+                    oldLimit: MAX_METRICS_COUNT,
+                    oldRowsLimit: MAX_TABLE_CATEGORIES_COUNT,
                 };
             } else if (hasColumns) {
                 warningMessageId = messages.measuresAttributes.id;

--- a/libs/sdk-ui-ext/src/internal/utils/uiConfigHelpers/pivotTableUiConfigHelper.ts
+++ b/libs/sdk-ui-ext/src/internal/utils/uiConfigHelpers/pivotTableUiConfigHelper.ts
@@ -43,6 +43,7 @@ function setPivotTableBucketWarningMessages(referencePoint: IExtendedReferencePo
     const buckets = referencePoint?.buckets;
     const updatedUiConfig = cloneDeep(referencePoint?.uiConfig);
 
+    const hasColumns = !hasNoColumns(buckets);
     forEach(buckets, (bucket) => {
         const localIdentifier = bucket?.localIdentifier ?? "";
         const bucketUiConfig = updatedUiConfig?.buckets?.[localIdentifier];
@@ -56,7 +57,7 @@ function setPivotTableBucketWarningMessages(referencePoint: IExtendedReferencePo
                 warningMessageValues = {
                     oldLimit: MAX_TABLE_CATEGORIES_COUNT,
                 };
-            } else {
+            } else if (hasColumns) {
                 warningMessageId = messages.measuresAttributes.id;
 
                 if (bucket.localIdentifier === BucketNames.MEASURES) {


### PR DESCRIPTION
Update pivot table warning message for different measures
and attributes count.
Also hide redundant message in rows/measures bucket
when columns bucket is empty.


<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |
| **Compatibility matrix test commands - TIGER Backend**  |                                                            |
| `extended test - matrix-test <AIO_version>`             | Run integrated tests against AIO versions.                 |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

`<AIO_version>` in commands is used to start test with multiple AIO instances - each instance in triggered by one jenkins build

-   To run with `master` and `stable`, execute command `extended test - matrix-test master,stable` or `extended test - matrix-test latest`
-   To run with specific version,ex: `2.3.0` and `2.3.1`, execute command `extended test - matrix-test 2.3.0,2.3.1`
-   In case `<AIO_version>` is empty, read versions from file `compTigerVersions.txt` of this repo

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)