### PR TITLE
BUGFIX: TNT-1967 Fix drill to custom url validation

### DIFF
--- a/libs/sdk-ui-dashboard/.dependency-cruiser.cjs
+++ b/libs/sdk-ui-dashboard/.dependency-cruiser.cjs
@@ -97,6 +97,7 @@ options = {
             "src/types.ts",
             "src/converters",
             "src/presentation/widget/common/useWidgetFilters.ts",
+            "src/presentation/widget/insight/configuration/DrillTargets/useInvalidFilteringParametersIdentifiers.ts",
         ]),
         depCruiser.moduleWithDependencies("filterBar", "src/presentation/filterBar", [
             "src/_staging/*",

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/tests/__snapshots__/modifyDrillsForInsightWidgetHandler.test.ts.snap
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/tests/__snapshots__/modifyDrillsForInsightWidgetHandler.test.ts.snap
@@ -8,6 +8,16 @@ exports[`modifyDrillsForInsightWidgetHandler > modify > should emit the appropri
     "type": "GDC.DASH/EVT.COMMAND.STARTED",
   },
   {
+    "correlationId": undefined,
+    "queryType": "GDC.DASH/QUERY.WIDGET.FILTERS",
+    "type": "GDC.DASH/EVT.QUERY.STARTED",
+  },
+  {
+    "correlationId": undefined,
+    "queryType": "GDC.DASH/QUERY.WIDGET.FILTERS",
+    "type": "GDC.DASH/EVT.QUERY.COMPLETED",
+  },
+  {
     "correlationId": "testCorrelationId",
     "type": "GDC.DASH/EVT.INSIGHT_WIDGET.DRILLS_MODIFIED",
   },

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/tests/__snapshots__/removeDrillsForInsightWidgetHandler.test.ts.snap
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/tests/__snapshots__/removeDrillsForInsightWidgetHandler.test.ts.snap
@@ -8,6 +8,16 @@ exports[`removeDrillsForInsightWidgetHandler > remove > should emit the appropri
     "type": "GDC.DASH/EVT.COMMAND.STARTED",
   },
   {
+    "correlationId": undefined,
+    "queryType": "GDC.DASH/QUERY.WIDGET.FILTERS",
+    "type": "GDC.DASH/EVT.QUERY.STARTED",
+  },
+  {
+    "correlationId": undefined,
+    "queryType": "GDC.DASH/QUERY.WIDGET.FILTERS",
+    "type": "GDC.DASH/EVT.QUERY.COMPLETED",
+  },
+  {
     "correlationId": "testCorrelationId",
     "type": "GDC.DASH/EVT.INSIGHT_WIDGET.DRILLS_REMOVED",
   },

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/validation/insightDrillDefinitionUtils.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/validation/insightDrillDefinitionUtils.ts
@@ -25,7 +25,9 @@ import { typesUtils } from "@gooddata/util";
 
 import {
     getAttributeIdentifiersPlaceholdersFromUrl,
+    getDashboardAttributeFilterPlaceholdersFromUrl,
     getDrillOriginLocalIdentifier,
+    getInsightAttributeFilterPlaceholdersFromUrl,
 } from "../../../../_staging/drills/drillingUtils.js";
 import { ObjRefMap } from "../../../../_staging/metadata/objRefMap.js";
 import { isDisplayFormRelevantToDrill } from "../../common/isDisplayFormRelevantToDrill.js";
@@ -117,6 +119,37 @@ export function extractDisplayFormIdentifiers(drillDefinitions: InsightDrillDefi
                     return [drillItem.target.displayForm, drillItem.target.hyperlinkDisplayForm];
                 }
             }),
+    );
+}
+
+export function extractDashboardFilterDisplayFormIdentifiers(
+    drillDefinitions: InsightDrillDefinition[],
+): ObjRef[] {
+    return flatMap(
+        drillDefinitions.filter(isDrillToCustomUrl).map((drillItem) => {
+            const dashboardAttributeFilterPlaceholdersFromUrl =
+                getDashboardAttributeFilterPlaceholdersFromUrl(drillItem.target.url);
+            // normalize ref take the value from state ...
+            // md object has to be identifier
+            return dashboardAttributeFilterPlaceholdersFromUrl.map((param) =>
+                idRef(param.identifier, "displayForm"),
+            );
+        }),
+    );
+}
+
+export function extractInsightFilterDisplayFormIdentifiers(
+    drillDefinitions: InsightDrillDefinition[],
+): ObjRef[] {
+    return flatMap(
+        drillDefinitions.filter(isDrillToCustomUrl).map((drillItem) => {
+            const insightAttributeFilterPlaceholders = getInsightAttributeFilterPlaceholdersFromUrl(
+                drillItem.target.url,
+            );
+            // normalize ref take the value from state ...
+            // md object has to be identifier
+            return insightAttributeFilterPlaceholders.map((param) => idRef(param.identifier, "displayForm"));
+        }),
     );
 }
 

--- a/libs/sdk-ui-dashboard/src/presentation/drill/DrillConfigPanel/DrillToUrl/CustomUrlEditor.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/drill/DrillConfigPanel/DrillToUrl/CustomUrlEditor.tsx
@@ -35,6 +35,7 @@ import { useWidgetFilters } from "../../../widget/common/useWidgetFilters.js";
 import compact from "lodash/compact.js";
 import uniqBy from "lodash/uniqBy.js";
 import { dashboardAttributeFilterToAttributeFilter } from "../../../../converters/index.js";
