### PR TITLE
RELATED: STL-138 Relax 2s timeout for async registrations

### DIFF
--- a/libs/sdk-ui-dashboard/src/model/commands/render.ts
+++ b/libs/sdk-ui-dashboard/src/model/commands/render.ts
@@ -1,4 +1,4 @@
-// (C) 2021-2022 GoodData Corporation
+// (C) 2021-2024 GoodData Corporation
 import { IDashboardCommand } from "./base.js";
 
 /**
@@ -25,11 +25,11 @@ export interface RequestAsyncRender extends IDashboardCommand {
  *
  * @remarks
  *  * Mechanism is following:
- * - You must request async rendering for at least 1 component within 2 seconds of the {@link DashboardInitialized} event.
- *   (If you do not register any asynchronous rendering, after 2 seconds the dashboard will announce that it is rendered by dispatching {@link DashboardRenderResolved} event.)
+ * - You must request async rendering for at least 1 component within 5 seconds of the {@link DashboardInitialized} event.
+ *   (If you do not register any asynchronous rendering, after 5 seconds the dashboard will announce that it is rendered by dispatching {@link DashboardRenderResolved} event.)
  * - You can request async rendering for any number of components. Requests are valid if the first rule is met
  *   and not all asynchronous renderings have been resolved and the maximum timeout (20min by default) has not elapsed.
- * - The component may again request asynchronous rendering within 2 seconds of resolution. Maximum 3x.
+ * - The component may again request asynchronous rendering within 5 seconds of resolution. Maximum 3x.
  *   (this is necessary to cover possible re-renders caused by data received from the components themselves, after they are rendered)
  * - Maximum rendering time of the dashboard is 20min - if some asynchronous renderings are not yet resolved at this time, {@link DashboardRenderResolved} event is dispatched anyway.
  *

--- a/libs/sdk-ui-dashboard/src/model/react/useDashboardAsyncRender.ts
+++ b/libs/sdk-ui-dashboard/src/model/react/useDashboardAsyncRender.ts
@@ -1,4 +1,4 @@
-// (C) 2020-2022 GoodData Corporation
+// (C) 2020-2024 GoodData Corporation
 import { useCallback } from "react";
 import { requestAsyncRender, resolveAsyncRender } from "../commands/index.js";
 import { useDispatchDashboardCommand } from "./useDispatchDashboardCommand.js";
@@ -27,11 +27,11 @@ export interface UseDashboardAsyncRender {
  * This mechanism is necessary for dashboard exports to PDF to work properly.
  *
  * Mechanism is following:
- * - You must request async rendering for at least 1 component within 2 seconds of the {@link DashboardInitialized} event.
- *   (If you do not register any asynchronous rendering, after 2 seconds the dashboard will announce that it is rendered by dispatching {@link DashboardRenderResolved} event.)
+ * - You must request async rendering for at least 1 component within 5 seconds of the {@link DashboardInitialized} event.
+ *   (If you do not register any asynchronous rendering, after 5 seconds the dashboard will announce that it is rendered by dispatching {@link DashboardRenderResolved} event.)
  * - You can request async rendering for any number of components. Requests are valid if the first rule is met
  *   and not all asynchronous renderings have been resolved and the maximum timeout (20min by default) has not elapsed.
- * - The component may again request asynchronous rendering within 2 seconds of resolution. Maximum 3x.
+ * - The component may again request asynchronous rendering within 5 seconds of resolution. Maximum 3x.
  *   (this is necessary to cover possible re-renders caused by data received from the components themselves, after they are rendered)
  * - Maximum rendering time of the dashboard is 20min - if some asynchronous renderings are not yet resolved at this time, {@link DashboardRenderResolved} event is dispatched anyway.
  *

--- a/libs/sdk-ui-dashboard/src/model/store/layout/layoutUtils.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/layout/layoutUtils.ts
@@ -2,6 +2,7 @@
 import {
     IDashboardLayoutSize,
     IDashboardLayout,
+    IDashboardWidget,
     ObjRef,
     areObjRefsEqual,
     IDashboardLayoutItem,
@@ -28,6 +29,23 @@ export function getWidgetCoordinates(
         };
     }
     return undefined;
+}
+
+export function getWidgetsOfType(layout: IDashboardLayout<IDashboardWidget>, types: string[]) {
+    const result = [];
+    for (let sectionIndex = 0; sectionIndex < layout.sections.length; sectionIndex++) {
+        const section = layout.sections[sectionIndex];
+
+        for (let itemIndex = 0; itemIndex < section.items.length; itemIndex++) {
+            const item = section.items[itemIndex];
+
+            if (item.widget?.type !== undefined && types.includes(item.widget?.type)) {
+                result.push(item.widget);
+            }
+        }
+    }
+
+    return result;
 }
 
 export function getWidgetCoordinatesAndItem(layout: IDashboardLayout<ExtendedDashboardWidget>, ref: ObjRef) {


### PR DESCRIPTION
JIRA: STL-138


<!--

Description of changes.

-->

---

Supported PR commands:

| Command                                                 | Description                                                |
| ------------------------------------------------------- | ---------------------------------------------------------- |
| `ok to test`                                            | Re-run standard checks                                     |
| `extended check sonar`                                  | SonarQube tests                                            |
| `extended test - backstop`                              | BackstopJS tests                                           |
| **E2E Cypress tests commands - TIGER**                  |                                                            |
| `extended test - tiger-cypress - isolated <testName>`   | Run isolated tests running against recorded Tiger backend. |
| `extended test - tiger-cypress - record <testName>`     | Create a new recording for isolated Tiger tests.           |
| `extended test - tiger-cypress - integrated <testName>` | Run integrated tests against live backend                  |
| **E2E Cypress tests commands - BEAR**                   |                                                            |
| `extended test - cypress - isolated <testName>`         | Run isolated tests running against recorded Bear backend.  |
| `extended test - cypress - record <testName>`           | Create a new recording for isolated Bear tests.            |
| `extended test - cypress - integrated <testName>`       | Run integrated tests against live backend                  |
| **Compatibility matrix test commands - TIGER Backend**  |                                                            |
| `extended test - matrix-test <AIO_version>`             | Run integrated tests against AIO versions.                 |

`<testName>` in cypress commands is used to filter specfiles. Example, to run record with BEAR backend

-   Against `dashboard.spec.ts` and `drilling.spec.ts`, execute command `extended test - cypress - record dashboard,drilling`
-   Against all specfiles, execute command `extended test - cypress - record` or `extended test - cypress - record *`

`<AIO_version>` in commands is used to start test with multiple AIO instances - each instance in triggered by one jenkins build

-   To run with `master` and `stable`, execute command `extended test - matrix-test master,stable` or `extended test - matrix-test latest`
-   To run with specific version,ex: `2.3.0` and `2.3.1`, execute command `extended test - matrix-test 2.3.0,2.3.1`
-   In case `<AIO_version>` is empty, read versions from file `compTigerVersions.txt` of this repo

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `extended test - backstop` passes
-   [ ] `extended test - tiger-cypress - record` to record new mapping files (Tiger BE)
-   [ ] `extended test - cypress - record` to record new mapping files (Bear BE)
-   [ ] `extended test - tiger-cypress - isolated` passes
-   [ ] `extended test - cypress - isolated` passes
-   [ ] `extended test - tiger-cypress - integrated` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)