### PR TITLE
FEATURE: add updateDescriptor methods to ws and org

### DIFF
--- a/libs/sdk-backend-base/src/customBackend/workspace.ts
+++ b/libs/sdk-backend-base/src/customBackend/workspace.ts
@@ -41,6 +41,10 @@ export class CustomWorkspace implements IAnalyticalWorkspace {
         throw new NotSupported("getting workspace descriptor is not supported");
     }
 
+    public updateDescriptor(): Promise<void> {
+        throw new NotSupported("updating workspace descriptor is not supported");
+    }
+
     public getParentWorkspace(): Promise<IAnalyticalWorkspace | undefined> {
         throw new NotSupported("getting parent workspace is not supported");
     }

--- a/libs/sdk-backend-base/src/decoratedBackend/analyticalWorkspace.ts
+++ b/libs/sdk-backend-base/src/decoratedBackend/analyticalWorkspace.ts
@@ -20,6 +20,7 @@ import {
     IAttributeHierarchiesService,
     IWorkspaceExportDefinitionsService,
     IDataFiltersService,
+    IWorkspaceDescriptorUpdate,
     IWorkspaceLogicalModelService,
 } from "@gooddata/sdk-backend-spi";
 import { DecoratorFactories } from "./types.js";
@@ -37,6 +38,10 @@ export class AnalyticalWorkspaceDecorator implements IAnalyticalWorkspace {
 
     public getDescriptor(includeParentPrefixes?: boolean): Promise<IWorkspaceDescriptor> {
         return this.decorated.getDescriptor(includeParentPrefixes);
+    }
+
+    public updateDescriptor(descriptor: IWorkspaceDescriptorUpdate): Promise<void> {
+        return this.decorated.updateDescriptor(descriptor);
     }
 
     public getParentWorkspace(): Promise<IAnalyticalWorkspace | undefined> {

--- a/libs/sdk-backend-base/src/decoratedBackend/organization.ts
+++ b/libs/sdk-backend-base/src/decoratedBackend/organization.ts
@@ -1,4 +1,4 @@
-// (C) 2023 GoodData Corporation
+// (C) 2023-2024 GoodData Corporation
 import {
     IOrganization,
     ISecuritySettingsService,
@@ -7,7 +7,7 @@ import {
     IOrganizationUserService,
     IOrganizationPermissionService,
 } from "@gooddata/sdk-backend-spi";
-import { IOrganizationDescriptor } from "@gooddata/sdk-model";
+import { IOrganizationDescriptor, IOrganizationDescriptorUpdate } from "@gooddata/sdk-model";
 import { DecoratorFactories } from "./types.js";
 
 export class OrganizationDecorator implements IOrganization {
@@ -23,6 +23,10 @@ export class OrganizationDecorator implements IOrganization {
 
     public getDescriptor(includeAdditionalDetails?: boolean): Promise<IOrganizationDescriptor> {
         return this.decorated.getDescriptor(includeAdditionalDetails);
+    }
+
+    public updateDescriptor(descriptor: IOrganizationDescriptorUpdate): Promise<void> {
+        return this.decorated.updateDescriptor(descriptor);
     }
 
     public securitySettings(): ISecuritySettingsService {

--- a/libs/sdk-backend-base/src/dummyBackend/index.ts
+++ b/libs/sdk-backend-base/src/dummyBackend/index.ts
@@ -680,6 +680,10 @@ class DummyOrganization implements IOrganization {
         });
     }
 
+    updateDescriptor(): Promise<void> {
+        return Promise.resolve();
+    }
+
     securitySettings(): ISecuritySettingsService {
         return {
             scope: `/gdc/domains/${this.organizationId}`,

--- a/libs/sdk-backend-base/src/dummyBackend/index.ts
+++ b/libs/sdk-backend-base/src/dummyBackend/index.ts
@@ -269,6 +269,9 @@ function dummyWorkspace(workspace: string, config: DummyBackendConfig): IAnalyti
         async getDescriptor(): Promise<IWorkspaceDescriptor> {
             return dummyDescriptor(this.workspace);
         },
+        async updateDescriptor(): Promise<void> {
+            throw new NotSupported("not supported");
+        },
         getParentWorkspace(): Promise<IAnalyticalWorkspace | undefined> {
             throw new NotSupported("not supported");
         },

--- a/libs/sdk-backend-mockingbird/src/legacyRecordedBackend/index.ts
+++ b/libs/sdk-backend-mockingbird/src/legacyRecordedBackend/index.ts
@@ -198,6 +198,9 @@ function recordedWorkspace(
         getDescriptor(): Promise<IWorkspaceDescriptor> {
             throw new NotSupported("not supported");
         },
+        updateDescriptor(): Promise<void> {
+            throw new NotSupported("not supported");
+        },
         getParentWorkspace(): Promise<IAnalyticalWorkspace | undefined> {
             throw new NotSupported("not supported");
         },

--- a/libs/sdk-backend-mockingbird/src/recordedBackend/index.ts
+++ b/libs/sdk-backend-mockingbird/src/recordedBackend/index.ts
@@ -183,6 +183,9 @@ function recordedWorkspace(
         async getDescriptor(): Promise<IWorkspaceDescriptor> {
             return recordedDescriptor(this.workspace, implConfig);
         },
+        async updateDescriptor(): Promise<void> {
+            throw new NotSupported("not supported");
+        },
         getParentWorkspace(): Promise<IAnalyticalWorkspace | undefined> {
             throw new NotSupported("not supported");
         },

--- a/libs/sdk-backend-mockingbird/src/recordedBackend/index.ts
+++ b/libs/sdk-backend-mockingbird/src/recordedBackend/index.ts
@@ -302,6 +302,9 @@ function recordedOrganization(organizationId: string, implConfig: RecordedBacken
                 title: "mock organization",
             });
         },
+        updateDescriptor(): Promise<void> {
+            return Promise.resolve();
+        },
         securitySettings(): ISecuritySettingsService {
             return {
                 scope: scopeFactory(organizationId),

--- a/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
+++ b/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
@@ -64,6 +64,7 @@ import { IMetadataObject } from '@gooddata/sdk-model';
 import { INullableFilter } from '@gooddata/sdk-model';
 import { IOrganizationAssignee } from '@gooddata/sdk-model';
 import { IOrganizationDescriptor } from '@gooddata/sdk-model';
+import { IOrganizationDescriptorUpdate } from '@gooddata/sdk-model';
 import { IOrganizationPermissionAssignment } from '@gooddata/sdk-model';
 import { IOrganizationUser } from '@gooddata/sdk-model';
 import { IOrganizationUserGroup } from '@gooddata/sdk-model';
@@ -665,6 +666,7 @@ export interface IOrganization {
     securitySettings(): ISecuritySettingsService;
     settings(): IOrganizationSettingsService;
     styling(): IOrganizationStylingService;
+    updateDescriptor(descriptor: IOrganizationDescriptorUpdate): Promise<void>;
     users(): IOrganizationUserService;
 }
 

--- a/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
+++ b/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
@@ -222,6 +222,7 @@ export interface IAnalyticalWorkspace {
     permissions(): IWorkspacePermissionsService;
     settings(): IWorkspaceSettingsService;
     styling(): IWorkspaceStylingService;
+    updateDescriptor(descriptor: IWorkspaceDescriptorUpdate): Promise<void>;
     userGroups(): IWorkspaceUserGroupsQuery;
     users(): IWorkspaceUsersQuery;
     // (undocumented)
@@ -1063,6 +1064,18 @@ export interface IWorkspaceDescriptor {
     prefix?: string;
     // (undocumented)
     title: string;
+}
+
+// @public
+export interface IWorkspaceDescriptorUpdate {
+    // (undocumented)
+    description?: string;
+    // (undocumented)
+    earlyAccess?: string | null;
+    // (undocumented)
+    prefix?: string | null;
+    // (undocumented)
+    title?: string;
 }
 
 // @alpha

--- a/libs/sdk-backend-spi/src/index.ts
+++ b/libs/sdk-backend-spi/src/index.ts
@@ -125,6 +125,7 @@ export {
     IWorkspacesQueryFactory,
     IWorkspacesQueryResult,
     IWorkspaceDescriptor,
+    IWorkspaceDescriptorUpdate,
 } from "./workspace/index.js";
 
 export { IAttributeHierarchiesService } from "./workspace/attributeHierarchies/index.js";

--- a/libs/sdk-backend-spi/src/organization/index.ts
+++ b/libs/sdk-backend-spi/src/organization/index.ts
@@ -1,5 +1,5 @@
-// (C) 2021-2023 GoodData Corporation
-import { IOrganizationDescriptor } from "@gooddata/sdk-model";
+// (C) 2021-2024 GoodData Corporation
+import { IOrganizationDescriptor, IOrganizationDescriptorUpdate } from "@gooddata/sdk-model";
 import { IOrganizationSettingsService } from "./settings/index.js";
 import { ISecuritySettingsService } from "./securitySettings/index.js";
 import { IOrganizationStylingService } from "./styling/index.js";
@@ -23,6 +23,13 @@ export interface IOrganization {
      * @param includeAdditionalDetails - include additional details such as bootstrap user and user group.
      */
     getDescriptor(includeAdditionalDetails?: boolean): Promise<IOrganizationDescriptor>;
+
+    /**
+     * Updates details about the organization.
+     *
+     * @param descriptor - properties to update
+     */
+    updateDescriptor(descriptor: IOrganizationDescriptorUpdate): Promise<void>;
 
     /**
      * Returns service that can be used to query and update organization security settings.

--- a/libs/sdk-backend-spi/src/workspace/index.ts
+++ b/libs/sdk-backend-spi/src/workspace/index.ts
@@ -41,6 +41,14 @@ export interface IAnalyticalWorkspace {
     getDescriptor(includeParentPrefixes?: boolean): Promise<IWorkspaceDescriptor>;
 
     /**
+     * Updates the details of the workspace.
+     * Throws error in case the workspace does not exist.
+     *
+     * @param descriptor - properties to update
+     */
+    updateDescriptor(descriptor: IWorkspaceDescriptorUpdate): Promise<void>;
+
+    /**
      * Returns parent analytical workspace when this workspace has a parent, undefined otherwise.
      */
     getParentWorkspace(): Promise<IAnalyticalWorkspace | undefined>;
@@ -174,6 +182,20 @@ export interface IWorkspaceDescriptor {
      * Early access attribute value of the workspace
      */
     earlyAccess?: string;
+}
+
+/**
+ * Workspace descriptor properties to update.
+ * Optional properties can be set to null to delete the value.
+ *
+ * @see IWorkspaceDescriptor
+ * @public
+ */
+export interface IWorkspaceDescriptorUpdate {
+    title?: string;
+    description?: string;
+    prefix?: string | null;
+    earlyAccess?: string | null;
 }
 
 /**

--- a/libs/sdk-backend-tiger/src/backend/organization/index.ts
+++ b/libs/sdk-backend-tiger/src/backend/organization/index.ts
@@ -9,7 +9,7 @@ import {
     IOrganizationUserService,
     IOrganizationPermissionService,
 } from "@gooddata/sdk-backend-spi";
-import { IOrganizationDescriptor, idRef } from "@gooddata/sdk-model";
+import { IOrganizationDescriptor, idRef, IOrganizationDescriptorUpdate } from "@gooddata/sdk-model";
 
 import { SecuritySettingsService } from "./securitySettings.js";
 import { TigerAuthenticatedCallGuard } from "../../types/index.js";
@@ -66,6 +66,26 @@ export class TigerOrganization implements IOrganization {
             id: organizationId,
             title: organizationName,
         };
+    }
+
+    public async updateDescriptor(descriptor: IOrganizationDescriptorUpdate): Promise<void> {
+        await this.authCall((client) =>
+            client.entities.patchEntityOrganizations({
+                id: this.organizationId,
+                jsonApiOrganizationPatchDocument: {
+                    data: {
+                        id: this.organizationId,
+                        type: "organization",
+                        attributes: {
+                            name: descriptor.title,
+                            // type casts are necessary because nulls are not allowed in the type definition,
+                            // but backend expects them in case we want to delete the value
+                            earlyAccess: descriptor.earlyAccess as string | undefined,
+                        },
+                    },
+                },
+            }),
+        );
     }
 
     public securitySettings(): ISecuritySettingsService {

--- a/libs/sdk-backend-tiger/src/backend/tigerSpecificFunctions.ts
+++ b/libs/sdk-backend-tiger/src/backend/tigerSpecificFunctions.ts
@@ -350,6 +350,9 @@ export type TigerSpecificFunctions = {
     createDemoWorkspace?: (sampleWorkspace: WorkspaceDefinition) => Promise<string>;
     createDemoDataSource?: (sampleDataSource: DataSourceDefinition) => Promise<string>;
     createWorkspace?: (id: string, name: string) => Promise<string>;
+    /**
+     * @deprecated use IAnalyticalBackend.workspace(id).updateDescriptor(\{ title: name \})
+     */
     updateWorkspaceTitle?: (id: string, name: string) => Promise<void>;
     deleteWorkspace?: (id: string) => Promise<void>;
     canDeleteWorkspace?: (id: string) => Promise<boolean>;
@@ -852,9 +855,9 @@ export const buildTigerSpecificFunctions = (
     updateWorkspaceTitle: async (id: string, name: string) => {
         try {
             return await authApiCall(async (sdk) => {
-                await sdk.entities.updateEntityWorkspaces({
+                await sdk.entities.patchEntityWorkspaces({
                     id,
-                    jsonApiWorkspaceInDocument: {
+                    jsonApiWorkspacePatchDocument: {
                         data: {
                             attributes: {
                                 name,

--- a/libs/sdk-backend-tiger/src/backend/workspace/index.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/index.ts
@@ -17,6 +17,7 @@ import {
     IWorkspaceMeasuresService,
     IWorkspaceFactsService,
     IWorkspaceDescriptor,
+    IWorkspaceDescriptorUpdate,
     IWorkspaceUserGroupsQuery,
     IWorkspaceAccessControlService,
     IAttributeHierarchiesService,
@@ -43,6 +44,7 @@ import { TigerWorkspaceAccessControlService } from "./accessControl/index.js";
 import { TigerAttributeHierarchiesService } from "./attributeHierarchies/index.js";
 import { GET_OPTIMIZED_WORKSPACE_PARAMS } from "./constants.js";
 import { TigerWorkspaceExportDefinitions } from "./exportDefinitions/index.js";
+import { convertWorkspaceUpdate } from "../../convertors/toBackend/WorkspaceConverter.js";
 import { TigerDataFiltersService } from "./dataFilters/index.js";
 import { TigerWorkspaceLogicalModelService } from "./ldm/index.js";
 
@@ -77,6 +79,17 @@ export class TigerWorkspace implements IAnalyticalWorkspace {
             );
         }
         return this.descriptor;
+    }
+
+    public async updateDescriptor(descriptor: IWorkspaceDescriptorUpdate): Promise<void> {
+        await this.authCall(async (client) => {
+            return client.entities.patchEntityWorkspaces({
+                id: this.workspace,
+                jsonApiWorkspacePatchDocument: {
+                    data: convertWorkspaceUpdate(descriptor, this.workspace),
+                },
+            });
+        });
     }
 
     public async getParentWorkspace(): Promise<IAnalyticalWorkspace | undefined> {

--- a/libs/sdk-backend-tiger/src/convertors/toBackend/WorkspaceConverter.ts
+++ b/libs/sdk-backend-tiger/src/convertors/toBackend/WorkspaceConverter.ts
@@ -1,0 +1,22 @@
+// (C) 2024 GoodData Corporation
+
+import { IWorkspaceDescriptorUpdate } from "@gooddata/sdk-backend-spi";
+import { JsonApiWorkspacePatch } from "@gooddata/api-client-tiger";
+
+export const convertWorkspaceUpdate = (
+    descriptor: IWorkspaceDescriptorUpdate,
+    workspaceId: string,
+): JsonApiWorkspacePatch => {
+    return {
+        id: workspaceId,
+        type: "workspace",
+        attributes: {
+            name: descriptor.title,
+            description: descriptor.description,
+            // type casts are necessary because nulls are not allowed in the type definition,
+            // but backend expects them in case we want to delete the value
+            prefix: descriptor.prefix as string | undefined,
+            earlyAccess: descriptor.earlyAccess as string | undefined,
+        },
+    };
+};

--- a/libs/sdk-model/api/sdk-model.api.md
+++ b/libs/sdk-model/api/sdk-model.api.md
@@ -2068,6 +2068,14 @@ export interface IOrganizationDescriptor {
     title: string;
 }
 
+// @public
+export interface IOrganizationDescriptorUpdate {
+    // (undocumented)
+    earlyAccess?: string | null;
+    // (undocumented)
+    title?: string;
+}
+
 // @alpha (undocumented)
 export interface IOrganizationPermissionAssignment {
     // (undocumented)

--- a/libs/sdk-model/src/index.ts
+++ b/libs/sdk-model/src/index.ts
@@ -848,6 +848,7 @@ export {
 
 export {
     IOrganizationDescriptor,
+    IOrganizationDescriptorUpdate,
     IWorkspacePermissionAssignment,
     IAssignedWorkspace,
     AssignedWorkspacePermission,

--- a/libs/sdk-model/src/organization/index.ts
+++ b/libs/sdk-model/src/organization/index.ts
@@ -16,6 +16,18 @@ export interface IOrganizationDescriptor {
 }
 
 /**
+ * Organization descriptor properties to update.
+ * Optional properties can be set to null to delete the value.
+ *
+ * @see IOrganizationDescriptor
+ * @public
+ */
+export interface IOrganizationDescriptorUpdate {
+    title?: string;
+    earlyAccess?: string | null;
+}
+
+/**
  * Information about assigned workspace.
  *
  * @alpha


### PR DESCRIPTION
Generic way to update attributes of ws/org, to use instead of tiger specific functions.


Not included:

Changing parent workspace - can be added to updateDescriptor, but PATCH currently does not work for relationships, so we would need to conditionally call GET+PUT when parentWorkspace update is requested. 

Allowed origins are also in organization attributes, however not in the descriptor yet. If they are added we can deprecate two more tiger specific functions, but this is out of scope now



---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** 🙏

---

Refer to [documentation](https://github.com/gooddata/gooddata-ui-sdk/blob/master/dev_docs/continuous_integration.md) to see how to run checks and tests in the pull request. This is the list of the most used commands:

```
extended test - backstop
```

```
extended test - tiger-cypress - integrated
extended test - tiger-cypress - isolated
extended test - tiger-cypress - record
```
