### PR TITLE
RELATED: RAIL-5219 fix the bug when "all time" date filter is not handled correctly by the reset button

### DIFF
--- a/common/config/rush/version-policies.json
+++ b/common/config/rush/version-policies.json
@@ -12,14 +12,14 @@
   {
     "definitionName": "lockStepVersion",
     "policyName": "sdk",
-    "version": "9.5.0-alpha.30",
+    "version": "9.5.0-alpha.30.fix.0",
     "nextBump": "prerelease",
     "mainProject": "@gooddata/sdk-ui-all"
   },
   {
     "definitionName": "lockStepVersion",
     "policyName": "sdk-examples",
-    "version": "9.5.0-alpha.30",
+    "version": "9.5.0-alpha.30.fix.0",
     "nextBump": "prerelease",
     "mainProject": "@gooddata/sdk-interactive-examples"
   }

--- a/common/config/rush/version-policies.json
+++ b/common/config/rush/version-policies.json
@@ -12,14 +12,14 @@
   {
     "definitionName": "lockStepVersion",
     "policyName": "sdk",
-    "version": "9.5.0-alpha.29",
+    "version": "9.5.0-alpha.30",
     "nextBump": "prerelease",
     "mainProject": "@gooddata/sdk-ui-all"
   },
   {
     "definitionName": "lockStepVersion",
     "policyName": "sdk-examples",
-    "version": "9.5.0-alpha.29",
+    "version": "9.5.0-alpha.30",
     "nextBump": "prerelease",
     "mainProject": "@gooddata/sdk-interactive-examples"
   }

--- a/examples/sdk-interactive-examples/examples-template/package.json
+++ b/examples/sdk-interactive-examples/examples-template/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gooddata/sdk-interactive-examples-template",
-    "version": "9.5.0-alpha.30",
+    "version": "9.5.0-alpha.30.fix.0",
     "title": "GoodData interactive example template",
     "description": "GoodData interactive example template",
     "author": "GoodData Corporation",

--- a/examples/sdk-interactive-examples/examples-template/package.json
+++ b/examples/sdk-interactive-examples/examples-template/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gooddata/sdk-interactive-examples-template",
-    "version": "9.5.0-alpha.29",
+    "version": "9.5.0-alpha.30",
     "title": "GoodData interactive example template",
     "description": "GoodData interactive example template",
     "author": "GoodData Corporation",

--- a/examples/sdk-interactive-examples/examples/example-attributefilter/package.json
+++ b/examples/sdk-interactive-examples/examples/example-attributefilter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gooddata/sdk-interactive-example-attributefilter",
-  "version": "9.5.0-alpha.30",
+  "version": "9.5.0-alpha.30.fix.0",
   "title": "Attribute Filter Example",
   "description": "This example demonstrates how to use the AttributeFilter component to filter data in a visualization.",
   "author": "GoodData Corporation",

--- a/examples/sdk-interactive-examples/examples/example-attributefilter/package.json
+++ b/examples/sdk-interactive-examples/examples/example-attributefilter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gooddata/sdk-interactive-example-attributefilter",
-  "version": "9.5.0-alpha.29",
+  "version": "9.5.0-alpha.30",
   "title": "Attribute Filter Example",
   "description": "This example demonstrates how to use the AttributeFilter component to filter data in a visualization.",
   "author": "GoodData Corporation",

--- a/examples/sdk-interactive-examples/examples/example-chartconfig/package.json
+++ b/examples/sdk-interactive-examples/examples/example-chartconfig/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gooddata/sdk-interactive-example-chartconfig",
-  "version": "9.5.0-alpha.30",
+  "version": "9.5.0-alpha.30.fix.0",
   "title": "Chart config manipulation",
   "description": "This interactive example demonstrates how to manipulate the chart config.",
   "author": "GoodData Corporation",

--- a/examples/sdk-interactive-examples/examples/example-chartconfig/package.json
+++ b/examples/sdk-interactive-examples/examples/example-chartconfig/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gooddata/sdk-interactive-example-chartconfig",
-  "version": "9.5.0-alpha.29",
+  "version": "9.5.0-alpha.30",
   "title": "Chart config manipulation",
   "description": "This interactive example demonstrates how to manipulate the chart config.",
   "author": "GoodData Corporation",

--- a/examples/sdk-interactive-examples/examples/example-columnchart/package.json
+++ b/examples/sdk-interactive-examples/examples/example-columnchart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gooddata/sdk-interactive-example-columnchart",
-  "version": "9.5.0-alpha.29",
+  "version": "9.5.0-alpha.30",
   "title": "ColumnChart",
   "description": "This example demonstrates the usage of the ColumnChart component with the viewBy and stackBy properties.",
   "author": "GoodData Corporation",

