### PR TITLE
fix: bring back selectors as always true

### DIFF
--- a/libs/sdk-backend-bear/src/backend/index.ts
+++ b/libs/sdk-backend-bear/src/backend/index.ts
@@ -69,6 +69,7 @@ const CAPABILITIES: IBackendCapabilities = {
     supportsLegacyReports: true,
     supportsRankingFilter: true,
     supportsRankingFilterWithMeasureValueFilter: true,
+    supportsElementsQueryParentFiltering: true,
     supportsKpiWidget: true,
     supportsWidgetEntity: true,
     supportsHyperlinkAttributeLabels: true,

--- a/libs/sdk-backend-mockingbird/src/recordedBackend/index.ts
+++ b/libs/sdk-backend-mockingbird/src/recordedBackend/index.ts
@@ -96,6 +96,7 @@ export const defaultRecordedBackendCapabilities: IBackendCapabilities = {
     allowsInconsistentRelations: false,
     supportsHierarchicalWorkspaces: false,
     supportsCustomColorPalettes: true,
+    supportsElementsQueryParentFiltering: true,
     supportsElementUris: true,
     supportsEveryoneUserGroupForAccessControl: true,
 };

--- a/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
+++ b/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
@@ -268,6 +268,7 @@ export interface IBackendCapabilities {
     supportsCrossFiltering?: boolean;
     supportsCsvUploader?: boolean;
     supportsCustomColorPalettes?: boolean;
+    supportsElementsQueryParentFiltering?: boolean;
     supportsElementUris?: boolean;
     supportsEnumeratingDatetimeAttributes?: boolean;
     supportsEveryoneUserGroupForAccessControl?: boolean;

--- a/libs/sdk-backend-spi/src/backend/capabilities.ts
+++ b/libs/sdk-backend-spi/src/backend/capabilities.ts
@@ -83,6 +83,11 @@ export interface IBackendCapabilities {
     supportsRankingFilterWithMeasureValueFilter?: boolean;
 
     /**
+     * Indicates whether backend supports element query parent filtering.
+     */
+    supportsElementsQueryParentFiltering?: boolean;
+
+    /**
      * Indicates whether backend supports a special dashboard-specific KPI Widget.
      */
     supportsKpiWidget?: boolean;

--- a/libs/sdk-backend-tiger/src/backend/index.ts
+++ b/libs/sdk-backend-tiger/src/backend/index.ts
@@ -66,6 +66,7 @@ const CAPABILITIES: IBackendCapabilities = {
     supportsCsvUploader: false,
     supportsRankingFilter: true,
     supportsRankingFilterWithMeasureValueFilter: false,
+    supportsElementsQueryParentFiltering: true,
     supportsKpiWidget: false,
     supportsWidgetEntity: false,
     supportsHyperlinkAttributeLabels: true,

--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -6745,6 +6745,9 @@ export const selectEnableInsightExportScheduling: DashboardSelector<boolean>;
 export const selectEnableKDCrossFiltering: DashboardSelector<boolean>;
 
 // @internal
+export const selectEnableKDDependentFilters: DashboardSelector<boolean>;
+
+// @internal
 export const selectEnableKDRichText: DashboardSelector<boolean>;
 
 // @public
@@ -6966,11 +6969,17 @@ export const selectIsInEditMode: DashboardSelector<boolean>;
 // @internal (undocumented)
 export const selectIsInViewMode: DashboardSelector<boolean>;
 
+// @internal
+export const selectIsKDDependentFiltersEnabled: DashboardSelector<boolean>;
+
 // @alpha (undocumented)
 export const selectIsKpiAlertHighlightedByWidgetRef: (ref: ObjRef | undefined) => (state: DashboardState) => boolean;
 
 // @alpha (undocumented)
 export const selectIsKpiAlertOpenedByWidgetRef: (ref: ObjRef | undefined) => (state: DashboardState) => boolean;
+
+// @internal
+export const selectIsKPIDashboardDependentFiltersEnabled: DashboardSelector<boolean>;
 
 // @internal (undocumented)
 export const selectIsKpiDeleteDialogOpen: DashboardSelector<boolean>;
@@ -7103,6 +7112,9 @@ export const selectSupportsAttributeHierarchies: DashboardSelector<boolean>;
 
 // @internal
 export const selectSupportsCrossFiltering: DashboardSelector<boolean>;
+
+// @public
+export const selectSupportsElementsQueryParentFiltering: DashboardSelector<boolean>;
 
 // @internal
 export const selectSupportsElementUris: DashboardSelector<boolean>;

--- a/libs/sdk-ui-dashboard/src/model/queryServices/tests/__snapshots__/queryWidgetFilters.test.ts.snap
+++ b/libs/sdk-ui-dashboard/src/model/queryServices/tests/__snapshots__/queryWidgetFilters.test.ts.snap
@@ -240,6 +240,7 @@ exports[`query widget filters > basic scenarios > should fail in case the widget
         "supportsCsvUploader": true,
         "supportsCustomColorPalettes": true,
         "supportsElementUris": true,
+        "supportsElementsQueryParentFiltering": true,
         "supportsEveryoneUserGroupForAccessControl": true,
         "supportsHierarchicalWorkspaces": false,
         "supportsKpiWidget": true,

--- a/libs/sdk-ui-dashboard/src/model/store/backendCapabilities/backendCapabilitiesSelectors.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/backendCapabilities/backendCapabilitiesSelectors.ts
@@ -24,6 +24,13 @@ export const selectBackendCapabilities: DashboardSelector<IBackendCapabilities> 
 );
 
 /**
+ * This selector returns capability if parent child filtering is enabled.
+ *
+ * @public
+ */
+export const selectSupportsElementsQueryParentFiltering: DashboardSelector<boolean> = () => true;
+
+/**
  * Selector for {@link @gooddata/sdk-backend-spi#IBackendCapabilities.supportsKpiWidget}
  *
  * @internal

--- a/libs/sdk-ui-dashboard/src/model/store/config/configSelectors.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/config/configSelectors.ts
@@ -509,6 +509,33 @@ export const selectIsDeleteFilterButtonEnabled: DashboardSelector<boolean> = cre
 );
 
 /**
+ * Returns whether dependent filters are enabled.
+ *
+ * @internal
+ */
+export const selectIsKPIDashboardDependentFiltersEnabled: DashboardSelector<boolean> = () => true;
+
+/**
+ * Returns whether new KD dependent filters are enabled.
+ *
+ * @internal
+ */
+export const selectEnableKDDependentFilters: DashboardSelector<boolean> = () => true;
+
+/**
+ * Returns whether KD dependent filters are enabled.
+ *
+ * @internal
+ */
+export const selectIsKDDependentFiltersEnabled: DashboardSelector<boolean> = createSelector(
+    selectEnableKDDependentFilters,
+    selectIsKPIDashboardDependentFiltersEnabled,
+    (enableKDDependentFilters, isKPIDashboardDependentFiltersEnabled) => {
+        return enableKDDependentFilters || isKPIDashboardDependentFiltersEnabled;
+    },
+);
+
+/**
  * Returns whether choice of alternate display forms is enabled.
  *
  * @internal

--- a/libs/sdk-ui-dashboard/src/model/store/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/index.ts
@@ -8,6 +8,7 @@ export { SavingState } from "./saving/savingState.js";
 export { BackendCapabilitiesState } from "./backendCapabilities/backendCapabilitiesState.js";
 export {
     selectBackendCapabilities,
+    selectSupportsElementsQueryParentFiltering,
     selectSupportsElementUris,
     selectSupportsKpiWidgetCapability,
     selectSupportsAccessControlCapability,
@@ -63,12 +64,15 @@ export {
     selectAllowCreateInsightRequest,
     selectIsAnalyticalDesignerEnabled,
     selectIsDeleteFilterButtonEnabled,
+    selectIsKPIDashboardDependentFiltersEnabled,
     selectIsAlternativeDisplayFormSelectionEnabled,
     selectEnableKPIDashboardDrillFromAttribute,
     selectIsShareButtonHidden,
     selectWeekStart,
     selectIsDrillDownEnabled,
     selectEnableUnavailableItemsVisibility,
+    selectEnableKDDependentFilters,
+    selectIsKDDependentFiltersEnabled,
     selectEnableKDCrossFiltering,
     selectEnableMultipleDateFilters,
     selectEnableKDRichText,


### PR DESCRIPTION
The selectors were previously removed as always true,
but old non-autoupgrade plugins could depend on them.

See #4617

JIRA: STL-293


<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** 🙏

---

Refer to [documentation](https://github.com/gooddata/gooddata-ui-sdk/blob/master/dev_docs/continuous_integration.md) to see how to run checks and tests in the pull request. This is the list of the most used commands:

```
extended test - backstop
```

```
// Tiger platform
extended test - tiger-cypress - integrated
extended test - tiger-cypress - isolated
extended test - tiger-cypress - record
```

```
// Bear platform
extended test - cypress - integrated
extended test - cypress - isolated
extended test - cypress - record
```