### PR TITLE
feat: export definitions service

### DIFF
--- a/common/changes/@gooddata/sdk-ui-all/stl-270-export-definitions-service_2024-04-09-12-14.json
+++ b/common/changes/@gooddata/sdk-ui-all/stl-270-export-definitions-service_2024-04-09-12-14.json
@@ -1,0 +1,10 @@
+{
+    "changes": [
+        {
+            "packageName": "@gooddata/sdk-ui-all",
+            "comment": "Added a workspace service for working with export definitions metadata objects",
+            "type": "none"
+        }
+    ],
+    "packageName": "@gooddata/sdk-ui-all"
+}

--- a/libs/api-client-tiger/api/api-client-tiger.api.md
+++ b/libs/api-client-tiger/api/api-client-tiger.api.md
@@ -11267,7 +11267,7 @@ export type MetadataGetEntitiesOptions = {
 export type MetadataGetEntitiesParams = MetadataGetEntitiesWorkspaceParams | MetadataGetEntitiesUserParams | MetadataGetEntitiesThemeParams | MetadataGetEntitiesColorPaletteParams;
 
 // @internal
-export type MetadataGetEntitiesResult = JsonApiVisualizationObjectOutList | JsonApiAnalyticalDashboardOutList | JsonApiDashboardPluginOutList | JsonApiDatasetOutList | JsonApiAttributeOutList | JsonApiLabelOutList | JsonApiMetricOutList | JsonApiFactOutList | JsonApiFilterContextOutList | JsonApiApiTokenOutList | JsonApiThemeOutList | JsonApiColorPaletteOutList;
+export type MetadataGetEntitiesResult = JsonApiVisualizationObjectOutList | JsonApiAnalyticalDashboardOutList | JsonApiDashboardPluginOutList | JsonApiDatasetOutList | JsonApiAttributeOutList | JsonApiLabelOutList | JsonApiMetricOutList | JsonApiFactOutList | JsonApiFilterContextOutList | JsonApiApiTokenOutList | JsonApiThemeOutList | JsonApiColorPaletteOutList | JsonApiExportDefinitionOutList;
 
 // @internal
 export type MetadataGetEntitiesThemeParams = {
@@ -11837,7 +11837,7 @@ export interface OrganizationEntityAPIsApiUpdateEntityOrganizationsRequest {
 export type OrganizationGetEntitiesFn<T extends OrganizationGetEntitiesResult, P extends OrganizationGetEntitiesParams> = (params: P, options: AxiosRequestConfig) => AxiosPromise<T>;
 
 // @internal
-export type OrganizationGetEntitiesParams = EntitiesApiGetAllEntitiesAttributesRequest | EntitiesApiGetAllEntitiesFactsRequest | EntitiesApiGetAllEntitiesAnalyticalDashboardsRequest | EntitiesApiGetAllEntitiesDashboardPluginsRequest | EntitiesApiGetAllEntitiesVisualizationObjectsRequest | EntitiesApiGetAllEntitiesMetricsRequest | EntitiesApiGetAllEntitiesWorkspacesRequest;
+export type OrganizationGetEntitiesParams = EntitiesApiGetAllEntitiesAttributesRequest | EntitiesApiGetAllEntitiesFactsRequest | EntitiesApiGetAllEntitiesAnalyticalDashboardsRequest | EntitiesApiGetAllEntitiesDashboardPluginsRequest | EntitiesApiGetAllEntitiesVisualizationObjectsRequest | EntitiesApiGetAllEntitiesMetricsRequest | EntitiesApiGetAllEntitiesWorkspacesRequest | EntitiesApiGetAllEntitiesExportDefinitionsRequest;
 
 // @internal
 export type OrganizationGetEntitiesResult = JsonApiDataSourceIdentifierOutList | OrganizationGetEntitiesSupportingIncludedResult;

--- a/libs/api-client-tiger/src/metadataUtilities.ts
+++ b/libs/api-client-tiger/src/metadataUtilities.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2022 GoodData Corporation
+// (C) 2019-2024 GoodData Corporation
 
 import { AxiosPromise } from "axios";
 import flatMap from "lodash/flatMap.js";
@@ -19,6 +19,7 @@ import {
     JsonApiThemeOutList,
     JsonApiColorPaletteOutList,
     JsonApiVisualizationObjectOutList,
+    JsonApiExportDefinitionOutList,
 } from "./generated/metadata-json-api/index.js";
 
 const DefaultPageSize = 250;
@@ -118,7 +119,8 @@ export type MetadataGetEntitiesResult =
     | JsonApiFilterContextOutList
     | JsonApiApiTokenOutList
     | JsonApiThemeOutList
-    | JsonApiColorPaletteOutList;
+    | JsonApiColorPaletteOutList
+    | JsonApiExportDefinitionOutList;
 
 /**
  * All API client getEntities* functions follow this signature.

--- a/libs/api-client-tiger/src/organizationUtilities.ts
+++ b/libs/api-client-tiger/src/organizationUtilities.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2022 GoodData Corporation
+// (C) 2019-2024 GoodData Corporation
 
 import { AxiosPromise, AxiosRequestConfig } from "axios";
 import flatMap from "lodash/flatMap.js";
@@ -18,6 +18,7 @@ import {
     EntitiesApiGetAllEntitiesDashboardPluginsRequest,
     EntitiesApiGetAllEntitiesVisualizationObjectsRequest,
     EntitiesApiGetAllEntitiesAnalyticalDashboardsRequest,
+    EntitiesApiGetAllEntitiesExportDefinitionsRequest,
 } from "./generated/metadata-json-api/index.js";
 
 const DefaultPageSize = 250;
@@ -56,7 +57,8 @@ export type OrganizationGetEntitiesParams =
     | EntitiesApiGetAllEntitiesDashboardPluginsRequest
     | EntitiesApiGetAllEntitiesVisualizationObjectsRequest
     | EntitiesApiGetAllEntitiesMetricsRequest
-    | EntitiesApiGetAllEntitiesWorkspacesRequest;
+    | EntitiesApiGetAllEntitiesWorkspacesRequest
+    | EntitiesApiGetAllEntitiesExportDefinitionsRequest;
 
 /**
  * All API client getEntities* functions follow this signature.

--- a/libs/sdk-backend-base/src/customBackend/workspace.ts
+++ b/libs/sdk-backend-base/src/customBackend/workspace.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2021 GoodData Corporation
+// (C) 2019-2024 GoodData Corporation
 
 import {
     IAnalyticalWorkspace,
@@ -20,6 +20,7 @@ import {
     IWorkspaceUserGroupsQuery,
     IWorkspaceAccessControlService,
     IAttributeHierarchiesService,
+    IWorkspaceExportDefinitionsService,
 } from "@gooddata/sdk-backend-spi";
 import { CustomExecutionFactory } from "./execution.js";
 import { CustomBackendConfig, CustomBackendState } from "./config.js";
@@ -114,5 +115,8 @@ export class CustomWorkspace implements IAnalyticalWorkspace {
 
     public attributeHierarchies(): IAttributeHierarchiesService {
         throw new NotSupported("attribute hierarchy is not supported");
+    }
+    public exportDefinitions(): IWorkspaceExportDefinitionsService {
+        throw new NotSupported("export definitions are not supported");
     }
 }

--- a/libs/sdk-backend-base/src/decoratedBackend/analyticalWorkspace.ts
+++ b/libs/sdk-backend-base/src/decoratedBackend/analyticalWorkspace.ts
@@ -18,6 +18,7 @@ import {
     IWorkspaceUserGroupsQuery,
     IWorkspaceAccessControlService,
     IAttributeHierarchiesService,
+    IWorkspaceExportDefinitionsService,
 } from "@gooddata/sdk-backend-spi";
 import { DecoratorFactories } from "./types.js";
 
@@ -132,5 +133,9 @@ export class AnalyticalWorkspaceDecorator implements IAnalyticalWorkspace {
 
     public attributeHierarchies(): IAttributeHierarchiesService {
         return this.decorated.attributeHierarchies();
+    }
+
+    public exportDefinitions(): IWorkspaceExportDefinitionsService {
+        return this.decorated.exportDefinitions();
     }
 }

--- a/libs/sdk-backend-base/src/dummyBackend/index.ts
+++ b/libs/sdk-backend-base/src/dummyBackend/index.ts
@@ -60,6 +60,7 @@ import {
     IOrganizationUserService,
     IAttributeHierarchiesService,
     IDataSourcesService,
+    IWorkspaceExportDefinitionsService,
 } from "@gooddata/sdk-backend-spi";
 import {
     defFingerprint,
@@ -315,6 +316,9 @@ function dummyWorkspace(workspace: string, config: DummyBackendConfig): IAnalyti
             throw new NotSupported("not supported");
         },
         attributeHierarchies(): IAttributeHierarchiesService {
+            throw new NotSupported("not supported");
+        },
+        exportDefinitions(): IWorkspaceExportDefinitionsService {
             throw new NotSupported("not supported");
         },
     };

--- a/libs/sdk-backend-mockingbird/src/legacyRecordedBackend/index.ts
+++ b/libs/sdk-backend-mockingbird/src/legacyRecordedBackend/index.ts
@@ -44,6 +44,7 @@ import {
     IEntitlements,
     IAttributeHierarchiesService,
     IDataSourcesService,
+    IWorkspaceExportDefinitionsService,
 } from "@gooddata/sdk-backend-spi";
 import {
     defFingerprint,
@@ -247,6 +248,10 @@ function recordedWorkspace(
         },
 
         attributeHierarchies(): IAttributeHierarchiesService {
+            throw new NotSupported("not supported");
+        },
+
+        exportDefinitions(): IWorkspaceExportDefinitionsService {
             throw new NotSupported("not supported");
         },
     };

--- a/libs/sdk-backend-mockingbird/src/recordedBackend/index.ts
+++ b/libs/sdk-backend-mockingbird/src/recordedBackend/index.ts
@@ -1,74 +1,75 @@
 // (C) 2019-2024 GoodData Corporation
 
+import { InMemoryPaging } from "@gooddata/sdk-backend-base";
 import {
-    IAuthenticatedPrincipal,
     IAnalyticalBackend,
     IAnalyticalWorkspace,
+    IAttributeHierarchiesService,
+    IAuthenticatedPrincipal,
     IAuthenticationProvider,
+    IBackendCapabilities,
+    IDataSourcesService,
+    IDateFilterConfigsQuery,
+    IDateFilterConfigsQueryResult,
+    IEntitlements,
     IExecutionFactory,
-    IWorkspaceCatalogFactory,
-    IWorkspaceDatasetsService,
+    IOrganization,
+    IOrganizationPermissionService,
+    IOrganizationSettingsService,
+    IOrganizationStylingService,
+    IOrganizationUserService,
+    IOrganizations,
+    ISecuritySettingsService,
+    IUserService,
+    IUserSettingsService,
+    IUserWorkspaceSettings,
+    IWorkspaceAccessControlService,
     IWorkspaceAttributesService,
-    IWorkspaceMeasuresService,
+    IWorkspaceCatalogFactory,
+    IWorkspaceDashboardsService,
+    IWorkspaceDatasetsService,
+    IWorkspaceDescriptor,
+    IWorkspaceExportDefinitionsService,
     IWorkspaceFactsService,
+    IWorkspaceInsightsService,
+    IWorkspaceMeasuresService,
     IWorkspacePermissionsService,
-    IWorkspacesQueryFactory,
     IWorkspaceSettings,
     IWorkspaceSettingsService,
     IWorkspaceStylingService,
-    NotSupported,
-    IUserService,
-    IWorkspaceInsightsService,
-    IUserSettingsService,
-    IWorkspaceDashboardsService,
-    IUserWorkspaceSettings,
-    IWorkspaceUsersQuery,
-    IDateFilterConfigsQuery,
-    IBackendCapabilities,
-    IWorkspaceDescriptor,
-    IOrganization,
-    ISecuritySettingsService,
-    ValidationContext,
-    IOrganizations,
-    IDateFilterConfigsQueryResult,
     IWorkspaceUserGroupsQuery,
-    IWorkspaceAccessControlService,
-    IOrganizationStylingService,
-    IOrganizationSettingsService,
-    IEntitlements,
-    IOrganizationPermissionService,
-    IOrganizationUserService,
-    IAttributeHierarchiesService,
-    IDataSourcesService,
+    IWorkspaceUsersQuery,
+    IWorkspacesQueryFactory,
+    NotSupported,
+    ValidationContext,
 } from "@gooddata/sdk-backend-spi";
 import {
     IColorPalette,
-    idRef,
+    IColorPaletteDefinition,
+    IColorPaletteMetadataObject,
+    IOrganizationDescriptor,
     ISeparators,
     ITheme,
-    IWorkspacePermissions,
-    IOrganizationDescriptor,
-    IUser,
     IThemeDefinition,
     IThemeMetadataObject,
-    IColorPaletteMetadataObject,
-    IColorPaletteDefinition,
+    IUser,
+    IWorkspacePermissions,
+    idRef,
 } from "@gooddata/sdk-model";
-import { RecordedExecutionFactory } from "./execution.js";
-import { RecordedBackendConfig, RecordingIndex } from "./types.js";
-import { RecordedInsights } from "./insights.js";
-import { RecordedCatalogFactory } from "./catalog.js";
+import RecordedAttributeHierarchiesService from "./attributeHierarchies.js";
 import { RecordedAttributes } from "./attributes.js";
-import { RecordedMeasures } from "./measures.js";
-import { RecordedFacts } from "./facts.js";
+import { RecordedCatalogFactory } from "./catalog.js";
 import { RecordedDashboards } from "./dashboards.js";
-import { InMemoryPaging } from "@gooddata/sdk-backend-base";
+import { RecordedExecutionFactory } from "./execution.js";
+import { RecordedFacts } from "./facts.js";
+import { RecordedInsights } from "./insights.js";
+import { RecordedMeasures } from "./measures.js";
+import { RecordedBackendConfig, RecordingIndex } from "./types.js";
 import {
+    RecordedWorkspaceUsersQuery,
     recordedAccessControlFactory,
     recordedUserGroupsQuery,
-    RecordedWorkspaceUsersQuery,
 } from "./userManagement.js";
-import RecordedAttributeHierarchiesService from "./attributeHierarchies.js";
 
 const defaultConfig: RecordedBackendConfig = {
     hostname: "test",
@@ -262,6 +263,9 @@ function recordedWorkspace(
         },
         attributeHierarchies(): IAttributeHierarchiesService {
             return new RecordedAttributeHierarchiesService(implConfig);
+        },
+        exportDefinitions(): IWorkspaceExportDefinitionsService {
+            throw new NotSupported("not supported");
         },
     };
 }

--- a/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
+++ b/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
@@ -49,6 +49,8 @@ import { IEntitlementDescriptor } from '@gooddata/sdk-model';
 import { IExecutionConfig } from '@gooddata/sdk-model';
 import { IExecutionDefinition } from '@gooddata/sdk-model';
 import { IExistingDashboard } from '@gooddata/sdk-model';
+import { IExportDefinition } from '@gooddata/sdk-model';
+import { IExportDefinitionBase } from '@gooddata/sdk-model';
 import { IFilter } from '@gooddata/sdk-model';
 import { IFilterContextDefinition } from '@gooddata/sdk-model';
 import { IGranularAccessGrantee } from '@gooddata/sdk-model';
@@ -155,6 +157,18 @@ export type ExplainConfig<T extends ExplainType | undefined> = {
 // @internal
 export type ExplainType = "MAQL" | "GRPC_MODEL" | "WDF" | "QT" | "QT_SVG" | "OPT_QT" | "OPT_QT_SVG" | "SQL";
 
+// @alpha
+export type ExportDefinitionOrdering = "id" | "title" | "updated";
+
+// @alpha
+export type ExportDefinitionQuerySort = ExportDefinitionQuerySortProperty | `${ExportDefinitionQuerySortProperty},${ExportDefinitionQuerySortDirection}`;
+
+// @alpha
+export type ExportDefinitionQuerySortDirection = "asc" | "desc";
+
+// @alpha
+export type ExportDefinitionQuerySortProperty = "id" | "title";
+
 // @public
 export type FilterWithResolvableElements = IAttributeFilter | IRelativeDateFilter;
 
@@ -193,6 +207,8 @@ export interface IAnalyticalWorkspace {
     datasets(): IWorkspaceDatasetsService;
     dateFilterConfigs(): IDateFilterConfigsQuery;
     execution(): IExecutionFactory;
+    // @alpha
+    exportDefinitions(): IWorkspaceExportDefinitionsService;
     facts(): IWorkspaceFactsService;
     getDescriptor(includeParentPrefixes?: boolean): Promise<IWorkspaceDescriptor>;
     getParentWorkspace(): Promise<IAnalyticalWorkspace | undefined>;
@@ -488,6 +504,30 @@ export interface IExportConfig {
     title?: string;
 }
 
+// @alpha
+export interface IExportDefinitionsQuery {
+    query(): Promise<IExportDefinitionsQueryResult>;
+    withFilter(filter: {
+        title?: string;
+    }): IExportDefinitionsQuery;
+    withPage(page: number): IExportDefinitionsQuery;
+    withSize(size: number): IExportDefinitionsQuery;
+    withSorting(sort: ExportDefinitionQuerySort[]): IExportDefinitionsQuery;
+}
+
+// @alpha
+export interface IExportDefinitionsQueryOptions {
+    author?: string;
+    limit?: number;
+    loadUserData?: boolean;
+    offset?: number;
+    orderBy?: ExportDefinitionOrdering;
+    title?: string;
+}
+
+// @alpha
+export type IExportDefinitionsQueryResult = IPagedResource<IExportDefinition>;
+
 // @public
 export interface IExportResult {
     fileName?: string;
@@ -511,6 +551,11 @@ export interface IGetDashboardOptions {
 
 // @alpha
 export interface IGetDashboardPluginOptions {
+    loadUserData?: boolean;
+}
+
+// @alpha
+export interface IGetExportDefinitionOptions {
     loadUserData?: boolean;
 }
 
@@ -996,6 +1041,16 @@ export interface IWorkspaceDescriptor {
     prefix?: string;
     // (undocumented)
     title: string;
+}
+
+// @alpha
+export interface IWorkspaceExportDefinitionsService {
+    createExportDefinition(exportDefinition: IExportDefinitionBase): Promise<IExportDefinition>;
+    deleteExportDefinition(ref: ObjRef): Promise<void>;
+    getExportDefinition(ref: ObjRef, options?: IGetExportDefinitionOptions): Promise<IExportDefinition>;
+    getExportDefinitions(options?: IExportDefinitionsQueryOptions): Promise<IExportDefinitionsQueryResult>;
+    getExportDefinitionsQuery(): IExportDefinitionsQuery;
+    updateExportDefinition(ref: ObjRef, exportDefinition: IExportDefinitionBase): Promise<IExportDefinition>;
 }
 
 // @public

--- a/libs/sdk-backend-spi/src/index.ts
+++ b/libs/sdk-backend-spi/src/index.ts
@@ -56,6 +56,18 @@ export {
 } from "./workspace/insights/index.js";
 
 export {
+    ExportDefinitionOrdering,
+    IExportDefinitionsQuery,
+    IExportDefinitionsQueryOptions,
+    IExportDefinitionsQueryResult,
+    IGetExportDefinitionOptions,
+    IWorkspaceExportDefinitionsService,
+    ExportDefinitionQuerySortDirection,
+    ExportDefinitionQuerySortProperty,
+    ExportDefinitionQuerySort,
+} from "./workspace/exportDefinitions/index.js";
+
+export {
     IElementsQueryFactory,
     IElementsQueryResult,
     IElementsQuery,

--- a/libs/sdk-backend-spi/src/workspace/exportDefinitions/index.ts
+++ b/libs/sdk-backend-spi/src/workspace/exportDefinitions/index.ts
@@ -1,0 +1,205 @@
+// (C) 2019-2024 GoodData Corporation
+
+import { ObjRef, IExportDefinition, IExportDefinitionBase } from "@gooddata/sdk-model";
+import { IPagedResource } from "../../common/paging.js";
+
+/**
+ * Service to query, update or delete exportDefinitions, and other methods related to exportDefinitions.
+ * Check IExportDefinition for more details.
+ *
+ * @alpha
+ */
+export interface IWorkspaceExportDefinitionsService {
+    /**
+     * Request exportDefinition for the given reference
+     *
+     * @param ref - exportDefinition reference
+     * @param options - specify additional options
+     * @returns promise of exportDefinition
+     */
+    getExportDefinition(ref: ObjRef, options?: IGetExportDefinitionOptions): Promise<IExportDefinition>;
+
+    /**
+     * Queries workspace exportDefinitions, using various criteria and paging settings.
+     *
+     * @param options - query options; if not specified defaults to no sorting, no filtering and 50 items per page
+     * @returns paged results, empty page with zero total count if there are no exportDefinitions stored in the workspace
+     */
+    getExportDefinitions(options?: IExportDefinitionsQueryOptions): Promise<IExportDefinitionsQueryResult>;
+
+    /**
+     * List exportDefinitions
+     *
+     * @returns methods for querying exportDefinitions
+     */
+    getExportDefinitionsQuery(): IExportDefinitionsQuery;
+
+    /**
+     * Create and save exportDefinition for the provided exportDefinition
+     *
+     * @param exportDefinition - exportDefinition to create
+     * @returns promise of created exportDefinition
+     */
+    createExportDefinition(exportDefinition: IExportDefinitionBase): Promise<IExportDefinition>;
+
+    /**
+     * Update provided exportDefinition
+     *
+     * @param ref - ref of the exportDefinition to update
+     * @param exportDefinition - exportDefinition to update
+     * @returns promise of updated exportDefinition
+     */
+    updateExportDefinition(ref: ObjRef, exportDefinition: IExportDefinitionBase): Promise<IExportDefinition>;
+
+    /**
+     * Delete exportDefinition with the given reference
+     *
+     * @param ref - ref of the exportDefinition to delete
+     * @returns promise of undefined
+     */
+    deleteExportDefinition(ref: ObjRef): Promise<void>;
+}
+
+/**
+ * Ordering options for exportDefinition query.
+ *
+ * @alpha
+ */
+export type ExportDefinitionOrdering = "id" | "title" | "updated";
+
+/**
+ * Configuration options for querying exportDefinitions
+ *
+ * @alpha
+ */
+export interface IExportDefinitionsQueryOptions {
+    /**
+     * Specify (zero-based) starting offset for the results. Default: 0
+     */
+    offset?: number;
+
+    /**
+     * Specify number of items per page. Default: 50
+     */
+    limit?: number;
+
+    /**
+     * Specify ordering of the exportDefinitions. Default: natural ordering provided by the
+     * analytical backend.
+     */
+    orderBy?: ExportDefinitionOrdering;
+
+    /**
+     * Filter exportDefinitions by their author. The value of this property is identifier of the author.
+     */
+    author?: string;
+
+    /**
+     * Filter exportDefinitions by their title
+     */
+    title?: string;
+
+    /**
+     * Specify if information about the users that created/modified the exportDefinitions should be loaded for each exportDefinition.
+     *
+     * @remarks
+     * Defaults to false.
+     */
+    loadUserData?: boolean;
+}
+
+/**
+ * Configuration options for getting a single exportDefinition.
+ *
+ * @alpha
+ */
+export interface IGetExportDefinitionOptions {
+    /**
+     * Specify if information about the users that created/modified the exportDefinition should be loaded.
+     *
+     * @remarks
+     * Defaults to false.
+     *
+     * If user is inactive or logged in user has not rights to access this information than users that created/modified is undefined.
+     */
+    loadUserData?: boolean;
+}
+
+/**
+ * Sort direction for exportDefinition query.
+ *
+ * @alpha
+ */
+export type ExportDefinitionQuerySortDirection = "asc" | "desc";
+
+/**
+ * Sort order for exportDefinition query.
+ *
+ * @alpha
+ */
+export type ExportDefinitionQuerySortProperty = "id" | "title";
+
+/**
+ * Sort criteria for exportDefinition query.
+ *
+ * @alpha
+ */
+export type ExportDefinitionQuerySort =
+    | ExportDefinitionQuerySortProperty
+    | `${ExportDefinitionQuerySortProperty},${ExportDefinitionQuerySortDirection}`;
+
+/**
+ * Service to query exportDefinitions.
+ *
+ * @alpha
+ */
+export interface IExportDefinitionsQuery {
+    /**
+     * Sets number of exportDefinitions to return per page.
+     * Default size: 50
+     *
+     * @param size - desired max number of exportDefinitions per page must be a positive number
+     * @returns exportDefinitions query
+     */
+    withSize(size: number): IExportDefinitionsQuery;
+
+    /**
+     * Sets starting page for the query. Backend WILL return no data if the page is greater than
+     * total number of pages.
+     * Default page: 0
+     *
+     * @param page - zero indexed, must be non-negative
+     * @returns exportDefinitions query
+     */
+    withPage(page: number): IExportDefinitionsQuery;
+
+    /**
+     * Sets filter for the query.
+     *
+     * @param filter - filter to apply
+     * @returns exportDefinitions query
+     */
+    withFilter(filter: { title?: string }): IExportDefinitionsQuery;
+
+    /**
+     * Sets sorting for the query.
+     *
+     * @param sort - Sorting criteria in the format: property,(asc|desc). Default sort order is ascending. Multiple sort criteria are supported.
+     * @returns exportDefinitions query
+     */
+    withSorting(sort: ExportDefinitionQuerySort[]): IExportDefinitionsQuery;
+
+    /**
+     * Starts the query.
+     *
+     * @returns promise of the first page of the results
+     */
+    query(): Promise<IExportDefinitionsQueryResult>;
+}
+
+/**
+ * Queried exportDefinitions are returned in a paged representation.
+ *
+ * @alpha
+ */
+export type IExportDefinitionsQueryResult = IPagedResource<IExportDefinition>;

--- a/libs/sdk-backend-spi/src/workspace/index.ts
+++ b/libs/sdk-backend-spi/src/workspace/index.ts
@@ -16,6 +16,7 @@ import { IWorkspaceFactsService } from "./facts/index.js";
 import { IWorkspaceAccessControlService } from "./accessControl/index.js";
 import { IWorkspaceUserGroupsQuery } from "./userGroups/index.js";
 import { IAttributeHierarchiesService } from "./attributeHierarchies/index.js";
+import { IWorkspaceExportDefinitionsService } from "./exportDefinitions/index.js";
 
 /**
  * Represents an analytical workspace hosted on a backend.
@@ -124,6 +125,12 @@ export interface IAnalyticalWorkspace {
      * @alpha
      */
     attributeHierarchies(): IAttributeHierarchiesService;
+
+    /**
+     * Returns service that operates over export definitions
+     * @alpha
+     */
+    exportDefinitions(): IWorkspaceExportDefinitionsService;
 }
 
 /**

--- a/libs/sdk-backend-tiger/api/sdk-backend-tiger.api.md
+++ b/libs/sdk-backend-tiger/api/sdk-backend-tiger.api.md
@@ -300,6 +300,7 @@ export const objectTypeToTigerIdType: {
     userGroup: TigerObjectType;
     dateHierarchyTemplate: TigerObjectType;
     dateAttributeHierarchy: TigerObjectType;
+    exportDefinition: TigerObjectType;
 };
 
 // @internal (undocumented)

--- a/libs/sdk-backend-tiger/src/backend/workspace/exportDefinitions/comparator.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/exportDefinitions/comparator.ts
@@ -1,0 +1,29 @@
+// (C) 2023-2024 GoodData Corporation
+import {
+    IExportDefinition,
+    exportDefinitionUpdated,
+    exportDefinitionCreated,
+    exportDefinitionTitle,
+} from "@gooddata/sdk-model";
+
+const exportDefinitionDate = (exportDefinition: IExportDefinition) =>
+    exportDefinitionUpdated(exportDefinition) ?? exportDefinitionCreated(exportDefinition) ?? "";
+
+const compareCaseInsensitive = (a: string, b: string) =>
+    a.localeCompare(b, undefined, { sensitivity: "base" });
+
+const compareDatesDesc = (exportDefinitionA: IExportDefinition, exportDefinitionB: IExportDefinition) =>
+    compareCaseInsensitive(exportDefinitionDate(exportDefinitionB), exportDefinitionDate(exportDefinitionA));
+
+const compareTitlesAsc = (exportDefinitionA: IExportDefinition, exportDefinitionB: IExportDefinition) =>
+    compareCaseInsensitive(
+        exportDefinitionTitle(exportDefinitionA),
+        exportDefinitionTitle(exportDefinitionB),
+    );
+
+export const exportDefinitionsListComparator = (
+    exportDefinitionA: IExportDefinition,
+    exportDefinitionB: IExportDefinition,
+) =>
+    compareDatesDesc(exportDefinitionA, exportDefinitionB) ||
+    compareTitlesAsc(exportDefinitionA, exportDefinitionB);

--- a/libs/sdk-backend-tiger/src/backend/workspace/exportDefinitions/exportDefinitionsQuery.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/exportDefinitions/exportDefinitionsQuery.ts
@@ -1,0 +1,123 @@
+// (C) 2024 GoodData Corporation
+
+import {
+    EntitiesApiGetAllEntitiesExportDefinitionsRequest,
+    MetadataUtilities,
+} from "@gooddata/api-client-tiger";
+import { ServerPaging } from "@gooddata/sdk-backend-base";
+import {
+    ExportDefinitionQuerySort,
+    ExportDefinitionQuerySortDirection,
+    ExportDefinitionQuerySortProperty,
+    IExportDefinitionsQuery,
+    IExportDefinitionsQueryResult,
+} from "@gooddata/sdk-backend-spi";
+import isNil from "lodash/isNil.js";
+import { exportDefinitionsOutListToExportDefinitions } from "../../../convertors/fromBackend/ExportDefinitionsConverter.js";
+import { TigerAuthenticatedCallGuard } from "../../../types/index.js";
+import { invariant } from "ts-invariant";
+
+export class ExportDefinitionsQuery implements IExportDefinitionsQuery {
+    private size = 50;
+    private page = 0;
+    private filter: { title?: string } = {};
+    private sort = {};
+    private allowedSortProperties: ExportDefinitionQuerySortProperty[] = ["title", "id"];
+    private allowedSortDirections: ExportDefinitionQuerySortDirection[] = ["asc", "desc"];
+    private totalCount: number | undefined = undefined;
+
+    constructor(
+        public readonly authCall: TigerAuthenticatedCallGuard,
+        private requestParameters: EntitiesApiGetAllEntitiesExportDefinitionsRequest,
+    ) {}
+
+    private setTotalCount = (value?: number) => {
+        this.totalCount = value;
+    };
+
+    private isValidSortItem = (sortItem = ""): sortItem is ExportDefinitionQuerySort => {
+        const [sortProp, optionalSortDirection, ...rest] = sortItem.split(",");
+
+        if (rest.length > 0) {
+            return false; // valid sort is either just the property or property,direction
+        }
+        if (!this.allowedSortProperties.includes(sortProp as ExportDefinitionQuerySortProperty)) {
+            return false; // invalid sort property check
+        }
+        return !(
+            optionalSortDirection &&
+            !this.allowedSortDirections.includes(optionalSortDirection as ExportDefinitionQuerySortDirection)
+        ); // invalid sort direction check
+    };
+
+    private validateQuerySort = (sort: ExportDefinitionQuerySort[]) => {
+        const isValidSort = sort.every(this.isValidSortItem);
+
+        invariant(
+            isValidSort,
+            `Invalid sort format. Use 'property' or 'property,direction' format. Allowed properties: ${this.allowedSortProperties.join(
+                ", ",
+            )}. Allowed directions: ${this.allowedSortDirections.join(", ")}.`,
+        );
+    };
+
+    withSize(size: number): IExportDefinitionsQuery {
+        this.size = size;
+        return this;
+    }
+
+    withPage(page: number): IExportDefinitionsQuery {
+        this.page = page;
+        return this;
+    }
+
+    withFilter(filter: { title?: string }): IExportDefinitionsQuery {
+        this.filter = { ...filter };
+        // We need to reset total count whenever filter changes
+        this.setTotalCount(undefined);
+        return this;
+    }
+
+    withSorting(sort: ExportDefinitionQuerySort[]): IExportDefinitionsQuery {
+        this.validateQuerySort(sort);
+        this.sort = { sort };
+        return this;
+    }
+
+    query(): Promise<IExportDefinitionsQueryResult> {
+        return ServerPaging.for(
+            async ({ limit, offset }) => {
+                /**
+                 * For backend performance reasons, we do not want to ask for paging info each time.
+                 */
+                const metaIncludeObj =
+                    this.totalCount === undefined ? { metaInclude: ["page" as const] } : {};
+
+                const filterObj = this.filter.title
+                    ? { filter: `title=containsic=${this.filter.title}` } // contains + ignore case
+                    : {};
+
+                const items = await this.authCall((client) =>
+                    client.entities.getAllEntitiesExportDefinitions({
+                        ...this.requestParameters,
+                        ...metaIncludeObj,
+                        ...filterObj,
+                        ...this.sort,
+                        size: limit,
+                        page: offset / limit,
+                    }),
+                )
+                    .then((res) => MetadataUtilities.filterValidEntities(res.data))
+                    .then((data) => {
+                        const totalCount = data.meta?.page?.totalElements;
+                        !isNil(totalCount) && this.setTotalCount(totalCount);
+                        return exportDefinitionsOutListToExportDefinitions(data);
+                    });
+
+                return { items, totalCount: this.totalCount! };
+            },
+            this.size,
+            this.page * this.size,
+        );
+    }
+}