--- a/examples/sdk-interactive-examples/examples/example-columnchart/package.json
+++ b/examples/sdk-interactive-examples/examples/example-columnchart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gooddata/sdk-interactive-example-columnchart",
-  "version": "9.5.0-alpha.30",
+  "version": "9.5.0-alpha.30.fix.0",
   "title": "ColumnChart",
   "description": "This example demonstrates the usage of the ColumnChart component with the viewBy and stackBy properties.",
   "author": "GoodData Corporation",

--- a/examples/sdk-interactive-examples/examples/example-combochart/package.json
+++ b/examples/sdk-interactive-examples/examples/example-combochart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gooddata/sdk-interactive-example-combochart",
-  "version": "9.5.0-alpha.30",
+  "version": "9.5.0-alpha.30.fix.0",
   "title": "ComboChart",
   "description": "Example demonstrates ComboChart secondaryMeasures definition. ",
   "author": "GoodData Corporation",

--- a/examples/sdk-interactive-examples/examples/example-combochart/package.json
+++ b/examples/sdk-interactive-examples/examples/example-combochart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gooddata/sdk-interactive-example-combochart",
-  "version": "9.5.0-alpha.29",
+  "version": "9.5.0-alpha.30",
   "title": "ComboChart",
   "description": "Example demonstrates ComboChart secondaryMeasures definition. ",
   "author": "GoodData Corporation",

--- a/examples/sdk-interactive-examples/examples/example-dashboard/package.json
+++ b/examples/sdk-interactive-examples/examples/example-dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gooddata/sdk-interactive-example-dashboard",
-  "version": "9.5.0-alpha.29",
+  "version": "9.5.0-alpha.30",
   "title": "Dashboard component",
   "description": "This example shows how to use the Dashboard component.",
   "author": "GoodData Corporation",

--- a/examples/sdk-interactive-examples/examples/example-dashboard/package.json
+++ b/examples/sdk-interactive-examples/examples/example-dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gooddata/sdk-interactive-example-dashboard",
-  "version": "9.5.0-alpha.30",
+  "version": "9.5.0-alpha.30.fix.0",
   "title": "Dashboard component",
   "description": "This example shows how to use the Dashboard component.",
   "author": "GoodData Corporation",

--- a/examples/sdk-interactive-examples/examples/example-datefilter/package.json
+++ b/examples/sdk-interactive-examples/examples/example-datefilter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gooddata/sdk-interactive-example-datefilter",
-  "version": "9.5.0-alpha.30",
+  "version": "9.5.0-alpha.30.fix.0",
   "title": "DateFilter",
   "description": "Example demonstrates usage of Date Filter component.",
   "author": "GoodData Corporation",

--- a/examples/sdk-interactive-examples/examples/example-datefilter/package.json
+++ b/examples/sdk-interactive-examples/examples/example-datefilter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gooddata/sdk-interactive-example-datefilter",
-  "version": "9.5.0-alpha.29",
+  "version": "9.5.0-alpha.30",
   "title": "DateFilter",
   "description": "Example demonstrates usage of Date Filter component.",
   "author": "GoodData Corporation",

--- a/examples/sdk-interactive-examples/examples/example-dependentfilters/package.json
+++ b/examples/sdk-interactive-examples/examples/example-dependentfilters/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gooddata/sdk-interactive-example-dependentfilters",
-  "version": "9.5.0-alpha.30",
+  "version": "9.5.0-alpha.30.fix.0",
   "title": "Dependent Filters Example",
   "description": "This example demonstrates how to use multiple attribute filters linked together to filter data in a visualization.",
   "author": "GoodData Corporation",

--- a/examples/sdk-interactive-examples/examples/example-dependentfilters/package.json
+++ b/examples/sdk-interactive-examples/examples/example-dependentfilters/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gooddata/sdk-interactive-example-dependentfilters",
-  "version": "9.5.0-alpha.29",
+  "version": "9.5.0-alpha.30",
   "title": "Dependent Filters Example",
   "description": "This example demonstrates how to use multiple attribute filters linked together to filter data in a visualization.",
   "author": "GoodData Corporation",

--- a/examples/sdk-interactive-examples/examples/example-execute/package.json
+++ b/examples/sdk-interactive-examples/examples/example-execute/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gooddata/sdk-interactive-example-execute",
-  "version": "9.5.0-alpha.29",
+  "version": "9.5.0-alpha.30",
   "title": "Execute",
   "description": "This example demonstrates using Execute component and build custom visualization.",
   "author": "GoodData Corporation",

