### PR TITLE
RELATED: STL-176 Unify get version and uses of local actions

### DIFF
--- a/.github/actions/get-version-action/action.yml
+++ b/.github/actions/get-version-action/action.yml
@@ -1,0 +1,15 @@
+name: Get current version of the sdk
+description: This action assumes nodejs installed and repository checkouted
+
+outputs:
+  version:
+    description: current version
+    value: ${{ steps.version.outputs.version }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Get version
+      id: version
+      run: echo "version=$(node -p "require('./libs/sdk-ui/package.json').version")" >> $GITHUB_OUTPUT
+      shell: bash

--- a/.github/workflows/release-code-drop.yml
+++ b/.github/workflows/release-code-drop.yml
@@ -19,11 +19,9 @@ jobs:
     permissions:
       contents: write
 
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+    steps:      
       - name: Run copy branch action
-        uses: ./.github/actions/branch-cutoff-action
+        uses: gooddata/gooddata-ui-sdk/.github/actions/branch-cutoff-action@master
         with:
           source-branch: 'master'
           target-branch: 'release'

--- a/.github/workflows/rw-bump-version.yml
+++ b/.github/workflows/rw-bump-version.yml
@@ -38,9 +38,11 @@ jobs:
       runs-on: [ubuntu-latest]
       outputs:
         version: ${{ steps.version.outputs.version }}
-      container:
-        image: node:18.17.0-bullseye
       steps:
+        - name: Setup node
+          uses: actions/setup-node@v4
+          with:
+            node-version: 18.17.0
         - name: Checkout code
           uses: actions/checkout@v4
           with:
@@ -48,17 +50,19 @@ jobs:
               token: ${{ secrets.TOKEN_GITHUB_YENKINS_ADMIN }}
 
         - name: Get version
+          uses: gooddata/gooddata-ui-sdk/.github/actions/get-version-action@master
           id: version
-          run: echo "version=$(node -p "require('./libs/sdk-ui/package.json').version")" >> $GITHUB_OUTPUT
 
     bump-version-and-commit:
         if: ${{ !inputs.skip-bump && inputs.bump }}
         runs-on: [ubuntu-latest]
         outputs:
             version: ${{ steps.version.outputs.version }}
-        container:
-            image: node:18.17.0-bullseye
         steps:
+            - name: Setup node
+              uses: actions/setup-node@v4
+              with:
+                node-version: 18.17.0
             - name: Checkout code
               uses: actions/checkout@v4
               with:
@@ -89,17 +93,18 @@ jobs:
                   BUMP: ${{ inputs.bump }}
               run: rush version --bump --override-bump $BUMP
 
+
+            - name: Get version
+              uses: gooddata/gooddata-ui-sdk/.github/actions/get-version-action@master
+              id: version
+
             - name: Git commit and push
               run: |
                 # add changelogs
                 git add libs/sdk-ui-all/CHANGELOG.* || true
                 git ls-files | grep '\.json' | xargs git add
 
-                VERSION=$(node -p "require('./libs/sdk-ui/package.json').version")
                 git commit -a -m "Bump versions to $VERSION"
                 git push origin ${{ inputs.source-branch }}
-
-            - name: Get version
-              id: version
-              run: echo "version=$(node -p "require('./libs/sdk-ui/package.json').version")" >> $GITHUB_OUTPUT
-
+              env:
+                VERSION: ${{ steps.version.outputs.version }}

--- a/.github/workflows/rw-doc-netlify-deploy.yml
+++ b/.github/workflows/rw-doc-netlify-deploy.yml
@@ -11,7 +11,7 @@ jobs:
         with:
           submodules: recursive
       - name: Hugo Build
-        uses: ./.github/actions/hugo-build-versioned-action
+        uses: gooddata/gooddata-ui-sdk/.github/actions/hugo-build-versioned-action@master
         with:
           base-url: https://www.gooddata.com/docs/gooddata-ui
       - name: Publish

--- a/.github/workflows/rw-doc-update-hugo-version.yml
+++ b/.github/workflows/rw-doc-update-hugo-version.yml
@@ -8,53 +8,42 @@ on:
         type: string
       version:
         required: true        
-        description: "Version to update Hugo router params"
+        description: "Version to update hugo router params"
         type: string
       path-to-version-config:
         required: false
-        default: "docs/config/public/params.toml"
+        default: "./docs/config/public/params.toml"
         description: "Path to the Hugo version config file"
         type: string
 
 jobs:
-  update-hugo-version:
-    runs-on: [ubuntu-latest]
-    permissions:
-        contents: write
-    steps:
-      # Checkout the master branch to get the action
-      - name: Checkout master for action
-        uses: actions/checkout@v4
-        with:
-          ref: master
-          path: action
-
-      # Checkout the source branch where changes will be made
-      - name: Checkout source branch
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.source-branch }}
-          path: source
-
-      # Update Hugo version using the action from the master branch
-      - name: Update Hugo version
-        uses: ./action/.github/actions/hugo-update-param-action
-        with:
-            path-to-version-config: ${{ github.workspace }}/source/${{ inputs.path-to-version-config }}
-            version: ${{ inputs.version }}
-
-      # Create and push branch
-      - name: Create and push branch
-        shell: bash
-        run: |
-              cd source
-              git config --global --add safe.directory $GITHUB_WORKSPACE/source
-              git config --global user.email "git-action@gooddata.com"
-              git config --global user.name "git-action"  
-              git add $CONFIG_PATH
-              git commit -m "Update Hugo version to $VERSION"
-              git push origin $BRANCH_NAME
-        env:
-          BRANCH_NAME: ${{inputs.source-branch}}
-          VERSION: ${{inputs.version}}
-          CONFIG_PATH: ${{ inputs.path-to-version-config }}
+    update-hugo-version:
+        runs-on: [ubuntu-latest]
+        permissions:
+            contents: write
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+              with:
+                ref: ${{ inputs.source-branch }}
+            - name: Add repository to git safe directories to avoid dubious ownership issue
+              run: git config --global --add safe.directory $GITHUB_WORKSPACE
+            - name: Config user
+              run: |
+                  git config --global user.email "git-action@gooddata.com"
+                  git config --global user.name "git-action"  
+            - name: Update Hugo version
+              uses: gooddata/gooddata-ui-sdk/.github/actions/hugo-update-param-action@master
+              with:
+                  path-to-version-config: ${{ inputs.path-to-version-config }}
+                  version: ${{inputs.version}}
+            - name: Create and push branch
+              shell: bash
+              run: |
+                    git add ${path_to_version_config}
+                    git commit -m "Update Hugo version to ${version}"
+                    git push origin ${brach_name}
+              env:
+                brach_name: ${{inputs.source-branch}}
+                version: ${{inputs.version}}
+                path_to_version_config: ${{ inputs.path-to-version-config }}

