### PR TITLE
RELATED: SD-3066 add CSV APIs into tigerSpecificFunctions

### DIFF
--- a/libs/sdk-backend-tiger/api/sdk-backend-tiger.api.md
+++ b/libs/sdk-backend-tiger/api/sdk-backend-tiger.api.md
@@ -5,6 +5,8 @@
 ```ts
 
 import { ActionsApiProcessInvitationRequest } from '@gooddata/api-client-tiger';
+import { AnalyzeCsvRequest } from '@gooddata/api-client-tiger';
+import { AnalyzeCsvResponse } from '@gooddata/api-client-tiger';
 import { AnonymousAuthProvider } from '@gooddata/sdk-backend-base';
 import { ApiEntitlement } from '@gooddata/api-client-tiger';
 import { ApiEntitlementNameEnum } from '@gooddata/api-client-tiger';
@@ -24,6 +26,7 @@ import { IAuthenticatedPrincipal } from '@gooddata/sdk-backend-spi';
 import { IAuthenticationContext } from '@gooddata/sdk-backend-spi';
 import { IAuthenticationProvider } from '@gooddata/sdk-backend-spi';
 import { IdentifierDuplications } from '@gooddata/api-client-tiger';
+import { ImportCsvRequest } from '@gooddata/api-client-tiger';
 import { ITigerClient } from '@gooddata/api-client-tiger';
 import { IUser } from '@gooddata/sdk-model';
 import { JsonApiAnalyticalDashboardOutMetaOrigin } from '@gooddata/api-client-tiger';
@@ -43,6 +46,7 @@ import { ObjectType } from '@gooddata/sdk-model';
 import { PlatformUsage } from '@gooddata/api-client-tiger';
 import { ScanResultPdm } from '@gooddata/api-client-tiger';
 import { ScanSqlResponse } from '@gooddata/api-client-tiger';
+import { StagingUploadLocation } from '@gooddata/api-client-tiger';
 import { TestDefinitionRequestTypeEnum } from '@gooddata/api-client-tiger';
 
 export { AnonymousAuthProvider }
@@ -423,6 +427,9 @@ export type TigerSpecificFunctions = {
     getEntityUser?: (id: string) => Promise<IUser>;
     scanSql?: (dataSourceId: string, sql: string) => Promise<ScanSqlResult>;
     checkEntityOverrides?: (workspaceId: string, entities: Array<HierarchyObjectIdentification>) => Promise<Array<IdentifierDuplications>>;
+    getStagingUploadLocation?: (dataSourceId: string) => Promise<StagingUploadLocation>;
+    analyzeCsv?: (dataSourceId: string, analyzeCsvRequest: AnalyzeCsvRequest) => Promise<Array<AnalyzeCsvResponse>>;
+    importCsv?: (dataSourceId: string, importCsvRequest: ImportCsvRequest) => Promise<void>;
 };
 
 // @public

--- a/libs/sdk-backend-tiger/src/backend/tigerSpecificFunctions.ts
+++ b/libs/sdk-backend-tiger/src/backend/tigerSpecificFunctions.ts
@@ -43,6 +43,10 @@ import {
     JsonApiWorkspaceDataFilterSettingOutDocument,
     JsonApiWorkspaceDataFilterSettingInDocument,
     ScanResultPdm,
+    StagingUploadLocation,
+    AnalyzeCsvRequest,
+    AnalyzeCsvResponse,
+    ImportCsvRequest,
 } from "@gooddata/api-client-tiger";
 import { convertApiError } from "../utils/errorHandling.js";
 import uniq from "lodash/uniq.js";
@@ -465,6 +469,28 @@ export type TigerSpecificFunctions = {
         workspaceId: string,
         entities: Array<HierarchyObjectIdentification>,
     ) => Promise<Array<IdentifierDuplications>>;
+
+    /**
+     * Get pre-signed S3 URL to upload a CSV file to the GDSTORAGE data source staging location
+     * @param dataSourceId - id of the data source
+     */
+    getStagingUploadLocation?: (dataSourceId: string) => Promise<StagingUploadLocation>;
+
+    /**
+     * Analyze CSV files in GDSTORAGE data source staging location
+     * @param analyzeRequest - the request to analyze CSV files
+     */
+    analyzeCsv?: (
+        dataSourceId: string,
+        analyzeCsvRequest: AnalyzeCsvRequest,
+    ) => Promise<Array<AnalyzeCsvResponse>>;
+
+    /**
+     * Import CSV files from GDSTORAGE data source staging location
+     * @param dataSourceId - id of the data source
+     * @param importRequest - the request to import CSV files
+     */
+    importCsv?: (dataSourceId: string, importCsvRequest: ImportCsvRequest) => Promise<void>;
 };
 
 const getDataSourceErrorMessage = (error: unknown) => {
@@ -1427,6 +1453,52 @@ export const buildTigerSpecificFunctions = (
                     .then((response) => {
                         return response.data as Array<IdentifierDuplications>;
                     });
+            });
+        } catch (error: any) {
+            throw convertApiError(error);
+        }
+    },
+
+    getStagingUploadLocation: async (dataSourceId: string) => {
+        try {
+            return await authApiCall(async (sdk) => {
+                return await sdk.result
+                    .getStagingUploadLocation({
+                        dataSourceId: dataSourceId,
+                    })
+                    .then((res) => {
+                        return res?.data;
+                    });
+            });
+        } catch (error: any) {
+            throw convertApiError(error);
+        }
+    },
+
+    analyzeCsv: async (dataSourceId: string, analyzeCsvRequest: AnalyzeCsvRequest) => {
+        try {
+            return await authApiCall(async (sdk) => {
+                return await sdk.result
+                    .analyzeCsv({
+                        dataSourceId: dataSourceId,
+                        analyzeCsvRequest: analyzeCsvRequest,
+                    })
+                    .then((res) => {
+                        return res?.data;
+                    });
+            });
+        } catch (error: any) {
+            throw convertApiError(error);
+        }
+    },
+
+    importCsv: async (dataSourceId: string, importCsvRequest: ImportCsvRequest) => {
+        try {
+            return await authApiCall(async (sdk) => {
+                await sdk.result.importCsv({
+                    dataSourceId: dataSourceId,
+                    importCsvRequest: importCsvRequest,
+                });
             });
         } catch (error: any) {
             throw convertApiError(error);


### PR DESCRIPTION
<!--


-->

JIRA: SD-3066

Introduce APIs for CSV analytics into tigerSpecificFunctions

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |
| **Compatibility matrix test commands - TIGER Backend**  |                                                            |
| `extended test - matrix-test <AIO_version>`             | Run integrated tests against AIO versions.                 |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

`<AIO_version>` in commands is used to start test with multiple AIO instances - each instance in triggered by one jenkins build

-   To run with `master` and `stable`, execute command `extended test - matrix-test master,stable` or `extended test - matrix-test latest`
-   To run with specific version,ex: `2.3.0` and `2.3.1`, execute command `extended test - matrix-test 2.3.0,2.3.1`
-   In case `<AIO_version>` is empty, read versions from file `compTigerVersions.txt` of this repo

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