--- a/examples/sdk-interactive-examples/examples/example-execute/package.json
+++ b/examples/sdk-interactive-examples/examples/example-execute/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gooddata/sdk-interactive-example-execute",
-  "version": "9.5.0-alpha.30",
+  "version": "9.5.0-alpha.30.fix.0",
   "title": "Execute",
   "description": "This example demonstrates using Execute component and build custom visualization.",
   "author": "GoodData Corporation",

--- a/examples/sdk-interactive-examples/examples/example-granularity/package.json
+++ b/examples/sdk-interactive-examples/examples/example-granularity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gooddata/sdk-interactive-example-granularity",
-  "version": "9.5.0-alpha.30",
+  "version": "9.5.0-alpha.30.fix.0",
   "title": "Granularity",
   "description": "This example exmplains DateFilter granularity ",
   "author": "GoodData Corporation",

--- a/examples/sdk-interactive-examples/examples/example-granularity/package.json
+++ b/examples/sdk-interactive-examples/examples/example-granularity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gooddata/sdk-interactive-example-granularity",
-  "version": "9.5.0-alpha.29",
+  "version": "9.5.0-alpha.30",
   "title": "Granularity",
   "description": "This example exmplains DateFilter granularity ",
   "author": "GoodData Corporation",

--- a/examples/sdk-interactive-examples/examples/example-headline/package.json
+++ b/examples/sdk-interactive-examples/examples/example-headline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gooddata/sdk-interactive-example-headline",
-  "version": "9.5.0-alpha.29",
+  "version": "9.5.0-alpha.30",
   "title": "Headline",
   "description": "This example shows how to use the Headline component.",
   "author": "GoodData Corporation",

--- a/examples/sdk-interactive-examples/examples/example-headline/package.json
+++ b/examples/sdk-interactive-examples/examples/example-headline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gooddata/sdk-interactive-example-headline",
-  "version": "9.5.0-alpha.30",
+  "version": "9.5.0-alpha.30.fix.0",
   "title": "Headline",
   "description": "This example shows how to use the Headline component.",
   "author": "GoodData Corporation",

--- a/examples/sdk-interactive-examples/examples/example-pivottable/package.json
+++ b/examples/sdk-interactive-examples/examples/example-pivottable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gooddata/sdk-interactive-example-pivottable",
-  "version": "9.5.0-alpha.29",
+  "version": "9.5.0-alpha.30",
   "title": "PivotTable",
   "description": "Basic PivotTable manipulation.",
   "author": "GoodData Corporation",

--- a/examples/sdk-interactive-examples/examples/example-pivottable/package.json
+++ b/examples/sdk-interactive-examples/examples/example-pivottable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gooddata/sdk-interactive-example-pivottable",
-  "version": "9.5.0-alpha.30",
+  "version": "9.5.0-alpha.30.fix.0",
   "title": "PivotTable",
   "description": "Basic PivotTable manipulation.",
   "author": "GoodData Corporation",

--- a/examples/sdk-interactive-examples/examples/example-relativedatefilter/package.json
+++ b/examples/sdk-interactive-examples/examples/example-relativedatefilter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gooddata/sdk-interactive-example-relativedatefilter",
-  "version": "9.5.0-alpha.29",
+  "version": "9.5.0-alpha.30",
   "title": "RelativeDateFilter",
   "description": "Example demonstrates how to set relative DateFilter for visualization.",
   "author": "GoodData Corporation",

--- a/examples/sdk-interactive-examples/examples/example-relativedatefilter/package.json
+++ b/examples/sdk-interactive-examples/examples/example-relativedatefilter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gooddata/sdk-interactive-example-relativedatefilter",
-  "version": "9.5.0-alpha.30",
+  "version": "9.5.0-alpha.30.fix.0",
   "title": "RelativeDateFilter",
   "description": "Example demonstrates how to set relative DateFilter for visualization.",
   "author": "GoodData Corporation",

--- a/examples/sdk-interactive-examples/package.json
+++ b/examples/sdk-interactive-examples/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gooddata/sdk-interactive-examples",
-    "version": "9.5.0-alpha.29",
+    "version": "9.5.0-alpha.30",
     "description": "GoodData React interactive examples",
     "license": "LicenseRef-LICENSE",
     "author": "GoodData Corporation",

--- a/examples/sdk-interactive-examples/package.json
+++ b/examples/sdk-interactive-examples/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gooddata/sdk-interactive-examples",
-    "version": "9.5.0-alpha.30",
+    "version": "9.5.0-alpha.30.fix.0",
     "description": "GoodData React interactive examples",
     "license": "LicenseRef-LICENSE",
     "author": "GoodData Corporation",

