### PR TITLE
RELATED: STL-38 Do not compute drills with ignores per widget

### DIFF
--- a/libs/sdk-ui-dashboard/src/model/store/widgetDrills/widgetDrillSelectors.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/widgetDrills/widgetDrillSelectors.ts
@@ -43,7 +43,6 @@ import {
     selectAllCatalogDisplayFormsMap,
     selectAttributesWithDisplayFormLink,
     selectAttributesWithHierarchyDescendants,
-    selectAttributesWithHierarchyDescendantsByWidgetRef,
 } from "../catalog/catalogSelectors.js";
 import { selectDrillableItems } from "../drill/drillSelectors.js";
 import {
@@ -95,11 +94,89 @@ function drillDefinitionToPredicates(drill: DrillDefinition): IHeaderPredicate[]
     ]);
 }
 
+function createDrillDefinition(
+    drill: IAvailableDrillTargetAttribute,
+    descendantRef: ObjRef,
+    allCatalogAttributesMap: ObjRefMap<ICatalogAttribute | ICatalogDateAttribute>,
+): IImplicitDrillWithPredicates {
+    /**
+     * Here we need to distinguish how the drill is defined in the attribute hierarchy.
+     *
+     * On Tiger, the drilldown is defined as "Attr --\> Attr" (so we take the default display form as the drill target)
+     * On Bear, the drilldown is defined as "Attr --\> specific display form" (= drill target implicitly)
+     */
+    const drillTargetAttributeFromCatalog = allCatalogAttributesMap.get(descendantRef);
+    const drillTargetDescriptionObj = drillTargetAttributeFromCatalog
+        ? {
+              target: drillTargetAttributeFromCatalog.defaultDisplayForm.ref,
+              title: drillTargetAttributeFromCatalog.attribute.title, // title is used to distinguish between multiple drill-downs
+          }
+        : {
+              target: descendantRef,
+          };
+
+    return {
+        drillDefinition: {
+            type: "drillDown",
+            origin: localIdRef(drill.attribute.attributeHeader.localIdentifier),
+            ...drillTargetDescriptionObj,
+        },
+        predicates: [HeaderPredicates.localIdentifierMatch(drill.attribute.attributeHeader.localIdentifier)],
+    };
+}
+
 function getDrillDownDefinitionsWithPredicates(
     availableDrillAttributes: IAvailableDrillTargetAttribute[],
     attributesWithHierarchyDescendants: Record<string, ObjRef[]>,
     allCatalogAttributesMap: ObjRefMap<ICatalogAttribute | ICatalogDateAttribute>,
+    allCatalogAttributeHierarchies: (ICatalogAttributeHierarchy | ICatalogDateAttributeHierarchy)[],
+    ignoredDrillDownHierarchies: IDrillDownReference[],
 ): IImplicitDrillWithPredicates[] {
+    // generate targets on the fly if ignored hierarchies are present
+    // this allows to have `selectAttributesWithHierarchyDescendants` be universal and
+    // be computed only once and not respect the ignores during creation.
+    // For the future, we may consider not creating this at all and always generate on the fly.
+    if (ignoredDrillDownHierarchies?.length) {
+        return availableDrillAttributes.flatMap((drill) => {
+            const attributeRef = drill.attribute.attributeHeader.formOf.ref;
+            const attributeDescendants: ObjRef[] = [];
+            allCatalogAttributeHierarchies.forEach((hierarchy) => {
+                const hierarchyRef = isCatalogAttributeHierarchy(hierarchy)
+                    ? hierarchy.attributeHierarchy.ref
+                    : hierarchy.dateDatasetRef;
+                const attributes = isCatalogAttributeHierarchy(hierarchy)
+                    ? hierarchy.attributeHierarchy.attributes
+                    : hierarchy.attributes;
+                const hierarchyAttributes = attributes.filter((attrRef) => {
+                    const ignoredIndex = ignoredDrillDownHierarchies.findIndex((reference) =>
+                        existBlacklistHierarchyPredicate(reference, hierarchyRef, attrRef),
+                    );
+                    return ignoredIndex < 0;
+                });
+
+                const foundAttributeIndex = hierarchyAttributes.findIndex((ref) =>
+                    areObjRefsEqual(ref, attributeRef),
+                );
+
+                if (foundAttributeIndex < 0) {
+                    return;
+                }
+
+                const foundDescendant = hierarchyAttributes[foundAttributeIndex + 1];
+
+                if (!foundDescendant) {
+                    return;
+                }
+
+                attributeDescendants.push(foundDescendant);
+            });
+
+            return attributeDescendants.map((descendantRef) => {
+                return createDrillDefinition(drill, descendantRef, allCatalogAttributesMap);
+            });
+        });
+    }
+
     const matchingAvailableDrillAttributes = availableDrillAttributes.filter(
         (candidate) =>
             objRefToString(candidate.attribute.attributeHeader.formOf.ref) in
@@ -107,36 +184,11 @@ function getDrillDownDefinitionsWithPredicates(
     );
 
     return matchingAvailableDrillAttributes.flatMap((drill) => {
-        const attributeDrillDescendants =
-            attributesWithHierarchyDescendants[objRefToString(drill.attribute.attributeHeader.formOf.ref)];
+        const drillRef = drill.attribute.attributeHeader.formOf.ref;
+        const attributeDrillDescendants = attributesWithHierarchyDescendants[objRefToString(drillRef)];
 
         return attributeDrillDescendants.map((descendantRef): IImplicitDrillWithPredicates => {
-            /**
-             * Here we need to distinguish how the drill is defined in the attribute hierarchy.
-             *
-             * On Tiger, the drilldown is defined as "Attr --\> Attr" (so we take the default display form as the drill target)
-             * On Bear, the drilldown is defined as "Attr --\> specific display form" (= drill target implicitly)
-             */
-            const drillTargetAttributeFromCatalog = allCatalogAttributesMap.get(descendantRef);
-            const drillTargetDescriptionObj = drillTargetAttributeFromCatalog
-                ? {
-                      target: drillTargetAttributeFromCatalog.defaultDisplayForm.ref,
-                      title: drillTargetAttributeFromCatalog.attribute.title, // title is used to distinguish between multiple drill-downs
-                  }
-                : {
-                      target: descendantRef,
-                  };
-
-            return {
-                drillDefinition: {
-                    type: "drillDown",
-                    origin: localIdRef(drill.attribute.attributeHeader.localIdentifier),
-                    ...drillTargetDescriptionObj,
-                },
-                predicates: [
-                    HeaderPredicates.localIdentifierMatch(drill.attribute.attributeHeader.localIdentifier),
-                ],
-            };
+            return createDrillDefinition(drill, descendantRef, allCatalogAttributesMap);
         });
     });
 }
@@ -249,25 +301,32 @@ export const selectImplicitDrillsDownByWidgetRef: (
 ) => DashboardSelector<IImplicitDrillWithPredicates[]> = createMemoizedSelector((ref: ObjRef) =>
     createSelector(
         selectDrillTargetsByWidgetRef(ref),
-        selectAttributesWithHierarchyDescendantsByWidgetRef(ref),
+        selectAttributesWithHierarchyDescendants,
         selectAllCatalogAttributesMap,
         selectIsDrillDownEnabled,
         selectInsightByWidgetRef(ref),
+        selectIgnoredDrillDownHierarchiesByWidgetRef(ref),
+        selectAllCatalogAttributeHierarchies,
         (
             availableDrillTargets,
             attributesWithHierarchyDescendants,
             allCatalogAttributesMap,
             isDrillDownEnabled,
             widgetInsight,
+            ignoredHierarchies,
+            allCatalogAttributeHierarchies,
         ) => {
             const isWidgetEnableDrillDown = !widgetInsight?.insight?.properties?.controls?.disableDrillDown;
             if (isDrillDownEnabled && isWidgetEnableDrillDown) {
                 const availableDrillAttributes =
                     availableDrillTargets?.availableDrillTargets?.attributes ?? [];
+
                 return getDrillDownDefinitionsWithPredicates(
                     availableDrillAttributes,
                     attributesWithHierarchyDescendants,
                     allCatalogAttributesMap,
+                    allCatalogAttributeHierarchies,
+                    ignoredHierarchies,
                 );
             }
 
@@ -591,18 +650,20 @@ export const selectImplicitDrillsByAvailableDrillTargets: (
 ) => DashboardSelector<IImplicitDrillWithPredicates[]> = createMemoizedSelector(
     (
         availableDrillTargets: IAvailableDrillTargets | undefined,
-        ignoredDrillDownHierarchies: IDrillDownReference[] | undefined,
+        ignoredDrillDownHierarchies: IDrillDownReference[] | undefined = [],
     ) =>
         createSelector(
             selectAttributesWithDisplayFormLink,
-            selectAttributesWithHierarchyDescendants(ignoredDrillDownHierarchies),
+            selectAttributesWithHierarchyDescendants,
             selectAllCatalogAttributesMap,
             selectIsDrillDownEnabled,
+            selectAllCatalogAttributeHierarchies,
             (
                 attributesWithLink,
                 attributesWithHierarchyDescendants,
                 allCatalogAttributesMap,
                 isDrillDownEnabled,
+                allCatalogHierarchies,
             ) => {
                 const availableDrillAttributes = availableDrillTargets?.attributes ?? [];
                 const drillDownDrills = isDrillDownEnabled
@@ -610,6 +671,8 @@ export const selectImplicitDrillsByAvailableDrillTargets: (
                           availableDrillAttributes,
                           attributesWithHierarchyDescendants,
                           allCatalogAttributesMap,
+                          allCatalogHierarchies,
+                          ignoredDrillDownHierarchies,
                       )
                     : [];
                 const drillToUrlDrills = getDrillToUrlDefinitionsWithPredicates(


### PR DESCRIPTION
When there are no ignores, compute attribute descendants only once
per whole dashboard, as it was before ignores were introduced.
When ignores are present, compute the targets on the fly instead of
computing the descendant map with ignores for all catalog attributes for
each widget.



<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |
| **Compatibility matrix test commands - TIGER Backend**  |                                                            |
| `extended test - matrix-test <AIO_version>`             | Run integrated tests against AIO versions.                 |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

`<AIO_version>` in commands is used to start test with multiple AIO instances - each instance in triggered by one jenkins build

-   To run with `master` and `stable`, execute command `extended test - matrix-test master,stable` or `extended test - matrix-test latest`
-   To run with specific version,ex: `2.3.0` and `2.3.1`, execute command `extended test - matrix-test 2.3.0,2.3.1`
-   In case `<AIO_version>` is empty, read versions from file `compTigerVersions.txt` of this repo

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)