### PR TITLE
QA-21429: switch to use internal cypress container image

### DIFF
--- a/common/scripts/ci/run_boiler_app_integration_tests_with_live_backend.sh
+++ b/common/scripts/ci/run_boiler_app_integration_tests_with_live_backend.sh
@@ -11,7 +11,7 @@ fi
 export BOILER_APP_NAME=new-boiler-app-$SDK_LANG
 export BOILER_APP_VERSION=app-toolkit@$SDK_VERSION
 export BOILER_APP_HOST=https://127.0.0.1:8080
-CYPRESS_IMAGE='020413372491.dkr.ecr.us-east-1.amazonaws.com/3rdparty/cypress/included:12.10.0'
+CYPRESS_IMAGE='020413372491.dkr.ecr.us-east-1.amazonaws.com/tools/gdc-frontend-cypress-factory:202311211156.11759a0'
 
 DIR=$(echo $(cd $(dirname "${BASH_SOURCE[0]}") && pwd -P))
 ROOT_DIR=$(echo $(cd $(dirname "${BASH_SOURCE[0]}")/../../../ && pwd -P))

--- a/libs/sdk-ui-tests-e2e/scripts/run_boiler_app.sh
+++ b/libs/sdk-ui-tests-e2e/scripts/run_boiler_app.sh
@@ -9,9 +9,10 @@ trap "npm run delete-ref-workspace || true" EXIT
 npm run create-ref-workspace
 export TEST_WORKSPACE_ID=$(grep TEST_WORKSPACE_ID .env | cut -d '=' -f 2)
 
-apt-get update && apt-get install -y curl jq sed && apt-get clean
-
-npx --yes @gooddata/$BOILER_APP_VERSION init $BOILER_APP_NAME --language $SDK_LANG
+#create folder .npm-global/lib as workaround for npm install issue
+#because npm config prefix is somehow set to /home/cypressuser/.npm-global
+mkdir -p /home/cypressuser/.npm-global/lib
+npx --verbose --yes @gooddata/$BOILER_APP_VERSION init $BOILER_APP_NAME --language $SDK_LANG
 
 tmp=$(mktemp)
 jq --arg host "${HOST}" --arg ws "${TEST_WORKSPACE_ID}" --arg backend "${sdk_backend}" \


### PR DESCRIPTION


<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** 🙏

---

Refer to [documentation](https://github.com/gooddata/gooddata-ui-sdk/blob/master/dev_docs/continuous_integration.md) to see how to run checks and tests in the pull request. This is the list of the most used commands:

```
extended test - backstop
```

```
// Tiger platform
extended test - tiger-cypress - integrated
extended test - tiger-cypress - isolated
extended test - tiger-cypress - record
```

```
// Bear platform
extended test - cypress - integrated
extended test - cypress - isolated
extended test - cypress - record
```
