### PR TITLE
RELATED: STL-121 UI Examples heroku publish

### DIFF
--- a/.github/workflows/examples-deploy.yml
+++ b/.github/workflows/examples-deploy.yml
@@ -1,0 +1,64 @@
+# (C) 2024 GoodData Corporation
+
+# Deploy of ui sdk examples
+name: Release ~ Examples deploy
+on:
+  workflow_dispatch:
+
+jobs:
+  prepare-branch:
+    runs-on: [infra1-medium]
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+# for testing, have 9.6 as it's currently the release on which examples run
+        with:
+            ref: rel/9.6
+
+      - name: Get tokens from Vault and set it as env variable
+        uses: hashicorp/vault-action@v2
+        with:
+            url: "https://vault.ord1.infra.intgdc.com"
+            method: jwt
+            path: jwt/github
+            # TODO: check role
+            role: front-end
+            secrets: |
+              secret/data/v2/na1/int/911/jenkins_ng_slave/data/live-examples-heroku-api secret | HEROKU_API_KEY ;
+#             secret/data/v2/na1/int/911/jenkins_ng_slave/data/mapbox-access-token secret | MAPBOX_TOKEN ;
+
+      - name: Install rush
+        run: |
+            npm install -g @microsoft/rush
+      - name: Rush install
+        run: |
+            rush install
+      - name: Rush build
+        env:
+            EXAMPLES_BUILD_TYPE: public
+#           EXAMPLE_MAPBOX_ACCESS_TOKEN: ${{env.MAPBOX_TOKEN}}
+            EXAMPLE_MAPBOX_ACCESS_TOKEN: "abc"
+            BROWSERSLIST_IGNORE_OLD_DATA: true
+        run: |
+            rush build -t @gooddata/sdk-examples
+
+      - name: Deploy to heroku
+        uses: akhileshns/heroku-deploy@v3.13.15
+        with:
+          appdir: "examples/sdk-examples"
+          heroku_api_key: ${{env.HEROKU_API_KEY}}
+          heroku_app_name: "gdui-examples"
+          heroku_email: "rail@gooddata.com"
+          team: "gooddata"
+          usedocker: true
+          docker_heroku_process_type: web
+          docker_build_args: |
+            BACKEND_HOST
+            BACKEND_URL
+# Note: heroku config:set BACKEND_HOST=${BACKEND_HOST} -a ${PUBLIC_APP_NAME} has to be there
+          env:
+            BACKEND_URL: "https://live-examples-proxy.herokuapp.com"
+            BACKEND_HOST: "live-examples-proxy.herokuapp.com"


### PR DESCRIPTION
<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |
| **Compatibility matrix test commands - TIGER Backend**  |                                                            |
| `extended test - matrix-test <AIO_version>`             | Run integrated tests against AIO versions.                 |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

`<AIO_version>` in commands is used to start test with multiple AIO instances - each instance in triggered by one jenkins build

-   To run with `master` and `stable`, execute command `extended test - matrix-test master,stable` or `extended test - matrix-test latest`
-   To run with specific version,ex: `2.3.0` and `2.3.1`, execute command `extended test - matrix-test 2.3.0,2.3.1`
-   In case `<AIO_version>` is empty, read versions from file `compTigerVersions.txt` of this repo

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)