### PR TITLE
RELATED: TNT-1906 Extend notNull check options also for measure filters

### DIFF
--- a/libs/sdk-backend-bear/src/convertors/toBackend/InsightConverter.ts
+++ b/libs/sdk-backend-bear/src/convertors/toBackend/InsightConverter.ts
@@ -48,14 +48,14 @@ const convertAttribute = (attribute: IAttribute): IVisualizationObjectAttribute 
     };
 };
 
-const convertBucketItem = (bucketItem: IAttributeOrMeasure): BucketItem => {
-    return isMeasure(bucketItem) ? convertMeasure(bucketItem) : convertAttribute(bucketItem);
+const convertBucketItem = (bucketItem: IAttributeOrMeasure, options?: IConvertInsightOptions): BucketItem => {
+    return isMeasure(bucketItem) ? convertMeasure(bucketItem, options) : convertAttribute(bucketItem);
 };
 
-const convertBucket = (bucket: IBucket): IBearBucket => {
+const convertBucket = (bucket: IBucket, options?: IConvertInsightOptions): IBearBucket => {
     const { totals } = bucket;
     return {
-        items: bucket.items.map(convertBucketItem),
+        items: bucket.items.map((item) => convertBucketItem(item, options)),
         localIdentifier: bucket.localIdentifier,
         ...(!isEmpty(totals) && { totals }),
     };
@@ -78,7 +78,7 @@ export const convertInsightContent = (
     const filters = insightFilters(insight).map((filter) => convertExtendedFilter(filter, options));
 
     return {
-        buckets: insightBuckets(insight).map(convertBucket),
+        buckets: insightBuckets(insight).map((bucket) => convertBucket(bucket, options)),
         visualizationClass: { uri: insightVisualizationUrl(insight) },
         ...(!isEmpty(nonEmptyProperties) && {
             properties: serializeProperties(nonEmptyProperties),

--- a/libs/sdk-backend-bear/src/convertors/toBackend/MeasureConverter.ts
+++ b/libs/sdk-backend-bear/src/convertors/toBackend/MeasureConverter.ts
@@ -38,7 +38,7 @@ import {
 } from "@gooddata/sdk-model";
 import isEmpty from "lodash/isEmpty.js";
 import { toBearRef } from "./ObjRefConverter.js";
-import { convertFilter } from "./FilterConverter.js";
+import { convertFilter, IConvertInsightOptions } from "./FilterConverter.js";
 import { convertAggregation } from "./afm/MeasureConverter.js";
 
 const convertPreviousPeriodDataSet = (
@@ -85,6 +85,7 @@ const convertArithmeticMeasureDefinition = (
 
 const convertSimpleMeasureDefinition = (
     measure: IMeasure<IMeasureDefinition>,
+    options?: IConvertInsightOptions,
 ): IVisualizationObjectMeasureDefinition => {
     const identifier = measureIdentifier(measure);
     const uri = measureUri(measure);
@@ -95,7 +96,7 @@ const convertSimpleMeasureDefinition = (
 
     const aggregation = convertAggregation(measureAggregation(measure));
     const computeRatio = measureDoesComputeRatio(measure);
-    const filters = (measureFilters(measure) || []).map((filter) => convertFilter(filter));
+    const filters = (measureFilters(measure) || []).map((filter) => convertFilter(filter, options));
 
     return {
         measureDefinition: {
@@ -109,9 +110,10 @@ const convertSimpleMeasureDefinition = (
 
 const convertMeasureDefinition = (
     measure: IMeasure<IMeasureDefinitionType>,
+    options?: IConvertInsightOptions,
 ): VisualizationObjectMeasureDefinitionType => {
     if (isSimpleMeasure(measure)) {
-        return convertSimpleMeasureDefinition(measure);
+        return convertSimpleMeasureDefinition(measure, options);
     } else if (isArithmeticMeasure(measure)) {
         return convertArithmeticMeasureDefinition(measure);
     } else if (isPoPMeasure(measure)) {
@@ -123,14 +125,17 @@ const convertMeasureDefinition = (
     throw new Error("Unknown measure type");
 };
 
-export const convertMeasure = (measure: IMeasure<IMeasureDefinitionType>): IVisualizationObjectMeasure => {
+export const convertMeasure = (
+    measure: IMeasure<IMeasureDefinitionType>,
+    options?: IConvertInsightOptions,
+): IVisualizationObjectMeasure => {
     const alias = measureAlias(measure);
     const format = measureFormat(measure);
     const title = measureTitle(measure);
 
     return {
         measure: {
-            definition: convertMeasureDefinition(measure),
+            definition: convertMeasureDefinition(measure, options),
             localIdentifier: measureLocalId(measure),
             ...(alias && { alias }),
             ...(format && { format }),


### PR DESCRIPTION
Completes the fix in TNT-1815.


<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |
| **Compatibility matrix test commands - TIGER Backend**  |                                                            |
| `extended test - matrix-test <AIO_version>`             | Run integrated tests against AIO versions.                 |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

`<AIO_version>` in commands is used to start test with multiple AIO instances - each instance in triggered by one jenkins build

-   To run with `master` and `stable`, execute command `extended test - matrix-test master,stable` or `extended test - matrix-test latest`
-   To run with specific version,ex: `2.3.0` and `2.3.1`, execute command `extended test - matrix-test 2.3.0,2.3.1`
-   In case `<AIO_version>` is empty, read versions from file `compTigerVersions.txt` of this repo

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)