### PR TITLE
RELATED: STL-107 add publish workflows

### DIFF
--- a/.github/workflows/publish-alpha.yml
+++ b/.github/workflows/publish-alpha.yml
@@ -1,0 +1,17 @@
+# (C) 2024 GoodData Corporation
+
+name: Release ~ Publish alpha
+description: ''
+on:
+  workflow_dispatch:
+jobs:
+  publish-alpha:
+    runs-on: infra1-medium
+    permissions:
+      contents: write
+    steps:
+      - name: Publish alpha from master
+        uses: ./.github/workflows/rw-publish-version.yml
+        with:
+          source-branch: 'master'
+          git-hub-token: ${{ secrets.TOKEN_GITHUB_YENKINS_ADMIN }}

--- a/.github/workflows/rw-bump-version.yml
+++ b/.github/workflows/rw-bump-version.yml
@@ -1,4 +1,4 @@
-name: Bump version
+name: rw ~ Rush ~ Bump version
 description: 'This workflow automatically bumps the version of the project based on the specified version bump type and prerelease ID. It also commits the changes to the source branch.'
 on:
   workflow_call:

--- a/.github/workflows/rw-publish-version.yml
+++ b/.github/workflows/rw-publish-version.yml
@@ -1,0 +1,36 @@
+name: rw ~ Rush ~ Publish version
+description: 'TODO'
+on:
+  workflow_call:
+    inputs:
+      git-hub-token:
+        description: 'GitHub token with write access to the source branch'
+        required: true
+      source-branch:
+        required: true
+        description: 'The name of the source branch'
+        type: string
+
+jobs:
+  bump-version:
+    runs-on: infra1-medium
+    container:
+      image: 020413372491.dkr.ecr.us-east-1.amazonaws.com/3rdparty/library/node:18.17.0-bullseye
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.source-branch }}
+          token: ${{ inputs.git-hub-token }} 
+      - name: Install rush
+        run: |
+          npm install -g @microsoft/rush
+      - name: Rush install 
+        run: |
+          rush install
+      - name: Rush build
+        run: |
+          rush build
+      - name: Rush publish
+        run: |
+          echo "TODO - publish to npm"


### PR DESCRIPTION
JIRA: STL-107

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |
| **Compatibility matrix test commands - TIGER Backend**  |                                                            |
| `extended test - matrix-test <AIO_version>`             | Run integrated tests against AIO versions.                 |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

`<AIO_version>` in commands is used to start test with multiple AIO instances - each instance in triggered by one jenkins build

-   To run with `master` and `stable`, execute command `extended test - matrix-test master,stable` or `extended test - matrix-test latest`
-   To run with specific version,ex: `2.3.0` and `2.3.1`, execute command `extended test - matrix-test 2.3.0,2.3.1`
-   In case `<AIO_version>` is empty, read versions from file `compTigerVersions.txt` of this repo

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
