### PR TITLE
RELATED: STL-154 Prepare api docs version workflow

### DIFF
--- a/.github/workflows/doc-test-apidocs.yml
+++ b/.github/workflows/doc-test-apidocs.yml
@@ -1,0 +1,24 @@
+name: Doc ~ Update ApiDocs
+on:
+    workflow_dispatch:
+jobs:
+    update-apidocs-next:
+        uses: ./.github/workflows/rw-doc-release-apidocs.yml
+        permissions:
+            contents: write
+            id-token: write
+        secrets: inherit
+        with:
+            source-branch: "master"
+            version: "Next"
+            is-new-latest: false
+    update-apidocs-version:
+        uses: ./.github/workflows/rw-doc-release-apidocs.yml
+        permissions:
+            contents: write
+            id-token: write
+        secrets: inherit
+        with:
+            source-branch: "release"
+            version: "9.7.0"
+            is-new-latest: true

--- a/.github/workflows/rw-doc-release-apidocs.yml
+++ b/.github/workflows/rw-doc-release-apidocs.yml
@@ -1,0 +1,89 @@
+# (C) 2024 GoodData Corporation
+
+name: rw ~ Release ~ Release apidocs
+on:
+  workflow_call:
+    inputs:
+      source-branch:
+          required: true
+          description: "The name of the source branch"
+          type: string
+      is-new-latest:
+        required: true
+        description: "Whether this is the latest release"
+        type: boolean
+      version:
+        required: true
+        description: "The version which was released, or Next"
+        type: string
+
+# run from release -> is-new-latest: true -> version: x.y.z
+# run from master -> is-new-latest: false -> version: Next
+jobs:
+  build-apidocs:
+    runs-on: [ubuntu-latest]
+    permissions:
+      contents: write
+    steps:
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+            ref: ${{ inputs.source-branch }}
+            token: ${{ secrets.TOKEN_GITHUB_YENKINS_ADMIN }}
+            path: "gooddata-ui-sdk"
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+            repository: 'gooddata/gooddata-ui-apidocs'
+            ref: test-version
+            token: ${{ secrets.TOKEN_GITHUB_YENKINS_ADMIN }}
+            path: "gooddata-ui-apidocs"
+
+      - name: Add repository to git safe directories to avoid dubious ownership issue
+        run: git config --global --add safe.directory $GITHUB_WORKSPACE
+
+      - name: Config user
+        run: |
+            git config --global user.email "git-action@gooddata.com"
+            git config --global user.name "git-action"
+
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18.17.0
+
+      - name: Install rush
+        run: |
+            npm install -g @microsoft/rush
+
+      - name: Build apidocs
+        run: |
+          cd gooddata-ui-sdk
+          rush install
+          # Use after tagging projects which use api-extractor
+          # rush build --to tag:api-doc
+          rush build
+          symlinks=$([ "$IS_NEW_LATEST" = true ] && echo "--update-symlink" || echo "")
+          echo "updating symlinks: $symlinks"
+          echo node common/scripts/build-docs.js -v $VERSION $symlinks
+          node common/scripts/build-docs.js -v $VERSION $symlinks
+          cd ..
+        env:
+          VERSION: ${{ inputs.version }}
+          IS_NEW_LATEST: ${{ inputs.is-new-latest }}
+
+      - name: Publish apidocs
+        run: |
+          cd gooddata-ui-apidocs
+          git add --all
+          git commit -m "Create a new api docs version $VERSION"
+          git show --stat
+
+          echo "Going to push to gooddata-ui-apidocs"
+          git push origin test-version
+          cd ..
+        env:
+          VERSION: ${{ inputs.version }}
+          IS_NEW_LATEST: ${{ inputs.is-new-latest }}


### PR DESCRIPTION
<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |
| **Compatibility matrix test commands - TIGER Backend**  |                                                            |
| `extended test - matrix-test <AIO_version>`             | Run integrated tests against AIO versions.                 |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

`<AIO_version>` in commands is used to start test with multiple AIO instances - each instance in triggered by one jenkins build

-   To run with `master` and `stable`, execute command `extended test - matrix-test master,stable` or `extended test - matrix-test latest`
-   To run with specific version,ex: `2.3.0` and `2.3.1`, execute command `extended test - matrix-test 2.3.0,2.3.1`
-   In case `<AIO_version>` is empty, read versions from file `compTigerVersions.txt` of this repo

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)