### PR TITLE
FEATURE: F1-2 Cross-filtering highlighting

### DIFF
--- a/.github/actions/check-pull-request-commits/src/action.js
+++ b/.github/actions/check-pull-request-commits/src/action.js
@@ -1,4 +1,4 @@
-// (C) 2022 GoodData Corporation
+// (C) 2022-2024 GoodData Corporation
 
 const core = require("@actions/core");
 const load = require("@commitlint/load").default;
@@ -10,7 +10,7 @@ const prHead = core.getInput("pr_head");
 const prBase = core.getInput("pr_base");
 const configFilePath = core.getInput("lint_config");
 
-const FOOTER_REGEX = /\n((JIRA\:\s[A-Z]+-\d+(, [A-Z]+-\d+)*)|TRIVIAL)(\n+)?$/;
+const FOOTER_REGEX = /\n((JIRA\:\s[A-Z0-9]+-\d+(, [A-Z]+-\d+)*)|TRIVIAL)(\n+)?$/;
 
 Promise.all([
     load({}, { file: configFilePath, cwd: process.cwd() }),
@@ -39,7 +39,7 @@ Promise.all([
 
         const allCommitsAreValid = results.every((report) => report.valid);
         const invalidCommits = results.reduce((result, report) => {
-            if(!report.valid) {
+            if (!report.valid) {
                 result.push(report);
             }
             return result;
@@ -51,7 +51,11 @@ Promise.all([
         if (allCommitsAreValid && allCommitsHaveTicket) {
             core.info("✅ Every commit message is formatted according to the contribution guide");
         } else {
-            core.setFailed(`⚠️ Not every commit message is formatted according to the contribution guide: ${JSON.stringify(invalidCommits)}`);
+            core.setFailed(
+                `⚠️ Not every commit message is formatted according to the contribution guide: ${JSON.stringify(
+                    invalidCommits,
+                )}`,
+            );
         }
     });
 });

--- a/libs/sdk-ui-charts/api/sdk-ui-charts.api.md
+++ b/libs/sdk-ui-charts/api/sdk-ui-charts.api.md
@@ -24,6 +24,7 @@ import { IColorPalette } from '@gooddata/sdk-model';
 import { IDataView } from '@gooddata/sdk-backend-spi';
 import { Identifier } from '@gooddata/sdk-model';
 import { IDrillEventCallback } from '@gooddata/sdk-ui';
+import { IDrillEventIntersectionElement } from '@gooddata/sdk-ui';
 import { IExecutionConfig } from '@gooddata/sdk-model';
 import { IExecutionFactory } from '@gooddata/sdk-backend-spi';
 import { IFilter } from '@gooddata/sdk-model';
@@ -286,6 +287,8 @@ export interface IChartConfig {
     secondary_xaxis?: IAxisConfig;
     secondary_yaxis?: IAxisConfig;
     secondaryChartType?: "line" | "column" | "area";
+    // @internal
+    selectedPoints?: IDrillEventIntersectionElement[][];
     separators?: ISeparators;
     // @internal
     stacking?: boolean;

--- a/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartCreators/customConfiguration.ts
+++ b/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartCreators/customConfiguration.ts
@@ -1,4 +1,4 @@
-// (C) 2007-2023 GoodData Corporation
+// (C) 2007-2024 GoodData Corporation
 import noop from "lodash/noop.js";
 import isString from "lodash/isString.js";
 import merge from "lodash/merge.js";
@@ -71,6 +71,7 @@ import { isMeasureFormatInPercent, ITheme } from "@gooddata/sdk-model";
 import { getContinuousLineConfiguration } from "./getContinuousLineConfiguration.js";
 import { getWaterfallXAxisConfiguration } from "./getWaterfallXAxisConfiguration.js";
 import { getChartOrientationConfiguration } from "./getChartOrientationConfiguration.js";
+import { getChartHighlightingConfiguration } from "./getChartHighlightingConfiguration.js";
 
 const EMPTY_DATA: IChartOptionsData = { categories: [], series: [] };
 
@@ -1443,6 +1444,7 @@ export function getCustomizedConfiguration(
         getContinuousLineConfiguration,
         getWaterfallXAxisConfiguration,
         getChartOrientationConfiguration,
+        getChartHighlightingConfiguration,
     ];
     const commonData = configurators.reduce((config: HighchartsOptions, configurator: any) => {
         return merge(config, configurator(chartOptions, config, chartConfig, drillConfig, intl, theme));

--- a/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartCreators/getChartHighlightingConfiguration.ts
+++ b/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartCreators/getChartHighlightingConfiguration.ts
@@ -1,0 +1,45 @@
+// (C) 2023-2024 GoodData Corporation
+
+import { IChartConfig } from "../../../interfaces/index.js";
+import { HighchartsOptions } from "../../lib/index.js";
+import { IChartOptions } from "../../typings/unsafe.js";
+import {
+    getSeriesHighlightingClassNameObj,
+    highlightChartPoints,
+} from "../_chartHighlighting/highlightPoints.js";
+
+export function getChartHighlightingConfiguration(
+    chartOptions: IChartOptions,
+    config: HighchartsOptions,
+    chartConfig?: IChartConfig,
+): HighchartsOptions {
+    // Here we overwrite the load event of the chart to highlight the points.
+    // Some charts already have this event, so we avoid overwriting it
+    // and rather extend the original events in particular chart's config.
+    const eventsObj =
+        chartOptions.type === "pie" || chartOptions.type === "donut"
+            ? {}
+            : {
+                  load() {
+                      highlightChartPoints(this.series, chartConfig);
+                  },
+              };
+
+    return {
+        ...config,
+        chart: {
+            ...config?.chart,
+            events: {
+                ...config?.chart?.events,
+                ...eventsObj,
+            },
+        },
+        plotOptions: {
+            ...config?.plotOptions,
+            series: {
+                ...config?.plotOptions?.series,
+                ...getSeriesHighlightingClassNameObj(chartConfig),
+            },
+        },
+    };
+}

--- a/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartCreators/test/customConfiguration.test.ts
+++ b/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartCreators/test/customConfiguration.test.ts
@@ -1,6 +1,7 @@
-// (C) 2007-2023 GoodData Corporation
+// (C) 2007-2024 GoodData Corporation
 import set from "lodash/set.js";
 import noop from "lodash/noop.js";
+import omit from "lodash/omit.js";
 import { dummyDataView } from "@gooddata/sdk-backend-mockingbird";
 import {
     escapeCategories,
@@ -24,6 +25,7 @@ import {
 import { IChartOptions, IPointData, ISeriesDataItem } from "../../../typings/unsafe.js";
 import { PlotBarDataLabelsOptions, PlotBubbleDataLabelsOptions } from "highcharts";
 import { describe, it, expect, vi } from "vitest";
+import { getChartHighlightingConfiguration } from "../getChartHighlightingConfiguration.js";
 
 function getData(dataValues: Partial<ISeriesDataItem>[]) {
     return {
@@ -140,6 +142,12 @@ describe("getCustomizedConfiguration", () => {
         });
 
         expect(result.plotOptions.series).toEqual({});
+    });
+
+    it("should set load event in configuration", () => {
+        const result = getCustomizedConfiguration(chartOptions);
+
+        expect(result.chart.events).toEqual({ load: expect.any(Function) });
     });
 
     it("should NOT set stacking for the Area chart only has one metric", () => {
@@ -299,7 +307,7 @@ describe("getCustomizedConfiguration", () => {
             };
 
             expect(result.xAxis[0]).toEqual(xAxisResult);
-            expect(result.chart).toEqual(undefined);
+            expect(omit(result.chart, "events")).toEqual({});
         });
 
         it("should set chart and X axis configurations with the minRange = 2 when the zooming is enabled and the categories are larger than 2", () => {
@@ -1304,5 +1312,19 @@ describe("getFormatterProperty", () => {
     it("should return no formatter", () => {
         const formatterProperty = getFormatterProperty(chartOptions, axisPropsKey, chartConfig, "#.##");
         expect(formatterProperty.formatter).toEqual(undefined);
+    });
+});
+
+describe("highlighting configuration", () => {
+    it("should return load event", () => {
+        const result = getChartHighlightingConfiguration(chartOptions, {}, {});
+
+        expect(result.chart.events).toEqual({ load: expect.any(Function) });
+    });
+
+    it.each([["pie"], ["donut"]])("should not return load event", (type: string) => {
+        const result = getChartHighlightingConfiguration({ ...chartOptions, type }, {}, {});
+
+        expect(result.chart.events).toEqual({});
     });
 });

--- a/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartHighlighting/highlightPoints.ts
+++ b/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartHighlighting/highlightPoints.ts
@@ -1,0 +1,48 @@
+// (C) 2023-2024 GoodData Corporation
+
+import { IChartConfig } from "../../../interfaces/index.js";
+import { IHighchartsPointObject } from "../_chartCreators/isGroupHighchartsDrillEvent.js";
+import isEqual from "lodash/isEqual.js";
+import cx from "classnames";
+
+/**
+ * Adds highlighting class to chart points based on provided drill intersections.
+ *
+ * @param series - chart series
+ * @param selectedPoints - selected points defined by drill intersections
+ */
+export const highlightChartPoints = (series: Highcharts.Series[], config?: IChartConfig) => {
+    const { selectedPoints, type } = config;
+
+    if (!selectedPoints?.length) {
+        return;
+    }
+
+    const borderClassName = ["heatmap", "dependencywheel", "sankey"].includes(type)
+        ? "gd-point-highlighted-border"
+        : undefined;
+    const classNames = cx("gd-point-highlighted", borderClassName);
+
+    series.forEach((seriesItem) => {
+        seriesItem.points.forEach((point: IHighchartsPointObject) => {
+            selectedPoints.forEach((selectedPointIntersection) => {
+                if (isEqual(point.drillIntersection, selectedPointIntersection)) {
+                    /**
+                     * In case of waterfall chart, we make sure that the `x` value is not changed.
+                     * For some reason it was always changed after any class update and categories were reordered and moved.
+                     */
+                    const xValueObj = type === "waterfall" ? { x: point.x } : {};
+
+                    point.update({ className: classNames, ...xValueObj }, true);
+                }
+            });
+        });
+    });
+};
+
+/**
+ * Returns classname for the whole series to change opacity of all other points at once.
+ */
+export const getSeriesHighlightingClassNameObj = (config?: IChartConfig) => {
+    return config?.selectedPoints?.length ? { className: "gd-highlighting" } : {};
+};

--- a/libs/sdk-ui-charts/src/highcharts/chartTypes/donutChart/donutConfiguration.ts
+++ b/libs/sdk-ui-charts/src/highcharts/chartTypes/donutChart/donutConfiguration.ts
@@ -1,9 +1,10 @@
-// (C) 2007-2021 GoodData Corporation
+// (C) 2007-2024 GoodData Corporation
 import merge from "lodash/merge.js";
 import { getPieConfiguration } from "../pieChart/pieConfiguration.js";
 import { alignChart } from "../_chartCreators/helpers.js";
 import { IChartConfig } from "../../../interfaces/index.js";
 import { HighchartsOptions } from "../../lib/index.js";
+import { highlightChartPoints } from "../_chartHighlighting/highlightPoints.js";
 
 export function getDonutConfiguration(config: IChartConfig): HighchartsOptions {
     return merge({}, getPieConfiguration(config), {
@@ -17,6 +18,8 @@ export function getDonutConfiguration(config: IChartConfig): HighchartsOptions {
                     });
 
                     alignChart(this, config.chart?.verticalAlign);
+
+                    highlightChartPoints(this.series, config);
                 },
             },
         },

--- a/libs/sdk-ui-charts/src/highcharts/chartTypes/pieChart/pieConfiguration.ts
+++ b/libs/sdk-ui-charts/src/highcharts/chartTypes/pieChart/pieConfiguration.ts
@@ -1,8 +1,9 @@
-// (C) 2007-2021 GoodData Corporation
+// (C) 2007-2024 GoodData Corporation
 import { IChartConfig } from "../../../interfaces/index.js";
 import { HighchartsOptions, SeriesPieOptions } from "../../lib/index.js";
 import { alignChart } from "../_chartCreators/helpers.js";
 import { getPieResponsiveConfig } from "../_chartCreators/responsive.js";
+import { highlightChartPoints } from "../_chartHighlighting/highlightPoints.js";
 
 export function getPieConfiguration(config: IChartConfig): HighchartsOptions {
     const pieConfiguration = {
@@ -19,6 +20,8 @@ export function getPieConfiguration(config: IChartConfig): HighchartsOptions {
                     };
                     this.series[0].update(options);
                     alignChart(this, config.chart?.verticalAlign);
+
+                    highlightChartPoints(this.series, config);
                 },
             },
         },

--- a/libs/sdk-ui-charts/src/interfaces/chartConfig.ts
+++ b/libs/sdk-ui-charts/src/interfaces/chartConfig.ts
@@ -1,6 +1,6 @@
-// (C) 2020-2023 GoodData Corporation
+// (C) 2020-2024 GoodData Corporation
 import { IColorPalette, Identifier, ISeparators } from "@gooddata/sdk-model";
-import { VisType } from "@gooddata/sdk-ui";
+import { IDrillEventIntersectionElement, VisType } from "@gooddata/sdk-ui";
 import { IColorMapping } from "@gooddata/sdk-ui-vis-commons";
 import { IComparison } from "./comparison.js";
 
@@ -295,6 +295,12 @@ export interface IChartConfig {
      * @internal
      */
     useGenericInteractionTooltip?: boolean;
+
+    /**
+     * Selected points to be highlighted defined by drill event intersections.
+     * @internal
+     */
+    selectedPoints?: IDrillEventIntersectionElement[][];
 }
 
 /**

--- a/libs/sdk-ui-charts/styles/scss/highlighting.scss
+++ b/libs/sdk-ui-charts/styles/scss/highlighting.scss
@@ -1,0 +1,30 @@
+// (C) 2024 GoodData Corporation
+@use "@gooddata/sdk-ui-kit/styles/scss/variables" as kit-variables;
+
+.gd-highlighting {
+    opacity: 1;
+
+    .highcharts-point,
+    path {
+        opacity: 0.2;
+    }
+
+    .highcharts-point-hover,
+    path:hover {
+        opacity: 1;
+    }
+
+    .gd-point-highlighted {
+        opacity: 1;
+
+        /**
+         * This is only used on some charts that need more obvious highlighting.
+         * For example heatmap.
+         */
+        &-border {
+            stroke: kit-variables.$gd-palette-primary-base;
+            stroke-width: 2px;
+            stroke-opacity: 1;
+        }
+    }
+}

--- a/libs/sdk-ui-charts/styles/scss/main.scss
+++ b/libs/sdk-ui-charts/styles/scss/main.scss
@@ -1,4 +1,5 @@
-// (C) 2007-2018 GoodData Corporation
+// (C) 2007-2024 GoodData Corporation
 @use "charts";
 @use "headline";
 @use "bulletChart";
+@use "highlighting";

--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -180,6 +180,7 @@ import { IdentifierRef } from '@gooddata/sdk-model';
 import { IDrillDownDefinition as IDrillDownDefinition_2 } from '../../../types.js';
 import { IDrillDownReference } from '@gooddata/sdk-model';
 import { IDrillEvent } from '@gooddata/sdk-ui';
+import { IDrillEventIntersectionElement } from '@gooddata/sdk-ui';
 import { IDrillToAttributeUrl } from '@gooddata/sdk-model';
 import { IDrillToCustomUrl } from '@gooddata/sdk-model';
 import { IDrillToDashboard } from '@gooddata/sdk-model';
@@ -3478,6 +3479,7 @@ export interface ICreatePanelItemComponentProps {
 // @beta (undocumented)
 export interface ICrossFilteringItem {
     filterLocalIdentifiers: string[];
+    selectedPoints?: IDrillEventIntersectionElement[][];
     widgetRef: ObjRef | undefined;
 }
 
@@ -4168,6 +4170,7 @@ export interface IInsightBodyProps extends Partial<IVisualizationCallbacks> {
         separators?: ISeparators;
         forceDisableDrillOnAxes?: boolean;
         isExportMode?: boolean;
+        selectedPoints?: IDrillEventIntersectionElement[][];
     };
     drillableItems: ExplicitDrill[] | undefined;
     ErrorComponent: React.ComponentType<IErrorProps>;
@@ -6445,6 +6448,9 @@ export const selectCrossFilteringItemByWidgetRef: (ref: ObjRef | undefined) => D
 
 // @beta (undocumented)
 export const selectCrossFilteringItems: DashboardSelector<ICrossFilteringItem[]>;
+
+// @beta (undocumented)
+export const selectCrossFilteringSelectedPointsByWidgetRef: (ref: ObjRef | undefined) => DashboardSelector<IDrillEventIntersectionElement[][] | undefined>;
 
 // @public
 export const selectCurrentUser: DashboardSelector<IUser>;

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/drill/crossFilteringHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/drill/crossFilteringHandler.ts
@@ -108,6 +108,9 @@ export function* crossFilteringHandler(ctx: DashboardContext, cmd: CrossFilterin
         drillActions.crossFilterByWidget({
             widgetRef,
             filterLocalIdentifiers: virtualFilters.map((vf) => vf.attributeFilter.localIdentifier!),
+            selectedPoints: cmd.payload.drillEvent.drillContext.intersection
+                ? [cmd.payload.drillEvent.drillContext.intersection]
+                : undefined,
         }),
     );
     yield all(

--- a/libs/sdk-ui-dashboard/src/model/store/drill/drillSelectors.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/drill/drillSelectors.ts
@@ -1,6 +1,6 @@
-// (C) 2021-2023 GoodData Corporation
+// (C) 2021-2024 GoodData Corporation
 import { createSelector } from "@reduxjs/toolkit";
-import { ExplicitDrill } from "@gooddata/sdk-ui";
+import { ExplicitDrill, IDrillEventIntersectionElement } from "@gooddata/sdk-ui";
 import { DashboardSelector, DashboardState } from "../types.js";
 import { ICrossFilteringItem } from "./types.js";
 import { ObjRef, areObjRefsEqual } from "@gooddata/sdk-model";
@@ -57,4 +57,14 @@ export const selectCrossFilteringFiltersLocalIdentifiersByWidgetRef: (
     ref: ObjRef | undefined,
 ) => DashboardSelector<string[] | undefined> = createMemoizedSelector((ref: ObjRef | undefined) =>
     createSelector(selectCrossFilteringItemByWidgetRef(ref), (item) => item?.filterLocalIdentifiers),
+);
+
+/**
+ * @beta
+ */
+export const selectCrossFilteringSelectedPointsByWidgetRef: (
+    ref: ObjRef | undefined,
+) => DashboardSelector<IDrillEventIntersectionElement[][] | undefined> = createMemoizedSelector(
+    (ref: ObjRef | undefined) =>
+        createSelector(selectCrossFilteringItemByWidgetRef(ref), (item) => item?.selectedPoints),
 );

--- a/libs/sdk-ui-dashboard/src/model/store/drill/types.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/drill/types.ts
@@ -1,5 +1,6 @@
-// (C) 2021-2023 GoodData Corporation
+// (C) 2021-2024 GoodData Corporation
 import { ObjRef } from "@gooddata/sdk-model";
+import { IDrillEventIntersectionElement } from "@gooddata/sdk-ui";
 
 /**
  * @beta
@@ -14,4 +15,10 @@ export interface ICrossFilteringItem {
      *  Virtual attribute filter local identifiers added by the widget cross filtering
      */
     filterLocalIdentifiers: string[];
+
+    /**
+     * Array of currently selected points.
+     * Each point is represented by an array of drill event intersection elements.
+     */
+    selectedPoints?: IDrillEventIntersectionElement[][];
 }

--- a/libs/sdk-ui-dashboard/src/model/store/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/index.ts
@@ -232,6 +232,7 @@ export {
     selectCrossFilteringItemByWidgetRef,
     selectCrossFilteringFiltersLocalIdentifiers,
     selectCrossFilteringFiltersLocalIdentifiersByWidgetRef,
+    selectCrossFilteringSelectedPointsByWidgetRef,
 } from "./drill/drillSelectors.js";
 export { DrillState } from "./drill/drillState.js";
 export { ICrossFilteringItem } from "./drill/types.js";

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/ViewModeDashboardInsight/Insight/DashboardInsight.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/ViewModeDashboardInsight/Insight/DashboardInsight.tsx
@@ -1,4 +1,4 @@
-// (C) 2020-2023 GoodData Corporation
+// (C) 2020-2024 GoodData Corporation
 import React, { CSSProperties, useCallback, useMemo, useState } from "react";
 import { IUserWorkspaceSettings } from "@gooddata/sdk-backend-spi";
 import { createSelector } from "@reduxjs/toolkit";
@@ -33,6 +33,7 @@ import {
     useDashboardSelector,
     useWidgetExecutionsHandler,
     selectIsInEditMode,
+    selectCrossFilteringSelectedPointsByWidgetRef,
 } from "../../../../../model/index.js";
 import { useResolveDashboardInsightProperties } from "../useResolveDashboardInsightProperties.js";
 import { IDashboardInsightProps } from "../../types.js";
@@ -101,6 +102,9 @@ export const DashboardInsight = (props: IDashboardInsightProps): JSX.Element => 
     const { locale, settings, colorPalette } = useDashboardSelector(selectCommonDashboardInsightProps);
     const { enableKDWidgetCustomHeight } = useDashboardSelector(selectSettings);
     const isInEditMode = useDashboardSelector(selectIsInEditMode);
+    const crossFilteringSelectedPoints = useDashboardSelector(
+        selectCrossFilteringSelectedPointsByWidgetRef(ref),
+    );
 
     const chartConfig = useDashboardSelector(selectChartConfig);
 
@@ -231,7 +235,10 @@ export const DashboardInsight = (props: IDashboardInsightProps): JSX.Element => 
                                 workspace={effectiveWorkspace}
                                 drillableItems={drillableItems}
                                 onDrill={onDrill}
-                                config={chartConfig}
+                                config={{
+                                    ...chartConfig,
+                                    selectedPoints: crossFilteringSelectedPoints,
+                                }}
                                 onLoadingChanged={handleLoadingChanged}
                                 locale={locale}
                                 settings={settings as IUserWorkspaceSettings}

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/types.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/types.ts
@@ -1,9 +1,10 @@
-// (C) 2020-2022 GoodData Corporation
+// (C) 2020-2024 GoodData Corporation
 import { ComponentType } from "react";
 import { IAnalyticalBackend, IUserWorkspaceSettings } from "@gooddata/sdk-backend-spi";
 import { IColorPalette, IInsight, IInsightWidget, ISeparators } from "@gooddata/sdk-model";
 import {
     ExplicitDrill,
+    IDrillEventIntersectionElement,
     IErrorProps,
     ILoadingProps,
     ILocale,
@@ -200,6 +201,7 @@ export interface IInsightBodyProps extends Partial<IVisualizationCallbacks> {
         separators?: ISeparators;
         forceDisableDrillOnAxes?: boolean;
         isExportMode?: boolean;
+        selectedPoints?: IDrillEventIntersectionElement[][];
     };
 
     /**


### PR DESCRIPTION
Selected points created by cross-filtering are passed to the charts. Each chart matches the point and adds classes for highlighting. These selected points are defined by drill intersection from the cross-filtering drill event.

JIRA: F1-2

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |
| **Compatibility matrix test commands - TIGER Backend**  |                                                            |
| `extended test - matrix-test <AIO_version>`             | Run integrated tests against AIO versions.                 |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

`<AIO_version>` in commands is used to start test with multiple AIO instances - each instance in triggered by one jenkins build

-   To run with `master` and `stable`, execute command `extended test - matrix-test master,stable` or `extended test - matrix-test latest`
-   To run with specific version,ex: `2.3.0` and `2.3.1`, execute command `extended test - matrix-test 2.3.0,2.3.1`
-   In case `<AIO_version>` is empty, read versions from file `compTigerVersions.txt` of this repo

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
