### PR TITLE
fix: remove bear docs after it was previously re-added

### DIFF
--- a/docs/content/en/latest/learn/visualize_data/export_catalog.md
+++ b/docs/content/en/latest/learn/visualize_data/export_catalog.md
@@ -68,7 +68,6 @@ This is how it works:
                 "hostname": "https://your.gooddata.hostname.com",
                 "workspaceId": "your_gooddata_workspaceid",
                 "catalogOutput": "desired_file_name.ts|js",
-                "backend": "tiger"
             },
             ...
         }
@@ -80,13 +79,10 @@ The hostname has to include the protocol (`http://` / `https://`), otherwise you
 
 {{% /alert %}}
 
-2.  It is not possible to specify credentials (`token`, `username` and `password` parameters) in `package.json` file, as it is typically saved in VCS (e.g. Git). Instead, credentials can be specified through environmental variables. We also load `.env` file if it's present in the same folder.
+2.  It is not possible to specify api token in `package.json` file, as it is typically saved in VCS (e.g. Git). Instead, credentials can be specified through environmental variables. We also load `.env` file if it's present in the same folder.
 
     ```ini
     TIGER_API_TOKEN=<your_token_for_the_tiger_server>
-    # or
-    GDC_USERNAME=<your_username>
-    GDC_PASSWORD=<your_password>
     ```
 
     **NOTE:** Make sure to never commit `.env` file to your version control system.


### PR DESCRIPTION
Originally removed in #4837 but for some reason
it was re-added in #4853. Removing again.

JIRA: STL-382


<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** 🙏

---

Refer to [documentation](https://github.com/gooddata/gooddata-ui-sdk/blob/master/dev_docs/continuous_integration.md) to see how to run checks and tests in the pull request. This is the list of the most used commands:

```
extended test - backstop
```

```
extended test - tiger-cypress - integrated
extended test - tiger-cypress - isolated
extended test - tiger-cypress - record
```