### PR TITLE
BUGFIX: LX-47 Provide date datasets during mode change

### DIFF
--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/common/stateInitializers.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/common/stateInitializers.ts
@@ -211,9 +211,9 @@ export function* actionsToInitializeExistingDashboard(
     insights: IInsight[],
     settings: ISettings,
     dateFilterConfig: IDateFilterConfig,
+    dateDataSets: ICatalogDateDataset[],
     displayForms?: ObjRefMap<IAttributeDisplayFormMetadataObject>,
     persistedDashboard?: IDashboard,
-    dateDataSets?: ICatalogDateDataset[],
 ): SagaIterator<Array<PayloadAction<any>>> {
     const sanitizedFilterContext = yield call(
         sanitizeFilterContext,

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/initializeDashboardHandler/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/initializeDashboardHandler/index.ts
@@ -198,9 +198,9 @@ function* loadExistingDashboard(
         insights,
         config.settings,
         effectiveDateFilterConfig.config,
+        catalog.dateDatasets(),
         createDisplayFormMapFromCatalog(catalog),
         cmd.payload.persistedDashboard,
-        catalog.dateDatasets(),
     );
 
     const batch: BatchAction = batchActions(

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/resetDashboardHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/resetDashboardHandler.ts
@@ -1,4 +1,4 @@
-// (C) 2021-2023 GoodData Corporation
+// (C) 2021-2024 GoodData Corporation
 import { DashboardContext } from "../../types/commonTypes.js";
 import { ResetDashboard } from "../../commands/index.js";
 import { SagaIterator } from "redux-saga";
@@ -18,6 +18,7 @@ import uniqWith from "lodash/uniqWith.js";
 import { areObjRefsEqual } from "@gooddata/sdk-model";
 import { resolveInsights } from "../../utils/insightResolver.js";
 import { insightReferences } from "./common/insightReferences.js";
+import { selectCatalogDateDatasets } from "../../store/catalog/catalogSelectors.js";
 
 export function* resetDashboardHandler(
     ctx: DashboardContext,
@@ -76,6 +77,9 @@ function* resetDashboardFromPersisted(ctx: DashboardContext) {
         const effectiveConfig: ReturnType<typeof selectEffectiveDateFilterConfig> = yield select(
             selectEffectiveDateFilterConfig,
         );
+        const dateDataSets: ReturnType<typeof selectCatalogDateDatasets> = yield select(
+            selectCatalogDateDatasets,
+        );
 
         const resolvedInsightsValues = Array(...resolvedInsights.resolved.values());
 
@@ -86,6 +90,7 @@ function* resetDashboardFromPersisted(ctx: DashboardContext) {
             resolvedInsightsValues,
             settings,
             effectiveConfig,
+            dateDataSets,
         );
     } else {
         /*


### PR DESCRIPTION
Date datasets used for DFs validation were not provided when switching between view/edit mode
JIRA: LX-47

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |
| **Compatibility matrix test commands - TIGER Backend**  |                                                            |
| `extended test - matrix-test <AIO_version>`             | Run integrated tests against AIO versions.                 |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

`<AIO_version>` in commands is used to start test with multiple AIO instances - each instance in triggered by one jenkins build

-   To run with `master` and `stable`, execute command `extended test - matrix-test master,stable` or `extended test - matrix-test latest`
-   To run with specific version,ex: `2.3.0` and `2.3.1`, execute command `extended test - matrix-test 2.3.0,2.3.1`
-   In case `<AIO_version>` is empty, read versions from file `compTigerVersions.txt` of this repo

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
