### PR TITLE
RELATED: STL-107 combine bump version and npm publish for alpha release

### DIFF
--- a/.github/workflows/publish-alpha.yml
+++ b/.github/workflows/publish-alpha.yml
@@ -4,11 +4,22 @@ name: Release ~ Publish alpha
 on:
     workflow_dispatch:
 jobs:
+    bump-version:
+        uses: ./.github/workflows/rw-bump-version.yml
+        permissions:
+            contents: write
+        secrets: inherit
+        with:
+            source-branch: "master"
+            bump: "prerelease"
+            prerelease-id: "alpha"
+
     publish-alpha:
+        needs: [bump-version]
         uses: ./.github/workflows/rw-publish-version.yml
         permissions:
             contents: write
         secrets: inherit
         with:
             source-branch: "master"
-            release-tag: "alpha"
+            release-tag: "prerelease"

--- a/.github/workflows/rw-publish-version.yml
+++ b/.github/workflows/rw-publish-version.yml
@@ -23,7 +23,15 @@ jobs:
               uses: actions/checkout@v4
               with:
                   ref: ${{ inputs.source-branch }}
-                  token: ${{ secrets.TOKEN_GITHUB_YENKINS_ADMIN }}
+            - name: Get NPM_PUBLISH_TOKEN from Vault and set it as env variable
+              uses: hashicorp/vault-action@v2
+              with:
+                  url: "https://vault.ord1.infra.intgdc.com"
+                  method: jwt
+                  path: jwt/github
+                  role: ecr-push
+              env:
+                  NPM_PUBLISH_TOKEN: secret/v3/int/npm/rw-token
             - name: Install rush
               run: |
                   npm install -g @microsoft/rush
@@ -37,5 +45,7 @@ jobs:
               run: |
                   rush publish --include-all --version-policy sdk --set-access-level public
             - name: Rush publish
+              env:
+                  TAG: ${{ inputs.release-tag }}
               run: |
-                  echo "Publishing to NPM"
+                  rush publish --publish --include-all --version-policy sdk --tag $TAG --set-access-level public


### PR DESCRIPTION
JIRA: STL-107

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |
| **Compatibility matrix test commands - TIGER Backend**  |                                                            |
| `extended test - matrix-test <AIO_version>`             | Run integrated tests against AIO versions.                 |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

`<AIO_version>` in commands is used to start test with multiple AIO instances - each instance in triggered by one jenkins build

-   To run with `master` and `stable`, execute command `extended test - matrix-test master,stable` or `extended test - matrix-test latest`
-   To run with specific version,ex: `2.3.0` and `2.3.1`, execute command `extended test - matrix-test 2.3.0,2.3.1`
-   In case `<AIO_version>` is empty, read versions from file `compTigerVersions.txt` of this repo

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
