### PR TITLE
RELATED: STL-140 add publish betas and alphas to code-drop

### DIFF
--- a/.github/workflows/code-drop.yml
+++ b/.github/workflows/code-drop.yml
@@ -50,6 +50,28 @@ jobs:
         bump: 'preminor'
         prerelease-id: 'alpha'
 
+  publish-pre-release-master:
+    needs: prepare-versions-master
+    uses: ./.github/workflows/rw-publish-prerelase.yml
+    permissions:
+      contents: write
+      id-token: write
+    secrets: inherit
+    with:
+      source-branch: "master"
+      skip-bump: true
+  
+  publish-pre-release-release:
+    needs: prepare-versions-release
+    uses: ./.github/workflows/rw-publish-prerelase.yml
+    permissions:
+      contents: write
+      id-token: write
+    secrets: inherit
+    with:
+      source-branch: "release"
+      skip-bump: true
+
   slack-notification:
     runs-on: [ubuntu-latest]
     needs: [prepare-versions-release, prepare-versions-master]

--- a/.github/workflows/rw-bump-version.yml
+++ b/.github/workflows/rw-bump-version.yml
@@ -2,6 +2,7 @@
 
 #This workflow automatically bumps the version of the project based on the specified version bump type and prerelease ID. 
 #It also commits the changes to the source branch.
+#when skip-bump is set to true, it just returns the current version
 
 name: rw ~ Rush ~ Bump version
 on:
@@ -19,6 +20,11 @@ on:
         required: true
         description: 'The prerelease ID (alpha, beta, etc.)'
         type: string
+      skip-bump:
+          required: false
+          default: false
+          description: "Skip bumping the version and just return the current version"
+          type: boolean
     outputs:
       version:
         description: "Version which was created"
@@ -40,7 +46,8 @@ jobs:
 
       - name: Add repository to git safe directories to avoid dubious ownership issue
         run: git config --global --add safe.directory $GITHUB_WORKSPACE
-      - name: Bump rush version and commit to source branch
+      - name: Bump rush version and commit to source branch #if skip-bump is set to true, it just returns the current version
+        if: ${{ !inputs.skip-bump }} 
         env:
           BUMP: ${{ inputs.bump }}
           PRERELEASE_ID: ${{ inputs.prerelease-id }}

--- a/.github/workflows/rw-publish-prerelase.yml
+++ b/.github/workflows/rw-publish-prerelase.yml
@@ -8,6 +8,11 @@ on:
         required: true
         description: "The name of the source branch"
         type: string
+      skip-bump:
+        required: false
+        default: false
+        description: "Skip bumping the version"
+        type: boolean
 
 # limit concurrency to one run per branch at a time
 # so that we can run this from master and a release branch at the same time
@@ -48,6 +53,7 @@ jobs:
       source-branch: ${{ inputs.source-branch }}
       bump: "prerelease"
       prerelease-id: ${{ needs.setup-params.outputs.prerelease-id }}
+      skip-bump: ${{ inputs.skip-bump }}
 
   publish-prerelease:
     needs: [bump-version]


### PR DESCRIPTION
JIRA: STL-140

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |
| **Compatibility matrix test commands - TIGER Backend**  |                                                            |
| `extended test - matrix-test <AIO_version>`             | Run integrated tests against AIO versions.                 |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

`<AIO_version>` in commands is used to start test with multiple AIO instances - each instance in triggered by one jenkins build

-   To run with `master` and `stable`, execute command `extended test - matrix-test master,stable` or `extended test - matrix-test latest`
-   To run with specific version,ex: `2.3.0` and `2.3.1`, execute command `extended test - matrix-test 2.3.0,2.3.1`
-   In case `<AIO_version>` is empty, read versions from file `compTigerVersions.txt` of this repo

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
