### PR TITLE
documentation bump 9.5

### DIFF
--- a/docs/config/public/params.toml
+++ b/docs/config/public/params.toml
@@ -8,9 +8,13 @@
 #                 on every patch release of respective branch
 
 [[versions]]
-    version = "9.4"
+    version = "9.5"
     dirpath = "latest"
     url = "/latest/"
+[[versions]]
+    version = "9.4"
+    dirpath = "9.4"
+    url = "/9.4/"
 [[versions]]
     version = "9.3"
     dirpath = "9.3"
@@ -19,10 +23,6 @@
     version = "9.2"
     dirpath = "9.2"
     url = "/9.2/"
-[[versions]]
-    version = "9.1"
-    dirpath = "9.1"
-    url = "/9.1/"
 [[versions]]
     version = "Older"
     url = "https://sdk.gooddata.com/gooddata-ui/versions.html"

--- a/docs/layouts/index.redir
+++ b/docs/layouts/index.redir
@@ -1,8 +1,9 @@
 # Redirects
 / {{ .Site.BaseURL }}/latest/ 301!
 /docs/ {{ .Site.BaseURL }}/latest/ 301!
-/9.4/ {{ .Site.BaseURL }}/latest/ 301!
-/9.4.0/ {{ .Site.BaseURL }}/latest/ 301!
+/9.5/ {{ .Site.BaseURL }}/latest/ 301!
+/9.5.0/ {{ .Site.BaseURL }}/latest/ 301!
+/9.4.0/ {{ .Site.BaseURL }}/9.4/ 301!
 /9.3.0/ {{ .Site.BaseURL }}/9.3/ 301!
 /9.2.0/ {{ .Site.BaseURL }}/9.2/ 301!
 /9.1.0/ {{ .Site.BaseURL }}/9.1/ 301!


### PR DESCRIPTION
TRIVIAL

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |
| **Compatibility matrix test commands - TIGER Backend**  |                                                            |
| `extended test - matrix-test <AIO_version>`             | Run integrated tests against AIO versions.                 |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

`<AIO_version>` in commands is used to start test with multiple AIO instances - each instance in triggered by one jenkins build

-   To run with `master` and `stable`, execute command `extended test - matrix-test master,stable` or `extended test - matrix-test latest`
-   To run with specific version,ex: `2.3.0` and `2.3.1`, execute command `extended test - matrix-test 2.3.0,2.3.1`
-   In case `<AIO_version>` is empty, read versions from file `compTigerVersions.txt` of this repo

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