--- a/.github/workflows/rw-git-backmerge.yml
+++ b/.github/workflows/rw-git-backmerge.yml
@@ -1,4 +1,4 @@
-name: rw ~ Git ~ Back merge release to master 
+name: rw ~ Git ~ Back merge release to master
 
 on:
   workflow_call:
@@ -51,6 +51,7 @@ jobs:
         id: prepare-pr
         run: |
           git checkout $TARGET_BRANCH
+          # this needs to be here directly, not via action as we are doing checkout before
           version=$(node -p "require('./libs/sdk-ui/package.json').version")
 
           git checkout $SOURCE_BRANCH
@@ -101,7 +102,7 @@ jobs:
           PR_OUTPUT=$(gh pr create --title "Merge $SOURCE_BRANCH into $TARGET_BRANCH" --body "This PR is created automatically by GitHub Actions. from $SOURCE_BRANCH into $TARGET_BRANCH via temporary branch $TMP_BRANCH" --base $TARGET_BRANCH --head "$TMP_BRANCH")
           PR_URL=$(echo "$PR_OUTPUT" | grep -o 'https://github.com[^ ]*')
           echo "Created pull-request: $PR_URL"
-          
+
           echo "pr_url=$PR_URL" >> $GITHUB_OUTPUT
           echo "pr_has_conflicts=$has_conflicts" >> $GITHUB_OUTPUT
         env:

--- a/.github/workflows/rw-perform-release-major-minor.yml
+++ b/.github/workflows/rw-perform-release-major-minor.yml
@@ -68,11 +68,9 @@ jobs:
         needs: [add-release-tag, prepare-variables]
         permissions:
             contents: write
