### PR TITLE
fix(sdk-backend-tiger): use only workspace description attribute as d…

### DIFF
--- a/common/changes/@gooddata/sdk-ui-all/pji-workspace-description-fix_2024-05-09-10-52.json
+++ b/common/changes/@gooddata/sdk-ui-all/pji-workspace-description-fix_2024-05-09-10-52.json
@@ -1,0 +1,10 @@
+{
+    "changes": [
+        {
+            "packageName": "@gooddata/sdk-ui-all",
+            "comment": "use only description attribute for workspace description",
+            "type": "none"
+        }
+    ],
+    "packageName": "@gooddata/sdk-ui-all"
+}

--- a/libs/sdk-backend-tiger/src/convertors/fromBackend/WorkspaceConverter.ts
+++ b/libs/sdk-backend-tiger/src/convertors/fromBackend/WorkspaceConverter.ts
@@ -8,8 +8,8 @@ export const workspaceConverter = (
 ): IWorkspaceDescriptor => {
     const parentWorkspace = relationships?.parent?.data?.id;
     return {
-        description: attributes?.description || attributes?.name || id,
-        title: attributes?.name || "",
+        description: attributes?.description ?? "",
+        title: attributes?.name ?? "",
         id: id,
         prefix: attributes?.prefix,
         parentWorkspace,


### PR DESCRIPTION
…escription

Also now using fallback empty string on nullish values only for workspace title and description.

JIRA: LX-248

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** 🙏

---

Refer to [documentation](https://github.com/gooddata/gooddata-ui-sdk/blob/master/dev_docs/continuous_integration.md) to see how to run checks and tests in the pull request. This is the list of the most used commands:

```
extended test - backstop
```

```
extended test - tiger-cypress - integrated
extended test - tiger-cypress - isolated
extended test - tiger-cypress - record
```
