### PR TITLE
fix: insight->visualization renaming backwards compatible with bear

### DIFF
--- a/libs/sdk-backend-bear/src/uiSettings.ts
+++ b/libs/sdk-backend-bear/src/uiSettings.ts
@@ -1,4 +1,4 @@
-// (C) 2023 GoodData Corporation
+// (C) 2023-2024 GoodData Corporation
 
 import { ISettings } from "@gooddata/sdk-model";
 
@@ -7,5 +7,6 @@ import { ISettings } from "@gooddata/sdk-model";
  */
 export const DefaultUiSettings: ISettings = {
     metadataTimeZone: "Europe/Prague", // Bear metadata are always stored in Prague time zone
+    keepInsightName: true,
     enableNewHeadline: true,
 };

--- a/libs/sdk-ui-dashboard/src/model/tests/DashboardTester.ts
+++ b/libs/sdk-ui-dashboard/src/model/tests/DashboardTester.ts
@@ -1,4 +1,4 @@
-// (C) 2021-2022 GoodData Corporation
+// (C) 2021-2024 GoodData Corporation
 
 import { PayloadAction } from "@reduxjs/toolkit";
 import { Identifier, idRef, ObjRef, uriRef } from "@gooddata/sdk-model";

--- a/libs/sdk-ui-dashboard/src/presentation/localization/bundles/en-US.json
+++ b/libs/sdk-ui-dashboard/src/presentation/localization/bundles/en-US.json
@@ -55,11 +55,21 @@
         "limit": 0
     },
     "messages.dashboard.invalidDrills.body.modern._measure|insight": {
-        "value": "One or more dashboard/visualization/measure/attribute has been changed or deleted causing some interactions to be removed from following widgets: <b>{listOfWidgetTitles}</b>",
+        "value": "One or more dashboard/insight/measure/attribute has been changed or deleted causing some interactions to be removed from following widgets: <b>{listOfWidgetTitles}</b>",
         "comment": "Expanded text of the warning message shown while editing KPI dashboard with some invalid drills. Don't translate placeholder '{listOfWidgetTitles}'.",
         "limit": 0
     },
     "messages.dashboard.invalidDrills.body.modern._metric|insight": {
+        "value": "One or more dashboard/insight/metric/attribute has been changed or deleted causing some interactions to be removed from following widgets: <b>{listOfWidgetTitles}</b>",
+        "comment": "Expanded text of the warning message shown while editing KPI dashboard with some invalid drills. Don't translate placeholder '{listOfWidgetTitles}'.",
+        "limit": 0
+    },
+    "messages.dashboard.invalidDrills.body.modern._measure|visualization": {
+        "value": "One or more dashboard/visualization/measure/attribute has been changed or deleted causing some interactions to be removed from following widgets: <b>{listOfWidgetTitles}</b>",
+        "comment": "Expanded text of the warning message shown while editing KPI dashboard with some invalid drills. Don't translate placeholder '{listOfWidgetTitles}'.",
+        "limit": 0
+    },
+    "messages.dashboard.invalidDrills.body.modern._metric|visualization": {
         "value": "One or more dashboard/visualization/metric/attribute has been changed or deleted causing some interactions to be removed from following widgets: <b>{listOfWidgetTitles}</b>",
         "comment": "Expanded text of the warning message shown while editing KPI dashboard with some invalid drills. Don't translate placeholder '{listOfWidgetTitles}'.",
         "limit": 0
@@ -82,6 +92,11 @@
         "limit": 0
     },
     "messages.dashboard.invalidCustomUrlDrills.body.modern|insight": {
+        "value": "Invalid URL parameters in your custom URLs are causing drill-into-URL interactions to fail on these widgets: <b>{listOfWidgetTitles}</b>",
+        "comment": "Expanded text of the warning message shown while editing KPI dashboard with some invalid drills. Don't translate placeholder '{listOfWidgetTitles}'.",
+        "limit": 0
+    },
+    "messages.dashboard.invalidCustomUrlDrills.body.modern|visualization": {
         "value": "Invalid URL parameters in your custom URLs are causing drill-into-URL interactions to fail on these widgets: <b>{listOfWidgetTitles}</b>",
         "comment": "Expanded text of the warning message shown while editing KPI dashboard with some invalid drills. Don't translate placeholder '{listOfWidgetTitles}'.",
         "limit": 0
@@ -143,6 +158,11 @@
         "limit": 0
     },
     "dialogs.export.filters|insight": {
+        "value": "INSIGHT CONTEXT",
+        "comment": "The filters that are applied to the report",
+        "limit": 0
+    },
+    "dialogs.export.filters|visualization": {
         "value": "VISUALIZATION CONTEXT",
         "comment": "The filters that are applied to the report",
         "limit": 0
@@ -450,6 +470,11 @@
         "limit": 0
     },
     "dialogs.schedule.email.attachment.select.disabled.message|insight": {
+        "value": "This dashboard does not contain any insights.",
+        "comment": "Message for button to add visualizations to the export, if there are no visualizations.",
+        "limit": 0
+    },
+    "dialogs.schedule.email.attachment.select.disabled.message|visualization": {
         "value": "This dashboard does not contain any visualizations.",
         "comment": "Message for button to add visualizations to the export, if there are no visualizations.",
         "limit": 0
@@ -472,6 +497,11 @@
         "translate": false
     },
     "dialogs.schedule.email.attachment.select.widgets.header|insight": {
+        "value": "Insights (CSV, XLSX)",
+        "comment": "Heading of section of checkboxes for selecting visualizations to be exported as CSV of XLSX file",
+        "limit": 0
+    },
+    "dialogs.schedule.email.attachment.select.widgets.header|visualization": {
         "value": "Visualizations (CSV, XLSX)",
         "comment": "Heading of section of checkboxes for selecting visualizations to be exported as CSV of XLSX file",
         "limit": 0
@@ -587,6 +617,11 @@
         "limit": 0
     },
     "dialogs.schedule.email.insight.format|insight": {
+        "value": "Insight format:",
+        "comment": "Label of a dropdown for selecting export format",
+        "limit": 0
+    },
+    "dialogs.schedule.email.insight.format|Visualization": {
         "value": "Visualization format:",
         "comment": "Label of a dropdown for selecting export format",
         "limit": 0
@@ -658,6 +693,11 @@
         "limit": 0
     },
     "dialogs.schedule.management.attachments.widgets|insight": {
+        "value": "{n, plural, one {# insight} other {# insights}}",
+        "comment": "Translate only uppercase in '{n, plural, one {# INSIGHT} other {# INSIGHTS}}'.",
+        "limit": 0
+    },
+    "dialogs.schedule.management.attachments.widgets|visualization": {
         "value": "{n, plural, one {# visualization} other {# visualizations}}",
         "comment": "Translate only uppercase in '{n, plural, one {# VISUALIZATION} other {# VISUALIZATIONS}}'.",
         "limit": 0
@@ -669,6 +709,11 @@
         "translate": false
     },
     "dialogs.schedule.management.attachments.mixed|insight": {
+        "value": "Dashboard and {n, plural, one {# insight} other {# insights}}",
+        "comment": "In '{n, plural, one {# INSIGHT} other {# INSIGHTS}}', translate only uppercase words.",
+        "limit": 0
+    },
+    "dialogs.schedule.management.attachments.mixed|visualization": {
         "value": "Dashboard and {n, plural, one {# visualization} other {# visualizations}}",
         "comment": "In '{n, plural, one {# VISUALIZATION} other {# VISUALIZATIONS}}', translate only uppercase words.",
         "limit": 0
@@ -905,6 +950,11 @@
         "limit": 0
     },
     "messages.exportResultRestrictedError|insight": {
+        "value": "You cannot export this insight because it contains restricted data.",
+        "comment": "Error dialog. Exporting visualization to the file fails because contains restricted data.",
+        "limit": 0
+    },
+    "messages.exportResultRestrictedError|visualization": {
         "value": "You cannot export this visualization because it contains restricted data.",
         "comment": "Error dialog. Exporting visualization to the file fails because contains restricted data.",
         "limit": 0
@@ -971,6 +1021,11 @@
         "limit": 0
     },
     "visualization.error.headline|insight": {
+        "value": "Sorry, we can't display this insight",
+        "comment": "",
+        "limit": 0
+    },
+    "visualization.error.headline|visualization": {
         "value": "Sorry, we can't display this visualization",
         "comment": "",
         "limit": 0
@@ -987,6 +1042,11 @@
         "limit": 0
     },
     "options.button.bubble|insight": {
+        "value": "Export insight data",
+        "comment": "Show this message when hovering on the options button",
+        "limit": 0
+    },
+    "options.button.bubble|visualization": {
         "value": "Export visualization data",
         "comment": "Show this message when hovering on the options button",
         "limit": 0
@@ -1008,11 +1068,21 @@
         "limit": 0
     },
     "options.menu.unsupported.error._measure|insight": {
-        "value": "The visualization cannot be exported at the moment. Try applying different filters, or using different measures or attributes.",
+        "value": "The insight cannot be exported at the moment. Try applying different filters, or using different measures or attributes.",
         "comment": "Error popup. Visualization cannot be exported to the file because of wrong setting of filters, measures or attributes.",
         "limit": 0
     },
     "options.menu.unsupported.error._metric|insight": {
+        "value": "The insight cannot be exported at the moment. Try applying different filters, or using different metrics or attributes.",
+        "comment": "Error popup. Visualization cannot be exported to the file because of wrong setting of filters, metrics or attributes.",
+        "limit": 0
+    },
+    "options.menu.unsupported.error._measure|visualization": {
+        "value": "The visualization cannot be exported at the moment. Try applying different filters, or using different measures or attributes.",
+        "comment": "Error popup. Visualization cannot be exported to the file because of wrong setting of filters, measures or attributes.",
+        "limit": 0
+    },
+    "options.menu.unsupported.error._metric|visualization": {
         "value": "The visualization cannot be exported at the moment. Try applying different filters, or using different metrics or attributes.",
         "comment": "Error popup. Visualization cannot be exported to the file because of wrong setting of filters, metrics or attributes.",
         "limit": 0
@@ -1030,6 +1100,11 @@
         "translate": false
     },
     "options.menu.unsupported.loading|insight": {
+        "value": "The insight cannot be exported at the moment.",
+        "comment": "Error popup. Visualization cannot be exported to the file.",
+        "limit": 0
+    },
+    "options.menu.unsupported.loading|Visualization": {
         "value": "The visualization cannot be exported at the moment.",
         "comment": "Error popup. Visualization cannot be exported to the file.",
         "limit": 0
@@ -1041,6 +1116,11 @@
         "translate": false
     },
     "export.defaultTitle|insight": {
+        "value": "Untitled insight",
+        "comment": "Default title for exported file",
+        "limit": 0
+    },
+    "export.defaultTitle|visualization": {
         "value": "Untitled visualization",
         "comment": "Default title for exported file",
         "limit": 0
@@ -1082,6 +1162,11 @@
         "limit": 0
     },
     "dashboard.error.empty.text|insight": {
+        "value": "All insights were removed.",
+        "comment": "The user has a dashboard that contains no widgets.",
+        "limit": 0
+    },
+    "dashboard.error.empty.text|visualization": {
         "value": "All visualizations were removed.",
         "comment": "The user has a dashboard that contains no widgets.",
         "limit": 0
@@ -1303,6 +1388,11 @@
         "limit": 0
     },
     "visualizationsList.noInsights|insight": {
+        "value": "This workspace contains no insights.",
+        "comment": "",
+        "limit": 0
+    },
+    "visualizationsList.noInsights|visualization": {
         "value": "This workspace contains no visualizations.",
         "comment": "",
         "limit": 0
@@ -1314,6 +1404,11 @@
         "translate": false
     },
     "visualizationsList.create|insight": {
+        "value": "Create insight",
+        "comment": "",
+        "limit": 0
+    },
+    "visualizationsList.create|visualization": {
         "value": "Create visualization",
         "comment": "",
         "limit": 0
@@ -1325,6 +1420,11 @@
         "limit": 0
     },
     "visualizationsList.noUserInsights|insight": {
+        "value": "No insights created.",
+        "comment": "",
+        "limit": 0
+    },
+    "visualizationsList.noUserInsights|visualization": {
         "value": "No visualizations created.",
         "comment": "",
         "limit": 0
@@ -1336,6 +1436,11 @@
         "translate": false
     },
     "visualizationsList.noVisualizationsFound|insight": {
+        "value": "No insight matched.",
+        "comment": "",
+        "limit": 0
+    },
+    "visualizationsList.noVisualizationsFound|visualization": {
         "value": "No visualization matched.",
         "comment": "",
         "limit": 0
@@ -1347,6 +1452,11 @@
         "translate": false
     },
     "search_insights|insight": {
+        "value": "Search all insights…",
+        "comment": "Use '…' as one character, not 3 dots ('...').",
+        "limit": 0
+    },
+    "search_insights|visualization": {
         "value": "Search all visualizations…",
         "comment": "Use '…' as one character, not 3 dots ('...').",
         "limit": 0
@@ -1428,6 +1538,11 @@
         "limit": 0
     },
     "visualizationsList.savedVisualizations|insight": {
+        "value": "Saved insights",
+        "comment": "",
+        "limit": 0
+    },
+    "visualizationsList.savedVisualizations|visualization": {
         "value": "Saved visualizations",
         "comment": "",
         "limit": 0
@@ -1599,6 +1714,11 @@
         "limit": 0
     },
     "configurationPanel.vizCantBeFilteredByAttribute|insight": {
+        "value": "The insight cannot be filtered by {attributeName}. Unselect the check box.",
+        "comment": "Don't translate placeholder '{attributeName}'.",
+        "limit": 0
+    },
+    "configurationPanel.vizCantBeFilteredByAttribute|visualization": {
         "value": "The visualization cannot be filtered by {attributeName}. Unselect the check box.",
         "comment": "Don't translate placeholder '{attributeName}'.",
         "limit": 0
@@ -1615,6 +1735,11 @@
         "limit": 0
     },
     "configurationPanel.vizCantBeFilteredByDate|insight": {
+        "value": "The insight cannot be filtered by Date. Unselect the check box.",
+        "comment": "",
+        "limit": 0
+    },
+    "configurationPanel.vizCantBeFilteredByDate|visualization": {
         "value": "The visualization cannot be filtered by Date. Unselect the check box.",
         "comment": "",
         "limit": 0
@@ -1631,6 +1756,11 @@
         "limit": 0
     },
     "configurationPanel.unrelatedVizDateInfo|insight": {
+        "value": "\"{dateDataSet}\" can no longer be applied to the insight. Select a different dimension or edit the insight.",
+        "comment": "Don't translate placeholder '{dateDataSet}' and keep '\"' characters as are.",
+        "limit": 0
+    },
+    "configurationPanel.unrelatedVizDateInfo|visualization": {
         "value": "\"{dateDataSet}\" can no longer be applied to the visualization. Select a different dimension or edit the visualization.",
         "comment": "Don't translate placeholder '{dateDataSet}' and keep '\"' characters as are.",
         "limit": 0
@@ -1717,6 +1847,11 @@
         "limit": 0
     },
     "configurationPanel.drillConfig.drillIntoInsight|insight": {
+        "value": "Drill into insight",
+        "comment": "",
+        "limit": 0
+    },
+    "configurationPanel.drillConfig.drillIntoInsight|visualization": {
         "value": "Drill into visualization",
         "comment": "",
         "limit": 0
@@ -1753,6 +1888,11 @@
         "limit": 0
     },
     "configurationPanel.drillConfig.drillIntoDashboard.dateFilterWarning|insight": {
+        "value": "The date attribute value from the insight will not be transferred to filter the target dashboard.",
+        "comment": "Warning displayed in drill config when drill into dashboard has date attribute as source or in intersection",
+        "limit": 0
+    },
+    "configurationPanel.drillConfig.drillIntoDashboard.dateFilterWarning|visualization": {
         "value": "The date attribute value from the visualization will not be transferred to filter the target dashboard.",
         "comment": "Warning displayed in drill config when drill into dashboard has date attribute as source or in intersection",
         "limit": 0
@@ -1790,6 +1930,11 @@
         "limit": 0
     },
     "configurationPanel.visualprops.inheritDescriptionHelp|insight": {
+        "value": "Inherit the description from the insight.",
+        "comment": "",
+        "limit": 0
+    },
+    "configurationPanel.visualprops.inheritDescriptionHelp|visualization": {
         "value": "Inherit the description from the visualization.",
         "comment": "",
         "limit": 0
@@ -1816,6 +1961,11 @@
         "limit": 0
     },
     "configurationPanel.visualprops.customDescriptionHelp|insight": {
+        "value": "Add a custom description for this instance of the insight.",
+        "comment": "",
+        "limit": 0
+    },
+    "configurationPanel.visualprops.customDescriptionHelp|visualization": {
         "value": "Add a custom description for this instance of the visualization.",
         "comment": "",
         "limit": 0
@@ -1847,11 +1997,21 @@
         "limit": 0
     },
     "configurationPanel.visualprops.includeMetricsHelp._measure|insight": {
-        "value": "Display section with list of visualization’s measures and their description.",
+        "value": "Display section with list of insight’s measures and their description.",
         "comment": "",
         "limit": 0
     },
     "configurationPanel.visualprops.includeMetricsHelp._metric|insight": {
+        "value": "Display section with list of insight’s metrics and their description.",
+        "comment": "",
+        "limit": 0
+    },
+    "configurationPanel.visualprops.includeMetricsHelp._measure|visualization": {
+        "value": "Display section with list of visualization’s measures and their description.",
+        "comment": "",
+        "limit": 0
+    },
+    "configurationPanel.visualprops.includeMetricsHelp._metric|visualization": {
         "value": "Display section with list of visualization’s metrics and their description.",
         "comment": "",
         "limit": 0
@@ -1940,6 +2100,11 @@
         "limit": 0
     },
     "configurationPanel.drillIntoUrl.editor.insightIdParameterLabel|insight": {
+        "value": "Insight ID",
+        "comment": "Label of the visualization parameter in Drill to URL 'Custom URL' editor.",
+        "limit": 0
+    },
+    "configurationPanel.drillIntoUrl.editor.insightIdParameterLabel|visualization": {
         "value": "Visualization ID",
         "comment": "Label of the visualization parameter in Drill to URL 'Custom URL' editor.",
         "limit": 0
@@ -1986,6 +2151,11 @@
         "limit": 0
     },
     "configurationPanel.drillIntoUrl.editor.insightParametersSectionLabel|insight": {
+        "value": "Insight",
+        "comment": "Label of the parameters section that contains attributes and measures in Drill to URL 'Custom URL' editor.",
+        "limit": 0
+    },
+    "configurationPanel.drillIntoUrl.editor.insightParametersSectionLabel|visualization": {
         "value": "Visualization",
         "comment": "Label of the parameters section that contains attributes and measures in Drill to URL 'Custom URL' editor.",
         "limit": 0
@@ -2062,6 +2232,11 @@
         "limit": 0
     },
     "configurationPanel.zoomInsight|insight": {
+        "value": "Zoomable insight",
+        "comment": "",
+        "limit": 0
+    },
+    "configurationPanel.zoomInsight|visualization": {
         "value": "Zoomable visualization",
         "comment": "",
         "limit": 0
@@ -2073,6 +2248,11 @@
         "limit": 0
     },
     "configurationPanel.zoomInsight.help|insight": {
+        "value": "Enable to zoom the insight to display a detailed view. Hold the shift key to pan the zoomed area.",
+        "comment": "",
+        "limit": 0
+    },
+    "configurationPanel.zoomInsight.help|visualization": {
         "value": "Enable to zoom the visualization to display a detailed view. Hold the shift key to pan the zoomed area.",
         "comment": "",
         "limit": 0
@@ -2089,6 +2269,11 @@
         "limit": 0
     },
     "configurationPanel.drillConfig.selectInsight|insight": {
+        "value": "Choose insight…",
+        "comment": "Hint guiding users that drill target visualization in select box has to be selected. Use '…' as one character, not 3 dots ('...').",
+        "limit": 0
+    },
+    "configurationPanel.drillConfig.selectInsight|visualization": {
         "value": "Choose visualization…",
         "comment": "Hint guiding users that drill target visualization in select box has to be selected. Use '…' as one character, not 3 dots ('...').",
         "limit": 0
@@ -2205,6 +2390,11 @@
         "limit": 0
     },
     "newDashboard.title|insight": {
+        "value": "Drag insight here",
+        "comment": "",
+        "limit": 0
+    },
+    "newDashboard.title|visualization": {
         "value": "Drag visualization here",
         "comment": "",
         "limit": 0
@@ -2216,6 +2406,11 @@
         "limit": 0
     },
     "newDashboard.dropInsight|insight": {
+        "value": "Drop insight",
+        "comment": "A placeholder showed when user drags new visualization into a dashboard canvas by cursor (drag and drop).",
+        "limit": 0
+    },
+    "newDashboard.dropInsight|visualization": {
         "value": "Drop visualization",
         "comment": "A placeholder showed when user drags new visualization into a dashboard canvas by cursor (drag and drop).",
         "limit": 0

--- a/libs/sdk-ui-dashboard/src/presentation/localization/createInternalIntl.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/localization/createInternalIntl.ts
@@ -1,4 +1,4 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2024 GoodData Corporation
 import { createIntl, IntlShape } from "react-intl";
 import { DefaultLocale, ILocale, pickCorrectWording } from "@gooddata/sdk-ui";
 
@@ -16,5 +16,6 @@ export function createInternalIntl(locale: ILocale = DefaultLocale): IntlShape {
      * this workaround can be removed.
      */
     const settings = window.gdSettings as IWorkspaceSettings;
+
     return createIntl({ locale, messages: pickCorrectWording(translations[locale], settings) });
 }

--- a/libs/sdk-ui-ext/src/internal/translations/en-US.json
+++ b/libs/sdk-ui-ext/src/internal/translations/en-US.json
@@ -495,11 +495,21 @@
         "limit": 0
     },
     "dashboard.bucket.category_view_by_warning._measure|insight": {
-        "value": "To view by another attribute, an visualization can have only one measure",
+        "value": "To view by another attribute, an insight can have only one measure",
         "comment": "",
         "limit": 0
     },
     "dashboard.bucket.category_view_by_warning._metric|insight": {
+        "value": "To view by another attribute, an insight can have only one metric",
+        "comment": "",
+        "limit": 0
+    },
+    "dashboard.bucket.category_view_by_warning._measure|visualization": {
+        "value": "To view by another attribute, an visualization can have only one measure",
+        "comment": "",
+        "limit": 0
+    },
+    "dashboard.bucket.category_view_by_warning._metric|visualization": {
         "value": "To view by another attribute, an visualization can have only one metric",
         "comment": "",
         "limit": 0
@@ -522,11 +532,21 @@
         "limit": 0
     },
     "dashboard.bucket.category_stack_by_warning._measure|insight": {
-        "value": "To stack by, an visualization can have only one measure",
+        "value": "To stack by, an insight can have only one measure",
         "comment": "",
         "limit": 0
     },
     "dashboard.bucket.category_stack_by_warning._metric|insight": {
+        "value": "To stack by, an insight can have only one metric",
+        "comment": "",
+        "limit": 0
+    },
+    "dashboard.bucket.category_stack_by_warning._measure|visualization": {
+        "value": "To stack by, an visualization can have only one measure",
+        "comment": "",
+        "limit": 0
+    },
+    "dashboard.bucket.category_stack_by_warning._metric|visualization": {
         "value": "To stack by, an visualization can have only one metric",
         "comment": "",
         "limit": 0
@@ -544,6 +564,11 @@
         "translate": false
     },
     "dashboard.bucket.stack_view_by_warning|insight": {
+        "value": "To stack by, an insight can have only one attribute in view by",
+        "comment": "",
+        "limit": 0
+    },
+    "dashboard.bucket.stack_view_by_warning|visualization": {
         "value": "To stack by, an visualization can have only one attribute in view by",
         "comment": "",
         "limit": 0
@@ -555,11 +580,21 @@
         "translate": false
     },
     "dashboard.bucket.measure_stack_by_warning._measure|insight": {
-        "value": "To stack by an attribute, an visualization can have only one measure",
+        "value": "To stack by an attribute, an insight can have only one measure",
         "comment": "",
         "limit": 0
     },
     "dashboard.bucket.measure_stack_by_warning._metric|insight": {
+        "value": "To stack by an attribute, an insight can have only one metric",
+        "comment": "",
+        "limit": 0
+    },
+    "dashboard.bucket.measure_stack_by_warning._measure|visualization": {
+        "value": "To stack by an attribute, an visualization can have only one measure",
+        "comment": "",
+        "limit": 0
+    },
+    "dashboard.bucket.measure_stack_by_warning._metric|visualization": {
         "value": "To stack by an attribute, an visualization can have only one metric",
         "comment": "",
         "limit": 0
@@ -592,11 +627,21 @@
         "limit": 0
     },
     "dashboard.bucket.category_category_by_warning._measure|insight": {
-        "value": "To view by, an visualization can have only one measure",
+        "value": "To view by, an insight can have only one measure",
         "comment": "",
         "limit": 0
     },
     "dashboard.bucket.category_category_by_warning._metric|insight": {
+        "value": "To view by, an insight can have only one metric",
+        "comment": "",
+        "limit": 0
+    },
+    "dashboard.bucket.category_category_by_warning._measure|visualization": {
+        "value": "To view by, an visualization can have only one measure",
+        "comment": "",
+        "limit": 0
+    },
+    "dashboard.bucket.category_category_by_warning._metric|visualization": {
         "value": "To view by, an visualization can have only one metric",
         "comment": "",
         "limit": 0
@@ -614,11 +659,21 @@
         "translate": false
     },
     "dashboard.bucket.category_segment_by_warning._measure|insight": {
-        "value": "To segment by, an visualization can have only one measure",
+        "value": "To segment by, an insight can have only one measure",
         "comment": "",
         "limit": 0
     },
     "dashboard.bucket.category_segment_by_warning._metric|insight": {
+        "value": "To segment by, an insight can have only one metric",
+        "comment": "",
+        "limit": 0
+    },
+    "dashboard.bucket.category_segment_by_warning._measure|visualization": {
+        "value": "To segment by, an visualization can have only one measure",
+        "comment": "",
+        "limit": 0
+    },
+    "dashboard.bucket.category_segment_by_warning._metric|visualization": {
         "value": "To segment by, an visualization can have only one metric",
         "comment": "",
         "limit": 0
@@ -686,11 +741,21 @@
         "limit": 0
     },
     "dashboard.error.missing_primary_bucket_item.heading._measure|insight": {
-        "value": "No primary measure in your visualization",
+        "value": "No primary measure in your insight",
         "comment": "",
         "limit": 0
     },
     "dashboard.error.missing_primary_bucket_item.heading._metric|insight": {
+        "value": "No primary metric in your insight",
+        "comment": "",
+        "limit": 0
+    },
+    "dashboard.error.missing_primary_bucket_item.heading._measure|visualization": {
+        "value": "No primary measure in your visualization",
+        "comment": "",
+        "limit": 0
+    },
+    "dashboard.error.missing_primary_bucket_item.heading._metric|visualization": {
         "value": "No primary metric in your visualization",
         "comment": "",
         "limit": 0
@@ -708,11 +773,21 @@
         "translate": false
     },
     "dashboard.error.missing_primary_bucket_item.text._measure|insight": {
-        "value": "Add a primary measure to your visualization, or switch to table.\nOnce done, you'll be able to save it.",
+        "value": "Add a primary measure to your insight, or switch to table.\nOnce done, you'll be able to save it.",
         "comment": "",
         "limit": 0
     },
     "dashboard.error.missing_primary_bucket_item.text._metric|insight": {
+        "value": "Add a primary metric to your insight, or switch to table.\nOnce done, you'll be able to save it.",
+        "comment": "",
+        "limit": 0
+    },
+    "dashboard.error.missing_primary_bucket_item.text._measure|visualization": {
+        "value": "Add a primary measure to your visualization, or switch to table.\nOnce done, you'll be able to save it.",
+        "comment": "",
+        "limit": 0
+    },
+    "dashboard.error.missing_primary_bucket_item.text._metric|visualization": {
         "value": "Add a primary metric to your visualization, or switch to table.\nOnce done, you'll be able to save it.",
         "comment": "",
         "limit": 0
@@ -750,6 +825,11 @@
         "limit": 0
     },
     "properties.config.not_applicable|insight": {
+        "value": "Configuration Panel is not applicable for this configuration of the insight",
+        "comment": "",
+        "limit": 0
+    },
+    "properties.config.not_applicable|visualization": {
         "value": "Configuration Panel is not applicable for this configuration of the visualization",
         "comment": "",
         "limit": 0
@@ -761,6 +841,11 @@
         "translate": false
     },
     "properties.not_applicable|insight": {
+        "value": "Property is not applicable for this configuration of the insight",
+        "comment": "",
+        "limit": 0
+    },
+    "properties.not_applicable|visualization": {
         "value": "Property is not applicable for this configuration of the visualization",
         "comment": "",
         "limit": 0
@@ -947,11 +1032,21 @@
         "limit": 0
     },
     "properties.axis.format.info.inherit._measure|insight": {
-        "value": "The format is inherited from the first measure in the visualization.",
+        "value": "The format is inherited from the first measure in the insight.",
         "comment": "Info text for axis format option.",
         "limit": 0
     },
     "properties.axis.format.info.inherit._metric|insight": {
+        "value": "The format is inherited from the first metric in the insight.",
+        "comment": "Info text for axis format option.",
+        "limit": 0
+    },
+    "properties.axis.format.info.inherit._measure|visualization": {
+        "value": "The format is inherited from the first measure in the visualization.",
+        "comment": "Info text for axis format option.",
+        "limit": 0
+    },
+    "properties.axis.format.info.inherit._metric|visualization": {
         "value": "The format is inherited from the first metric in the visualization.",
         "comment": "Info text for axis format option.",
         "limit": 0
@@ -1234,6 +1329,11 @@
         "limit": 0
     },
     "properties.colors.unsupported|insight": {
+        "value": "There are no colors for this configuration of the insight",
+        "comment": "",
+        "limit": 0
+    },
+    "properties.colors.unsupported|visualization": {
         "value": "There are no colors for this configuration of the visualization",
         "comment": "",
         "limit": 0
@@ -1245,6 +1345,11 @@
         "translate": false
     },
     "export_unsupported.colors|insight": {
+        "value": "The visualization is not compatible with custom colors. To open the insight as a report, click Reset Colors in Configuration —> Colors.",
+        "comment": "",
+        "limit": 0
+    },
+    "export_unsupported.colors|visualization": {
         "value": "The visualization is not compatible with custom colors. To open the visualization as a report, click Reset Colors in Configuration —> Colors.",
         "comment": "",
         "limit": 0
@@ -1301,6 +1406,11 @@
         "limit": 0
     },
     "sorting.disabled.explanation.attribute|insight": {
+        "value": "Sorting is not possible for this insight configuration.",
+        "comment": "Explains why sort button is disabled. Shown as tooltip",
+        "limit": 0
+    },
+    "sorting.disabled.explanation.attribute|visualization": {
         "value": "Sorting is not possible for this visualization configuration.",
         "comment": "Explains why sort button is disabled. Shown as tooltip",
         "limit": 0
@@ -1312,6 +1422,11 @@
         "translate": false
     },
     "sorting.disabled.explanation.measure._measure|insight": {
+        "value": "You must add at least one attribute to sort the insight. You can also adjust the position of items in the Measures section to change their position in the visualization.",
+        "comment": "Explains why sort button is disabled. Shown as tooltip",
+        "limit": 0
+    },
+    "sorting.disabled.explanation.measure._measure|visualization": {
         "value": "You must add at least one attribute to sort the visualization. You can also adjust the position of items in the Measures section to change their position in the visualization.",
         "comment": "Explains why sort button is disabled. Shown as tooltip",
         "limit": 0
@@ -1323,6 +1438,11 @@
         "translate": false
     },
     "sorting.disabled.explanation.measure._metric|insight": {
+        "value": "You must add at least one attribute to sort the insight. You can also adjust the position of items in the Metrics section to change their position in the visualization.",
+        "comment": "Explains why sort button is disabled. Shown as tooltip",
+        "limit": 0
+    },
+    "sorting.disabled.explanation.measure._metric|visualization": {
         "value": "You must add at least one attribute to sort the visualization. You can also adjust the position of items in the Metrics section to change their position in the visualization.",
         "comment": "Explains why sort button is disabled. Shown as tooltip",
         "limit": 0

--- a/libs/sdk-ui/src/base/localization/TranslationsCustomizationProvider/tests/TranslationsCustomizationProvider.test.tsx
+++ b/libs/sdk-ui/src/base/localization/TranslationsCustomizationProvider/tests/TranslationsCustomizationProvider.test.tsx
@@ -1,4 +1,4 @@
-// (C) 2020-2022 GoodData Corporation
+// (C) 2020-2024 GoodData Corporation
 import React from "react";
 import { render, screen, waitFor } from "@testing-library/react";
 import { recordedBackend } from "@gooddata/sdk-backend-mockingbird";
@@ -7,22 +7,24 @@ import { describe, expect, it } from "vitest";
 import { TranslationsCustomizationProvider } from "../TranslationsCustomizationProvider.js";
 
 const workspace = "testWorkspace";
-const getBackend = (enableInsightToReport = true) =>
+const getBackend = (keepInsightName, enableInsightToReport) =>
     recordedBackend(ReferenceRecordings.Recordings, {
         globalSettings: {
+            keepInsightName,
             enableInsightToReport,
         },
     });
 const messages = {
     "translatedString|insight": "Insight",
     "translatedString|report": "Report",
+    "translatedString|visualization": "Visualization",
 };
 
 describe("TranslationsCustomizationProvider", () => {
     it("should prepare the translations so there is always used `Insight` when `enableInsightToReport` feature flag is set to false as is by default", async () => {
         render(
             <TranslationsCustomizationProvider
-                backend={getBackend(false)}
+                backend={getBackend(true, false)}
                 workspace={workspace}
                 render={(translations) => <div>{translations.translatedString}</div>}
                 translations={messages}
@@ -37,7 +39,7 @@ describe("TranslationsCustomizationProvider", () => {
     it("should prepare the translations so there is always used `Report` when `enableInsightToReport` feature flag is set to true", async () => {
         render(
             <TranslationsCustomizationProvider
-                backend={getBackend()}
+                backend={getBackend(true, true)}
                 workspace={workspace}
                 render={(translations) => <div>{translations.translatedString}</div>}
                 translations={messages}
@@ -46,6 +48,21 @@ describe("TranslationsCustomizationProvider", () => {
         await waitFor(() => {
             expect(screen.queryByText("Insight")).not.toBeInTheDocument();
             expect(screen.queryByText("Report")).toBeInTheDocument();
+        });
+    });
+
+    it("should prepare the translations so there is always used `Visualization` when `keepInsightName` feature flag is set to false", async () => {
+        render(
+            <TranslationsCustomizationProvider
+                backend={getBackend(false, false)}
+                workspace={workspace}
+                render={(translations) => <div>{translations.translatedString}</div>}
+                translations={messages}
+            />,
+        );
+        await waitFor(() => {
+            expect(screen.queryByText("Visualization")).toBeInTheDocument();
+            expect(screen.queryByText("Report")).not.toBeInTheDocument();
         });
     });
 });

--- a/libs/sdk-ui/src/base/localization/TranslationsCustomizationProvider/tests/__snapshots__/utils.test.ts.snap
+++ b/libs/sdk-ui/src/base/localization/TranslationsCustomizationProvider/tests/__snapshots__/utils.test.ts.snap
@@ -2,7 +2,6 @@
 
 exports[`pickCorrectInsightWording > should return translations with insight when enableInsightToReport is set to false 1`] = `
 {
-  "mock.translation": "Insight",
   "mock.translation|insight": "Insight",
   "mock.translation|report": "Report",
 }

--- a/libs/sdk-ui/src/base/localization/bundles/en-US.json
+++ b/libs/sdk-ui/src/base/localization/bundles/en-US.json
@@ -135,11 +135,21 @@
         "limit": 0
     },
     "visualizations.totals.dropdown.tooltip.nat.disabled.mvf._measure|insight": {
-        "value": "Rollup (Total) aggregation is not available when filtering the visualization by measure value. To use Rollup (Total), remove all measure value filters from the filter bar.",
+        "value": "Rollup (Total) aggregation is not available when filtering the insight by measure value. To use Rollup (Total), remove all measure value filters from the filter bar.",
         "comment": "The tooltip that is shown in pivot's table totals menu when rollup (native) total is disabled because measure value filters are configured for the pivot.",
         "limit": 0
     },
     "visualizations.totals.dropdown.tooltip.nat.disabled.mvf._metric|insight": {
+        "value": "Rollup (Total) aggregation is not available when filtering the insight by metric value. To use Rollup (Total), remove all metric value filters from the filter bar.",
+        "comment": "The tooltip that is shown in pivot's table totals menu when rollup (native) total is disabled because metric value filters are configured for the pivot.",
+        "limit": 0
+    },
+    "visualizations.totals.dropdown.tooltip.nat.disabled.mvf._measure|visualization": {
+        "value": "Rollup (Total) aggregation is not available when filtering the visualization by measure value. To use Rollup (Total), remove all measure value filters from the filter bar.",
+        "comment": "The tooltip that is shown in pivot's table totals menu when rollup (native) total is disabled because measure value filters are configured for the pivot.",
+        "limit": 0
+    },
+    "visualizations.totals.dropdown.tooltip.nat.disabled.mvf._metric|visualization": {
         "value": "Rollup (Total) aggregation is not available when filtering the visualization by metric value. To use Rollup (Total), remove all metric value filters from the filter bar.",
         "comment": "The tooltip that is shown in pivot's table totals menu when rollup (native) total is disabled because metric value filters are configured for the pivot.",
         "limit": 0
@@ -157,6 +167,11 @@
         "translate": false
     },
     "visualizations.totals.dropdown.tooltip.nat.disabled.ranking|insight": {
+        "value": "Rollup (Total) aggregation is not available when filtering the insight by ranking filter. To use Rollup (Total), remove ranking filter from the filter bar.",
+        "comment": "The tooltip that is shown in pivot's table totals menu when rollup (native) total is disabled because ranking filters are configured for the pivot.",
+        "limit": 0
+    },
+    "visualizations.totals.dropdown.tooltip.nat.disabled.ranking|visualization": {
         "value": "Rollup (Total) aggregation is not available when filtering the visualization by ranking filter. To use Rollup (Total), remove ranking filter from the filter bar.",
         "comment": "The tooltip that is shown in pivot's table totals menu when rollup (native) total is disabled because ranking filters are configured for the pivot.",
         "limit": 0
@@ -263,6 +278,11 @@
         "limit": 0
     },
     "visualization.ErrorMessageGeneric|insight": {
+        "value": "Sorry, we can't display this insight",
+        "comment": "",
+        "limit": 0
+    },
+    "visualization.ErrorMessageGeneric|visualization": {
         "value": "Sorry, we can't display this visualization",
         "comment": "",
         "limit": 0
@@ -309,6 +329,11 @@
         "limit": 0
     },
     "visualization.ErrorDescriptionUnauthorized|insight": {
+        "value": "Sorry you don't have access to this insight. Login or ask your administrator to grant you permissions.",
+        "comment": "",
+        "limit": 0
+    },
+    "visualization.ErrorDescriptionUnauthorized|visualization": {
         "value": "Sorry you don't have access to this visualization. Login or ask your administrator to grant you permissions.",
         "comment": "",
         "limit": 0
@@ -320,6 +345,11 @@
         "translate": false
     },
     "visualization.ErrorMessageNotFound|insight": {
+        "value": "Sorry, we can't find this insight",
+        "comment": "",
+        "limit": 0
+    },
+    "visualization.ErrorMessageNotFound|visualization": {
         "value": "Sorry, we can't find this visualization",
         "comment": "",
         "limit": 0
@@ -331,6 +361,11 @@
         "translate": false
     },
     "visualization.ErrorDescriptionNotFound|insight": {
+        "value": "The insight with this URL does not exist.",
+        "comment": "",
+        "limit": 0
+    },
+    "visualization.ErrorDescriptionNotFound|visualization": {
         "value": "The visualization with this URL does not exist.",
         "comment": "",
         "limit": 0
@@ -1387,6 +1422,11 @@
         "limit": 0
     },
     "rankingFilter.allRecords.tooltip|insight": {
+        "value": "Apply the filter to all attributes in the insight.",
+        "comment": "Explanation of 'All' option.",
+        "limit": 0
+    },
+    "rankingFilter.allRecords.tooltip|visualization": {
         "value": "Apply the filter to all attributes in the visualization.",
         "comment": "Explanation of 'All' option.",
         "limit": 0
@@ -1398,6 +1438,11 @@
         "translate": false
     },
     "rankingFilter.attributeDropdown.oneAttributeTooltip|insight": {
+        "value": "The insight is sliced only by one attribute. The filter will apply to all its values.",
+        "comment": "Tooltip when no options are available for attribute dropdown.",
+        "limit": 0
+    },
+    "rankingFilter.attributeDropdown.oneAttributeTooltip|visualization": {
         "value": "The visualization is sliced only by one attribute. The filter will apply to all its values.",
         "comment": "Tooltip when no options are available for attribute dropdown.",
         "limit": 0
@@ -1454,6 +1499,11 @@
         "limit": 0
     },
     "rankingFilter.valueTooltip|insight": {
+        "value": "If multiple items have the same value, the filter shows all items with this value. The insight may then display more items than the number set.",
+        "comment": "Tooltip with explanation of why ranking filter can return more rows than the number user entered in the filter.",
+        "limit": 0
+    },
+    "rankingFilter.valueTooltip|visualization": {
         "value": "If multiple items have the same value, the filter shows all items with this value. The visualization may then display more items than the number set.",
         "comment": "Tooltip with explanation of why ranking filter can return more rows than the number user entered in the filter.",
         "limit": 0
@@ -1750,6 +1800,11 @@
         "limit": 0
     },
     "sorting.dropdown.header|insight": {
+        "value": "Sort insight",
+        "comment": "The title of sorting dropdown where you can choose which sort options you want to use. For example sort by attribute A1.",
+        "limit": 0
+    },
+    "sorting.dropdown.header|visualization": {
         "value": "Sort visualization",
         "comment": "The title of sorting dropdown where you can choose which sort options you want to use. For example sort by attribute A1.",
         "limit": 0
@@ -1861,6 +1916,11 @@
         "limit": 0
     },
     "embedInsightDialog.code.options.include.config.info|insight": {
+        "value": "Include the insight configuration of colors, axes, legend, and canvas if available.",
+        "comment": "Tool tip that explain Include configuration",
+        "limit": 0
+    },
+    "embedInsightDialog.code.options.include.config.info|visualization": {
         "value": "Include the visualization configuration of colors, axes, legend, and canvas if available.",
         "comment": "Tool tip that explain Include configuration",
         "limit": 0
@@ -1882,6 +1942,11 @@
         "limit": 0
     },
     "embedInsightDialog.headLine.embedInsight|insight": {
+        "value": "Embed insight",
+        "comment": "",
+        "limit": 0
+    },
+    "embedInsightDialog.headLine.embedInsight|visualization": {
         "value": "Embed visualization",
         "comment": "",
         "limit": 0
@@ -1893,6 +1958,11 @@
         "translate": false
     },
     "embedInsightDialog.componentType.byReference.tooltip|insight": {
+        "value": "Embed as a reference to a saved insight in a generic GD.UI react component. Any future changes to the insight (such as insight type, metrics, attributes) will be reflected in the embedded version.",
+        "comment": "Tooltip that explain what Embed as a live insight means",
+        "limit": 0
+    },
+    "embedInsightDialog.componentType.byReference.tooltip|visualization": {
         "value": "Embed as a reference to a saved visualization in a generic GD.UI react component. Any future changes to the visualization (such as visualization type, metrics, attributes) will be reflected in the embedded version.",
         "comment": "Tooltip that explain what Embed as a live visualization means",
         "limit": 0
@@ -1904,6 +1974,11 @@
         "translate": false
     },
     "embedInsightDialog.componentType.byDefinition.tooltip|insight": {
+        "value": "Embed as an insight definition in a specific GD.UI react component based on the currently selected insight type. No future changes to the insight (such as insight type, metrics, attributes) made in this application will be reflected in the embedded version.",
+        "comment": "Tooltip that explain what Embed as a a permanent report",
+        "limit": 0
+    },
+    "embedInsightDialog.componentType.byDefinition.tooltip|visualization": {
         "value": "Embed as an visualization definition in a specific GD.UI react component based on the currently selected visualization type. No future changes to the visualization (such as visualization type, metrics, attributes) made in this application will be reflected in the embedded version.",
         "comment": "Tooltip that explain what Embed as a a permanent report",
         "limit": 0
@@ -1950,7 +2025,12 @@
         "limit": 0
     },
     "embedInsightDialog.emptyInsight.byReference|insight": {
-        "value": "Code snipped will be displayed here once you <a>save the visualization</a>.",
+        "value": "Code snipped will be displayed here once you <a>save the insight</a>.",
+        "comment": "The disabled message for code area. Do not translate html tags <a>, </a>",
+        "limit": 0
+    },
+    "embedInsightDialog.emptyInsight.byReference|visualization": {
+        "value": "Code snipped will be displayed here once you <a>save the insight</a>.",
         "comment": "The disabled message for code area. Do not translate html tags <a>, </a>",
         "limit": 0
     },
@@ -1961,6 +2041,11 @@
         "translate": false
     },
     "embedInsightDialog.emptyInsight.byDefinition|insight": {
+        "value": "This insight type cannot be embedded as programmatic type component.",
+        "comment": "The disabled message for code area",
+        "limit": 0
+    },
+    "embedInsightDialog.emptyInsight.byDefinition|visualization": {
         "value": "This visualization type cannot be embedded as programmatic type component.",
         "comment": "The disabled message for code area",
         "limit": 0
@@ -2292,6 +2377,11 @@
         "limit": 0
     },
     "workspaceHierarchy.lockedInsight|insight": {
+        "value": "Only Admins can save changes to this insight.",
+        "comment": "Shown when hovering over lock indicator.",
+        "limit": 0
+    },
+    "workspaceHierarchy.lockedInsight|visualization": {
         "value": "Only Admins can save changes to this visualization.",
         "comment": "Shown when hovering over lock indicator.",
         "limit": 0
@@ -2303,6 +2393,11 @@
         "limit": 0
     },
     "workspaceHierarchy.inheritedInsight|insight": {
+        "value": "You cannot edit or delete this insight.{br}It is centrally managed and certified.",
+        "comment": "Shown when hovering over lock indicator. Dont translate html tag placeholder {br}.",
+        "limit": 0
+    },
+    "workspaceHierarchy.inheritedInsight|visualization": {
         "value": "You cannot edit or delete this visualization.{br}It is centrally managed and certified.",
         "comment": "Shown when hovering over lock indicator. Dont translate html tag placeholder {br}.",
         "limit": 0

--- a/tools/i18n-toolkit/src/data.ts
+++ b/tools/i18n-toolkit/src/data.ts
@@ -1,9 +1,10 @@
-// (C) 2021-2022 GoodData Corporation
+// (C) 2021-2024 GoodData Corporation
 
 export const DefaultLocale = "en-US.json";
 
 export const CheckInsightPipe = "|insight";
 export const CheckReportPipe = "|report";
+export const CheckVisualizationPipe = "|visualization";
 
 export const CheckMeasureSuffix = "._measure";
 export const CheckMetricSuffix = "._metric";
@@ -16,6 +17,7 @@ export type ToolkitOptions = {
     intl?: boolean;
     html?: boolean;
     insightToReport?: boolean;
+    insightToVisualization?: boolean;
     usage?: boolean;
     debug?: boolean;
 };

--- a/tools/i18n-toolkit/src/fixtures/en-US.json
+++ b/tools/i18n-toolkit/src/fixtures/en-US.json
@@ -20,6 +20,12 @@
         "limit": 0,
         "translate": false
     },
+    "text.with.insight|visualization": {
+        "value": "Test text with visualization",
+        "comment": "test",
+        "limit": 0,
+        "translate": false
+    },
     "text.with.1": {
         "value": "Test text 1 2 3",
         "comment": "test",

--- a/tools/i18n-toolkit/src/validate.ts
+++ b/tools/i18n-toolkit/src/validate.ts
@@ -1,4 +1,4 @@
-// (C) 2021-2022 GoodData Corporation
+// (C) 2021-2024 GoodData Corporation
 
 import * as path from "path";
 import { ToolkitConfigFile } from "./data.js";
@@ -11,7 +11,7 @@ import { getInsightToReportCheck } from "./validations/insightToReport.js";
 import { getUsageMessagesCheck } from "./validations/messagesUsage.js";
 
 export async function validate(cwd: string, opts: ToolkitConfigFile) {
-    const { paths = [], insightToReport } = opts;
+    const { paths = [], insightToReport, insightToVisualization } = opts;
     const localizationPaths = paths.map((pth) => path.join(cwd, pth));
 
     const localizations = getParsedLocalizations(await getLocalizationFiles(localizationPaths));
@@ -21,14 +21,18 @@ export async function validate(cwd: string, opts: ToolkitConfigFile) {
     await getStructureCheck(localizations, opts.structure || false, opts.debug);
     await getIntlMessageFormatCheck(localizationValues, opts.intl || false, opts.debug);
     await getHtmlSyntaxCheck(localizationValues, opts.html || false, opts.debug);
-    await getInsightToReportCheck(localizations, opts.insightToReport || false, opts.debug);
+    await getInsightToReportCheck(
+        localizations,
+        insightToReport || insightToVisualization || false,
+        opts.debug,
+    );
 
     const { rules, source } = opts;
     await getUsageMessagesCheck(
         cwd,
         localizations,
         opts.usage || false,
-        { source, rules, insightToReport },
+        { source, rules, insightToReport, insightToVisualization },
         opts.debug,
     );
 }

--- a/tools/i18n-toolkit/src/validations/messagesUsage.ts
+++ b/tools/i18n-toolkit/src/validations/messagesUsage.ts
@@ -1,4 +1,4 @@
-// (C) 2021-2022 GoodData Corporation
+// (C) 2021-2024 GoodData Corporation
 import { extract } from "@formatjs/cli-lib";
 import fastGlob from "fast-glob";
 import * as path from "path";
@@ -18,10 +18,12 @@ export async function getUsageMessagesCheck(
         source = "src/**/*.{ts,js,tsx,jsx}",
         rules = [],
         insightToReport,
+        insightToVisualization,
     }: {
         source: string;
         rules: ToolkitConfigFile["rules"];
         insightToReport: boolean;
+        insightToVisualization: boolean;
     },
     debug: boolean = false,
 ) {
@@ -44,6 +46,7 @@ export async function getUsageMessagesCheck(
 
     const { results, uncontrolled } = checkTranslations(defaultLocalizations, rules, extracted, {
         insightToReport,
+        insightToVisualization,
     });
     resultsInfo(cwd, results, uncontrolled, debug);
 

--- a/tools/i18n-toolkit/src/validations/test/insightToReport.test.ts
+++ b/tools/i18n-toolkit/src/validations/test/insightToReport.test.ts
@@ -1,4 +1,4 @@
-// (C) 2020-2022 GoodData Corporation
+// (C) 2020-2024 GoodData Corporation
 
 import { getInsightToReportCheck } from "../insightToReport.js";
 import { LocalesStructure } from "../../schema/localization.js";
@@ -47,7 +47,7 @@ describe("validate insight to report", () => {
                     limit: 0,
                 },
             },
-            `Some keys missing in localisation file, missing keys: ["message.id|report"]`,
+            `Some keys missing in localisation file, missing keys: ["message.id|report","message.id|visualization"]`,
         ],
         [
             "invalid localisation with report inside value and valid pipe, missing insight pipe",
@@ -73,6 +73,11 @@ describe("validate insight to report", () => {
                     comment: "This is comment",
                     limit: 0,
                 },
+                "message.id|visualization": {
+                    value: "This is message contains Visualization word.",
+                    comment: "This is comment",
+                    limit: 0,
+                },
             },
             `Translation is enable for report keys, use translate=false, invalid keys: ["message.id|report"]`,
         ],
@@ -89,6 +94,11 @@ describe("validate insight to report", () => {
                     comment: "This is comment",
                     limit: 0,
                     translate: false,
+                },
+                "message.id|visualization": {
+                    value: "This is message contains Visualization word.",
+                    comment: "This is comment",
+                    limit: 0,
                 },
             },
             null,

--- a/tools/i18n-toolkit/src/validations/usage/checkTranslations.ts
+++ b/tools/i18n-toolkit/src/validations/usage/checkTranslations.ts
@@ -1,4 +1,4 @@
-// (C) 2021-2022 GoodData Corporation
+// (C) 2021-2024 GoodData Corporation
 import groupBy from "lodash/groupBy.js";
 import difference from "lodash/difference.js";
 import intersection from "lodash/intersection.js";
@@ -12,6 +12,7 @@ import {
     Uncontrolled,
     CheckInsightPipe,
     CheckReportPipe,
+    CheckVisualizationPipe,
     CheckMeasureSuffix,
     CheckMetricSuffix,
 } from "../../data.js";
@@ -27,10 +28,13 @@ export function checkTranslations(
     localizations: Array<[string, LocalesStructure]>,
     rules: ToolkitConfigFile["rules"],
     extracted: Record<string, any>,
-    { insightToReport }: { insightToReport?: boolean },
+    {
+        insightToReport,
+        insightToVisualization,
+    }: { insightToReport?: boolean; insightToVisualization?: boolean },
 ): { results: UsageResult[]; groups: Record<string, string[]>; uncontrolled: Array<string> } {
     const { groups, ignoredRules, validateRules } = getGroupedRules(rules, extracted);
-    const keysInFiles = getTranslationKeysFromFiles(localizations, insightToReport);
+    const keysInFiles = getTranslationKeysFromFiles(localizations, insightToReport, insightToVisualization);
 
     const ignoredResults = getIgnoresResults(keysInFiles, ignoredRules, groups);
     const validResults = getValidResults(keysInFiles, validateRules, groups, ignoredResults);
@@ -122,6 +126,7 @@ function patternsAsFunction(pattern: RegExp | RegExp[] | undefined) {
 function getTranslationKeysFromFiles(
     localizations: Array<[string, LocalesStructure]>,
     insightToReport = false,
+    insightToVisualization = false,
 ): Array<[string, string[]]> {
     return localizations.map(([fileName, content]) => {
         let keys = Object.keys(content);
@@ -130,6 +135,10 @@ function getTranslationKeysFromFiles(
         if (insightToReport) {
             keys = keys.map((key) => {
                 return key.replace(CheckInsightPipe, "").replace(CheckReportPipe, "");
+            });
+        } else if (insightToVisualization) {
+            keys = keys.map((key) => {
+                return key.replace(CheckInsightPipe, "").replace(CheckVisualizationPipe, "");
             });
         }
         //remove metric and measure suffix


### PR DESCRIPTION
Should unblock 9.x row for bear.
Keeping defaults to `visualization` but overriding to `insight`
for bear backend by a custom setting set to true.

JIRA: STL-293


<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** 🙏

---

Refer to [documentation](https://github.com/gooddata/gooddata-ui-sdk/blob/master/dev_docs/continuous_integration.md) to see how to run checks and tests in the pull request. This is the list of the most used commands:

```
extended test - backstop
```

```
// Tiger platform
extended test - tiger-cypress - integrated
extended test - tiger-cypress - isolated
extended test - tiger-cypress - record
```

```
// Bear platform
extended test - cypress - integrated
extended test - cypress - isolated
extended test - cypress - record
```