-        steps:
-            - name: Checkout repository
-              uses: actions/checkout@v4            
+        steps:           
             - name: Run copy branch action
-              uses: ./.github/actions/branch-cutoff-action
+              uses: gooddata/gooddata-ui-sdk/.github/actions/branch-cutoff-action@master
               with:
                   source-branch: "release"
                   target-branch: ${{ needs.prepare-variables.outputs.rel-branch }}

--- a/.github/workflows/rw-publish-prerelease.yml
+++ b/.github/workflows/rw-publish-prerelease.yml
@@ -39,9 +39,11 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 18.17.0
+
       - name: Get version
+        uses: gooddata/gooddata-ui-sdk/.github/actions/get-version-action@master
         id: get-version
-        run: echo "VERSION=$(node -p "require('./libs/sdk-ui/package.json').version")" >> $GITHUB_ENV
+
       - name: Check version
         run: |
           if [[ ! $VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+-(beta|alpha)\.[0-9]+$ ]]; then

--- a/.github/workflows/rw-publish-release.yml
+++ b/.github/workflows/rw-publish-release.yml
@@ -38,17 +38,20 @@ jobs:
           node-version: 18.17.0
       - name: Get version
         id: get-version
-        run: echo "VERSION=$(node -p "require('./libs/sdk-ui/package.json').version")" >> $GITHUB_ENV
+        uses: gooddata/gooddata-ui-sdk/.github/actions/get-version-action@master
       - name: Check version
         run: |
           if [[ ! $VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+-beta\.[0-9]+$ ]]; then
             echo "The version $VERSION does not match X.Y.Z-beta.W"
             exit 1
           fi
+        env:
+          # TODO check if correct
+          VERSION: ${{ steps.get-version.outputs.version }}
 
   bump-version:
     needs: [check-version]
-    uses: ./.github/workflows/rw-bump-version.yml    
+    uses: ./.github/workflows/rw-bump-version.yml
     permissions:
       contents: write
       id-token: write
@@ -67,22 +70,20 @@ jobs:
     with:
       source-branch: "release"
       release-tag: "latest"
-  
+
   check-npm-package:
     outputs:
       verified: ${{ steps.check-npm-package.outputs.exists }}
     runs-on: [ubuntu-latest]
     needs: [bump-version,publish-release]
     steps:
-      - name: checkout
-        uses: actions/checkout@v4
       - name: Check NPM package
         id: check-npm-package
-        uses: ./.github/actions/check-npm-version
+        uses: gooddata/gooddata-ui-sdk/.github/actions/check-npm-version@master
         with:
           package: "@gooddata/sdk-ui"
           version: ${{ needs.bump-version.outputs.version }}
-        
+
   slack-notification:
     runs-on: [ubuntu-latest]
     needs: [bump-version, check-npm-package]

--- a/.github/workflows/rw-publish-version.yml
+++ b/.github/workflows/rw-publish-version.yml
@@ -15,13 +15,15 @@ on:
 
 jobs:
     publish-version:
-        runs-on: [infra1-medium]
-        container:
-            image: node:18.17.0-bullseye
+        runs-on: [infra1-medium]        
         permissions:
             contents: read
             id-token: write
         steps:
+            - name: Setup node
+              uses: actions/setup-node@v4
+              with:
+                node-version: 18.17.0
             - name: Checkout code
               uses: actions/checkout@v4
               with:


### PR DESCRIPTION
JIRA: STL-176

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |
| **Compatibility matrix test commands - TIGER Backend**  |                                                            |
| `extended test - matrix-test <AIO_version>`             | Run integrated tests against AIO versions.                 |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

`<AIO_version>` in commands is used to start test with multiple AIO instances - each instance in triggered by one jenkins build

-   To run with `master` and `stable`, execute command `extended test - matrix-test master,stable` or `extended test - matrix-test latest`
-   To run with specific version,ex: `2.3.0` and `2.3.1`, execute command `extended test - matrix-test 2.3.0,2.3.1`
-   In case `<AIO_version>` is empty, read versions from file `compTigerVersions.txt` of this repo

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
