### PR TITLE
BUGFIX: QA-21170 stabilize dependent filter tests

### DIFF
--- a/libs/sdk-ui-tests-e2e/cypress/integration/01-sdk-ui-dashboard/dependentFilters.spec.ts
+++ b/libs/sdk-ui-tests-e2e/cypress/integration/01-sdk-ui-dashboard/dependentFilters.spec.ts
@@ -1,4 +1,4 @@
-// (C) 2023 GoodData Corporation
+// (C) 2023-2024 GoodData Corporation
 import * as Navigation from "../../tools/navigation";
 import { AttributeFilter } from "../../tools/filterBar";
 import { TopBar } from "../../tools/dashboards";
@@ -226,9 +226,16 @@ describe("Dependent filter", () => {
         "child filter can reduce to zero element by parent filter",
         { tags: "checklist_integrated_tiger" },
         () => {
+            cy.intercept("GET", "**/attributes**").as("attributes");
             topBar.enterEditMode().editButtonIsVisible(false);
             product.open().selectAttributesWithoutApply("TouchAll").apply();
-            stageName.open().elementsAreLoaded().hasNoRelevantMessage().showAllElementValuesIsVisible(true);
+            cy.wait("@attributes").then(() => {
+                stageName
+                    .open()
+                    .elementsAreLoaded()
+                    .hasNoRelevantMessage()
+                    .showAllElementValuesIsVisible(true);
+            });
             table.isEmpty();
         },
     );
@@ -246,19 +253,26 @@ describe("Dependent filter", () => {
     });
 
     it("can reload elements after removing parent filter", { tags: "checklist_integrated_tiger" }, () => {
+        cy.intercept("GET", "**/attributes**").as("attributes");
         topBar.enterEditMode().editButtonIsVisible(false);
         stateFilter.open().selectAttributesWithoutApply("Alabama").apply();
-        cityFilter.open().elementsAreLoaded().hasFilterListSize(5);
-        stateFilter.removeFilter();
-        cityFilter.isLoaded().open().elementsAreLoaded().hasFilterListSize(287);
+        cy.wait("@attributes").then(() => {
+            cityFilter.open().elementsAreLoaded().hasFilterListSize(5).close();
+            stateFilter.removeFilter();
+            cityFilter.isLoaded().open().elementsAreLoaded().hasFilterListSize(287);
+        });
     });
 
     it(
         "should test a circle parent - child filter in edit mode",
         { tags: "checklist_integrated_tiger" },
         () => {
+            cy.intercept("GET", "**/attributes**").as("attributes");
+
             topBar.enterEditMode().editButtonIsVisible(false);
-            cityFilter.open().selectAttribute(["Portland"]).apply();
+            cy.wait("@attributes").then(() => {
+                cityFilter.open().selectAttribute(["Portland"]).apply();
+            });
 
             stateFilter
                 .open()

--- a/libs/sdk-ui-tests-e2e/cypress/tools/filterBar.ts
+++ b/libs/sdk-ui-tests-e2e/cypress/tools/filterBar.ts
@@ -1,4 +1,4 @@
-// (C) 2021-2022 GoodData Corporation
+// (C) 2021-2024 GoodData Corporation
 import { DashboardAttributeFilterConfigMode, DashboardDateFilterConfigMode } from "@gooddata/sdk-model";
 import { getTestClassByTitle } from "../support/commands/tools/classes";
 import { DropZone } from "./enum/DropZone";
@@ -126,9 +126,10 @@ export class AttributeFilter {
     search(attributeValue: string) {
         this.getDropdownElement()
             .find(".gd-list-searchfield .gd-input-field")
+            .as("searchField")
             .should("be.visible")
-            .clear()
-            .type(attributeValue);
+            .clear();
+        cy.get("@searchField").type(attributeValue);
         return this;
     }
 


### PR DESCRIPTION
Passed on my branch:
https://checklist.intgdc.com/job/cypress-tests/job/gooddata-ui-sdk-cypress-checklist_integrated_tiger-worker/499/console

https://checklist.intgdc.com/job/cypress-tests/job/gooddata-ui-sdk-cypress-checklist_integrated_tiger-worker/500/console

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |
| **Compatibility matrix test commands - TIGER Backend**  |                                                            |
| `extended test - matrix-test <AIO_version>`             | Run integrated tests against AIO versions.                 |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

`<AIO_version>` in commands is used to start test with multiple AIO instances - each instance in triggered by one jenkins build

-   To run with `master` and `stable`, execute command `extended test - matrix-test master,stable` or `extended test - matrix-test latest`
-   To run with specific version,ex: `2.3.0` and `2.3.1`, execute command `extended test - matrix-test 2.3.0,2.3.1`
-   In case `<AIO_version>` is empty, read versions from file `compTigerVersions.txt` of this repo

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
