### PR TITLE
RELATED: STL-155 Add environments for manual triggers

### DIFF
--- a/.github/workflows/release-code-drop.yml
+++ b/.github/workflows/release-code-drop.yml
@@ -1,25 +1,27 @@
 # (C) 2024 GoodData Corporation
 
-# Automated Code Drop Workflow: Initiates a code drop from the master branch to a new release branch. 
-# Manages version increments, setting the master to a new alpha preminor version and the release branch to a beta prerelease version. 
+# Automated Code Drop Workflow: Initiates a code drop from the master branch to a new release branch.
+# Manages version increments, setting the master to a new alpha preminor version and the release branch to a beta prerelease version.
 # Notifies the team via Slack upon successful completion.
 name: Release ~ Code drop
 on:
   workflow_dispatch:
-      inputs:
-        password:
-          description: Password for the workflow to run
-          required: true
 
 jobs:
+  gate-approval:
+    runs-on: ubuntu-latest
+    environment:
+      name: production
+    steps:
+      - run: echo "Initiating approval"
+
   prepare-branch:
-    # have dummy password to prevent accidental run
-    if: github.event.inputs.password == 'dummy'
+    needs: gate-approval
     runs-on: [ubuntu-latest]
     permissions:
       contents: write
 
-    steps:      
+    steps:
       - name: Run copy branch action
         uses: gooddata/gooddata-ui-sdk/.github/actions/branch-cutoff-action@master
         with:
@@ -36,7 +38,7 @@ jobs:
         source-branch: 'release'
         bump: 'prerelease'
         prerelease-id: 'beta'
-        
+
   prepare-versions-master:
     needs: prepare-branch
     uses: ./.github/workflows/rw-bump-version.yml
@@ -58,7 +60,7 @@ jobs:
     with:
       source-branch: "master"
       skip-bump: true
-  
+
   publish-pre-release-release:
     needs: prepare-versions-release
     uses: ./.github/workflows/rw-publish-prerelase.yml

--- a/.github/workflows/release-code-drop.yml
+++ b/.github/workflows/release-code-drop.yml
@@ -52,7 +52,7 @@ jobs:
 
   publish-pre-release-master:
     needs: prepare-versions-master
-    uses: ./.github/workflows/rw-publish-prerelase.yml
+    uses: ./.github/workflows/rw-publish-prerelease.yml
     permissions:
       contents: write
       id-token: write
@@ -63,7 +63,7 @@ jobs:
 
   publish-pre-release-release:
     needs: prepare-versions-release
-    uses: ./.github/workflows/rw-publish-prerelase.yml
+    uses: ./.github/workflows/rw-publish-prerelease.yml
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/release-postrelease.yml
+++ b/.github/workflows/release-postrelease.yml
@@ -5,7 +5,15 @@ on:
     workflow_dispatch:
 
 jobs:
+    gate-approval:
+        runs-on: ubuntu-latest
+        environment:
+            name: production
+        steps:
+            - run: echo "Initiating approval"
+
     publish-documentation:
+        needs: gate-approval
         uses: ./.github/workflows/rw-publish-documentation.yml
 
     # TODO: delete-release-branch:

--- a/.github/workflows/release-release-minor.yml
+++ b/.github/workflows/release-release-minor.yml
@@ -1,17 +1,19 @@
 # (C) 2024 GoodData Corporation
 
-name: Release ~ Release minor version 
+name: Release ~ Release minor version
 on:
   workflow_dispatch:
-      inputs:
-        password:
-          description: Password for the workflow to run
-          required: true
 
-jobs: 
+jobs:
+    gate-approval:
+        runs-on: ubuntu-latest
+        environment:
+            name: production
+        steps:
+            - run: echo "Initiating approval"
+
     publish-release-npm:
-      # have dummy password to prevent accidental run
-      if: github.event.inputs.password == 'dummy'
+      needs: gate-approval
       uses: ./.github/workflows/rw-perform-release-major-minor.yml
       permissions:
         pull-requests: write

--- a/.github/workflows/rw-publish-prerelease.yml
+++ b/.github/workflows/rw-publish-prerelease.yml
@@ -103,7 +103,7 @@ jobs:
         uses: slackapi/slack-github-action@v1.25.0
         with:
           channel-id: "#javascript-notifications"
-          slack-message: "The latest *prerelase* version, *gooddata-ui-sdk@${{ env.RELEASE_VERSION }}*, has been successfully published on NPM by the github user *${{env.GITHUB_USER}}*. :tada:"
+          slack-message: "The latest *prerelease* version, *gooddata-ui-sdk@${{ env.RELEASE_VERSION }}*, has been successfully published on NPM by the github user *${{env.GITHUB_USER}}*. :tada:"
         env:
           RELEASE_VERSION: ${{ needs.bump-version.outputs.version }}
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
@@ -113,7 +113,7 @@ jobs:
         uses: slackapi/slack-github-action@v1.25.0
         with:
           channel-id: "#javascript-notifications"
-          slack-message: "The latest *prerelase* version, *gooddata-ui-sdk@${{ env.RELEASE_VERSION }}*, has been successfully published on NPM. :tada:"
+          slack-message: "The latest *prerelease* version, *gooddata-ui-sdk@${{ env.RELEASE_VERSION }}*, has been successfully published on NPM. :tada:"
         env:
           RELEASE_VERSION: ${{ needs.bump-version.outputs.version }}
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}


### PR DESCRIPTION
<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |
| **Compatibility matrix test commands - TIGER Backend**  |                                                            |
| `extended test - matrix-test <AIO_version>`             | Run integrated tests against AIO versions.                 |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

`<AIO_version>` in commands is used to start test with multiple AIO instances - each instance in triggered by one jenkins build

-   To run with `master` and `stable`, execute command `extended test - matrix-test master,stable` or `extended test - matrix-test latest`
-   To run with specific version,ex: `2.3.0` and `2.3.1`, execute command `extended test - matrix-test 2.3.0,2.3.1`
-   In case `<AIO_version>` is empty, read versions from file `compTigerVersions.txt` of this repo

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)