### PR TITLE
FEATURE: TNT-1805 Filter selection in drill to custom url

### DIFF
--- a/common/changes/@gooddata/sdk-ui-all/mkn-tnt-1805_2023-12-13-22-01.json
+++ b/common/changes/@gooddata/sdk-ui-all/mkn-tnt-1805_2023-12-13-22-01.json
@@ -1,0 +1,10 @@
+{
+    "changes": [
+        {
+            "packageName": "@gooddata/sdk-ui-all",
+            "comment": "Add support for attribute filter selection in drill to custom url.",
+            "type": "none"
+        }
+    ],
+    "packageName": "@gooddata/sdk-ui-all"
+}

--- a/libs/sdk-model/src/dashboard/drillUrl.ts
+++ b/libs/sdk-model/src/dashboard/drillUrl.ts
@@ -27,10 +27,12 @@ function matchAll(regex: RegExp, text: string): RegExpExecArray[] {
     return matches;
 }
 
-const identifierSplitRegexp = /(\{attribute_title\(.*?\)\})/g;
-const identifierMatchRegexp = /\{attribute_title\((.*?)\)\}/g;
+const attributeIdentifierSplitRegexp = /(\{attribute_title\(.*?\)\})/g;
+const attributeIdentifierMatchRegexp = /\{attribute_title\((.*?)\)\}/g;
+const dashboardAttributeFilterMatchRegexp = /\{dash_attribute_filter_selection\((.*?)\)\}/g;
+const insightAttributeFilterMatchRegexp = /\{attribute_filter_selection\((.*?)\)\}/g;
 
