### PR TITLE
feat: add filter for root workspaces only to workspaces query

### DIFF
--- a/common/changes/@gooddata/sdk-ui-all/pji-lx-217-workspace-hierarchy-data_2024-04-24-16-11.json
+++ b/common/changes/@gooddata/sdk-ui-all/pji-lx-217-workspace-hierarchy-data_2024-04-24-16-11.json
@@ -1,0 +1,10 @@
+{
+    "changes": [
+        {
+            "packageName": "@gooddata/sdk-ui-all",
+            "comment": "added filter for root workspaces only to workspaces query",
+            "type": "none"
+        }
+    ],
+    "packageName": "@gooddata/sdk-ui-all"
+}

--- a/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
+++ b/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
@@ -1152,11 +1152,7 @@ export interface IWorkspaceSettingsService {
 export interface IWorkspacesQuery {
     query(): Promise<IWorkspacesQueryResult>;
     // @alpha
-    withFilter(filter: {
-        description?: string;
-        earlyAccess?: string;
-        prefix?: string;
-    }): IWorkspacesQuery;
+    withFilter(filter: IWorkspacesQueryFilter): IWorkspacesQuery;
     withLimit(limit: number): IWorkspacesQuery;
     withOffset(offset: number): IWorkspacesQuery;
     withParent(workspaceId: string | undefined): IWorkspacesQuery;
@@ -1167,6 +1163,14 @@ export interface IWorkspacesQuery {
 export interface IWorkspacesQueryFactory {
     forCurrentUser(): IWorkspacesQuery;
     forUser(userId: string): IWorkspacesQuery;
+}
+
+// @public
+export interface IWorkspacesQueryFilter {
+    description?: string;
+    earlyAccess?: string;
+    prefix?: string;
+    rootWorkspacesOnly?: boolean;
 }
 
 // @public

--- a/libs/sdk-backend-spi/src/index.ts
+++ b/libs/sdk-backend-spi/src/index.ts
@@ -124,6 +124,7 @@ export {
     IWorkspacesQuery,
     IWorkspacesQueryFactory,
     IWorkspacesQueryResult,
+    IWorkspacesQueryFilter,
     IWorkspaceDescriptor,
     IWorkspaceDescriptorUpdate,
 } from "./workspace/index.js";

--- a/libs/sdk-backend-spi/src/workspace/index.ts
+++ b/libs/sdk-backend-spi/src/workspace/index.ts
@@ -225,6 +225,30 @@ export interface IWorkspacesQueryFactory {
 }
 
 /**
+ * Filter options for workspaces query.
+ *
+ * @public
+ */
+export interface IWorkspacesQueryFilter {
+    /**
+     * Filter by description of the workspace
+     */
+    description?: string;
+    /**
+     * Filter by earlyAccess property on the workspace
+     */
+    earlyAccess?: string;
+    /**
+     * Filter by entity identifiers prefix in the workspace
+     */
+    prefix?: string;
+    /**
+     * When applied, only root workspaces without a parent workspace are queried
+     */
+    rootWorkspacesOnly?: boolean;
+}
+
+/**
  * Query to retrieve available workspaces.
  *
  * @public
@@ -255,7 +279,7 @@ export interface IWorkspacesQuery {
      * @param filter - an object of attributes and values to filter by
      * @alpha
      */
-    withFilter(filter: { description?: string; earlyAccess?: string; prefix?: string }): IWorkspacesQuery;
+    withFilter(filter: IWorkspacesQueryFilter): IWorkspacesQuery;
 
     /**
      * Sets a text to search.


### PR DESCRIPTION
JIRA: LX-217

Added a new filter option to the workspaces query to be able to filter out only root workspaces without a parent workspace.

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** 🙏

---

Refer to [documentation](https://github.com/gooddata/gooddata-ui-sdk/blob/master/dev_docs/continuous_integration.md) to see how to run checks and tests in the pull request. This is the list of the most used commands:

```
extended test - backstop
```

```
extended test - tiger-cypress - integrated
extended test - tiger-cypress - isolated
extended test - tiger-cypress - record
```
