### PR TITLE
fix: show repeater column titles for measures

### DIFF
--- a/libs/sdk-ui-ext/src/insightView/InsightRenderer.tsx
+++ b/libs/sdk-ui-ext/src/insightView/InsightRenderer.tsx
@@ -16,6 +16,7 @@ import {
     ITheme,
     insightSetProperties,
     insightVisualizationUrl,
+    insightVisualizationType,
 } from "@gooddata/sdk-model";
 
 import {
@@ -139,9 +140,20 @@ class InsightRendererCore extends React.PureComponent<IInsightRendererProps & Wr
             theme: this.props.theme,
         };
 
-        const insight = fillMissingFormats(
-            ignoreTitlesForSimpleMeasures(fillMissingTitles(this.props.insight, this.props.locale)),
-        );
+        const visClass = insightVisualizationType(this.props.insight);
+        let insight = fillMissingFormats(fillMissingTitles(this.props.insight, this.props.locale));
+
+        /**
+         * Ignore titles for simple measures in all visualizations except for repeater.
+         * This is not nice, and InsightRenderer should not be aware of the visualization types.
+         * However, repeater is transforming simple measures to inline ones, so we need to keep the titles for them.
+         * We can remove this once we have a better solution on execution level,
+         * or all the visualizations start to use actual measure titles specified in AD, and not measure metadata titles.
+         * See also https://gooddata.atlassian.net/browse/SD-1012
+         */
+        if (visClass !== "repeater") {
+            insight = ignoreTitlesForSimpleMeasures(insight);
+        }
         this.visualization.update(visProps, insight, {}, this.getExecutionFactory());
     };
 

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/repeater/PluggableRepeater.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/repeater/PluggableRepeater.tsx
@@ -62,6 +62,38 @@ const REPEATER_SUPPORTER_PROPERTIES_LIST = [
     "cellImageSizing",
 ];
 
+/**
+ * PluggableRepeater
+ *
+ * ## Buckets
+ *
+ * | Name      | Id       -| Accepts              |
+ * |-----------|-----------|----------------------|
+ * | Attribute | attribute | attribute only       |
+ * | Columns   | columns   | attribute or measure |
+ * | ViewBy    | view      | attribute or date    |
+ *
+ *
+ * ### Bucket axioms
+ *
+ * - |Attribute| = 1
+ * - |Columns| ≥ 1
+ * - |ViewBy| ≤ 1
+ *
+ * ## Dimensions
+ *
+ * The PluggableRepeater creates one or two dimensional execution, based on  the buckets.
+ *
+ * With main attribute and column attributes only:
+ * - [[Attribute, ...ColumnAttributes]]
+ * With main attribute, column attributes and viewBy:
+ * - [[Attribute, ...ColumnAttributes], [ViewBy]]
+ * With main attribute and column attributes and measures:
+ * - [[Attribute, ...ColumnAttributes], [MeasureGroupIdentifier]]
+ * With main attribute, column attributes and measures, and viewBy:
+ * - [[Attribute, ...ColumnAttributes], [ViewBy, MeasureGroupIdentifier]]
+ *
+ */
 export class PluggableRepeater extends AbstractPluggableVisualization {
     private environment: VisualizationEnvironment;
     private featureFlags?: ISettings;


### PR DESCRIPTION
Do not remove simple measure titles for repeater,
as they can be transformed to inline measures for the execution, and then we don't have access to the original measure descriptor and title.

JIRA: F1-148

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** 🙏

---

Refer to [documentation](https://github.com/gooddata/gooddata-ui-sdk/blob/master/dev_docs/continuous_integration.md) to see how to run checks and tests in the pull request. This is the list of the most used commands:

```
extended test - backstop
```

```
extended test - tiger-cypress - integrated
extended test - tiger-cypress - isolated
extended test - tiger-cypress - record
```
