### PR TITLE
RELATED: STL-107 manual triggered alpha release

### DIFF
--- a/.github/workflows/publish-alpha.yml
+++ b/.github/workflows/publish-alpha.yml
@@ -8,6 +8,7 @@ jobs:
         uses: ./.github/workflows/rw-bump-version.yml
         permissions:
             contents: write
+            id-token: write
         secrets: inherit
         with:
             source-branch: "master"
@@ -18,8 +19,22 @@ jobs:
         needs: [bump-version]
         uses: ./.github/workflows/rw-publish-version.yml
         permissions:
-            contents: write
+            contents: read
+            id-token: write
         secrets: inherit
         with:
             source-branch: "master"
             release-tag: "prerelease"
+
+    slack-notification:
+        runs-on: [infra1-small]
+        needs: [bump-version, publish-alpha]
+        steps:
+            - name: Notify to slack
+              uses: slackapi/slack-github-action@v1.23.0
+              with:
+                  channel-id: "#javascript-notifications"
+                  slack-message: "SDK-UI versions *${{ env.RELEASE_VERSION }}* has been successfully published to NPM."
+              env:
+                  RELEASE_VERSION: ${{ needs.bump-version.outputs.version }}
+                  SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/rw-bump-version.yml
+++ b/.github/workflows/rw-bump-version.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Add repository to git safe directories to avoid dubious ownership issue
         run: git config --global --add safe.directory $GITHUB_WORKSPACE
-      - name: Create and push branch
+      - name: Bum rush version and commit to source branch
         env:
           BUMP: ${{ inputs.bump }}
           PRERELEASE_ID: ${{ inputs.prerelease-id }}
@@ -51,7 +51,8 @@ jobs:
           # it needs git configured already user.email/name
           rush version --bump --override-bump $BUMP --override-prerelease-id $PRERELEASE_ID
           git add -A
-          git commit -m "Bump versions"
+          VERSION=$(node -p "require('./libs/sdk-ui/package.json').version")
+          git commit -m "Bump versions to $VERSION"
           git push origin ${{ inputs.source-branch }}
       - name: Get version
         id: version

--- a/.github/workflows/rw-publish-version.yml
+++ b/.github/workflows/rw-publish-version.yml
@@ -18,20 +18,25 @@ jobs:
         runs-on: [infra1-medium]
         container:
             image: 020413372491.dkr.ecr.us-east-1.amazonaws.com/3rdparty/library/node:18.17.0-bullseye
+        permissions:
+            contents: read
+            id-token: write
         steps:
             - name: Checkout code
               uses: actions/checkout@v4
               with:
                   ref: ${{ inputs.source-branch }}
+            - name: Add repository to git safe directories to avoid dubious ownership issue
+              run: git config --global --add safe.directory $GITHUB_WORKSPACE
             - name: Get NPM_PUBLISH_TOKEN from Vault and set it as env variable
               uses: hashicorp/vault-action@v2
               with:
                   url: "https://vault.ord1.infra.intgdc.com"
                   method: jwt
                   path: jwt/github
-                  role: ecr-push
+                  role: front-end
                   secrets: |
-                    secret/v3/int/npm/rw-token secret | NPM_PUBLISH_TOKEN
+                    secret/data/v3/int/npm/rw-token secret | NPM_PUBLISH_TOKEN ;
             - name: Install rush
               run: |
                   npm install -g @microsoft/rush


### PR DESCRIPTION
JIRA: STL-107

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |
| **Compatibility matrix test commands - TIGER Backend**  |                                                            |
| `extended test - matrix-test <AIO_version>`             | Run integrated tests against AIO versions.                 |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

`<AIO_version>` in commands is used to start test with multiple AIO instances - each instance in triggered by one jenkins build

-   To run with `master` and `stable`, execute command `extended test - matrix-test master,stable` or `extended test - matrix-test latest`
-   To run with specific version,ex: `2.3.0` and `2.3.1`, execute command `extended test - matrix-test 2.3.0,2.3.1`
-   In case `<AIO_version>` is empty, read versions from file `compTigerVersions.txt` of this repo

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