--- a/libs/api-client-bear/package.json
+++ b/libs/api-client-bear/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gooddata/api-client-bear",
-    "version": "9.5.0-alpha.30",
+    "version": "9.5.0-alpha.30.fix.0",
     "author": "GoodData",
     "description": "API Client for the GoodData platform",
     "repository": {

--- a/libs/api-client-bear/package.json
+++ b/libs/api-client-bear/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gooddata/api-client-bear",
-    "version": "9.5.0-alpha.29",
+    "version": "9.5.0-alpha.30",
     "author": "GoodData",
     "description": "API Client for the GoodData platform",
     "repository": {

--- a/libs/api-client-tiger/package.json
+++ b/libs/api-client-tiger/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gooddata/api-client-tiger",
-    "version": "9.5.0-alpha.30",
+    "version": "9.5.0-alpha.30.fix.0",
     "author": "GoodData",
     "description": "API Client for GoodData Cloud and GoodData.CN",
     "repository": {

--- a/libs/api-client-tiger/package.json
+++ b/libs/api-client-tiger/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gooddata/api-client-tiger",
-    "version": "9.5.0-alpha.29",
+    "version": "9.5.0-alpha.30",
     "author": "GoodData",
     "description": "API Client for GoodData Cloud and GoodData.CN",
     "repository": {

--- a/libs/api-model-bear/package.json
+++ b/libs/api-model-bear/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gooddata/api-model-bear",
-    "version": "9.5.0-alpha.29",
+    "version": "9.5.0-alpha.30",
     "description": "TypeScript definition files for GoodData platform",
     "repository": {
         "type": "git",

--- a/libs/api-model-bear/package.json
+++ b/libs/api-model-bear/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gooddata/api-model-bear",
-    "version": "9.5.0-alpha.30",
+    "version": "9.5.0-alpha.30.fix.0",
     "description": "TypeScript definition files for GoodData platform",
     "repository": {
         "type": "git",

--- a/libs/sdk-backend-base/package.json
+++ b/libs/sdk-backend-base/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gooddata/sdk-backend-base",
-    "version": "9.5.0-alpha.30",
+    "version": "9.5.0-alpha.30.fix.0",
     "author": "GoodData",
     "description": "GoodData.UI SDK - Base for backend implementations",
     "repository": {

--- a/libs/sdk-backend-base/package.json
+++ b/libs/sdk-backend-base/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gooddata/sdk-backend-base",
-    "version": "9.5.0-alpha.29",
+    "version": "9.5.0-alpha.30",
     "author": "GoodData",
     "description": "GoodData.UI SDK - Base for backend implementations",
     "repository": {

--- a/libs/sdk-backend-bear/package.json
+++ b/libs/sdk-backend-bear/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gooddata/sdk-backend-bear",
-    "version": "9.5.0-alpha.30",
+    "version": "9.5.0-alpha.30.fix.0",
     "author": "GoodData",
     "description": "GoodData Backend SPI implementation for the GoodData platform",
     "repository": {

--- a/libs/sdk-backend-bear/package.json
+++ b/libs/sdk-backend-bear/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gooddata/sdk-backend-bear",
-    "version": "9.5.0-alpha.29",
+    "version": "9.5.0-alpha.30",
     "author": "GoodData",
     "description": "GoodData Backend SPI implementation for the GoodData platform",
     "repository": {

--- a/libs/sdk-backend-mockingbird/package.json
+++ b/libs/sdk-backend-mockingbird/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gooddata/sdk-backend-mockingbird",
-    "version": "9.5.0-alpha.30",
+    "version": "9.5.0-alpha.30.fix.0",
     "author": "GoodData",
     "description": "Mock GoodData Backend SPI implementation",
     "repository": {

--- a/libs/sdk-backend-mockingbird/package.json
+++ b/libs/sdk-backend-mockingbird/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gooddata/sdk-backend-mockingbird",
-    "version": "9.5.0-alpha.29",
+    "version": "9.5.0-alpha.30",
     "author": "GoodData",
     "description": "Mock GoodData Backend SPI implementation",
     "repository": {

--- a/libs/sdk-backend-spi/package.json
+++ b/libs/sdk-backend-spi/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gooddata/sdk-backend-spi",
-    "version": "9.5.0-alpha.30",
+    "version": "9.5.0-alpha.30.fix.0",
     "author": "GoodData",
     "description": "GoodData Backend SPI abstraction interfaces",
     "repository": {

--- a/libs/sdk-backend-spi/package.json
+++ b/libs/sdk-backend-spi/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gooddata/sdk-backend-spi",
-    "version": "9.5.0-alpha.29",
+    "version": "9.5.0-alpha.30",
     "author": "GoodData",
     "description": "GoodData Backend SPI abstraction interfaces",
     "repository": {

--- a/libs/sdk-backend-tiger/package.json
+++ b/libs/sdk-backend-tiger/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gooddata/sdk-backend-tiger",
-    "version": "9.5.0-alpha.29",
+    "version": "9.5.0-alpha.30",
     "author": "GoodData",
     "description": "GoodData Backend SPI implementation for GoodData Cloud and GoodData.CN",
     "repository": {

--- a/libs/sdk-backend-tiger/package.json
+++ b/libs/sdk-backend-tiger/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gooddata/sdk-backend-tiger",
-    "version": "9.5.0-alpha.30",
+    "version": "9.5.0-alpha.30.fix.0",
     "author": "GoodData",
     "description": "GoodData Backend SPI implementation for GoodData Cloud and GoodData.CN",
     "repository": {

--- a/libs/sdk-embedding/package.json
+++ b/libs/sdk-embedding/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gooddata/sdk-embedding",
-    "version": "9.5.0-alpha.29",
+    "version": "9.5.0-alpha.30",
     "author": "GoodData",
     "description": "GoodData Embedding APIs",
     "repository": {

--- a/libs/sdk-embedding/package.json
+++ b/libs/sdk-embedding/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gooddata/sdk-embedding",
-    "version": "9.5.0-alpha.30",
+    "version": "9.5.0-alpha.30.fix.0",
     "author": "GoodData",
     "description": "GoodData Embedding APIs",
     "repository": {

--- a/libs/sdk-model/package.json
+++ b/libs/sdk-model/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gooddata/sdk-model",
-    "version": "9.5.0-alpha.29",
+    "version": "9.5.0-alpha.30",
     "author": "GoodData",
     "description": "GoodData Model definitions used by UI components and Backend SPI and its implementations",
     "repository": {

--- a/libs/sdk-model/package.json
+++ b/libs/sdk-model/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gooddata/sdk-model",
-    "version": "9.5.0-alpha.30",
+    "version": "9.5.0-alpha.30.fix.0",
     "author": "GoodData",
     "description": "GoodData Model definitions used by UI components and Backend SPI and its implementations",
     "repository": {

--- a/libs/sdk-ui-all/package.json
+++ b/libs/sdk-ui-all/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gooddata/sdk-ui-all",
-    "version": "9.5.0-alpha.29",
+    "version": "9.5.0-alpha.30",
     "author": "GoodData",
     "description": "GoodData SDK - All-In-One",
     "repository": {

--- a/libs/sdk-ui-all/package.json
+++ b/libs/sdk-ui-all/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gooddata/sdk-ui-all",
-    "version": "9.5.0-alpha.30",
+    "version": "9.5.0-alpha.30.fix.0",
     "author": "GoodData",
     "description": "GoodData SDK - All-In-One",
     "repository": {

--- a/libs/sdk-ui-charts/package.json
+++ b/libs/sdk-ui-charts/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gooddata/sdk-ui-charts",
-    "version": "9.5.0-alpha.29",
+    "version": "9.5.0-alpha.30",
     "description": "GoodData.UI SDK - Charts",
     "repository": {
         "type": "git",

--- a/libs/sdk-ui-charts/package.json
+++ b/libs/sdk-ui-charts/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gooddata/sdk-ui-charts",
-    "version": "9.5.0-alpha.30",
+    "version": "9.5.0-alpha.30.fix.0",
     "description": "GoodData.UI SDK - Charts",
     "repository": {
         "type": "git",

--- a/libs/sdk-ui-dashboard/package.json
+++ b/libs/sdk-ui-dashboard/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gooddata/sdk-ui-dashboard",
-    "version": "9.5.0-alpha.29",
+    "version": "9.5.0-alpha.30",
     "description": "GoodData SDK - Dashboard Component",
     "repository": {
         "type": "git",

--- a/libs/sdk-ui-dashboard/package.json
+++ b/libs/sdk-ui-dashboard/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gooddata/sdk-ui-dashboard",
-    "version": "9.5.0-alpha.30",
+    "version": "9.5.0-alpha.30.fix.0",
     "description": "GoodData SDK - Dashboard Component",
     "repository": {
         "type": "git",

--- a/libs/sdk-ui-dashboard/src/presentation/filterBar/filterBar/hooks/useResetFiltersButton.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/filterBar/filterBar/hooks/useResetFiltersButton.ts
@@ -1,6 +1,13 @@
 // (C) 2023 GoodData Corporation
 import React from "react";
 import isEqual from "lodash/isEqual.js";
+import partition from "lodash/partition.js";
+import {
+    IDashboardAttributeFilter,
+    IDashboardDateFilter,
+    isDashboardDateFilter,
+    newAllTimeDashboardDateFilter,
+} from "@gooddata/sdk-model";
 
 import {
     changeFilterContextSelection,
@@ -35,8 +42,19 @@ export const useResetFiltersButton = (): [boolean, () => void] => {
             return;
         }
 
+        // Normalize filters to include "All time" date filter
+        const [[dateFilter], attributeFilters] = partition(originalFilters, isDashboardDateFilter) as [
+            IDashboardDateFilter[],
+            IDashboardAttributeFilter[],
+        ];
+
         // Dispatch a command, so it goes through the proper piping and trigger all the events
-        dispatch(changeFilterContextSelection(originalFilters));
+        dispatch(
+            changeFilterContextSelection([
+                dateFilter ?? newAllTimeDashboardDateFilter(),
+                ...attributeFilters,
+            ]),
+        );
         // Report the reset as user interaction
         filterContextStateReset();
     }, [dispatch, filterContextStateReset, originalFilters, canReset]);

--- a/libs/sdk-ui-ext/package.json
+++ b/libs/sdk-ui-ext/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gooddata/sdk-ui-ext",
-    "version": "9.5.0-alpha.29",
+    "version": "9.5.0-alpha.30",
     "description": "GoodData.UI SDK - Extensions",
     "repository": {
         "type": "git",

--- a/libs/sdk-ui-ext/package.json
+++ b/libs/sdk-ui-ext/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gooddata/sdk-ui-ext",
-    "version": "9.5.0-alpha.30",
+    "version": "9.5.0-alpha.30.fix.0",
     "description": "GoodData.UI SDK - Extensions",
     "repository": {
         "type": "git",

--- a/libs/sdk-ui-filters/package.json
+++ b/libs/sdk-ui-filters/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gooddata/sdk-ui-filters",
-    "version": "9.5.0-alpha.29",
+    "version": "9.5.0-alpha.30",
     "description": "GoodData.UI SDK - Filter Components",
     "repository": {
         "type": "git",

--- a/libs/sdk-ui-filters/package.json
+++ b/libs/sdk-ui-filters/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gooddata/sdk-ui-filters",
-    "version": "9.5.0-alpha.30",
+    "version": "9.5.0-alpha.30.fix.0",
     "description": "GoodData.UI SDK - Filter Components",
     "repository": {
         "type": "git",

--- a/libs/sdk-ui-geo/package.json
+++ b/libs/sdk-ui-geo/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gooddata/sdk-ui-geo",
-    "version": "9.5.0-alpha.30",
+    "version": "9.5.0-alpha.30.fix.0",
     "description": "GoodData.UI SDK - Geo Charts",
     "repository": {
         "type": "git",

--- a/libs/sdk-ui-geo/package.json
+++ b/libs/sdk-ui-geo/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gooddata/sdk-ui-geo",
-    "version": "9.5.0-alpha.29",
+    "version": "9.5.0-alpha.30",
     "description": "GoodData.UI SDK - Geo Charts",
     "repository": {
         "type": "git",

--- a/libs/sdk-ui-kit/package.json
+++ b/libs/sdk-ui-kit/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gooddata/sdk-ui-kit",
-    "version": "9.5.0-alpha.30",
+    "version": "9.5.0-alpha.30.fix.0",
     "description": "GoodData SDK - UI Building Components",
     "repository": {
         "type": "git",

--- a/libs/sdk-ui-kit/package.json
+++ b/libs/sdk-ui-kit/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gooddata/sdk-ui-kit",
-    "version": "9.5.0-alpha.29",
+    "version": "9.5.0-alpha.30",
     "description": "GoodData SDK - UI Building Components",
     "repository": {
         "type": "git",

--- a/libs/sdk-ui-loaders/package.json
+++ b/libs/sdk-ui-loaders/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gooddata/sdk-ui-loaders",
-    "version": "9.5.0-alpha.30",
+    "version": "9.5.0-alpha.30.fix.0",
     "description": "GoodData SDK Runtime Component Loaders",
     "repository": {
         "type": "git",

--- a/libs/sdk-ui-loaders/package.json
+++ b/libs/sdk-ui-loaders/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gooddata/sdk-ui-loaders",
-    "version": "9.5.0-alpha.29",
+    "version": "9.5.0-alpha.30",
     "description": "GoodData SDK Runtime Component Loaders",
     "repository": {
         "type": "git",

--- a/libs/sdk-ui-pivot/package.json
+++ b/libs/sdk-ui-pivot/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gooddata/sdk-ui-pivot",
-    "version": "9.5.0-alpha.29",
+    "version": "9.5.0-alpha.30",
     "description": "GoodData.UI SDK - Pivot Table",
     "repository": {
         "type": "git",

--- a/libs/sdk-ui-pivot/package.json
+++ b/libs/sdk-ui-pivot/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gooddata/sdk-ui-pivot",
-    "version": "9.5.0-alpha.30",
+    "version": "9.5.0-alpha.30.fix.0",
     "description": "GoodData.UI SDK - Pivot Table",
     "repository": {
         "type": "git",

--- a/libs/sdk-ui-theme-provider/package.json
+++ b/libs/sdk-ui-theme-provider/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gooddata/sdk-ui-theme-provider",
-    "version": "9.5.0-alpha.29",
+    "version": "9.5.0-alpha.30",
     "description": "GoodData SDK - Theme provider",
     "repository": {
         "type": "git",

--- a/libs/sdk-ui-theme-provider/package.json
+++ b/libs/sdk-ui-theme-provider/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gooddata/sdk-ui-theme-provider",
-    "version": "9.5.0-alpha.30",
+    "version": "9.5.0-alpha.30.fix.0",
     "description": "GoodData SDK - Theme provider",
     "repository": {
         "type": "git",

--- a/libs/sdk-ui-vis-commons/package.json
+++ b/libs/sdk-ui-vis-commons/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gooddata/sdk-ui-vis-commons",
-    "version": "9.5.0-alpha.29",
+    "version": "9.5.0-alpha.30",
     "description": "GoodData.UI SDK - common functionality for different types of visualizations",
     "repository": {
         "type": "git",

--- a/libs/sdk-ui-vis-commons/package.json
+++ b/libs/sdk-ui-vis-commons/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gooddata/sdk-ui-vis-commons",
-    "version": "9.5.0-alpha.30",
+    "version": "9.5.0-alpha.30.fix.0",
     "description": "GoodData.UI SDK - common functionality for different types of visualizations",
     "repository": {
         "type": "git",

--- a/libs/sdk-ui/package.json
+++ b/libs/sdk-ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gooddata/sdk-ui",
-    "version": "9.5.0-alpha.29",
+    "version": "9.5.0-alpha.30",
     "description": "GoodData.UI SDK - Core",
     "repository": {
         "type": "git",

--- a/libs/sdk-ui/package.json
+++ b/libs/sdk-ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gooddata/sdk-ui",
-    "version": "9.5.0-alpha.30",
+    "version": "9.5.0-alpha.30.fix.0",
     "description": "GoodData.UI SDK - Core",
     "repository": {
         "type": "git",

--- a/libs/util/package.json
+++ b/libs/util/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gooddata/util",
-    "version": "9.5.0-alpha.29",
+    "version": "9.5.0-alpha.30",
     "author": "GoodData",
     "description": "GoodData Utility Functions",
     "repository": {

--- a/libs/util/package.json
+++ b/libs/util/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gooddata/util",
-    "version": "9.5.0-alpha.30",
+    "version": "9.5.0-alpha.30.fix.0",
     "author": "GoodData",
     "description": "GoodData Utility Functions",
     "repository": {

--- a/tools/app-toolkit/package.json
+++ b/tools/app-toolkit/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gooddata/app-toolkit",
-    "version": "9.5.0-alpha.30",
+    "version": "9.5.0-alpha.30.fix.0",
     "author": "GoodData",
     "description": "CLI with useful tools for creating and maintaining GoodData web applications.",
     "repository": {

--- a/tools/app-toolkit/package.json
+++ b/tools/app-toolkit/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gooddata/app-toolkit",
-    "version": "9.5.0-alpha.29",
+    "version": "9.5.0-alpha.30",
     "author": "GoodData",
     "description": "CLI with useful tools for creating and maintaining GoodData web applications.",
     "repository": {

--- a/tools/catalog-export/package.json
+++ b/tools/catalog-export/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gooddata/catalog-export",
-    "version": "9.5.0-alpha.29",
+    "version": "9.5.0-alpha.30",
     "author": "GoodData",
     "description": "GoodData SDK Catalog Export tooling",
     "repository": {

--- a/tools/catalog-export/package.json
+++ b/tools/catalog-export/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gooddata/catalog-export",
-    "version": "9.5.0-alpha.30",
+    "version": "9.5.0-alpha.30.fix.0",
     "author": "GoodData",
     "description": "GoodData SDK Catalog Export tooling",
     "repository": {

--- a/tools/experimental-workspace/package.json
+++ b/tools/experimental-workspace/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gooddata/experimental-workspace",
-    "version": "9.5.0-alpha.30",
+    "version": "9.5.0-alpha.30.fix.0",
     "author": "GoodData",
     "description": "GoodData SDK - Experimental workspace for features in dev",
     "repository": {

--- a/tools/experimental-workspace/package.json
+++ b/tools/experimental-workspace/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gooddata/experimental-workspace",
-    "version": "9.5.0-alpha.29",
+    "version": "9.5.0-alpha.30",
     "author": "GoodData",
     "description": "GoodData SDK - Experimental workspace for features in dev",
     "repository": {

--- a/tools/i18n-toolkit/package.json
+++ b/tools/i18n-toolkit/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gooddata/i18n-toolkit",
-    "version": "9.5.0-alpha.29",
+    "version": "9.5.0-alpha.30",
     "author": "GoodData",
     "description": "Localization validator to validate localization complexity and intl and html format.",
     "repository": {

--- a/tools/i18n-toolkit/package.json
+++ b/tools/i18n-toolkit/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gooddata/i18n-toolkit",
-    "version": "9.5.0-alpha.30",
+    "version": "9.5.0-alpha.30.fix.0",
     "author": "GoodData",
     "description": "Localization validator to validate localization complexity and intl and html format.",
     "repository": {

--- a/tools/live-examples-workspace/package.json
+++ b/tools/live-examples-workspace/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gooddata/live-examples-workspace",
-    "version": "9.5.0-alpha.29",
+    "version": "9.5.0-alpha.30",
     "author": "GoodData",
     "description": "GoodData SDK - Live examples workspace for tests",
     "repository": {

--- a/tools/live-examples-workspace/package.json
+++ b/tools/live-examples-workspace/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gooddata/live-examples-workspace",
-    "version": "9.5.0-alpha.30",
+    "version": "9.5.0-alpha.30.fix.0",
     "author": "GoodData",
     "description": "GoodData SDK - Live examples workspace for tests",
     "repository": {

--- a/tools/mock-handling/package.json
+++ b/tools/mock-handling/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gooddata/mock-handling",
-    "version": "9.5.0-alpha.29",
+    "version": "9.5.0-alpha.30",
     "author": "GoodData",
     "description": "GoodData SDK Mock data capture and management tool",
     "repository": {

--- a/tools/mock-handling/package.json
+++ b/tools/mock-handling/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gooddata/mock-handling",
-    "version": "9.5.0-alpha.30",
+    "version": "9.5.0-alpha.30.fix.0",
     "author": "GoodData",
     "description": "GoodData SDK Mock data capture and management tool",
     "repository": {

--- a/tools/plugin-toolkit/package.json
+++ b/tools/plugin-toolkit/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gooddata/plugin-toolkit",
-    "version": "9.5.0-alpha.29",
+    "version": "9.5.0-alpha.30",
     "author": "GoodData",
     "description": "GoodData Set of Tools for working with Plugins",
     "repository": {

--- a/tools/plugin-toolkit/package.json
+++ b/tools/plugin-toolkit/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gooddata/plugin-toolkit",
-    "version": "9.5.0-alpha.30",
+    "version": "9.5.0-alpha.30.fix.0",
     "author": "GoodData",
     "description": "GoodData Set of Tools for working with Plugins",
     "repository": {

--- a/tools/reference-workspace/package.json
+++ b/tools/reference-workspace/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gooddata/reference-workspace",
-    "version": "9.5.0-alpha.30",
+    "version": "9.5.0-alpha.30.fix.0",
     "author": "GoodData",
     "description": "GoodData SDK - Reference Workspace for tests",
     "repository": {

--- a/tools/reference-workspace/package.json
+++ b/tools/reference-workspace/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gooddata/reference-workspace",
-    "version": "9.5.0-alpha.29",
+    "version": "9.5.0-alpha.30",
     "author": "GoodData",
     "description": "GoodData SDK - Reference Workspace for tests",
     "repository": {


### PR DESCRIPTION
Backporting hotfix

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |
| **Compatibility matrix test commands - TIGER Backend**  |                                                            |
| `extended test - matrix-test <AIO_version>`             | Run integrated tests against AIO versions.                 |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

`<AIO_version>` in commands is used to start test with multiple AIO instances - each instance in triggered by one jenkins build

-   To run with `master` and `stable`, execute command `extended test - matrix-test master,stable` or `extended test - matrix-test latest`
-   To run with specific version,ex: `2.3.0` and `2.3.1`, execute command `extended test - matrix-test 2.3.0,2.3.1`
-   In case `<AIO_version>` is empty, read versions from file `compTigerVersions.txt` of this repo

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