+import { useInvalidFilteringParametersIdentifiers } from "../../../widget/insight/configuration/DrillTargets/useInvalidFilteringParametersIdentifiers.js";
 
 export interface IUrlInputProps {
     currentUrlValue: string;
@@ -281,6 +282,15 @@ const CustomUrlEditorDialog: React.FunctionComponent<CustomUrlEditorProps> = (pr
 
     const insightFilters = useSanitizedInsightFilters(widgetRef);
     const dashboardFilters = useSanitizedDashboardFilters();
+    const invalidFilteringParametersIdentifiers = useInvalidFilteringParametersIdentifiers(
+        urlDrillTarget,
+        insightFilters,
+        dashboardFilters,
+    );
+
+    const invalidParameters = useMemo(() => {
+        return [...invalidAttributeDisplayFormIdentifiers, ...invalidFilteringParametersIdentifiers];
+    }, [invalidAttributeDisplayFormIdentifiers, invalidFilteringParametersIdentifiers]);
 
     const previousValue = urlDrillTarget
         ? (isDrillToCustomUrlConfig(urlDrillTarget) && urlDrillTarget.customUrl) || ""
@@ -299,9 +309,7 @@ const CustomUrlEditorDialog: React.FunctionComponent<CustomUrlEditorProps> = (pr
         setCurrentValue(insertPlaceholderAtCursor(currentValue, parameterPlaceholder, cursorPosition));
 
     const editorWarningText =
-        invalidAttributeDisplayFormIdentifiers.length > 0
-            ? getWarningTextForInvalidParameters(invalidAttributeDisplayFormIdentifiers)
-            : undefined;
+        invalidParameters.length > 0 ? getWarningTextForInvalidParameters(invalidParameters) : undefined;
 
     return (
         <ConfirmDialogBase

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/configuration/DrillTargets/useInvalidFilteringParametersIdentifiers.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/configuration/DrillTargets/useInvalidFilteringParametersIdentifiers.ts
@@ -1,0 +1,62 @@
+// (C) 2020-2022 GoodData Corporation
+
+import { IAttributeFilter, areObjRefsEqual, filterObjRef, idRef } from "@gooddata/sdk-model";
+import { UrlDrillTarget, isDrillToCustomUrlConfig } from "../../../../drill/types.js";
+import { useDashboardSelector, selectAllCatalogDisplayFormsMap } from "../../../../../model/index.js";
+import { useMemo } from "react";
+import uniq from "lodash/uniq.js";
+import {
+    getDashboardAttributeFilterPlaceholdersFromUrl,
+    getInsightAttributeFilterPlaceholdersFromUrl,
+} from "../../../../../_staging/drills/drillingUtils.js";
+
+//
+export function useInvalidFilteringParametersIdentifiers(
+    urlDrillTarget: UrlDrillTarget | undefined,
+    insightFilters: IAttributeFilter[] | undefined,
+    dashboardFilters: IAttributeFilter[] | undefined,
+) {
+    const displayForms = useDashboardSelector(selectAllCatalogDisplayFormsMap);
+
+    return useMemo(() => {
+        if (isDrillToCustomUrlConfig(urlDrillTarget)) {
+            const dashboardAttributeFilterParameters = getDashboardAttributeFilterPlaceholdersFromUrl(
+                urlDrillTarget.customUrl,
+            );
+            const insightAttributeFilterParameters = getInsightAttributeFilterPlaceholdersFromUrl(
+                urlDrillTarget.customUrl,
+            );
+
+            const invalidDashboardParameters = dashboardAttributeFilterParameters
+                .filter(({ identifier }) => {
+                    // parameter is invalid if either it points to display form that no longer exists
+                    const relevantDf = displayForms.get(idRef(identifier, "displayForm"));
+                    if (!relevantDf) {
+                        return false;
+                    }
+
+                    return !dashboardFilters?.some((filter) => {
+                        return areObjRefsEqual(filterObjRef(filter), idRef(identifier, "displayForm"));
+                    });
+                })
+                .map(({ identifier }) => identifier);
+
+            const invalidInsightParameters = insightAttributeFilterParameters
+                .filter(({ identifier }) => {
+                    // parameter is invalid if either it points to display form that no longer exists
+                    const relevantDf = displayForms.get(idRef(identifier, "displayForm"));
+                    if (!relevantDf) {
+                        return false;
+                    }
+
+                    return !insightFilters?.some((filter) => {
+                        return areObjRefsEqual(filterObjRef(filter), idRef(identifier, "displayForm"));
+                    });
+                })
+                .map(({ identifier }) => identifier);
+
+            return uniq([...invalidDashboardParameters, ...invalidInsightParameters]);
+        }
+        return [];
+    }, [displayForms, urlDrillTarget, insightFilters, dashboardFilters]);
+}


### PR DESCRIPTION
Fix drill to custom url parameters validation
so it displays correct warnings and error messages for filtering parameters.

JIRA: TNT-1967

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |
| **Compatibility matrix test commands - TIGER Backend**  |                                                            |
| `extended test - matrix-test <AIO_version>`             | Run integrated tests against AIO versions.                 |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

`<AIO_version>` in commands is used to start test with multiple AIO instances - each instance in triggered by one jenkins build

-   To run with `master` and `stable`, execute command `extended test - matrix-test master,stable` or `extended test - matrix-test latest`
-   To run with specific version,ex: `2.3.0` and `2.3.1`, execute command `extended test - matrix-test 2.3.0,2.3.1`
-   In case `<AIO_version>` is empty, read versions from file `compTigerVersions.txt` of this repo

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
