### PR TITLE
BUGFIX: TNT-1959 Filters in drill to custom url

### DIFF
--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/drill/resolveDrillToCustomUrl.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/drill/resolveDrillToCustomUrl.ts
@@ -246,7 +246,7 @@ export function* getDashboardAttributeFilterReplacements(
     );
 
     return attributeFilterPlaceholders.map(
-        ({ placeholder: toBeReplaced, ref, toBeEncoded }): IDrillToUrlPlaceholderReplacement => {
+        ({ placeholder: toBeReplaced, ref }): IDrillToUrlPlaceholderReplacement => {
             const usedFilter = attributeFilters.find((filter) => {
                 const df = catalogDisplayForms.get(filter.attributeFilter.displayForm);
                 return df && areObjRefsEqual(idRef(df.id), ref);
@@ -262,7 +262,7 @@ export function* getDashboardAttributeFilterReplacements(
                 ? stringifyAttributeFilterSelection(attributeElementsValues, isNegative!)
                 : undefined;
 
-            const replacement = toBeEncoded ? encodeParameterIfSet(parsedFilter) : parsedFilter;
+            const replacement = encodeParameterIfSet(parsedFilter);
 
             return {
                 toBeReplaced,
@@ -288,7 +288,7 @@ export function* getInsightAttributeFilterReplacements(
     );
 
     return attributeFilterPlaceholders.map(
-        ({ placeholder: toBeReplaced, ref, toBeEncoded }): IDrillToUrlPlaceholderReplacement => {
+        ({ placeholder: toBeReplaced, ref }): IDrillToUrlPlaceholderReplacement => {
             const usedFilter = widgetFilters.find((filter) => {
                 const filterRef = filterObjRef(filter);
                 const df = filterRef && catalogDisplayForms.get(filterRef);
@@ -305,7 +305,7 @@ export function* getInsightAttributeFilterReplacements(
                 ? stringifyAttributeFilterSelection(attributeElementsValues, isNegative)
                 : undefined;
 
-            const replacement = toBeEncoded ? encodeParameterIfSet(parsedFilter) : parsedFilter;
+            const replacement = encodeParameterIfSet(parsedFilter);
 
             return {
                 toBeReplaced,

--- a/libs/sdk-ui-dashboard/src/presentation/drill/DrillConfigPanel/DrillToUrl/CustomUrlEditor.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/drill/DrillConfigPanel/DrillToUrl/CustomUrlEditor.tsx
@@ -29,9 +29,11 @@ import {
     isAttributeFilter,
     isNegativeAttributeFilter,
     isUriRef,
+    serializeObjRef,
 } from "@gooddata/sdk-model";
 import { useWidgetFilters } from "../../../widget/common/useWidgetFilters.js";
 import compact from "lodash/compact.js";
+import uniqBy from "lodash/uniqBy.js";
 import { dashboardAttributeFilterToAttributeFilter } from "../../../../converters/index.js";
 
 export interface IUrlInputProps {
@@ -377,7 +379,10 @@ function useSanitizedInsightFilters(widgetRef: ObjRef) {
     return useMemo(() => {
         return widgetFiltersResult.status === "success"
             ? // Date filters are currently not supported, so filter them out
-              widgetFiltersResult.result?.filter(isAttributeFilter).map(sanitizeAttributeFilter)
+              uniqBy(
+                  widgetFiltersResult.result?.filter(isAttributeFilter).map(sanitizeAttributeFilter),
+                  (f) => serializeObjRef(filterObjRef(f)),
+              )
             : undefined;
     }, [widgetFiltersResult.status, widgetFiltersResult.result, sanitizeAttributeFilter]);
 }
@@ -404,7 +409,7 @@ function useSanitizeAttributeFilter() {
                         ...filter,
                         negativeAttributeFilter: {
                             ...filter.negativeAttributeFilter,
-                            displayForm: idRef(displayForm.id),
+                            displayForm: idRef(displayForm.id, "displayForm"),
                         },
                     };
                 } else {
@@ -412,7 +417,7 @@ function useSanitizeAttributeFilter() {
                         ...filter,
                         positiveAttributeFilter: {
                             ...filter.positiveAttributeFilter,
-                            displayForm: idRef(displayForm.id),
+                            displayForm: idRef(displayForm.id, "displayForm"),
                         },
                     };
                 }

--- a/libs/sdk-ui-dashboard/src/presentation/drill/DrillConfigPanel/DrillToUrl/CustomUrlEditorParametersSections/DashboardParametersSection.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/drill/DrillConfigPanel/DrillToUrl/CustomUrlEditorParametersSections/DashboardParametersSection.tsx
@@ -34,6 +34,7 @@ export const DashboardParametersSection: React.FC<IDashboardParametersSectionPro
                         onAdd={() => {
                             onAdd(`{dash_attribute_filter_selection(${filterIdentifier})}`);
                         }}
+                        isFilter
                     />
                 ) : null;
             })}

--- a/libs/sdk-ui-dashboard/src/presentation/drill/DrillConfigPanel/DrillToUrl/CustomUrlEditorParametersSections/DisplayFormParam.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/drill/DrillConfigPanel/DrillToUrl/CustomUrlEditorParametersSections/DisplayFormParam.tsx
@@ -5,24 +5,31 @@ import { AttributeDisplayFormParameterDetail } from "../ParameterDetails/Attribu
 import { Parameter } from "./Parameter.js";
 import { useWorkspaceStrict } from "@gooddata/sdk-ui";
 import { AttributeDisplayFormType, IAttributeDisplayFormMetadataObject } from "@gooddata/sdk-model";
-import { selectAllCatalogAttributesMap, useDashboardSelector } from "../../../../../model/index.js";
+import {
+    selectAllCatalogAttributesMap,
+    selectFilterContextAttributeFilterByDisplayForm,
+    useDashboardSelector,
+} from "../../../../../model/index.js";
 
 interface XProps {
     item: IAttributeDisplayFormMetadataObject;
     onAdd: (placeholder: string) => void;
     iconClassName?: string;
+    isFilter?: boolean;
 }
 
-export const DisplayFormParam: React.FC<XProps> = ({ item, onAdd, iconClassName }) => {
+export const DisplayFormParam: React.FC<XProps> = ({ item, onAdd, iconClassName, isFilter }) => {
     const x = useDashboardSelector(selectAllCatalogAttributesMap);
     const y = x.get(item.attribute);
     const intl = useIntl();
     const projectId = useWorkspaceStrict();
+    const dashboardFilter = useDashboardSelector(selectFilterContextAttributeFilterByDisplayForm(item.ref));
+    const defaultTitle = y?.attribute.title || "";
 
     return (
         <Parameter
             key={item.id}
-            name={y?.attribute.title || ""}
+            name={isFilter ? dashboardFilter?.attributeFilter?.title ?? defaultTitle : defaultTitle}
             description={item.title}
             detailContent={
                 <AttributeDisplayFormParameterDetail

--- a/libs/sdk-ui-dashboard/src/presentation/drill/DrillConfigPanel/DrillToUrl/CustomUrlEditorParametersSections/InsightParametersSection.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/drill/DrillConfigPanel/DrillToUrl/CustomUrlEditorParametersSections/InsightParametersSection.tsx
@@ -53,6 +53,7 @@ export const InsightParametersSection: React.FC<IInsightParametersSectionProps> 
                                     onAdd={() => onAdd(`{attribute_filter_selection(${df.id})}`)}
                                     iconClassName="gd-icon-filter"
                                     key={index}
+                                    isFilter
                                 />
                             )
                         );


### PR DESCRIPTION
Avoid duplicating filters in insight parameters section, when the same filter is both on insight and dashboard.

If the filter is renamed, show filter context title instead of attribute filter title in the parameters section.

Always use encodeURIComponent for stringified filters.

JIRA: TNT-1959

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |
| **Compatibility matrix test commands - TIGER Backend**  |                                                            |
| `extended test - matrix-test <AIO_version>`             | Run integrated tests against AIO versions.                 |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

`<AIO_version>` in commands is used to start test with multiple AIO instances - each instance in triggered by one jenkins build

-   To run with `master` and `stable`, execute command `extended test - matrix-test master,stable` or `extended test - matrix-test latest`
-   To run with specific version,ex: `2.3.0` and `2.3.1`, execute command `extended test - matrix-test 2.3.0,2.3.1`
-   In case `<AIO_version>` is empty, read versions from file `compTigerVersions.txt` of this repo

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
