### PR TITLE
RELATED: STL-55 fix establishSession on localhost e2e test

### DIFF
--- a/libs/sdk-ui-tests-e2e/cypress/support/index.ts
+++ b/libs/sdk-ui-tests-e2e/cypress/support/index.ts
@@ -1,10 +1,15 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2024 GoodData Corporation
 import "./isolatedTest";
-import "./session";
+import { establishSession } from "./session";
 import "./commands";
 import "./recordings";
 import "cypress-real-events/support";
 import "./featureHub";
+
+// this is very strange - but it seems that the before() and beforeEach() hooks are not executed when was in ./session script
+// so token was not provided when you try to run integration tests on localhost
+before(establishSession);
+beforeEach(establishSession);
 
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore

--- a/libs/sdk-ui-tests-e2e/cypress/support/session.ts
+++ b/libs/sdk-ui-tests-e2e/cypress/support/session.ts
@@ -1,4 +1,4 @@
-// (C) 2023 GoodData Corporation
+// (C) 2023-2024 GoodData Corporation
 import { getUserName } from "./constants";
 import { Api, getTigerAuthToken } from "../tools/api";
 
@@ -14,9 +14,6 @@ export const establishSession = () => {
         cy.session(getUserName(), cy.login);
     }
 };
-
-before(establishSession);
-beforeEach(establishSession);
 
 Cypress.on("uncaught:exception", (error) => {
     console.error("Uncaught exception cause", error);

--- a/libs/sdk-ui-tests-e2e/scenarios/webpack.config.cjs
+++ b/libs/sdk-ui-tests-e2e/scenarios/webpack.config.cjs
@@ -15,6 +15,7 @@ process.env.NODE_OPTIONS = "--max-old-space-size=4096";
 
 // we are providing tiger token ourselves, clear it so that it's not
 // baked inside the testing app image
+// result is that scenarios will not work on localhost without cypress
 process.env.TIGER_API_TOKEN = "";
 
 module.exports = async (env, argv) => {


### PR DESCRIPTION
JIRA: STL-55

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |
| **Compatibility matrix test commands - TIGER Backend**  |                                                            |
| `extended test - matrix-test <AIO_version>`             | Run integrated tests against AIO versions.                 |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

`<AIO_version>` in commands is used to start test with multiple AIO instances - each instance in triggered by one jenkins build

-   To run with `master` and `stable`, execute command `extended test - matrix-test master,stable` or `extended test - matrix-test latest`
-   To run with specific version,ex: `2.3.0` and `2.3.1`, execute command `extended test - matrix-test 2.3.0,2.3.1`
-   In case `<AIO_version>` is empty, read versions from file `compTigerVersions.txt` of this repo

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
