### PR TITLE
BUGFIX: QA-21418 keep visualization name for invalid interaction warning

### DIFF
--- a/libs/sdk-ui-tests-e2e/cypress/integration/01-sdk-ui-dashboard/drilling.spec.ts
+++ b/libs/sdk-ui-tests-e2e/cypress/integration/01-sdk-ui-dashboard/drilling.spec.ts
@@ -74,7 +74,7 @@ describe("Interaction", () => {
             message
                 .hasWarningMessage(true)
                 .clickShowMore()
-                .hasInsightNameIsBolder(true, "Visualization has invalid interaction");
+                .hasInsightNameIsBolder(true, "Insight has invalid interaction");
             widget1
                 .waitChartLoaded()
                 .scrollIntoView()


### PR DESCRIPTION
Solution: Should keep "Insight has..." here, because it's showing visualization name, not
 a term of "Insight"

Passed on my branch:
- bear: https://checklist.intgdc.com/job/cypress-tests/job/gooddata-ui-sdk-cypress-checklist_integrated_bear-worker/1935/
- panther: https://checklist.intgdc.com/job/cypress-tests/job/gooddata-ui-sdk-cypress-checklist_integrated_tiger-worker/622/

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** 🙏

---

Refer to [documentation](https://github.com/gooddata/gooddata-ui-sdk/blob/master/dev_docs/continuous_integration.md) to see how to run checks and tests in the pull request. This is the list of the most used commands:

```
extended test - backstop
```

```
// Tiger platform
extended test - tiger-cypress - integrated
extended test - tiger-cypress - isolated
extended test - tiger-cypress - record
```

```
// Bear platform
extended test - cypress - integrated
extended test - cypress - isolated
extended test - cypress - record
```
