### PR TITLE
BUGFIX: EGL-420, EGL-428 use attribute id instead of label id in blacklist hierarchies

### DIFF
--- a/libs/sdk-model/api/sdk-model.api.md
+++ b/libs/sdk-model/api/sdk-model.api.md
@@ -628,9 +628,9 @@ export interface IAttributeHierarchyMetadataObject extends IMetadataObjectIdenti
 // @alpha (undocumented)
 export interface IAttributeHierarchyReference {
     // (undocumented)
-    attributeHierarchy: ObjRef;
+    attribute: ObjRef;
     // (undocumented)
-    label: ObjRef;
+    attributeHierarchy: ObjRef;
     // (undocumented)
     type: "attributeHierarchyReference";
 }

--- a/libs/sdk-model/src/dashboard/drill.ts
+++ b/libs/sdk-model/src/dashboard/drill.ts
@@ -336,7 +336,7 @@ export function isDrillToAttributeUrl(obj: unknown): obj is IDrillToAttributeUrl
 export interface IAttributeHierarchyReference {
     type: "attributeHierarchyReference";
     attributeHierarchy: ObjRef;
-    label: ObjRef;
+    attribute: ObjRef;
 }
 
 /**

--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -2968,7 +2968,7 @@ export interface EntitlementsState {
 }
 
 // @internal (undocumented)
-export function existBlacklistHierarchyPredicate(reference: IDrillDownReference, attributeHierarchyRef: ObjRef, attributeIdentifier?: string): boolean;
+export function existBlacklistHierarchyPredicate(reference: IDrillDownReference, attributeHierarchyRef: ObjRef, attributeIdentifier?: ObjRef): boolean;
 
 // @beta (undocumented)
 export interface ExportDashboardToPdf extends IDashboardCommand {

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/addDrillDownForInsightWidgetHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/addDrillDownForInsightWidgetHandler.ts
@@ -3,8 +3,6 @@
 import { SagaIterator } from "redux-saga";
 import { put, select } from "redux-saga/effects";
 
-import { objRefToString } from "@gooddata/sdk-model";
-
 import { DashboardContext } from "../../types/commonTypes.js";
 import { AddDrillDownForInsightWidget } from "../../commands/index.js";
 import { DashboardInsightWidgetDrillDownAdded, insightWidgetDrillDownAdded } from "../../events/insight.js";
@@ -27,12 +25,7 @@ export function* addDrillDownForInsightWidgetHandler(
 
     const newBlacklistHierarchies = currentBlacklistHierarchies
         ? currentBlacklistHierarchies.filter(
-              (ref) =>
-                  !existBlacklistHierarchyPredicate(
-                      ref,
-                      attributeHierarchy,
-                      objRefToString(attributeIdentifier),
-                  ),
+              (ref) => !existBlacklistHierarchyPredicate(ref, attributeHierarchy, attributeIdentifier),
           )
         : [];
 

--- a/libs/sdk-ui-dashboard/src/model/store/catalog/catalogSelectors.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/catalog/catalogSelectors.ts
@@ -361,7 +361,7 @@ function getAttributesWithHierarchyDescendants(
                 : hierarchy.attributes;
             const hierarchyAttributes = attributes.filter((attrRef) => {
                 const ignoredIndex = ignoredDrillDownHierarchies.findIndex((reference) =>
-                    existBlacklistHierarchyPredicate(reference, hierarchyRef, objRefToString(attrRef)),
+                    existBlacklistHierarchyPredicate(reference, hierarchyRef, attrRef),
                 );
                 return ignoredIndex < 0;
             });

--- a/libs/sdk-ui-dashboard/src/model/store/layout/tests/__snapshots__/layoutReducers.test.ts.snap
+++ b/libs/sdk-ui-dashboard/src/model/store/layout/tests/__snapshots__/layoutReducers.test.ts.snap
@@ -410,7 +410,7 @@ exports[`layout slice reducer > replaceWidgetBlacklistHierarchies action > shoul
           },
           "attributeIdentifier": {
             "identifier": "f_owner.department_id",
-            "type": "displayForm",
+            "type": "attribute",
           },
           "ref": {
             "uri": "/gdc/md/referenceworkspace/obj/1310",
@@ -432,13 +432,13 @@ exports[`layout slice reducer > replaceWidgetBlacklistHierarchies action > shoul
           ],
           "value": [
             {
+              "attribute": {
+                "identifier": "f_owner.department_id",
+                "type": "attribute",
+              },
               "attributeHierarchy": {
                 "identifier": "test_attribute_hierarchies_1",
                 "type": "attributeHierarchy",
-              },
-              "label": {
-                "identifier": "f_owner.department_id",
-                "type": "displayForm",
               },
               "type": "attributeHierarchyReference",
             },

--- a/libs/sdk-ui-dashboard/src/model/store/layout/tests/layoutReducers.test.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/layout/tests/layoutReducers.test.ts
@@ -112,7 +112,7 @@ describe("layout slice reducer", () => {
         };
 
         it("should correctly handle replace widget blacklist hierarchies and create undo entry", () => {
-            const attribute = (ignoredHierarchies[0] as IAttributeHierarchyReference).label;
+            const attribute = (ignoredHierarchies[0] as IAttributeHierarchyReference).attribute;
             const hierarchy = (ignoredHierarchies[0] as IAttributeHierarchyReference).attributeHierarchy;
             const initialState = createLayoutSliceInitialState(SimpleDashboardLayout);
             const newState = produce(initialState, (draft) => {

--- a/libs/sdk-ui-dashboard/src/model/store/widgetDrills/tests/widgetDrillSelectors.fixture.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/widgetDrills/tests/widgetDrillSelectors.fixture.ts
@@ -347,6 +347,6 @@ export const ignoredHierarchies: IDrillDownReference[] = [
             "477f101d580549049144fdb8aa39f7b4_attribute_hierarchies_1",
             "attributeHierarchy",
         ),
-        label: idRef("f_owner.department_id", "displayForm"),
+        attribute: idRef("f_owner.department_id", "attribute"),
     },
 ];

--- a/libs/sdk-ui-dashboard/src/model/store/widgetDrills/widgetDrillSelectors.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/widgetDrills/widgetDrillSelectors.ts
@@ -217,7 +217,7 @@ function getGlobalDrillDownAttributeHierarchyDefinitions(
                     objRefToString(attributeHeader.formOf.ref),
                 );
                 const inBlacklistIndex = ignoredDrillDownHierarchies.findIndex((reference) =>
-                    existBlacklistHierarchyPredicate(reference, ref, attributeHeader.identifier),
+                    existBlacklistHierarchyPredicate(reference, ref, attributeHeader.formOf.ref),
                 );
                 if (isAttributeInHierarchy && inBlacklistIndex < 0) {
                     globalDrillDowns.push({

--- a/libs/sdk-ui-dashboard/src/model/tests/fixtures/Dashboard.fixtures.ts
+++ b/libs/sdk-ui-dashboard/src/model/tests/fixtures/Dashboard.fixtures.ts
@@ -23,6 +23,6 @@ export const ignoredHierarchies: IDrillDownReference[] = [
     {
         type: "attributeHierarchyReference",
         attributeHierarchy: idRef("test_attribute_hierarchies_1", "attributeHierarchy"),
-        label: idRef("f_owner.department_id", "displayForm"),
+        attribute: idRef("f_owner.department_id", "attribute"),
     },
 ];

--- a/libs/sdk-ui-dashboard/src/model/utils/attributeHierarchyUtils.ts
+++ b/libs/sdk-ui-dashboard/src/model/utils/attributeHierarchyUtils.ts
@@ -5,7 +5,6 @@ import {
     IDrillDownReference,
     isAttributeHierarchyReference,
     ObjRef,
-    objRefToString,
 } from "@gooddata/sdk-model";
 
 /**
@@ -14,16 +13,16 @@ import {
 export function existBlacklistHierarchyPredicate(
     reference: IDrillDownReference,
     attributeHierarchyRef: ObjRef,
-    attributeIdentifier?: string,
+    attributeIdentifier?: ObjRef,
 ): boolean {
     if (isAttributeHierarchyReference(reference)) {
         return (
             areObjRefsEqual(reference.attributeHierarchy, attributeHierarchyRef) &&
-            objRefToString(reference.label) === attributeIdentifier
+            areObjRefsEqual(reference.attribute, attributeIdentifier)
         );
     }
     return (
         areObjRefsEqual(reference.dateHierarchyTemplate, attributeHierarchyRef) &&
-        objRefToString(reference.dateDatasetAttribute) === attributeIdentifier
+        areObjRefsEqual(reference.dateDatasetAttribute, attributeIdentifier)
     );
 }

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/configuration/DrillTargets/AttributeHierarchyDropdown.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/configuration/DrillTargets/AttributeHierarchyDropdown.tsx
@@ -65,13 +65,13 @@ function buildHierarchyItemList(
             existBlacklistHierarchyPredicate(
                 ref,
                 hierarchyRef,
-                attributeDescriptor?.attributeHeader.identifier,
+                attributeDescriptor?.attributeHeader.formOf.ref,
             ),
         );
-        const isInHierarchy = attributesRef.find(
-            (ref) => objRefToString(ref) === attributeDescriptor?.attributeHeader.identifier,
+        const indexInHierarchy = attributesRef.findIndex(
+            (ref) => objRefToString(ref) === attributeDescriptor?.attributeHeader.formOf.identifier,
         );
-        if (isInHierarchy) {
+        if (indexInHierarchy >= 0 && indexInHierarchy < attributesRef.length - 1) {
             items.push({
                 isDisabled: !isInBlacklist,
                 hierarchy: hierarchy,

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/configuration/DrillTargets/DrillTargetAttributeHierarchyItem.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/configuration/DrillTargets/DrillTargetAttributeHierarchyItem.tsx
@@ -2,10 +2,10 @@
 import React from "react";
 import isEmpty from "lodash/isEmpty.js";
 import {
+    areObjRefsEqual,
     ICatalogAttributeHierarchy,
     ICatalogDateAttributeHierarchy,
     isCatalogAttributeHierarchy,
-    objRefToString,
 } from "@gooddata/sdk-model";
 import { AttributeHierarchyDialog } from "@gooddata/sdk-ui-ext";
 
@@ -45,8 +45,8 @@ const DrillTargetAttributeHierarchyItem: React.FC<IDrillTargetDashboardItemProps
         const attributesRef = isCatalogAttributeHierarchy(hierarchy)
             ? hierarchy.attributeHierarchy.attributes
             : hierarchy.attributes;
-        return attributesRef.some(
-            (ref) => objRefToString(ref) === attributeDescriptor?.attributeHeader.identifier,
+        return attributesRef.some((ref) =>
+            areObjRefsEqual(ref, attributeDescriptor?.attributeHeader.formOf.ref),
         );
     });
 

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/configuration/InsightDrillConfigItem.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/configuration/InsightDrillConfigItem.tsx
@@ -2,8 +2,10 @@
 import React, { ReactNode, useMemo } from "react";
 import cx from "classnames";
 import { FormattedMessage, IntlShape, useIntl } from "react-intl";
-import { stringUtils } from "@gooddata/util";
+import cloneDeep from "lodash/cloneDeep.js";
+import { invariant } from "ts-invariant";
 
+import { stringUtils } from "@gooddata/util";
 import { messages } from "@gooddata/sdk-ui";
 import { DRILL_TARGET_TYPE, IDrillConfigItem } from "../../../drill/types.js";
 import { DrillOriginItem } from "./DrillOriginItem.js";
@@ -23,7 +25,6 @@ import {
     selectSelectedWidgetRef,
     useDashboardSelector,
 } from "../../../../model/index.js";
-import { invariant } from "ts-invariant";
 
 export interface IDrillConfigItemProps {
     item: IDrillConfigItem;
@@ -37,20 +38,19 @@ function disableDrillDownIfMeasure(
     isMeasure: boolean,
     intl: IntlShape,
 ) {
+    const drillTargetTypes = cloneDeep(enabledDrillTargetTypeItems);
     if (isMeasure) {
-        const drillDownIndex = enabledDrillTargetTypeItems.findIndex(
-            (item) => item.id === DRILL_TARGET_TYPE.DRILL_DOWN,
-        );
+        const drillDownIndex = drillTargetTypes.findIndex((item) => item.id === DRILL_TARGET_TYPE.DRILL_DOWN);
         if (drillDownIndex >= 0) {
-            const drillDownTarget = enabledDrillTargetTypeItems[drillDownIndex];
+            const drillDownTarget = drillTargetTypes[drillDownIndex];
             drillDownTarget.disabled = true;
             drillDownTarget.disableTooltipMessage = intl.formatMessage(
                 messages.drilldownTooltipDisabledMetric,
             );
-            enabledDrillTargetTypeItems.splice(drillDownIndex, 1, drillDownTarget);
+            drillTargetTypes.splice(drillDownIndex, 1, drillDownTarget);
         }
     }
-    return enabledDrillTargetTypeItems;
+    return drillTargetTypes;
 }
 
 const DrillConfigItem: React.FunctionComponent<IDrillConfigItemProps> = ({

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/configuration/InsightDrillConfigPanel/useInsightDrillConfigPanel.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/configuration/InsightDrillConfigPanel/useInsightDrillConfigPanel.ts
@@ -5,7 +5,6 @@ import { invariant } from "ts-invariant";
 import { useToastMessage } from "@gooddata/sdk-ui-kit";
 import { IAvailableDrillTargets } from "@gooddata/sdk-ui";
 import {
-    idRef,
     IDrillDownReference,
     InsightDrillDefinition,
     isInsightWidget,
@@ -200,7 +199,7 @@ export const useInsightDrillConfigPanel = (props: IUseDrillConfigPanelProps) => 
                 dispatch(
                     addDrillDownForInsightWidget(
                         widgetRef,
-                        idRef(attributeDescriptor!.attributeHeader.identifier, "displayForm"),
+                        attributeDescriptor!.attributeHeader.formOf.ref,
                         (changedItem as IDrillDownAttributeHierarchyConfig).attributeHierarchyRef,
                     ),
                 );
@@ -256,7 +255,7 @@ function buildBlacklistHierarchies(item: IDrillDownAttributeHierarchyConfig): ID
             {
                 type: "dateHierarchyReference",
                 dateHierarchyTemplate: item.attributeHierarchyRef,
-                dateDatasetAttribute: idRef(attributeDescriptor.attributeHeader.identifier, "displayForm"),
+                dateDatasetAttribute: attributeDescriptor.attributeHeader.formOf.ref,
             },
         ];
     }
@@ -264,7 +263,7 @@ function buildBlacklistHierarchies(item: IDrillDownAttributeHierarchyConfig): ID
         {
             type: "attributeHierarchyReference",
             attributeHierarchy: item.attributeHierarchyRef,
-            label: idRef(attributeDescriptor.attributeHeader.identifier, "displayForm"),
+            attribute: attributeDescriptor.attributeHeader.formOf.ref,
         },
     ];
 }


### PR DESCRIPTION


JIRA: EGL-420, EGL-328

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |
| **Compatibility matrix test commands - TIGER Backend**  |                                                            |
| `extended test - matrix-test <AIO_version>`             | Run integrated tests against AIO versions.                 |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

`<AIO_version>` in commands is used to start test with multiple AIO instances - each instance in triggered by one jenkins build

-   To run with `master` and `stable`, execute command `extended test - matrix-test master,stable` or `extended test - matrix-test latest`
-   To run with specific version,ex: `2.3.0` and `2.3.1`, execute command `extended test - matrix-test 2.3.0,2.3.1`
-   In case `<AIO_version>` is empty, read versions from file `compTigerVersions.txt` of this repo

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
