### PR TITLE
TRIVIAL: Revert "feat(ext-update): update ext-image files in gdc-nas"

### DIFF
--- a/.github/workflows/post-merge-pipeline.yml
+++ b/.github/workflows/post-merge-pipeline.yml
@@ -107,18 +107,39 @@ jobs:
     outputs:
       github_short_sha: ${{ env.GITHUB_SHORT_SHA }}
   generate-update:
-    runs-on: [ infra1-small ]
+    runs-on: [infra1-small]
     permissions:
-      contents: write
+      contents: read
       id-token: write
-      pull-requests: write
-    needs: [ docker-build-web-components ]
-    uses: gooddata/github-actions/.github/workflows/update-ext-repo.yaml@master
-    with:
-      branch: ${GITHUB_REF_NAME}
-      commit_sha: ${{ needs.docker-build-web-components.outputs.github_short_sha }}
-      component_name: web-components
-    secrets:
-      token_push: ${{ secrets.TOKEN_GITHUB_YENKINS_ADMIN }}
-      token_approve: ${{ secrets.TOKEN_GITHUB_YENKINS }}
-
+    needs: [docker-build-web-components]
+    container:
+      image: 020413372491.dkr.ecr.us-east-1.amazonaws.com/infra/tools:3.5.0
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Add repository to git safe directories to void dubious ownership issue
+        run: git config --global --add safe.directory $GITHUB_WORKSPACE
+      - name: Get the commit before SHA
+        run: echo "GITHUB_COMMIT_BEFORE_SHA=$(git rev-parse HEAD^)" >> $GITHUB_ENV
+      - name: Get Vault secrets for creating MR to gdc-nas gitlab project
+        uses: hashicorp/vault-action@v2
+        with:
+          url: "https://vault.ord1.infra.intgdc.com"
+          method: jwt
+          path: jwt/github
+          role: front-end
+          secrets: |
+            secret/data/v3/int/github/github-runner-gitlab-token gitlab_approver_token | GITLAB_APPROVER_TOKEN ;
+            secret/data/v3/int/github/github-runner-gitlab-token gitlab_merger_token | GITLAB_MERGER_TOKEN ;
+      - name: Generate MR with a new version of web-components image to gdc-nas
+        run: /scripts/update_ext_image_version.py web-components
+        env:
+          CI_API_V4_URL: https://gitlab.com/api/v4
+          CI_PROJECT_NAME: ${{ github.event.repository.name }}
+          CI_COMMIT_SHORT_SHA: ${{ needs.docker-build-web-components.outputs.github_short_sha }}
+          CI_COMMIT_BEFORE_SHA: ${{ env.GITHUB_COMMIT_BEFORE_SHA }}
+          CI_COMMIT_BRANCH: ${{ github.ref_name }}
+          GITLAB_APPROVER_TOKEN: ${{ env.GITLAB_APPROVER_TOKEN }}
+          GITLAB_MERGER_TOKEN: ${{ env.GITLAB_MERGER_TOKEN }}


### PR DESCRIPTION
Reason - we can't use reusable workflow from private repository

This reverts commit fd717a60e20e3ab29004e74c7be6441af058b03f.

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |
| **Compatibility matrix test commands - TIGER Backend**  |                                                            |
| `extended test - matrix-test <AIO_version>`             | Run integrated tests against AIO versions.                 |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

`<AIO_version>` in commands is used to start test with multiple AIO instances - each instance in triggered by one jenkins build

-   To run with `master` and `stable`, execute command `extended test - matrix-test master,stable` or `extended test - matrix-test latest`
-   To run with specific version,ex: `2.3.0` and `2.3.1`, execute command `extended test - matrix-test 2.3.0,2.3.1`
-   In case `<AIO_version>` is empty, read versions from file `compTigerVersions.txt` of this repo

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
