### PR TITLE
feat: include hierarchy data in workspace descriptor

### DIFF
--- a/common/changes/@gooddata/sdk-ui-all/pji-lx-217-workspace-hierarchy-data_2024-04-23-16-41.json
+++ b/common/changes/@gooddata/sdk-ui-all/pji-lx-217-workspace-hierarchy-data_2024-04-23-16-41.json
@@ -1,0 +1,10 @@
+{
+    "changes": [
+        {
+            "packageName": "@gooddata/sdk-ui-all",
+            "comment": "Include hierarchy data in workspace descriptor",
+            "type": "none"
+        }
+    ],
+    "packageName": "@gooddata/sdk-ui-all"
+}

--- a/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
+++ b/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
@@ -1054,6 +1054,7 @@ export interface IWorkspaceDatasetsService {
 
 // @public
 export interface IWorkspaceDescriptor {
+    childWorkspacesCount?: number;
     // (undocumented)
     description: string;
     earlyAccess?: string;

--- a/libs/sdk-backend-spi/src/workspace/index.ts
+++ b/libs/sdk-backend-spi/src/workspace/index.ts
@@ -182,6 +182,10 @@ export interface IWorkspaceDescriptor {
      * Early access attribute value of the workspace
      */
     earlyAccess?: string;
+    /**
+     * Number of child workspaces
+     */
+    childWorkspacesCount?: number;
 }
 
 /**

--- a/libs/sdk-backend-tiger/src/backend/workspaces/index.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspaces/index.ts
@@ -6,7 +6,11 @@ import {
     IAnalyticalWorkspace,
     IWorkspaceDescriptor,
 } from "@gooddata/sdk-backend-spi";
-import { JsonApiWorkspaceOutList, DeclarativeWorkspace } from "@gooddata/api-client-tiger";
+import {
+    JsonApiWorkspaceOutList,
+    DeclarativeWorkspace,
+    EntitiesApiGetAllEntitiesWorkspacesRequest,
+} from "@gooddata/api-client-tiger";
 import { TigerAuthenticatedCallGuard } from "../../types/index.js";
 import { DateFormatter } from "../../convertors/fromBackend/dateFormatting/types.js";
 import { workspaceConverter } from "../../convertors/fromBackend/WorkspaceConverter.js";
@@ -34,6 +38,11 @@ class TigerWorkspaceQuery implements IWorkspacesQuery {
     private search: string | undefined = undefined;
     private filter: Partial<DeclarativeWorkspace> = {};
     private parentWorkspaceId: string | undefined = undefined;
+
+    private defaultMetaIncludeParam: Required<EntitiesApiGetAllEntitiesWorkspacesRequest>["metaInclude"] = [
+        "hierarchy",
+    ];
+    private defaultIncludeParam: EntitiesApiGetAllEntitiesWorkspacesRequest["include"] = ["parent"];
 
     constructor(
         private readonly authCall: TigerAuthenticatedCallGuard,
@@ -80,7 +89,11 @@ class TigerWorkspaceQuery implements IWorkspacesQuery {
                         size: limit,
                         page: offset / limit,
                         filter: this.constructFilter(),
-                        metaInclude: totalCount === undefined ? ["page"] : undefined,
+                        metaInclude:
+                            totalCount === undefined
+                                ? ["page", ...this.defaultMetaIncludeParam]
+                                : this.defaultMetaIncludeParam,
+                        include: this.defaultIncludeParam,
                     }),
                 );
 

--- a/libs/sdk-backend-tiger/src/convertors/fromBackend/WorkspaceConverter.ts
+++ b/libs/sdk-backend-tiger/src/convertors/fromBackend/WorkspaceConverter.ts
@@ -3,7 +3,7 @@ import { JsonApiWorkspaceOut, JsonApiWorkspaceOutWithLinks } from "@gooddata/api
 import { IWorkspaceDescriptor } from "@gooddata/sdk-backend-spi";
 
 export const workspaceConverter = (
-    { relationships, attributes, id }: JsonApiWorkspaceOut | JsonApiWorkspaceOutWithLinks,
+    { relationships, attributes, id, meta }: JsonApiWorkspaceOut | JsonApiWorkspaceOutWithLinks,
     parentPrefixes: string[],
 ): IWorkspaceDescriptor => {
     const parentWorkspace = relationships?.parent?.data?.id;
@@ -15,5 +15,6 @@ export const workspaceConverter = (
         parentWorkspace,
         parentPrefixes,
         earlyAccess: attributes?.earlyAccess,
+        childWorkspacesCount: meta?.hierarchy?.childrenCount,
     };
 };


### PR DESCRIPTION
JIRA: LX-217

<!--
Added parent workspace ID and number of child workspaces to workspace descriptor. In the case of the parent workspace, it is in fact a fix as it used to be included before switching to server-side paging for workspaces.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** 🙏

---

Refer to [documentation](https://github.com/gooddata/gooddata-ui-sdk/blob/master/dev_docs/continuous_integration.md) to see how to run checks and tests in the pull request. This is the list of the most used commands:

```
extended test - backstop
```

```
extended test - tiger-cypress - integrated
extended test - tiger-cypress - isolated
extended test - tiger-cypress - record
```
