### PR TITLE
RELATED: STL-118 add publish pre-release from PR

### DIFF
--- a/.github/workflows/publish-alpha.yml
+++ b/.github/workflows/publish-alpha.yml
@@ -4,37 +4,11 @@ name: Release ~ Publish alpha
 on:
     workflow_dispatch:
 jobs:
-    bump-version:
-        uses: ./.github/workflows/rw-bump-version.yml
+    publish-pre-release:
+        uses: ./.github/workflows/rw-publish-prerelase.yml
         permissions:
             contents: write
             id-token: write
         secrets: inherit
         with:
             source-branch: "master"
-            bump: "prerelease"
-            prerelease-id: "alpha"
-
-    publish-alpha:
-        needs: [bump-version]
-        uses: ./.github/workflows/rw-publish-version.yml
-        permissions:
-            contents: read
-            id-token: write
-        secrets: inherit
-        with:
-            source-branch: "master"
-            release-tag: "prerelease"
-
-    slack-notification:
-        runs-on: [infra1-small]
-        needs: [bump-version, publish-alpha]
-        steps:
-            - name: Notify to slack
-              uses: slackapi/slack-github-action@v1.23.0
-              with:
-                  channel-id: "#javascript-notifications"
-                  slack-message: "SDK-UI versions *${{ env.RELEASE_VERSION }}* has been successfully published to NPM."
-              env:
-                  RELEASE_VERSION: ${{ needs.bump-version.outputs.version }}
-                  SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/pull-request-prerelease.yml
+++ b/.github/workflows/pull-request-prerelease.yml
@@ -1,0 +1,17 @@
+name: Pull request ~ Prerelease
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - master
+      - release
+
+jobs:
+  publish-pre-release:
+    name: Publish pre-release
+    if: >
+        github.event.pull_request.merged == true &&
+        any(github.event.pull_request.labels.*.name, '==', 'publish pre-release')
+    uses: ./.github/workflows/rw-publish-prerelase.yml
+    with:      
+      source-branch: ${{ github.event.pull_request.base.ref }}

--- a/.github/workflows/rw-publish-prerelase.yml
+++ b/.github/workflows/rw-publish-prerelase.yml
@@ -1,0 +1,74 @@
+# (C) 2024 GoodData Corporation
+
+name: rw ~ Release ~ Publish prerelease
+on:
+  workflow_call:
+    inputs:
+      source-branch:
+        required: true
+        description: "The name of the source branch"
+        type: string
+
+# limit concurrency to one run per branch at a time
+# so that we can run this from master and a release branch at the same time
+# When a concurrent job or workflow is queued,
+# if another job or workflow using the same concurrency group in the repository is in progress,
+# the queued job or workflow will be pending. Any previously pending job or workflow in the concurrency group will be canceled.
+concurrency:
+  group: prerelease-${{ github.event.inputs.source-branch }}
+  cancel-in-progress: false
+
+jobs:
+  setup-params:
+    runs-on: [infra-small]
+    outputs:
+      prerelease-id: ${{ steps.validate-params.outputs.prerelease-id }}
+
+    steps:
+      - name: validate params
+        id: validate-params
+        run: |
+          if [ "${{ inputs.source-branch }}" = "master" ]; then
+            echo "prerelease-id=alpha" >> $GITHUB_OUTPUT
+          elif [ "${{ inputs.source-branch }}" = "release" ]; then
+            echo "prerelease-id=beta" >> $GITHUB_OUTPUT
+          else
+            echo "Invalid branch provided. Please provide either 'master' or 'release'."
+            exit 1
+          fi
+
+  bump-version:
+    needs: [setup-params]
+    uses: ./.github/workflows/rw-bump-version.yml
+    permissions:
+      contents: write
+      id-token: write
+    secrets: inherit
+    with:
+      source-branch: ${{ github.event.inputs.source-branch }}
+      bump: "prerelease"
+      prerelease-id: ${{ needs.setup-params.outputs.prerelease-id }}
+
+  publish-prerelease:
+    needs: [bump-version]
+    uses: ./.github/workflows/rw-publish-version.yml
+    permissions:
+      contents: read
+      id-token: write
+    secrets: inherit
+    with:
+      source-branch: ${{ github.event.inputs.source-branch }}
+      release-tag: "prerelease"
+
+  slack-notification:
+    runs-on: [infra1-small]
+    needs: [bump-version, publish-prerelease]
+    steps:
+      - name: Notify to slack
+        uses: slackapi/slack-github-action@v1.23.0
+        with:
+          channel-id: "#javascript-notifications"
+          slack-message: "SDK-UI versions *${{ env.RELEASE_VERSION }}* has been successfully published to NPM."
+        env:
+          RELEASE_VERSION: ${{ needs.bump-version.outputs.version }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}


### PR DESCRIPTION
JIRA: STL-118

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |
| **Compatibility matrix test commands - TIGER Backend**  |                                                            |
| `extended test - matrix-test <AIO_version>`             | Run integrated tests against AIO versions.                 |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

`<AIO_version>` in commands is used to start test with multiple AIO instances - each instance in triggered by one jenkins build

-   To run with `master` and `stable`, execute command `extended test - matrix-test master,stable` or `extended test - matrix-test latest`
-   To run with specific version,ex: `2.3.0` and `2.3.1`, execute command `extended test - matrix-test 2.3.0,2.3.1`
-   In case `<AIO_version>` is empty, read versions from file `compTigerVersions.txt` of this repo

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
