### PR TITLE
RELATED: STL-107 rush publish and code drop workflows

### DIFF
--- a/.github/workflows/code-drop.yml
+++ b/.github/workflows/code-drop.yml
@@ -1,7 +1,9 @@
 # (C) 2024 GoodData Corporation
 
+# Automated Code Drop Workflow: Initiates a code drop from the master branch to a new release branch. 
+# Manages version increments, setting the master to a new alpha preminor version and the release branch to a beta prerelease version. 
+# Notifies the team via Slack upon successful completion.
 name: Release ~ Code drop
-description: 'Automated Code Drop Workflow: Initiates a code drop from the master branch to a new release branch. Manages version increments, setting the master to a new alpha preminor version and the release branch to a beta prerelease version. Notifies the team via Slack upon successful completion.'
 on:
   workflow_dispatch:
       inputs:
@@ -33,7 +35,6 @@ jobs:
     permissions:
       contents: write
     with:
-        git-hub-token: ${{ secrets.TOKEN_GITHUB_YENKINS_ADMIN }}
         source-branch: 'release'
         bump: 'prerelease'
         prerelease-id: 'beta'
@@ -45,7 +46,6 @@ jobs:
     permissions:
       contents: write
     with:
-        git-hub-token: ${{ secrets.TOKEN_GITHUB_YENKINS_ADMIN }}
         source-branch: 'master'
         bump: 'preminor'
         prerelease-id: 'alpha'

--- a/.github/workflows/publish-alpha.yml
+++ b/.github/workflows/publish-alpha.yml
@@ -1,17 +1,14 @@
 # (C) 2024 GoodData Corporation
 
 name: Release ~ Publish alpha
-description: ''
 on:
-  workflow_dispatch:
+    workflow_dispatch:
 jobs:
-  publish-alpha:
-    runs-on: infra1-medium
-    permissions:
-      contents: write
-    steps:
-      - name: Publish alpha from master
+    publish-alpha:
         uses: ./.github/workflows/rw-publish-version.yml
+        permissions:
+            contents: write
+        secrets: inherit
         with:
-          source-branch: 'master'
-          git-hub-token: ${{ secrets.TOKEN_GITHUB_YENKINS_ADMIN }}
+            source-branch: "master"
+            release-tag: "alpha"

--- a/.github/workflows/rw-bump-version.yml
+++ b/.github/workflows/rw-bump-version.yml
@@ -1,11 +1,12 @@
+# (C) 2024 GoodData Corporation
+
+#This workflow automatically bumps the version of the project based on the specified version bump type and prerelease ID. 
+#It also commits the changes to the source branch.
+
 name: rw ~ Rush ~ Bump version
-description: 'This workflow automatically bumps the version of the project based on the specified version bump type and prerelease ID. It also commits the changes to the source branch.'
 on:
   workflow_call:
     inputs:
-      git-hub-token:
-        description: 'GitHub token with write access to the source branch'
-        required: true
       source-branch:
         required: true
         description: 'The name of the source branch'
@@ -35,7 +36,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.source-branch }}
-          token: ${{ inputs.git-hub-token }} 
+          token: ${{ secrets.TOKEN_GITHUB_YENKINS_ADMIN }} 
 
       - name: Add repository to git safe directories to avoid dubious ownership issue
         run: git config --global --add safe.directory $GITHUB_WORKSPACE

--- a/.github/workflows/rw-publish-version.yml
+++ b/.github/workflows/rw-publish-version.yml
@@ -1,36 +1,41 @@
+# (C) 2024 GoodData Corporation
+
 name: rw ~ Rush ~ Publish version
-description: 'TODO'
 on:
-  workflow_call:
-    inputs:
-      git-hub-token:
-        description: 'GitHub token with write access to the source branch'
-        required: true
-      source-branch:
-        required: true
-        description: 'The name of the source branch'
-        type: string
+    workflow_call:
+        inputs:
+            source-branch:
+                required: true
+                description: "The name of the source branch"
+                type: string
+            release-tag:
+                required: true
+                description: "The release NPM tag e.g. prerelease, latest, hotfix ..."
+                type: string
 
 jobs:
-  bump-version:
-    runs-on: infra1-medium
-    container:
-      image: 020413372491.dkr.ecr.us-east-1.amazonaws.com/3rdparty/library/node:18.17.0-bullseye
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.source-branch }}
-          token: ${{ inputs.git-hub-token }} 
-      - name: Install rush
-        run: |
-          npm install -g @microsoft/rush
-      - name: Rush install 
-        run: |
-          rush install
-      - name: Rush build
-        run: |
-          rush build
-      - name: Rush publish
-        run: |
-          echo "TODO - publish to npm"
+    publish-version:
+        runs-on: [infra1-medium]
+        container:
+            image: 020413372491.dkr.ecr.us-east-1.amazonaws.com/3rdparty/library/node:18.17.0-bullseye
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+              with:
+                  ref: ${{ inputs.source-branch }}
+                  token: ${{ secrets.TOKEN_GITHUB_YENKINS_ADMIN }}
+            - name: Install rush
+              run: |
+                  npm install -g @microsoft/rush
+            - name: Rush install
+              run: |
+                  rush install
+            - name: Rush build
+              run: |
+                  rush build
+            - name: Rush publish dry run
+              run: |
+                  rush publish --include-all --version-policy sdk --set-access-level public
+            - name: Rush publish
+              run: |
+                  echo "Publishing to NPM"


### PR DESCRIPTION
JIRA: STL-107

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |
| **Compatibility matrix test commands - TIGER Backend**  |                                                            |
| `extended test - matrix-test <AIO_version>`             | Run integrated tests against AIO versions.                 |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

`<AIO_version>` in commands is used to start test with multiple AIO instances - each instance in triggered by one jenkins build

-   To run with `master` and `stable`, execute command `extended test - matrix-test master,stable` or `extended test - matrix-test latest`
-   To run with specific version,ex: `2.3.0` and `2.3.1`, execute command `extended test - matrix-test 2.3.0,2.3.1`
-   In case `<AIO_version>` is empty, read versions from file `compTigerVersions.txt` of this repo

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