--- a/libs/sdk-backend-tiger/src/backend/workspace/exportDefinitions/index.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/exportDefinitions/index.ts
@@ -1,0 +1,188 @@
+// (C) 2019-2024 GoodData Corporation
+import {
+    EntitiesApiGetAllEntitiesExportDefinitionsRequest,
+    jsonApiHeaders,
+    MetadataUtilities,
+    ValidateRelationsHeader,
+} from "@gooddata/api-client-tiger";
+import {
+    IExportDefinitionsQuery,
+    IExportDefinitionsQueryOptions,
+    IExportDefinitionsQueryResult,
+    IGetExportDefinitionOptions,
+    IWorkspaceExportDefinitionsService,
+    UnexpectedError,
+} from "@gooddata/sdk-backend-spi";
+import { IExportDefinition, IExportDefinitionBase, ObjRef, objRefToString } from "@gooddata/sdk-model";
+
+import { TigerAuthenticatedCallGuard } from "../../../types/index.js";
+import { objRefToIdentifier } from "../../../utils/api.js";
+
+import { InMemoryPaging } from "@gooddata/sdk-backend-base";
+import {
+    exportDefinitionOutDocumentToExportDefinition,
+    exportDefinitionOutDocumentToExportDefinitionOutWithLinks,
+    exportDefinitionOutToExportDefinition,
+    exportDefinitionToExportDefinitionInDocument,
+    exportDefinitionToExportDefinitionPostOptionalIdDocument,
+} from "../../../convertors/fromBackend/ExportDefinitionsConverter.js";
+import { ExportDefinitionsQuery } from "./exportDefinitionsQuery.js";
+import { exportDefinitionsListComparator } from "./comparator.js";
+
+export class TigerWorkspaceExportDefinitions implements IWorkspaceExportDefinitionsService {
+    constructor(private readonly authCall: TigerAuthenticatedCallGuard, public readonly workspace: string) {}
+
+    public getExportDefinitions = async (
+        options?: IExportDefinitionsQueryOptions,
+    ): Promise<IExportDefinitionsQueryResult> => {
+        const requestParameters = this.getExportDefinitionsRequestParameters(options);
+        const allExportDefinitions = await this.authCall((client) => {
+            return MetadataUtilities.getAllPagesOf(
+                client,
+                client.entities.getAllEntitiesExportDefinitions,
+                requestParameters,
+                { headers: ValidateRelationsHeader },
+            )
+                .then(MetadataUtilities.mergeEntitiesResults)
+                .then(MetadataUtilities.filterValidEntities)
+                .then((res) => {
+                    if (options?.title) {
+                        const lowercaseSearch = options.title.toLocaleLowerCase();
+
+                        return res.data
+                            .filter((ed) => {
+                                const title = ed.attributes?.title;
+
+                                return title && title.toLowerCase().indexOf(lowercaseSearch) > -1;
+                            })
+                            .map((ed) => exportDefinitionOutToExportDefinition(ed, res.included));
+                    }
+                    return res.data.map((ep) => exportDefinitionOutToExportDefinition(ep, res.included));
+                });
+        });
+
+        // Remove when API starts to support sort=modifiedBy,createdBy,insight.title
+        // (first verify that modifiedBy,createdBy behave as the code below, i.e., use createdBy if modifiedBy is
+        // not defined as it is missing for the insights that were just created and never updated, also title
+        // should be compared in case-insensitive manner)
+
+        const sanitizedOrder =
+            requestParameters.sort === undefined && allExportDefinitions.length > 0
+                ? [...allExportDefinitions].sort(exportDefinitionsListComparator)
+                : allExportDefinitions;
+
+        /*
+         * The InMemory paging here is used similarly here as in the insights service getInsights method and is only a temporary solution.
+         * TODO: replace InMemoryPaging with ServerPaging (https://gooddata.atlassian.net/browse/STL-397) once https://gooddata.atlassian.net/browse/STL-369 has been implemented for insights service.
+         */
+        return new InMemoryPaging(sanitizedOrder, options?.limit ?? 50, options?.offset ?? 0);
+    };
+
+    public getExportDefinitionsQuery = (): IExportDefinitionsQuery => {
+        return new ExportDefinitionsQuery(this.authCall, { workspaceId: this.workspace });
+    };
+
+    private getExportDefinitionsRequestParameters = (
+        options?: IExportDefinitionsQueryOptions,
+    ): EntitiesApiGetAllEntitiesExportDefinitionsRequest => {
+        const orderBy = options?.orderBy;
+        const usesOrderingByUpdated = !orderBy || orderBy === "updated";
+        const sortConfiguration = usesOrderingByUpdated ? {} : { sort: [orderBy!] }; // sort: ["modifiedAt", "createdAt"]
+        const includeUser =
+            options?.loadUserData || options?.author
+                ? { include: ["createdBy" as const, "modifiedBy" as const] }
+                : {};
+        const authorFilter = options?.author ? { filter: `createdBy.id=='${options?.author}'` } : {};
+
+        return { workspaceId: this.workspace, ...sortConfiguration, ...includeUser, ...authorFilter };
+    };
+
+    public getExportDefinition = async (
+        ref: ObjRef,
+        options: IGetExportDefinitionOptions = {},
+    ): Promise<IExportDefinition> => {
+        const id = await objRefToIdentifier(ref, this.authCall);
+        const includeUser = options?.loadUserData
+            ? { include: ["createdBy" as const, "modifiedBy" as const] }
+            : {};
+        const response = await this.authCall((client) =>
+            client.entities.getEntityExportDefinitions(
+                {
+                    objectId: id,
+                    workspaceId: this.workspace,
+                    ...includeUser,
+                },
+                {
+                    headers: jsonApiHeaders,
+                },
+            ),
+        );
+
+        if (!response.data) {
+            throw new UnexpectedError(`Export definition for ${objRefToString(ref)} not found!`);
+        }
+
+        const exportDefinition = exportDefinitionOutDocumentToExportDefinitionOutWithLinks(response.data);
+
+        return exportDefinitionOutToExportDefinition(exportDefinition, response.data.included);
+    };
+
+    public createExportDefinition = async (
+        exportDefinition: IExportDefinitionBase,
+    ): Promise<IExportDefinition> => {
+        const createResponse = await this.authCall((client) => {
+            return client.entities.createEntityExportDefinitions(
+                {
+                    workspaceId: this.workspace,
+                    jsonApiExportDefinitionPostOptionalIdDocument:
+                        exportDefinitionToExportDefinitionPostOptionalIdDocument(exportDefinition),
+                },
+                {
+                    headers: jsonApiHeaders,
+                },
+            );
+        });
+
+        const exportDefinitionData = createResponse.data;
+
+        return exportDefinitionOutDocumentToExportDefinition(exportDefinitionData);
+    };
+
+    public updateExportDefinition = async (
+        ref: ObjRef,
+        exportDefinition: IExportDefinitionBase,
+    ): Promise<IExportDefinition> => {
+        const id = await objRefToIdentifier(ref, this.authCall);
+
+        const updateResponse = await this.authCall((client) => {
+            return client.entities.updateEntityExportDefinitions(
+                {
+                    objectId: id,
+                    workspaceId: this.workspace,
+                    jsonApiExportDefinitionInDocument: exportDefinitionToExportDefinitionInDocument(
+                        exportDefinition,
+                        id,
+                    ),
+                },
+                {
+                    headers: jsonApiHeaders,
+                },
+            );
+        });
+
+        const exportDefinitionData = updateResponse.data;
+
+        return exportDefinitionOutDocumentToExportDefinition(exportDefinitionData);
+    };
+
+    public deleteExportDefinition = async (ref: ObjRef): Promise<void> => {
+        const id = await objRefToIdentifier(ref, this.authCall);
+
+        await this.authCall((client) =>
+            client.entities.deleteEntityExportDefinitions({
+                objectId: id,
+                workspaceId: this.workspace,
+            }),
+        );
+    };
+}

