### PR TITLE
fix: re-export UploadFileResponse from sdk-backend-tiger

### DIFF
--- a/libs/sdk-backend-tiger/api/sdk-backend-tiger.api.md
+++ b/libs/sdk-backend-tiger/api/sdk-backend-tiger.api.md
@@ -470,6 +470,8 @@ export class TigerTokenAuthProvider extends TigerAuthProviderBase {
     updateApiToken: (apiToken: string) => void;
 }
 
+export { UploadFileResponse }
+
 // @internal (undocumented)
 export type WorkspaceDataFilter = JsonApiWorkspaceDataFilterInDocument;
 

--- a/libs/sdk-backend-tiger/src/backend/tigerSpecificFunctions.ts
+++ b/libs/sdk-backend-tiger/src/backend/tigerSpecificFunctions.ts
@@ -1491,7 +1491,7 @@ export const buildTigerSpecificFunctions = (
         }
     },
 
-    getStagingUploadLocation: async (dataSourceId: string) => {
+    getStagingUploadLocation: async (dataSourceId: string): Promise<StagingUploadLocation> => {
         try {
             return await authApiCall(async (sdk) => {
                 return await sdk.result

--- a/libs/sdk-backend-tiger/src/index.ts
+++ b/libs/sdk-backend-tiger/src/index.ts
@@ -58,6 +58,7 @@ export {
     AnalyzeCsvResponse,
     ImportCsvRequest,
     GdStorageFile,
+    UploadFileResponse,
 } from "@gooddata/api-client-tiger";
 export {
     ContextDeferredAuthProvider,


### PR DESCRIPTION
This is to allow it being used in the applications without direct api-client-tiger imports.

JIRA: CQ-279

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** 🙏

---

Refer to [documentation](https://github.com/gooddata/gooddata-ui-sdk/blob/master/dev_docs/continuous_integration.md) to see how to run checks and tests in the pull request. This is the list of the most used commands:

```
extended test - backstop
```

```
extended test - tiger-cypress - integrated
extended test - tiger-cypress - isolated
extended test - tiger-cypress - record
```
