### PR TITLE
BUGFIX: RAIL-5218 Fix applink infinite rebuild

### DIFF
--- a/tools/applink/src/devConsole/action.ts
+++ b/tools/applink/src/devConsole/action.ts
@@ -1,4 +1,4 @@
-// (C) 2020-2021 GoodData Corporation
+// (C) 2020-2024 GoodData Corporation
 import { getSourceDescriptor } from "../base/sourceDiscovery.js";
 import { getTargetDescriptor } from "../base/targetDiscovery.js";
 import { TerminalUi } from "./ui/ui.js";
@@ -12,7 +12,9 @@ import { NoopPublisher } from "./pipeline/noopPublisher.js";
 
 export async function devConsole(targetDir: string): Promise<void> {
     const sourceDescriptor = await getSourceDescriptor(
-        (pkg) => !pkg.projectFolder.startsWith("examples") && !pkg.projectFolder.startsWith("skel"),
+        // omit packages that are not published to npm from the dev builds
+        // (e.g examples, tests, web components. etc)
+        (pkg) => !pkg.shouldPublish === false,
     );
 
     if (!sourceDescriptor) {

--- a/tools/applink/src/devConsole/pipeline/changeDetector.ts
+++ b/tools/applink/src/devConsole/pipeline/changeDetector.ts
@@ -1,4 +1,4 @@
-// (C) 2020-2022 GoodData Corporation
+// (C) 2020-2024 GoodData Corporation
 import { PackageDescriptor, SourceDescriptor, TargetDescriptor } from "../../base/types.js";
 import chokidar from "chokidar";
 import path from "path";
@@ -198,6 +198,15 @@ export class ChangeDetector implements IEventListener {
                 changes[packageName] = change;
             } else {
                 existingRequest.files!.push(...change.files!);
+            }
+        }
+
+        for (const changeId in changes) {
+            const change = changes[changeId];
+            // Omit __version files generated during the build, otherwise build ends up in endless cycle
+            changes[changeId].files = change.files.filter((file) => !file.includes("__version.ts"));
+            if (changes[changeId].files.length === 0) {
+                delete changes[changeId];
             }
         }
 


### PR DESCRIPTION
Avoid infinite rebuilds caused by generated
`__version.ts` files created during the build.

Include only packages that are published to npm,
avoid rebuild of the packages that are not necessary during the dev workflow (tests, examples, etc).

JIRA: RAIL-5218

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |
| **Compatibility matrix test commands - TIGER Backend**  |                                                            |
| `extended test - matrix-test <AIO_version>`             | Run integrated tests against AIO versions.                 |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

`<AIO_version>` in commands is used to start test with multiple AIO instances - each instance in triggered by one jenkins build

-   To run with `master` and `stable`, execute command `extended test - matrix-test master,stable` or `extended test - matrix-test latest`
-   To run with specific version,ex: `2.3.0` and `2.3.1`, execute command `extended test - matrix-test 2.3.0,2.3.1`
-   In case `<AIO_version>` is empty, read versions from file `compTigerVersions.txt` of this repo

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
