### PR TITLE
RELATED: STL-120 chore: add backmerge workflows

### DIFF
--- a/.github/workflows/git-backmerge.yml
+++ b/.github/workflows/git-backmerge.yml
@@ -1,0 +1,39 @@
+name: Git ~ Backmerge Release to Master
+on:
+    workflow_dispatch:
+jobs:
+    auto-merge:
+        uses: ./.github/workflows/rw-git-backmerge.yml
+        permissions:
+            contents: write
+            pull-requests: write
+            repository-projects: write
+        secrets: inherit
+        with:
+            source-branch: "release"
+            target-branch: "master"
+    
+    slack-notification:
+        runs-on: [ubuntu-latest]
+        needs: [auto-merge]
+        steps:
+        - name: print auto-merge outputs
+          run: echo "The auto-merge outputs are ${{ needs.auto-merge.outputs.has-conflicts }} and ${{ needs.auto-merge.outputs.pull-request-url }}"
+        - name: Notify to slack no conflicts
+          if: ${{ needs.auto-merge.outputs.has-conflicts == 'false' }}
+          uses: slackapi/slack-github-action@v1.25.0
+          with:
+            channel-id: "#javascript-notifications"
+            slack-message: "The backmerge from the release is ready and can be easily merged to the master branch. It won't cause any problems because there are *no conflicts*. ${{env.PULL_REQUEST }}"
+          env:            
+            PULL_REQUEST: ${{ needs.auto-merge.outputs.pull-request-url }}
+            SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        - name: Notify to slack has conflicts
+          if: ${{ needs.auto-merge.outputs.has-conflicts == 'true' }}
+          uses: slackapi/slack-github-action@v1.25.0
+          with:
+            channel-id: "#javascript-notifications"
+            slack-message: "The backmerge from the release is ready and can not be easily merged into the master branch. However, *there are conflicts* in the PR that needs to be resolved. ${{env.PULL_REQUEST }}"
+          env:            
+            PULL_REQUEST: ${{ needs.auto-merge.outputs.pull-request-url }}
+            SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/rw-git-backmerge.yml
+++ b/.github/workflows/rw-git-backmerge.yml
@@ -1,0 +1,111 @@
+name: Automated Merge and Conflict Resolution
+
+on:
+  workflow_call:
+    inputs:
+      source-branch:
+        required: false
+        type: string
+        default: 'release'
+      target-branch:
+        required: false
+        type: string
+        default: 'master'
+
+
+    outputs:
+      pull-request-url:
+        description: "The URL of the created Pull Request"
+        value: ${{ jobs.merge-and-resolve-conflicts.outputs.pr_url }}
+      has-conflicts:
+        description: "Pull Request has conflicts"
+        value: ${{ jobs.merge-and-resolve-conflicts.outputs.pr_has_conflicts }}
+
+jobs:
+  merge-and-resolve-conflicts:
+    runs-on: ubuntu-latest
+    outputs:
+      pr_url: ${{ steps.prepare-pr.outputs.pr_url }}
+      pr_has_conflicts: ${{ steps.prepare-pr.outputs.pr_has_conflicts }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18.17.0
+
+      - name: Install rush
+        run: |
+            npm install -g @microsoft/rush
+
+      - name: Configure Git
+        run: |
+          git config user.name 'github-actions'
+          git config user.email 'github-actions@github.com'
+
+      - name: Merge and Resolve Conflicts or Create Pull Request
+        id: prepare-pr
+        run: |
+          git checkout $TARGET_BRANCH
+          version=$(node -p "require('./libs/sdk-ui/package.json').version")
+
+          git checkout $SOURCE_BRANCH
+
+          TMP_BRANCH=$SOURCE_BRANCH-to-$TARGET_BRANCH
+
+          # Check if the remote temporary branch exists and delete it if it does
+          if git ls-remote --heads origin "$TMP_BRANCH" | grep "$TMP_BRANCH" >/dev/null; then
+               echo "Remote branch $TMP_BRANCH exists. Deleting..."
+               git push origin --delete "$TMP_BRANCH"
+          fi
+
+          # Check if local temporary branch exists and delete it if it does
+          if git rev-parse --verify "$TMP_BRANCH" >/dev/null 2>&1; then
+              echo "Local branch $TMP_BRANCH exists. Deleting..."
+              git branch -D "$TMP_BRANCH"
+          fi
+
+          # Create a temporary branch
+          git checkout -b $TMP_BRANCH
+
+          # policies.json is not a valid json, cannot use `cat common/config/rush/version-policies.json | jq -r '.[].policyName'`
+          policies=$(cat common/config/rush/version-policies.json | grep '^\s\+"policyName' | sed 's/.*"policyName": "\(.*\)",/\1/')
+
+          for policy in $policies
+          do
+            rush version --ensure-version-policy --override-version $version --version-policy $policy
+          done
+
+          # commit only if bump produced some changes
+          git diff --exit-code || git commit --no-verify -a -m "Bumped version of sdk packages to $version which is in $TARGET_BRANCH"
+
+          # rush bump to something that's in target branch
+          git merge --verbose --no-ff origin/$TARGET_BRANCH || true
+
+          # we are resolving only conflicts which we can do, we silently ignore other potential conflits
+          conflicting_files=$(git diff --name-only --diff-filter=U)
+          has_conflicts=false
+
+          if [ -n "$conflicting_files" ]; then
+            echo "There are conflicts which still need to be resolved, aborting"
+            has_conflicts=true
+            git merge --abort
+          fi
+
+          git push origin $TMP_BRANCH
+
+          PR_OUTPUT=$(gh pr create --title "Merge $SOURCE_BRANCH into $TARGET_BRANCH" --body "This PR is created automatically by GitHub Actions. from $SOURCE_BRANCH into $TARGET_BRANCH via temporary branch $TMP_BRANCH" --base $TARGET_BRANCH --head "$TMP_BRANCH")
+          PR_URL=$(echo "$PR_OUTPUT" | grep -o 'https://github.com[^ ]*')
+          echo "Created pull-request: $PR_URL"
+          
+          echo "pr_url=$PR_URL" >> $GITHUB_OUTPUT
+          echo "pr_has_conflicts=$has_conflicts" >> $GITHUB_OUTPUT
+        env:
+          SOURCE_BRANCH: ${{ inputs.source-branch }}
+          TARGET_BRANCH: ${{ inputs.target-branch }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash


### PR DESCRIPTION
JIRA: STL-120

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |
| **Compatibility matrix test commands - TIGER Backend**  |                                                            |
| `extended test - matrix-test <AIO_version>`             | Run integrated tests against AIO versions.                 |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

`<AIO_version>` in commands is used to start test with multiple AIO instances - each instance in triggered by one jenkins build

-   To run with `master` and `stable`, execute command `extended test - matrix-test master,stable` or `extended test - matrix-test latest`
-   To run with specific version,ex: `2.3.0` and `2.3.1`, execute command `extended test - matrix-test 2.3.0,2.3.1`
-   In case `<AIO_version>` is empty, read versions from file `compTigerVersions.txt` of this repo

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