--- a/libs/sdk-backend-tiger/src/backend/workspace/index.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/index.ts
@@ -20,6 +20,7 @@ import {
     IWorkspaceUserGroupsQuery,
     IWorkspaceAccessControlService,
     IAttributeHierarchiesService,
+    IWorkspaceExportDefinitionsService,
 } from "@gooddata/sdk-backend-spi";
 import { TigerExecution } from "./execution/executionFactory.js";
 import { TigerWorkspaceCatalogFactory } from "./catalog/factory.js";
@@ -39,6 +40,7 @@ import { TigerWorkspaceDateFilterConfigsQuery } from "./dateFilterConfigs/index.
 import { TigerWorkspaceAccessControlService } from "./accessControl/index.js";
 import { TigerAttributeHierarchiesService } from "./attributeHierarchies/index.js";
 import { GET_OPTIMIZED_WORKSPACE_PARAMS } from "./constants.js";
+import { TigerWorkspaceExportDefinitions } from "./exportDefinitions/index.js";
 
 export class TigerWorkspace implements IAnalyticalWorkspace {
     constructor(
@@ -143,5 +145,9 @@ export class TigerWorkspace implements IAnalyticalWorkspace {
 
     public attributeHierarchies(): IAttributeHierarchiesService {
         return new TigerAttributeHierarchiesService(this.authCall, this.workspace);
+    }
+
+    public exportDefinitions(): IWorkspaceExportDefinitionsService {
+        return new TigerWorkspaceExportDefinitions(this.authCall, this.workspace);
     }
 }

--- a/libs/sdk-backend-tiger/src/convertors/fromBackend/ExportDefinitionsConverter.ts
+++ b/libs/sdk-backend-tiger/src/convertors/fromBackend/ExportDefinitionsConverter.ts
@@ -1,0 +1,110 @@
+// (C) 2020-2024 GoodData Corporation
+import {
+    JsonApiExportDefinitionInDocument,
+    JsonApiExportDefinitionOutDocument,
+    JsonApiExportDefinitionOutIncludes,
+    JsonApiExportDefinitionOutList,
+    JsonApiExportDefinitionOutWithLinks,
+    JsonApiExportDefinitionOutWithLinksTypeEnum,
+    JsonApiExportDefinitionPostOptionalIdDocument,
+    JsonApiVisualizationObjectLinkageTypeEnum,
+} from "@gooddata/api-client-tiger";
+import {
+    idRef,
+    IExportDefinition,
+    IExportDefinitionBase,
+    IExportDefinitionRequestPayload,
+} from "@gooddata/sdk-model";
+import { convertUserIdentifier } from "./UsersConverter.js";
+
+export const exportDefinitionOutToExportDefinition = (
+    exportDefinitionOut: JsonApiExportDefinitionOutWithLinks,
+    included: JsonApiExportDefinitionOutIncludes[] = [],
+): IExportDefinition => {
+    const { id, attributes, links, relationships = {} } = exportDefinitionOut;
+    const { createdBy, modifiedBy } = relationships;
+    const { title = "", description = "", tags = [], requestPayload, createdAt, modifiedAt } = attributes;
+
+    return {
+        type: "exportDefinition",
+        id,
+        uri: links!.self,
+        ref: idRef(id, "exportDefinition"),
+        title,
+        description,
+        tags,
+        requestPayload: requestPayload as IExportDefinitionRequestPayload,
+        created: createdAt,
+        updated: modifiedAt,
+        createdBy: convertUserIdentifier(createdBy, included),
+        updatedBy: convertUserIdentifier(modifiedBy, included),
+        production: true,
+        deprecated: false,
+        unlisted: false,
+    };
+};
+
+export const exportDefinitionOutDocumentToExportDefinitionOutWithLinks = (
+    exportDefinitionDocument: JsonApiExportDefinitionOutDocument,
+): JsonApiExportDefinitionOutWithLinks => {
+    const { data: exportDefinitionOut, ...restExportDefinitionOut } = exportDefinitionDocument;
+
+    return { ...exportDefinitionOut, ...restExportDefinitionOut };
+};
+
+export const exportDefinitionOutDocumentToExportDefinition = (
+    exportDefinitionDocument: JsonApiExportDefinitionOutDocument,
+): IExportDefinition => {
+    const exportDefinitionOut =
+        exportDefinitionOutDocumentToExportDefinitionOutWithLinks(exportDefinitionDocument);
+
+    return exportDefinitionOutToExportDefinition(exportDefinitionOut);
+};
+
+export const exportDefinitionsOutListToExportDefinitions = (
+    exportDefinitions: JsonApiExportDefinitionOutList,
+): IExportDefinition[] => {
+    return exportDefinitions.data.map((exportDefinition) =>
+        exportDefinitionOutToExportDefinition(exportDefinition, exportDefinitions.included),
+    );
+};
+
+export const exportDefinitionToExportDefinitionPostOptionalIdDocument = (
+    exportDefinition: IExportDefinitionBase,
+): JsonApiExportDefinitionPostOptionalIdDocument => {
+    const { title, description, tags, requestPayload } = exportDefinition;
+
+    return {
+        data: {
+            type: JsonApiExportDefinitionOutWithLinksTypeEnum.EXPORT_DEFINITION,
+            attributes: {
+                title,
+                description,
+                tags,
+                requestPayload,
+            },
+            relationships: {
+                visualizationObject: {
+                    data: {
+                        id: requestPayload.visualizationObjectId,
+                        type: JsonApiVisualizationObjectLinkageTypeEnum.VISUALIZATION_OBJECT,
+                    },
+                },
+            },
+        },
+    };
+};
+
+export const exportDefinitionToExportDefinitionInDocument = (
+    exportDefinition: IExportDefinitionBase,
+    identifier: string,
+): JsonApiExportDefinitionInDocument => {
+    const postDefinition = exportDefinitionToExportDefinitionPostOptionalIdDocument(exportDefinition);
+
+    return {
+        data: {
+            ...postDefinition.data,
+            id: identifier,
+        },
+    };
+};

--- a/libs/sdk-model/api/sdk-model.api.md
+++ b/libs/sdk-model/api/sdk-model.api.md
@@ -451,6 +451,15 @@ export type DrillType = "drillToInsight" | "drillToDashboard" | "drillToLegacyDa
 // @public
 export function emptyDef(workspace: string): IExecutionDefinition;
 
+// @alpha
+export function exportDefinitionCreated(exportDefinition: IExportDefinition): string | undefined;
+
+// @alpha
+export function exportDefinitionTitle(exportDefinition: IExportDefinition): string;
+
+// @alpha
+export function exportDefinitionUpdated(exportDefinition: IExportDefinition): string | undefined;
+
 // @public
 export const factoryNotationFor: (data: any, additionalConversion?: ((data: any) => string | undefined) | undefined) => string;
 
@@ -1421,6 +1430,42 @@ export interface IExecutionDefinition {
 // @alpha
 export interface IExistingDashboard extends IDashboardObjectIdentity {
     title?: string;
+}
+
+// @alpha
+export interface IExportDefinition extends IExportDefinitionBase, IMetadataObject, IAuditable {
+    // (undocumented)
+    type: "exportDefinition";
+}
+
+// @alpha
+export interface IExportDefinitionBase {
+    // (undocumented)
+    description: string;
+    // (undocumented)
+    requestPayload: IExportDefinitionRequestPayload;
+    // (undocumented)
+    tags: string[];
+    // (undocumented)
+    title: string;
+}
+
+// @alpha
+export interface IExportDefinitionPdfOptions {
+    // (undocumented)
+    orientation: "portrait" | "landscape";
+}
+
+// @alpha
+export interface IExportDefinitionRequestPayload {
+    // (undocumented)
+    filters?: IFilter[];
+    // (undocumented)
+    format: "PDF";
+    // (undocumented)
+    pdfOptions?: IExportDefinitionPdfOptions;
+    // (undocumented)
+    visualizationObjectId: Identifier;
 }
 
 // @alpha
@@ -3616,7 +3661,7 @@ export function newTwoDimensional(dim1Input: DimensionItem[], dim2Input: Dimensi
 export function newVirtualArithmeticMeasure(measuresOrIds: ReadonlyArray<MeasureOrLocalId>, operator: ArithmeticMeasureOperator, modifications?: MeasureModifications<VirtualArithmeticMeasureBuilder>): IMeasure<IVirtualArithmeticMeasureDefinition>;
 
 // @public
-export type ObjectType = "measure" | "fact" | "attribute" | "displayForm" | "dataSet" | "tag" | "insight" | "variable" | "analyticalDashboard" | "theme" | "colorPalette" | "filterContext" | "dashboardPlugin" | "attributeHierarchy" | "user" | "userGroup" | "dateHierarchyTemplate" | "dateAttributeHierarchy";
+export type ObjectType = "measure" | "fact" | "attribute" | "displayForm" | "dataSet" | "tag" | "insight" | "variable" | "analyticalDashboard" | "theme" | "colorPalette" | "filterContext" | "dashboardPlugin" | "attributeHierarchy" | "user" | "userGroup" | "dateHierarchyTemplate" | "dateAttributeHierarchy" | "exportDefinition";
 
 // @public
 export type ObjRef = UriRef | IdentifierRef;

--- a/libs/sdk-model/src/exportDefinitions/index.ts
+++ b/libs/sdk-model/src/exportDefinitions/index.ts
@@ -1,0 +1,90 @@
+// (C) 2024 GoodData Corporation
+
+import { invariant } from "ts-invariant";
+import { Identifier } from "../objRef/index.js";
+import { IFilter } from "../execution/filter/index.js";
+import { IMetadataObject } from "../ldm/metadata/index.js";
+import { IAuditable } from "../base/metadata.js";
+
+/**
+ * Export definition PDF Options
+ *
+ * @alpha
+ */
+export interface IExportDefinitionPdfOptions {
+    orientation: "portrait" | "landscape";
+}
+
+/**
+ * Export definition request payload
+ *
+ * @alpha
+ */
+export interface IExportDefinitionRequestPayload {
+    format: "PDF";
+    visualizationObjectId: Identifier;
+    filters?: IFilter[];
+    pdfOptions?: IExportDefinitionPdfOptions;
+}
+
+/**
+ * Export definition base
+ * An object containing the core properties of an export definition
+ *
+ * @alpha
+ */
+export interface IExportDefinitionBase {
+    title: string;
+    description: string;
+    tags: string[];
+    requestPayload: IExportDefinitionRequestPayload;
+}
+
+/**
+ * Export definition
+ *
+ * @alpha
+ */
+
+export interface IExportDefinition extends IExportDefinitionBase, IMetadataObject, IAuditable {
+    type: "exportDefinition";
+}
+
+/**
+ * Gets the exportDefinition title
+ *
+ * @param exportDefinition - exportDefinition to get title of
+ * @returns string - the exportDefinition title
+ * @alpha
+ */
+export function exportDefinitionTitle(exportDefinition: IExportDefinition): string {
+    invariant(exportDefinition, "export definition to get title from must be specified");
+
+    return exportDefinition.title;
+}
+
+/**
+ * Gets the date when the exportDefinition was created
+ *
+ * @param exportDefinition - exportDefinition
+ * @returns string - YYYY-MM-DD HH:mm:ss
+ * @alpha
+ */
+export function exportDefinitionCreated(exportDefinition: IExportDefinition): string | undefined {
+    invariant(exportDefinition, "export definition must be specified");
+
+    return exportDefinition.created;
+}
+
+/**
+ * Gets the date of the last exportDefinition update
+ *
+ * @param exportDefinition - exportDefinition
+ * @returns string - YYYY-MM-DD HH:mm:ss
+ * @alpha
+ */
+export function exportDefinitionUpdated(exportDefinition: IExportDefinition): string | undefined {
+    invariant(exportDefinition, "export definition must be specified");
+
+    return exportDefinition.updated;
+}

--- a/libs/sdk-model/src/index.ts
+++ b/libs/sdk-model/src/index.ts
@@ -863,3 +863,13 @@ export {
 } from "./organization/index.js";
 export { IEntitlementsName, IEntitlementDescriptor } from "./entitlements/index.js";
 export { DataSourceType, IDataSourceIdentifierDescriptor } from "./dataSources/index.js";
+
+export {
+    IExportDefinition,
+    IExportDefinitionRequestPayload,
+    IExportDefinitionBase,
+    IExportDefinitionPdfOptions,
+    exportDefinitionTitle,
+    exportDefinitionCreated,
+    exportDefinitionUpdated,
+} from "./exportDefinitions/index.js";

--- a/libs/sdk-model/src/objRef/index.ts
+++ b/libs/sdk-model/src/objRef/index.ts
@@ -54,7 +54,8 @@ export type ObjectType =
     | "user"
     | "userGroup"
     | "dateHierarchyTemplate"
-    | "dateAttributeHierarchy";
+    | "dateAttributeHierarchy"
+    | "exportDefinition";
 
 /**
  * Model object reference using object's unique identifier.


### PR DESCRIPTION
[STL-270](https://gooddata.atlassian.net/browse/STL-270)


<!--
Description of changes.
-->

On the Export Definitions:

The tiger backend now supports a new type of metadata object called exportDefinitions. The use case for the EDs is to enable saving export configuration & metadata(such as title, and description..) for particular insights, based on which users will be able to create reports (a tabular representation of any insight, that will be later exported to PDF either ad hoc or as a scheduled email).

The service contains similar methods for CRUD operations on EDs as the insights service. For now, it's marked as @alpha since the API may still go through some changes while being integrated in real-world scenarios.


---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** 🙏

---

Refer to [documentation](https://github.com/gooddata/gooddata-ui-sdk/blob/master/dev_docs/continuous_integration.md) to see how to run checks and tests in the pull request. This is the list of the most used commands:

```
extended test - backstop
```

```
extended test - tiger-cypress - integrated
extended test - tiger-cypress - isolated
extended test - tiger-cypress - record
```


[STL-270]: https://gooddata.atlassian.net/browse/STL-270?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