### PR TITLE
RELATED: CQ-266 cherry-pick cacheId fixes

### DIFF
--- a/libs/sdk-backend-tiger/tests/integrated/__snapshots__/elements.test.ts.snap
+++ b/libs/sdk-backend-tiger/tests/integrated/__snapshots__/elements.test.ts.snap
@@ -1,10 +1,10 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`tiger elements > forDisplayForm > should load attribute elements for existing display form 1`] = `
-ServerPaging {
+{
   "all": [Function],
   "allSorted": [Function],
-  "cacheId": undefined,
+  "cacheId": Any<String>,
   "getData": [Function],
   "goTo": [Function],
   "items": [
@@ -170,7 +170,7 @@ exports[`tiger elements > forFilter > should return correct page for given displ
 {
   "all": [Function],
   "allSorted": [Function],
-  "cacheId": undefined,
+  "cacheId": Any<String>,
   "getData": [Function],
   "goTo": [Function],
   "limit": 2,
@@ -181,10 +181,10 @@ exports[`tiger elements > forFilter > should return correct page for given displ
 `;
 
 exports[`tiger elements > forFilter > should return empty result for out-of-range page in initial request 1`] = `
-ServerPaging {
+{
   "all": [Function],
   "allSorted": [Function],
-  "cacheId": undefined,
+  "cacheId": Any<String>,
   "getData": [Function],
   "goTo": [Function],
   "items": [],
@@ -196,10 +196,10 @@ ServerPaging {
 `;
 
 exports[`tiger elements > forFilter > should return empty result for out-of-range page with goTo 1`] = `
-ServerPaging {
+{
   "all": [Function],
   "allSorted": [Function],
-  "cacheId": undefined,
+  "cacheId": Any<String>,
   "getData": [Function],
   "goTo": [Function],
   "items": [],
@@ -211,10 +211,10 @@ ServerPaging {
 `;
 
 exports[`tiger elements > forFilter > should return empty result for out-of-range page with next 1`] = `
-ServerPaging {
+{
   "all": [Function],
   "allSorted": [Function],
-  "cacheId": undefined,
+  "cacheId": Any<String>,
   "getData": [Function],
   "goTo": [Function],
   "items": [],

--- a/libs/sdk-backend-tiger/tests/integrated/__snapshots__/elements.test.ts.snap
+++ b/libs/sdk-backend-tiger/tests/integrated/__snapshots__/elements.test.ts.snap
@@ -4,7 +4,6 @@ exports[`tiger elements > forDisplayForm > should load attribute elements for ex
 {
   "all": [Function],
   "allSorted": [Function],
-  "cacheId": Any<String>,
   "getData": [Function],
   "goTo": [Function],
   "items": [
@@ -170,7 +169,6 @@ exports[`tiger elements > forFilter > should return correct page for given displ
 {
   "all": [Function],
   "allSorted": [Function],
-  "cacheId": Any<String>,
   "getData": [Function],
   "goTo": [Function],
   "limit": 2,
@@ -184,7 +182,6 @@ exports[`tiger elements > forFilter > should return empty result for out-of-rang
 {
   "all": [Function],
   "allSorted": [Function],
-  "cacheId": Any<String>,
   "getData": [Function],
   "goTo": [Function],
   "items": [],
@@ -199,7 +196,6 @@ exports[`tiger elements > forFilter > should return empty result for out-of-rang
 {
   "all": [Function],
   "allSorted": [Function],
-  "cacheId": Any<String>,
   "getData": [Function],
   "goTo": [Function],
   "items": [],
@@ -214,7 +210,6 @@ exports[`tiger elements > forFilter > should return empty result for out-of-rang
 {
   "all": [Function],
   "allSorted": [Function],
-  "cacheId": Any<String>,
   "getData": [Function],
   "goTo": [Function],
   "items": [],

--- a/libs/sdk-backend-tiger/tests/integrated/elements.test.ts
+++ b/libs/sdk-backend-tiger/tests/integrated/elements.test.ts
@@ -29,9 +29,7 @@ describe("tiger elements", () => {
                 .withLimit(20)
                 .query();
 
-            expect(result).toMatchSnapshot({
-                cacheId: expect.any(String),
-            });
+            expect(omit(result, "cacheId")).toMatchSnapshot();
         });
     });
 
@@ -113,9 +111,7 @@ describe("tiger elements", () => {
                 .withLimit(2)
                 .query();
             const page = await result.goTo(3);
-            expect(omit(page, "items")).toMatchSnapshot({
-                cacheId: expect.any(String),
-            });
+            expect(omit(page, "items", "cacheId")).toMatchSnapshot();
         });
 
         it("should return empty result for out-of-range page in initial request", async () => {
@@ -128,9 +124,7 @@ describe("tiger elements", () => {
                 .withOffset(5000)
                 .query();
 
-            expect(result).toMatchSnapshot({
-                cacheId: expect.any(String),
-            });
+            expect(omit(result, "cacheId")).toMatchSnapshot();
         });
 
         it("should return empty result for out-of-range page with goTo", async () => {
@@ -143,9 +137,7 @@ describe("tiger elements", () => {
                 .query();
 
             const page = await result.goTo(100);
-            expect(page).toMatchSnapshot({
-                cacheId: expect.any(String),
-            });
+            expect(omit(page, "cacheId")).toMatchSnapshot();
         });
 
         it("should return empty result for out-of-range page with next", async () => {
@@ -159,9 +151,7 @@ describe("tiger elements", () => {
                 .query();
 
             const page = await result.next();
-            expect(page).toMatchSnapshot({
-                cacheId: expect.any(String),
-            });
+            expect(omit(page, "cacheId")).toMatchSnapshot();
         });
     });
 });

--- a/libs/sdk-backend-tiger/tests/integrated/elements.test.ts
+++ b/libs/sdk-backend-tiger/tests/integrated/elements.test.ts
@@ -1,4 +1,4 @@
-// (C) 2022 GoodData Corporation
+// (C) 2022-2024 GoodData Corporation
 import { testBackend, testWorkspace } from "./backend.js";
 import {
     attributeDisplayFormRef,
@@ -29,7 +29,9 @@ describe("tiger elements", () => {
                 .withLimit(20)
                 .query();
 
-            expect(result).toMatchSnapshot();
+            expect(result).toMatchSnapshot({
+                cacheId: expect.any(String),
+            });
         });
     });
 
@@ -111,7 +113,9 @@ describe("tiger elements", () => {
                 .withLimit(2)
                 .query();
             const page = await result.goTo(3);
-            expect(omit(page, "items")).toMatchSnapshot();
+            expect(omit(page, "items")).toMatchSnapshot({
+                cacheId: expect.any(String),
+            });
         });
 
         it("should return empty result for out-of-range page in initial request", async () => {
@@ -124,7 +128,9 @@ describe("tiger elements", () => {
                 .withOffset(5000)
                 .query();
 
-            expect(result).toMatchSnapshot();
+            expect(result).toMatchSnapshot({
+                cacheId: expect.any(String),
+            });
         });
 
         it("should return empty result for out-of-range page with goTo", async () => {
@@ -137,7 +143,9 @@ describe("tiger elements", () => {
                 .query();
 
             const page = await result.goTo(100);
-            expect(page).toMatchSnapshot();
+            expect(page).toMatchSnapshot({
+                cacheId: expect.any(String),
+            });
         });
 
         it("should return empty result for out-of-range page with next", async () => {
@@ -151,7 +159,9 @@ describe("tiger elements", () => {
                 .query();
 
             const page = await result.next();
-            expect(page).toMatchSnapshot();
+            expect(page).toMatchSnapshot({
+                cacheId: expect.any(String),
+            });
         });
     });
 });


### PR DESCRIPTION
This should fix the tests.

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** 🙏

---

Refer to [documentation](https://github.com/gooddata/gooddata-ui-sdk/blob/master/dev_docs/continuous_integration.md) to see how to run checks and tests in the pull request. This is the list of the most used commands:

```
extended test - backstop
```

```
// Tiger platform
extended test - tiger-cypress - integrated
extended test - tiger-cypress - isolated
extended test - tiger-cypress - record
```

```
// Bear platform
extended test - cypress - integrated
extended test - cypress - isolated
extended test - cypress - record
```
