### PR TITLE
fix: store proper template id to DD ignore list

### DIFF
--- a/libs/sdk-backend-tiger/src/backend/workspace/attributeHierarchies/index.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/attributeHierarchies/index.ts
@@ -1,4 +1,4 @@
-// (C) 2023 GoodData Corporation
+// (C) 2023-2024 GoodData Corporation
 import { v4 as uuid } from "uuid";
 import uniqBy from "lodash/uniqBy.js";
 import flatMap from "lodash/flatMap.js";
@@ -126,7 +126,7 @@ export class TigerAttributeHierarchiesService implements IAttributeHierarchiesSe
         return Promise.resolve([
             {
                 type: "dateHierarchyTemplate",
-                ref: idRef("default"),
+                ref: idRef("default", "dateHierarchyTemplate"),
                 id: "default",
                 uri: "/default",
                 title: "Year, quarter, month, date, hour, minute",

--- a/libs/sdk-backend-tiger/src/convertors/shared/layoutConverter.ts
+++ b/libs/sdk-backend-tiger/src/convertors/shared/layoutConverter.ts
@@ -1,4 +1,4 @@
-// (C) 2023 GoodData Corporation
+// (C) 2023-2024 GoodData Corporation
 
 import {
     IDashboardLayout,
@@ -111,7 +111,7 @@ export function getPathConverterForIgnoredAttributeHierarchiesFromBackend(
         } else {
             pathConverterPairs.push({
                 path: [...widgetPath, "ignoredDrillDownHierarchies", index, "dateHierarchyTemplate"],
-                converter: (id: string) => idRef(id, "dataSet"),
+                converter: (id: string) => idRef(id, "dateHierarchyTemplate"),
             });
         }
     });
@@ -151,6 +151,7 @@ export function getPathConverterForIgnoredAttributeHierarchiesToBackend(
         } else {
             pathConverterPairs.push({
                 path: [...widgetPath, "ignoredDrillDownHierarchies", index, "dateHierarchyTemplate"],
+                // DateHierarchyTemplate is not valid MD type yet so we can not store full objRef but just id string
                 converter: objRefToString,
             });
         }

--- a/libs/sdk-model/api/sdk-model.api.md
+++ b/libs/sdk-model/api/sdk-model.api.md
@@ -478,6 +478,15 @@ export function filterObjRef(filter: IFilter): ObjRef | undefined;
 // @internal
 export function getAttributeElementsItems(attributeElements: IAttributeElements): Array<string | null>;
 
+// @internal (undocumented)
+export const getHierarchyAttributes: (hierarchy: ICatalogAttributeHierarchy | ICatalogDateAttributeHierarchy) => ObjRef[];
+
+// @internal (undocumented)
+export const getHierarchyRef: (hierarchy: ICatalogAttributeHierarchy | ICatalogDateAttributeHierarchy) => ObjRef;
+
+// @internal (undocumented)
+export const getHierarchyTitle: (hierarchy: ICatalogAttributeHierarchy | ICatalogDateAttributeHierarchy) => string;
+
 // @alpha
 export function getSelectedElementsCount(filter: IDashboardAttributeFilter): number;
 
@@ -776,10 +785,10 @@ export interface ICatalogDateAttribute {
 
 // @internal (undocumented)
 export interface ICatalogDateAttributeHierarchy {
-    // (undocumented)
     attributes: ObjRef[];
-    // (undocumented)
     dateDatasetRef: ObjRef;
+    // (undocumented)
+    ref: ObjRef;
     // (undocumented)
     templateId: string;
     // (undocumented)
@@ -2484,6 +2493,9 @@ export function isDateFilter(obj: unknown): obj is IDateFilter;
 
 // @alpha
 export const isDateFilterGranularity: (obj: unknown) => obj is DateFilterGranularity;
+
+// @alpha
+export function isDateHierarchyReference(obj: unknown): obj is IDateHierarchyReference;
 
 // @public
 export function isDimension(obj: unknown): obj is IDimension;

--- a/libs/sdk-model/src/dashboard/drill.ts
+++ b/libs/sdk-model/src/dashboard/drill.ts
@@ -1,4 +1,4 @@
-// (C) 2020-2022 GoodData Corporation
+// (C) 2020-2024 GoodData Corporation
 import isEmpty from "lodash/isEmpty.js";
 import { ObjRef, ObjRefInScope } from "../objRef/index.js";
 
@@ -357,6 +357,14 @@ export interface IDateHierarchyReference {
  */
 export function isAttributeHierarchyReference(obj: unknown): obj is IAttributeHierarchyReference {
     return !isEmpty(obj) && (obj as IAttributeHierarchyReference).type === "attributeHierarchyReference";
+}
+
+/**
+ * Type-guard testing whether the provided object is an instance of {@link IDateHierarchyReference}.
+ * @alpha
+ */
+export function isDateHierarchyReference(obj: unknown): obj is IDateHierarchyReference {
+    return !isEmpty(obj) && (obj as IDateHierarchyReference).type === "dateHierarchyReference";
 }
 
 /**

--- a/libs/sdk-model/src/index.ts
+++ b/libs/sdk-model/src/index.ts
@@ -525,6 +525,7 @@ export {
     isDrillToInsight,
     isDrillToLegacyDashboard,
     isAttributeHierarchyReference,
+    isDateHierarchyReference,
     isCrossFiltering,
 } from "./dashboard/drill.js";
 
@@ -591,6 +592,9 @@ export {
     GroupableCatalogItem,
     catalogItemMetadataObject,
     ICatalogDateAttributeHierarchy,
+    getHierarchyRef,
+    getHierarchyTitle,
+    getHierarchyAttributes,
 } from "./ldm/catalog/index.js";
 
 export {

--- a/libs/sdk-model/src/ldm/catalog/attributeHierarchy/index.ts
+++ b/libs/sdk-model/src/ldm/catalog/attributeHierarchy/index.ts
@@ -1,4 +1,4 @@
-// (C) 2023 GoodData Corporation
+// (C) 2023-2024 GoodData Corporation
 
 import isEmpty from "lodash/isEmpty.js";
 import { IAttributeHierarchyMetadataObject } from "../../metadata/index.js";
@@ -39,8 +39,45 @@ export function isCatalogDateAttributeHierarchy(obj: unknown): obj is ICatalogDa
  */
 export interface ICatalogDateAttributeHierarchy {
     type: "dateAttributeHierarchy";
+    // hierarchy ref
+    ref: ObjRef;
+    /**
+     * Date dataset ref
+     */
     dateDatasetRef: ObjRef;
+    /**
+     * refs to attributes in hierarchy
+     */
+    attributes: ObjRef[];
     title: string;
     templateId: string;
-    attributes: ObjRef[];
 }
+
+/**
+ * @internal
+ */
+export const getHierarchyRef = (
+    hierarchy: ICatalogAttributeHierarchy | ICatalogDateAttributeHierarchy,
+): ObjRef => {
+    return isCatalogAttributeHierarchy(hierarchy) ? hierarchy.attributeHierarchy.ref : hierarchy.ref;
+};
+
+/**
+ * @internal
+ */
+export const getHierarchyTitle = (
+    hierarchy: ICatalogAttributeHierarchy | ICatalogDateAttributeHierarchy,
+): string => {
+    return isCatalogAttributeHierarchy(hierarchy) ? hierarchy.attributeHierarchy.title : hierarchy.title;
+};
+
+/**
+ * @internal
+ */
+export const getHierarchyAttributes = (
+    hierarchy: ICatalogAttributeHierarchy | ICatalogDateAttributeHierarchy,
+): ObjRef[] => {
+    return isCatalogAttributeHierarchy(hierarchy)
+        ? hierarchy.attributeHierarchy.attributes
+        : hierarchy.attributes;
+};

--- a/libs/sdk-model/src/ldm/catalog/index.ts
+++ b/libs/sdk-model/src/ldm/catalog/index.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2020 GoodData Corporation
+// (C) 2019-2024 GoodData Corporation
 import { ICatalogAttribute, isCatalogAttribute } from "./attribute/index.js";
 import { ICatalogMeasure, isCatalogMeasure } from "./measure/index.js";
 import { ICatalogFact, isCatalogFact } from "./fact/index.js";
@@ -65,4 +65,7 @@ export {
     isCatalogAttributeHierarchy,
     isCatalogDateAttributeHierarchy,
     ICatalogDateAttributeHierarchy,
+    getHierarchyRef,
+    getHierarchyTitle,
+    getHierarchyAttributes,
 } from "./attributeHierarchy/index.js";

--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -3199,7 +3199,7 @@ export interface EntitlementsState {
 }
 
 // @internal (undocumented)
-export function existBlacklistHierarchyPredicate(reference: IDrillDownReference, attributeHierarchyRef: ObjRef, attributeIdentifier?: ObjRef): boolean;
+export function existBlacklistHierarchyPredicate(reference: IDrillDownReference, attributeHierarchy: ICatalogAttributeHierarchy | ICatalogDateAttributeHierarchy, attributeIdentifier?: ObjRef): boolean;
 
 // @beta (undocumented)
 export interface ExportDashboardToPdf extends IDashboardCommand {

--- a/libs/sdk-ui-dashboard/src/model/store/catalog/catalogSelectors.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/catalog/catalogSelectors.ts
@@ -1,4 +1,4 @@
-// (C) 2021-2023 GoodData Corporation
+// (C) 2021-2024 GoodData Corporation
 import { createSelector } from "@reduxjs/toolkit";
 import flatMap from "lodash/flatMap.js";
 import {
@@ -14,7 +14,8 @@ import {
     objRefToString,
     IDateHierarchyTemplate,
     ICatalogDateAttributeHierarchy,
-    isCatalogAttributeHierarchy,
+    idRef,
+    getHierarchyAttributes,
 } from "@gooddata/sdk-model";
 
 import {
@@ -305,9 +306,7 @@ function getAttributesWithHierarchyDescendants(
     allCatalogAttributes.forEach((attribute) => {
         const attributeRef = attribute.attribute.ref;
         attributeHierarchies.forEach((hierarchy) => {
-            const attributes = isCatalogAttributeHierarchy(hierarchy)
-                ? hierarchy.attributeHierarchy.attributes
-                : hierarchy.attributes;
+            const attributes = getHierarchyAttributes(hierarchy);
             const foundAttributeIndex = attributes.findIndex((ref) => areObjRefsEqual(ref, attributeRef));
 
             if (foundAttributeIndex < 0) {
@@ -362,6 +361,12 @@ function buildDateHierarchy(
     if (!isEmpty(dateAttributesInHierarchy)) {
         return {
             type: "dateAttributeHierarchy",
+            // create ref of adhoc date hierarchy by combining date dataset id and date template id
+            // this ref should not be stored on MD server as it is not existing MD object
+            ref: idRef(
+                `${dateTemplate.id}/${objRefToString(dateDataset.dataSet.ref)}`,
+                "dateAttributeHierarchy",
+            ),
             templateId: dateTemplate.id,
             dateDatasetRef: dateDataset.dataSet.ref,
             title: dateDataset.dataSet.title,

--- a/libs/sdk-ui-dashboard/src/model/store/catalog/tests/__snapshots__/catalogSelectors.test.ts.snap
+++ b/libs/sdk-ui-dashboard/src/model/store/catalog/tests/__snapshots__/catalogSelectors.test.ts.snap
@@ -29,6 +29,10 @@ exports[`catalogSelectors > should return adhoc date hierarchies 1`] = `
       "identifier": "order_date",
       "type": "dataSet",
     },
+    "ref": {
+      "identifier": "default/order_date",
+      "type": "dateAttributeHierarchy",
+    },
     "templateId": "default",
     "title": "Order date",
     "type": "dateAttributeHierarchy",
@@ -63,6 +67,10 @@ exports[`catalogSelectors > should return adhoc date hierarchies 1`] = `
     "dateDatasetRef": {
       "identifier": "return_date",
       "type": "dataSet",
+    },
+    "ref": {
+      "identifier": "default/return_date",
+      "type": "dateAttributeHierarchy",
     },
     "templateId": "default",
     "title": "Return date",

--- a/libs/sdk-ui-dashboard/src/model/utils/attributeHierarchyUtils.ts
+++ b/libs/sdk-ui-dashboard/src/model/utils/attributeHierarchyUtils.ts
@@ -1,10 +1,14 @@
-// (C) 2023 GoodData Corporation
+// (C) 2023-2024 GoodData Corporation
 
-import isEqual from "lodash/isEqual.js";
 import {
     areObjRefsEqual,
+    ICatalogAttributeHierarchy,
+    ICatalogDateAttributeHierarchy,
     IDrillDownReference,
     isAttributeHierarchyReference,
+    isCatalogAttributeHierarchy,
+    isCatalogDateAttributeHierarchy,
+    isDateHierarchyReference,
     ObjRef,
     objRefToString,
 } from "@gooddata/sdk-model";
@@ -14,17 +18,20 @@ import {
  */
 export function existBlacklistHierarchyPredicate(
     reference: IDrillDownReference,
-    attributeHierarchyRef: ObjRef,
+    attributeHierarchy: ICatalogAttributeHierarchy | ICatalogDateAttributeHierarchy,
     attributeIdentifier?: ObjRef,
 ): boolean {
-    if (isAttributeHierarchyReference(reference)) {
+    if (isAttributeHierarchyReference(reference) && isCatalogAttributeHierarchy(attributeHierarchy)) {
         return (
-            areObjRefsEqual(reference.attributeHierarchy, attributeHierarchyRef) &&
+            areObjRefsEqual(reference.attributeHierarchy, attributeHierarchy.attributeHierarchy.ref) &&
             areObjRefsEqual(reference.attribute, attributeIdentifier)
         );
     }
-    return (
-        isEqual(objRefToString(reference.dateHierarchyTemplate), objRefToString(attributeHierarchyRef)) &&
-        areObjRefsEqual(reference.dateDatasetAttribute, attributeIdentifier)
-    );
+    if (isDateHierarchyReference(reference) && isCatalogDateAttributeHierarchy(attributeHierarchy)) {
+        return (
+            objRefToString(reference.dateHierarchyTemplate) === attributeHierarchy.templateId &&
+            areObjRefsEqual(reference.dateDatasetAttribute, attributeIdentifier)
+        );
+    }
+    return false;
 }

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/configuration/DrillTargets/AttributeHierarchyListItem.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/configuration/DrillTargets/AttributeHierarchyListItem.tsx
@@ -1,4 +1,4 @@
-// (C) 2023 GoodData Corporation
+// (C) 2023-2024 GoodData Corporation
 
 import React, { MouseEvent } from "react";
 import cx from "classnames";
@@ -10,8 +10,9 @@ import {
     ICatalogAttributeHierarchy,
     ICatalogDateAttribute,
     ICatalogDateAttributeHierarchy,
+    getHierarchyAttributes,
+    getHierarchyTitle,
     isCatalogAttribute,
-    isCatalogAttributeHierarchy,
     isCatalogDateAttributeHierarchy,
 } from "@gooddata/sdk-model";
 import {
@@ -46,9 +47,7 @@ function buildAttributeHierarchyDetailItems(
     hierarchy: ICatalogAttributeHierarchy | ICatalogDateAttributeHierarchy,
     allCatalogAttributes: ObjRefMap<ICatalogAttribute | ICatalogDateAttribute>,
 ) {
-    const attributeRefs = isCatalogAttributeHierarchy(hierarchy)
-        ? hierarchy.attributeHierarchy.attributes
-        : hierarchy.attributes;
+    const attributeRefs = getHierarchyAttributes(hierarchy);
     const items: IAttributeHierarchyDetailItem[] = [];
     attributeRefs.forEach((ref) => {
         const attribute = allCatalogAttributes.get(ref);
@@ -77,7 +76,7 @@ export const AttributeHierarchyListItem: React.FC<IAttributeHierarchyListItemPro
         props.onEdit(item);
     };
 
-    const hierarchyTitle = isCatalogAttributeHierarchy(item) ? item.attributeHierarchy.title : item.title;
+    const hierarchyTitle = getHierarchyTitle(item);
 
     const hierarchyListItemClassname = cx(
         "attribute-hierarchy-list-item s-attribute-hierarchy-list-item",

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/configuration/DrillTargets/DrillTargetAttributeHierarchyItem.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/configuration/DrillTargets/DrillTargetAttributeHierarchyItem.tsx
@@ -1,8 +1,9 @@
-// (C) 2023 GoodData Corporation
+// (C) 2023-2024 GoodData Corporation
 import React from "react";
 import isEmpty from "lodash/isEmpty.js";
 import {
     areObjRefsEqual,
+    getHierarchyAttributes,
     ICatalogAttributeHierarchy,
     ICatalogDateAttributeHierarchy,
     isCatalogAttributeHierarchy,
@@ -47,9 +48,7 @@ const DrillTargetAttributeHierarchyItem: React.FC<IDrillTargetDashboardItemProps
     );
 
     const existInHierarchies = catalogAttributeHierarchies.filter((hierarchy) => {
-        const attributesRef = isCatalogAttributeHierarchy(hierarchy)
-            ? hierarchy.attributeHierarchy.attributes
-            : hierarchy.attributes;
+        const attributesRef = getHierarchyAttributes(hierarchy);
         return attributesRef.some((ref) =>
             areObjRefsEqual(ref, attributeDescriptor?.attributeHeader.formOf.ref),
         );

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/configuration/DrillTargets/DrillTargets.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/configuration/DrillTargets/DrillTargets.tsx
@@ -2,6 +2,7 @@
 import React from "react";
 import {
     DrillOrigin,
+    getHierarchyRef,
     ICatalogAttributeHierarchy,
     ICatalogDateAttributeHierarchy,
     idRef,
@@ -11,7 +12,6 @@ import {
     IDrillToInsight,
     IInsight,
     InsightDrillDefinition,
-    isCatalogAttributeHierarchy,
 } from "@gooddata/sdk-model";
 import {
     DRILL_TARGET_TYPE,
@@ -44,9 +44,7 @@ export const DrillTargets: React.FunctionComponent<IDrillTargetsProps> = (props)
     const onDrillDownTargetSelect = (
         targetItem: ICatalogAttributeHierarchy | ICatalogDateAttributeHierarchy,
     ) => {
-        const hierarchyRef = isCatalogAttributeHierarchy(targetItem)
-            ? targetItem.attributeHierarchy.ref
-            : targetItem.dateDatasetRef;
+        const hierarchyRef = getHierarchyRef(targetItem);
 
         const drillDownItem: IDrillDownAttributeHierarchyDefinition = {
             attributeHierarchyRef: (item as IDrillDownAttributeHierarchyConfig).attributeHierarchyRef,

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/configuration/InsightDrillConfigPanel/useInsightDrillConfigPanel.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/configuration/InsightDrillConfigPanel/useInsightDrillConfigPanel.ts
@@ -5,8 +5,14 @@ import { invariant } from "ts-invariant";
 import { useToastMessage } from "@gooddata/sdk-ui-kit";
 import { IAvailableDrillTargets } from "@gooddata/sdk-ui";
 import {
+    areObjRefsEqual,
+    getHierarchyRef,
+    ICatalogAttributeHierarchy,
+    ICatalogDateAttributeHierarchy,
+    idRef,
     IDrillDownReference,
     InsightDrillDefinition,
+    isCatalogDateAttributeHierarchy,
     isInsightWidget,
     localIdRef,
     ObjRef,
@@ -28,6 +34,7 @@ import {
     addDrillDownForInsightWidget,
     modifyDrillDownForInsightWidget,
     selectSupportsAttributeHierarchies,
+    selectAllCatalogAttributeHierarchies,
 } from "../../../../../model/index.js";
 import { getGlobalDrillDownMappedConfigForWidget, getMappedConfigForWidget } from "./drillConfigMapper.js";
 import {
@@ -142,6 +149,8 @@ export const useInsightDrillConfigPanel = (props: IUseDrillConfigPanelProps) => 
     const { enableKDZooming } = settings;
     const availableDrillTargets = configItems?.availableDrillTargets;
 
+    const attributeHierarchies = useDashboardSelector(selectAllCatalogAttributeHierarchies);
+
     const drillItems = useMemo(() => {
         return availableDrillTargets
             ? getMappedConfigForWidget(
@@ -192,7 +201,7 @@ export const useInsightDrillConfigPanel = (props: IUseDrillConfigPanelProps) => 
             const isNew = isItemNew(changedItem);
             if (!isDrillDownToAttributeHierarchyDefinition(drill)) {
                 const blacklistHierarchiesToUpdate = isDrillDownToAttributeHierarchyConfig(changedItem)
-                    ? buildBlacklistHierarchies(changedItem)
+                    ? buildBlacklistHierarchies(changedItem, attributeHierarchies)
                     : [];
 
                 dispatch(modifyDrillsForInsightWidget(widgetRef, [drill], blacklistHierarchiesToUpdate));
@@ -214,7 +223,10 @@ export const useInsightDrillConfigPanel = (props: IUseDrillConfigPanelProps) => 
                             widgetRef,
                             attributeDescriptor!.attributeHeader.formOf.ref,
                             (changedItem as IDrillDownAttributeHierarchyConfig).attributeHierarchyRef,
-                            buildBlacklistHierarchies(drill as IDrillDownAttributeHierarchyDefinition),
+                            buildBlacklistHierarchies(
+                                drill as IDrillDownAttributeHierarchyDefinition,
+                                attributeHierarchies,
+                            ),
                         ),
                     );
                 } else {
@@ -232,24 +244,32 @@ export const useInsightDrillConfigPanel = (props: IUseDrillConfigPanelProps) => 
             }
             addSuccess(isNew ? messages.added : messages.modified, { duration: 3000 });
         },
-        [widgetRef, completeItem, addSuccess, isItemNew, dispatch],
+        [
+            widgetRef,
+            completeItem,
+            addSuccess,
+            isItemNew,
+            dispatch,
+            attributeHierarchies,
+            deleteIncompleteItem,
+        ],
     );
 
     const onDeleteItem = useCallback(
         (item: IDrillConfigItem) => {
             if (item.complete) {
-                item.drillTargetType === DRILL_TARGET_TYPE.DRILL_DOWN
+                isDrillDownToAttributeHierarchyConfig(item)
                     ? dispatch(
                           removeDrillDownForInsightWidget(
                               widgetRef,
-                              buildBlacklistHierarchies(item as IDrillDownAttributeHierarchyConfig),
+                              buildBlacklistHierarchies(item, attributeHierarchies),
                           ),
                       )
                     : dispatch(removeDrillsForInsightWidget(widgetRef, [localIdRef(item.localIdentifier!)]));
             }
             deleteIncompleteItem(item);
         },
-        [widgetRef, dispatch, deleteIncompleteItem],
+        [widgetRef, dispatch, deleteIncompleteItem, attributeHierarchies],
     );
 
     return {
@@ -269,6 +289,7 @@ export const useInsightDrillConfigPanel = (props: IUseDrillConfigPanelProps) => 
 
 export function buildBlacklistHierarchies(
     item: IDrillDownAttributeHierarchyDefinition | IDrillDownAttributeHierarchyConfig,
+    attributeHierarchies: (ICatalogAttributeHierarchy | ICatalogDateAttributeHierarchy)[],
 ): IDrillDownReference[] {
     const attributeDescriptor = item.attributes.find(
         (attr) => attr.attributeHeader.localIdentifier === item.originLocalIdentifier,
@@ -278,10 +299,14 @@ export function buildBlacklistHierarchies(
     }
     const isDateAttribute = !!attributeDescriptor.attributeHeader.granularity;
     if (isDateAttribute) {
+        const dateHierarchy = attributeHierarchies
+            .filter(isCatalogDateAttributeHierarchy)
+            .find((hierarchy) => areObjRefsEqual(getHierarchyRef(hierarchy), item.attributeHierarchyRef));
         return [
             {
                 type: "dateHierarchyReference",
-                dateHierarchyTemplate: item.attributeHierarchyRef,
+                // dateHierarchyTemplate is ObjRef but templateId is string
+                dateHierarchyTemplate: idRef(dateHierarchy!.templateId, "dateHierarchyTemplate"),
                 dateDatasetAttribute: attributeDescriptor.attributeHeader.formOf.ref,
             },
         ];


### PR DESCRIPTION
When date attribute based hierarchy
is added to ignore list we need to store
correct hierarchy template id
DateHierarchyTemplate is not valid MD type yet
so we can not store full objRef but just id string JIRA: LX-145

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** 🙏

---

Refer to [documentation](https://github.com/gooddata/gooddata-ui-sdk/blob/master/dev_docs/continuous_integration.md) to see how to run checks and tests in the pull request. This is the list of the most used commands:

```
extended test - backstop
```

```
// Tiger platform
extended test - tiger-cypress - integrated
extended test - tiger-cypress - isolated
extended test - tiger-cypress - record
```

```
// Bear platform
extended test - cypress - integrated
extended test - cypress - isolated
extended test - cypress - record
```