-const identifierToPlaceholder = (ref: IdentifierRef) => `{attribute_title(${ref.identifier})}`;
+const attributeIdentifierToPlaceholder = (ref: IdentifierRef) => `{attribute_title(${ref.identifier})}`;
 
 const matchToUrlPlaceholder = (match: any): IDrillToUrlPlaceholder => ({
     placeholder: match[0],
@@ -39,14 +41,14 @@ const matchToUrlPlaceholder = (match: any): IDrillToUrlPlaceholder => ({
     toBeEncoded: match.index !== 0,
 });
 
-const splitUrl = (url: string): string[] => url.split(identifierSplitRegexp);
+const splitAttributeIdentifierUrl = (url: string): string[] => url.split(attributeIdentifierSplitRegexp);
 
 /**
  * @internal
  */
 export const splitDrillUrlParts = (url: string): IDrillUrlPart[] => {
-    return splitUrl(url).map((urlPart: string) => {
-        const match = identifierMatchRegexp.exec(urlPart);
+    return splitAttributeIdentifierUrl(url).map((urlPart: string) => {
+        const match = attributeIdentifierMatchRegexp.exec(urlPart);
         if (match !== null) {
             return matchToUrlPlaceholder(match).ref;
         }
@@ -67,7 +69,7 @@ export const joinDrillUrlParts = (parts: IDrillUrlPart[] | string): string => {
     return parts
         .map((urlPart: IDrillUrlPart) => {
             if (isIdentifierRef(urlPart)) {
-                return identifierToPlaceholder(urlPart);
+                return attributeIdentifierToPlaceholder(urlPart);
             }
 
             return urlPart;
@@ -79,4 +81,16 @@ export const joinDrillUrlParts = (parts: IDrillUrlPart[] | string): string => {
  * @internal
  */
 export const getAttributeIdentifiersPlaceholdersFromUrl = (url: string): IDrillToUrlPlaceholder[] =>
-    matchAll(identifierMatchRegexp, url).map(matchToUrlPlaceholder);
+    matchAll(attributeIdentifierMatchRegexp, url).map(matchToUrlPlaceholder);
+
+/**
+ * @internal
+ */
+export const getDashboardAttributeFilterPlaceholdersFromUrl = (url: string): IDrillToUrlPlaceholder[] =>
+    matchAll(dashboardAttributeFilterMatchRegexp, url).map(matchToUrlPlaceholder);
+
+/**
+ * @internal
+ */
+export const getInsightAttributeFilterPlaceholdersFromUrl = (url: string): IDrillToUrlPlaceholder[] =>
+    matchAll(insightAttributeFilterMatchRegexp, url).map(matchToUrlPlaceholder);

--- a/libs/sdk-model/src/internal.ts
+++ b/libs/sdk-model/src/internal.ts
@@ -4,4 +4,6 @@ export {
     joinDrillUrlParts,
     splitDrillUrlParts,
     getAttributeIdentifiersPlaceholdersFromUrl,
+    getDashboardAttributeFilterPlaceholdersFromUrl,
+    getInsightAttributeFilterPlaceholdersFromUrl,
 } from "./dashboard/drillUrl.js";

--- a/libs/sdk-ui-dashboard/.dependency-cruiser.cjs
+++ b/libs/sdk-ui-dashboard/.dependency-cruiser.cjs
@@ -95,6 +95,8 @@ options = {
             "src/presentation/types.ts",
             "src/presentation/localization",
             "src/types.ts",
+            "src/converters",
+            "src/presentation/widget/common/useWidgetFilters.ts",
         ]),
         depCruiser.moduleWithDependencies("filterBar", "src/presentation/filterBar", [
             "src/_staging/*",

--- a/libs/sdk-ui-dashboard/src/_staging/drills/drillingUtils.ts
+++ b/libs/sdk-ui-dashboard/src/_staging/drills/drillingUtils.ts
@@ -36,7 +36,11 @@ import {
 } from "../../types.js";
 import isEqual from "lodash/isEqual.js";
 
-export { getAttributeIdentifiersPlaceholdersFromUrl } from "@gooddata/sdk-model/internal";
+export {
+    getAttributeIdentifiersPlaceholdersFromUrl,
+    getDashboardAttributeFilterPlaceholdersFromUrl,
+    getInsightAttributeFilterPlaceholdersFromUrl,
+} from "@gooddata/sdk-model/internal";
 
 interface IImplicitDrillWithPredicates {
     drillDefinition: DrillDefinition | IDrillDownDefinition;

--- a/libs/sdk-ui-dashboard/src/presentation/drill/DrillConfigPanel/DrillToUrl/CustomUrlEditorParameters.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/drill/DrillConfigPanel/DrillToUrl/CustomUrlEditorParameters.tsx
@@ -8,8 +8,14 @@ import {
     InsightParametersSection,
 } from "./CustomUrlEditorParametersSections/InsightParametersSection.js";
 import { IIdentifierParametersSectionProps } from "./types.js";
+import {
+    DashboardParametersSection,
+    IDashboardParametersSectionProps,
+} from "./CustomUrlEditorParametersSections/DashboardParametersSection.js";
 
-type IParametersPanelProps = IInsightParametersSectionProps & IIdentifierParametersSectionProps;
+type IParametersPanelProps = IInsightParametersSectionProps &
+    IIdentifierParametersSectionProps &
+    IDashboardParametersSectionProps;
 
 export const ParametersPanel: React.FC<IParametersPanelProps> = ({
     attributeDisplayForms,
@@ -19,6 +25,8 @@ export const ParametersPanel: React.FC<IParametersPanelProps> = ({
     enableWidgetIdParameter,
     onAdd,
     intl,
+    dashboardFilters,
+    insightFilters,
 }) => (
     <div>
         <label className="gd-label">
@@ -36,7 +44,9 @@ export const ParametersPanel: React.FC<IParametersPanelProps> = ({
                 loadingAttributeDisplayForms={loadingAttributeDisplayForms}
                 onAdd={onAdd}
                 intl={intl}
+                insightFilters={insightFilters}
             />
+            <DashboardParametersSection intl={intl} onAdd={onAdd} dashboardFilters={dashboardFilters} />
             <IdentifierParametersSection
                 enableClientIdParameter={enableClientIdParameter}
                 enableDataProductIdParameter={enableDataProductIdParameter}

--- a/libs/sdk-ui-dashboard/src/presentation/drill/DrillConfigPanel/DrillToUrl/CustomUrlEditorParametersSections/DashboardParametersSection.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/drill/DrillConfigPanel/DrillToUrl/CustomUrlEditorParametersSections/DashboardParametersSection.tsx
@@ -1,0 +1,42 @@
+// (C) 2020-2022 GoodData Corporation
+import React from "react";
+import { FormattedMessage } from "react-intl";
+import { DropdownSectionHeader } from "../DropdownSectionHeader.js";
+import { selectAllCatalogDisplayFormsMap, useDashboardSelector } from "../../../../../model/index.js";
+import { DisplayFormParam } from "./DisplayFormParam.js";
+import { IAttributeFilter, filterObjRef } from "@gooddata/sdk-model";
+import { IParametersPanelSectionsCommonProps } from "../types.js";
+
+export interface IDashboardParametersSectionProps extends IParametersPanelSectionsCommonProps {
+    dashboardFilters?: IAttributeFilter[];
+}
+
+export const DashboardParametersSection: React.FC<IDashboardParametersSectionProps> = ({
+    dashboardFilters,
+    onAdd,
+}) => {
+    const catalogDisplayFormsMap = useDashboardSelector(selectAllCatalogDisplayFormsMap);
+
+    return (
+        <>
+            <DropdownSectionHeader>
+                <FormattedMessage id="configurationPanel.drillIntoUrl.editor.dashboardParametersSectionLabel" />
+            </DropdownSectionHeader>
+            {dashboardFilters?.map((filter, index) => {
+                const df = catalogDisplayFormsMap.get(filterObjRef(filter));
+                const filterIdentifier = df?.id;
+
+                return df ? (
+                    <DisplayFormParam
+                        key={index}
+                        item={df}
+                        iconClassName="gd-icon-filter"
+                        onAdd={() => {
+                            onAdd(`{dash_attribute_filter_selection(${filterIdentifier})}`);
+                        }}
+                    />
+                ) : null;
+            })}
+        </>
+    );
+};

--- a/libs/sdk-ui-dashboard/src/presentation/drill/DrillConfigPanel/DrillToUrl/CustomUrlEditorParametersSections/DisplayFormParam.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/drill/DrillConfigPanel/DrillToUrl/CustomUrlEditorParametersSections/DisplayFormParam.tsx
@@ -1,0 +1,57 @@
+// (C) 2020-2023 GoodData Corporation
+import React from "react";
+import { useIntl } from "react-intl";
+import { AttributeDisplayFormParameterDetail } from "../ParameterDetails/AttributeDisplayFormParameterDetail.js";
+import { Parameter } from "./Parameter.js";
+import { useWorkspaceStrict } from "@gooddata/sdk-ui";
+import { AttributeDisplayFormType, IAttributeDisplayFormMetadataObject } from "@gooddata/sdk-model";
+import { selectAllCatalogAttributesMap, useDashboardSelector } from "../../../../../model/index.js";
+
+interface XProps {
+    item: IAttributeDisplayFormMetadataObject;
+    onAdd: (placeholder: string) => void;
+    iconClassName?: string;
+}
+
+export const DisplayFormParam: React.FC<XProps> = ({ item, onAdd, iconClassName }) => {
+    const x = useDashboardSelector(selectAllCatalogAttributesMap);
+    const y = x.get(item.attribute);
+    const intl = useIntl();
+    const projectId = useWorkspaceStrict();
+
+    return (
+        <Parameter
+            key={item.id}
+            name={y?.attribute.title || ""}
+            description={item.title}
+            detailContent={
+                <AttributeDisplayFormParameterDetail
+                    title={y?.attribute.title || ""}
+                    label={item.title}
+                    type={item.displayFormType as AttributeDisplayFormType}
+                    projectId={projectId}
+                    displayFormRef={item.ref}
+                    showValues={true} // TODO
+                />
+            }
+            iconClassName={
+                iconClassName ?? getDisplayFormIcon(item.displayFormType as AttributeDisplayFormType)
+            }
+            onAdd={() => onAdd(`{attribute_title(${item.id})}`)}
+            intl={intl}
+        />
+    );
+};
+
+const getDisplayFormIcon = (type: AttributeDisplayFormType | undefined) => {
+    switch (type) {
+        case "GDC.link":
+            return "gd-icon-hyperlink-warning";
+        case "GDC.geo.pin":
+        case "GDC.geo.pin_latitude":
+        case "GDC.geo.pin_longitude":
+            return "gd-icon-earth";
+        default:
+            return "gd-icon-label-warning";
+    }
+};

--- a/libs/sdk-ui-dashboard/src/presentation/drill/DrillConfigPanel/DrillToUrl/CustomUrlEditorParametersSections/InsightParametersSection.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/drill/DrillConfigPanel/DrillToUrl/CustomUrlEditorParametersSections/InsightParametersSection.tsx
@@ -1,73 +1,30 @@
 // (C) 2020-2023 GoodData Corporation
 import React from "react";
-import { FormattedMessage, useIntl } from "react-intl";
+import { FormattedMessage } from "react-intl";
 import { DropdownSectionHeader } from "../DropdownSectionHeader.js";
-import { AttributeDisplayFormParameterDetail } from "../ParameterDetails/AttributeDisplayFormParameterDetail.js";
-import { Parameter } from "./Parameter.js";
-import { useWorkspaceStrict } from "@gooddata/sdk-ui";
 import { IAttributeWithDisplayForm, IParametersPanelSectionsCommonProps } from "../types.js";
-import { AttributeDisplayFormType, IAttributeDisplayFormMetadataObject } from "@gooddata/sdk-model";
-import { selectAllCatalogAttributesMap, useDashboardSelector } from "../../../../../model/index.js";
-
-interface XProps {
-    item: IAttributeDisplayFormMetadataObject;
-    onAdd: (placeholder: string) => void;
-}
-
-const ParameterX: React.FC<XProps> = ({ item, onAdd }) => {
-    const x = useDashboardSelector(selectAllCatalogAttributesMap);
-    const y = x.get(item.attribute);
-    const intl = useIntl();
-    const projectId = useWorkspaceStrict();
-
-    return (
-        <Parameter
-            key={item.id}
-            name={y?.attribute.title || ""}
-            description={item.title}
-            detailContent={
-                <AttributeDisplayFormParameterDetail
-                    title={y?.attribute.title || ""}
-                    label={item.title}
-                    type={item.displayFormType as AttributeDisplayFormType}
-                    projectId={projectId}
-                    displayFormRef={item.ref}
-                    showValues={true} // TODO
-                />
-            }
-            iconClassName={getDisplayFormIcon(item.displayFormType as AttributeDisplayFormType)}
-            onAdd={() => onAdd(`{attribute_title(${item.id})}`)}
-            intl={intl}
-        />
-    );
-};
-
-const getDisplayFormIcon = (type: AttributeDisplayFormType | undefined) => {
-    switch (type) {
-        case "GDC.link":
-            return "gd-icon-hyperlink-warning";
-        case "GDC.geo.pin":
-        case "GDC.geo.pin_latitude":
-        case "GDC.geo.pin_longitude":
-            return "gd-icon-earth";
-        default:
-            return "gd-icon-label-warning";
-    }
-};
+import { filterObjRef, IAttributeFilter } from "@gooddata/sdk-model";
+import { useDashboardSelector, selectAllCatalogDisplayFormsMap } from "../../../../../model/index.js";
+import { DisplayFormParam } from "./DisplayFormParam.js";
 
 export interface IInsightParametersSectionProps extends IParametersPanelSectionsCommonProps {
     attributeDisplayForms?: IAttributeWithDisplayForm[];
     loadingAttributeDisplayForms: boolean;
+    insightFilters?: IAttributeFilter[];
 }
 
 export const InsightParametersSection: React.FC<IInsightParametersSectionProps> = ({
     attributeDisplayForms,
     loadingAttributeDisplayForms,
+    insightFilters,
     onAdd,
 }) => {
+    const catalogDisplayForms = useDashboardSelector(selectAllCatalogDisplayFormsMap);
     return (
         <>
-            {(attributeDisplayForms && attributeDisplayForms.length > 0) || loadingAttributeDisplayForms ? (
+            {(attributeDisplayForms && attributeDisplayForms.length > 0) ||
+            loadingAttributeDisplayForms ||
+            insightFilters ? (
                 <>
                     <DropdownSectionHeader>
                         <FormattedMessage id="configurationPanel.drillIntoUrl.editor.insightParametersSectionLabel" />
@@ -78,9 +35,28 @@ export const InsightParametersSection: React.FC<IInsightParametersSectionProps> 
                         </div>
                     ) : (
                         attributeDisplayForms?.map((item) => (
-                            <ParameterX key={item.displayForm.id} item={item.displayForm} onAdd={onAdd} />
+                            <DisplayFormParam
+                                key={item.displayForm.id}
+                                item={item.displayForm}
+                                onAdd={onAdd}
+                            />
                         ))
                     )}
+                    {insightFilters?.map((filter, index) => {
+                        const displayFormRef = filterObjRef(filter);
+                        const df = catalogDisplayForms.get(displayFormRef);
+
+                        return (
+                            df && (
+                                <DisplayFormParam
+                                    item={df}
+                                    onAdd={() => onAdd(`{attribute_filter_selection(${df.id})}`)}
+                                    iconClassName="gd-icon-filter"
+                                    key={index}
+                                />
+                            )
+                        );
+                    })}
                 </>
             ) : null}
         </>

--- a/libs/sdk-ui-dashboard/src/presentation/localization/bundles/en-US.json
+++ b/libs/sdk-ui-dashboard/src/presentation/localization/bundles/en-US.json
@@ -1965,6 +1965,11 @@
         "comment": "Label of the parameters section that contains identifiers in Drill to URL 'Custom URL' editor.",
         "limit": 0
     },
+    "configurationPanel.drillIntoUrl.editor.dashboardParametersSectionLabel": {
+        "value": "Dashboard",
+        "comment": "Label of the parameters section that contains dashboard filters in Drill to URL 'Custom URL' editor.",
+        "limit": 0
+    },
     "configurationPanel.drillIntoUrl.editor.applyButtonLabel": {
         "value": "Apply",
         "comment": "Label of the button that applies changes in Drill to URL 'Custom URL' editor.",

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/configuration/DrillTargets/DrillTargetUrlItem.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/configuration/DrillTargets/DrillTargetUrlItem.tsx
@@ -49,13 +49,14 @@ function useButtonValue(urlDrillTarget: UrlDrillTarget | undefined): string {
 const dropdownAlignPoints: IAlignPoint[] = [{ align: "bl tl" }, { align: "tl bl" }];
 
 export interface DrillUrlItemProps {
+    widgetRef: ObjRef;
     urlDrillTarget?: UrlDrillTarget;
     attributes: IAttributeDescriptor[];
     onSelect: (selectedTarget: UrlDrillTarget) => void;
 }
 
 export const DrillTargetUrlItem: React.FunctionComponent<DrillUrlItemProps> = (props) => {
-    const { onSelect, urlDrillTarget, attributes } = props;
+    const { onSelect, urlDrillTarget, attributes, widgetRef } = props;
 
     const capabilities = useDashboardSelector(selectBackendCapabilities);
     const settings = useDashboardSelector(selectSettings);
@@ -129,6 +130,7 @@ export const DrillTargetUrlItem: React.FunctionComponent<DrillUrlItemProps> = (p
                         />
                         {showModal ? (
                             <CustomUrlEditor
+                                widgetRef={widgetRef}
                                 urlDrillTarget={urlDrillTarget}
                                 attributeDisplayForms={targetAttributesFormsAll}
                                 invalidAttributeDisplayFormIdentifiers={

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/configuration/DrillTargets/DrillTargets.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/configuration/DrillTargets/DrillTargets.tsx
@@ -121,6 +121,7 @@ export const DrillTargets: React.FunctionComponent<IDrillTargetsProps> = (props)
         case DRILL_TARGET_TYPE.DRILL_TO_URL:
             return (
                 <DrillTargetUrlItem
+                    widgetRef={item.widgetRef}
                     urlDrillTarget={isDrillToUrlConfig(item) ? item.urlDrillTarget : undefined}
                     attributes={item.attributes}
                     onSelect={onCustomUrlTargetSelect}

--- a/libs/sdk-ui-dashboard/styles/scss/drillConfigPanel.scss
+++ b/libs/sdk-ui-dashboard/styles/scss/drillConfigPanel.scss
@@ -579,6 +579,12 @@ $gd-gd-drill-to-url-body-width: 230px;
             text-align: center;
         }
 
+        &.gd-icon-filter::before {
+            content: "\E63C";
+            color: #94a1ad;
+            text-align: center;
+        }
+
         &.gd-icon-earth::before {
             content: "\E624";
             color: kit-variables.$gd-color-warning-text;
@@ -714,8 +720,13 @@ $gd-gd-drill-to-url-body-width: 230px;
             color: kit-variables.$gd-color-warning-text;
         }
 
+        .cm-filter {
+            color: kit-variables.$gd-color-warning-text;
+        }
+
         .cm-invalid-identifier,
-        .cm-invalid-attribute {
+        .cm-invalid-attribute,
+        .cm-invalid-filter {
             color: kit-variables.$gd-palette-error-base;
         }
     }


### PR DESCRIPTION
Add support for attribute filter selection in drill to custom url.

Filter is serialized as `IN${JSON.stringify(value[] | uri[])}` or `NOT_IN${JSON.stringify(value[] | uri[])}`,
depending on the filter type and target platform.

New placeholder for global attribute filters:
{dash_attribute_filter_selection(displayFormId)}

New placeholder for insight attribute filters:
{attribute_filter_selection(displayFormId)}

JIRA: TNT-1805

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |
| **Compatibility matrix test commands - TIGER Backend**  |                                                            |
| `extended test - matrix-test <AIO_version>`             | Run integrated tests against AIO versions.                 |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

`<AIO_version>` in commands is used to start test with multiple AIO instances - each instance in triggered by one jenkins build

-   To run with `master` and `stable`, execute command `extended test - matrix-test master,stable` or `extended test - matrix-test latest`
-   To run with specific version,ex: `2.3.0` and `2.3.1`, execute command `extended test - matrix-test 2.3.0,2.3.1`
-   In case `<AIO_version>` is empty, read versions from file `compTigerVersions.txt` of this repo

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
