### PR TITLE
fix: forecast is disable when selecting "show on right axis" item

### DIFF
--- a/libs/sdk-ui-ext/src/internal/components/configurationControls/forecast/ForecastSection.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/configurationControls/forecast/ForecastSection.tsx
@@ -84,7 +84,7 @@ class ForecastSection extends React.PureComponent<IForecastSection> {
                 />
 
                 {Boolean(slicedForecast) && (
-                    <Message type="warning" className="adi-input-warning gd-slicedForecast-message">
+                    <Message type="progress" className="adi-input-progress gd-slicedForecast-message">
                         <FormattedMessage id={messages.forecastSlicedWarningTitle.id} tagName="strong" />
                         <FormattedMessage id={messages.forecastSlicedWarningDescription.id} tagName="div" />
                     </Message>

--- a/libs/sdk-ui-ext/src/internal/constants/supportedProperties.ts
+++ b/libs/sdk-ui-ext/src/internal/constants/supportedProperties.ts
@@ -98,6 +98,7 @@ export const LINE_CHART_SUPPORTED_PROPERTIES = {
         ...BASE_PROPERTIES,
         ...BASE_X_AXIS_PROPERTIES,
         ...BASE_SECONDARY_AXIS_PROPERTIES,
+        ...FORECAST_PROPERTIES,
         "dataPoints.visible",
         "continuousLine.enabled",
     ],

--- a/libs/sdk-ui-ext/src/internal/translations/en-US.json
+++ b/libs/sdk-ui-ext/src/internal/translations/en-US.json
@@ -1017,12 +1017,12 @@
         "limit": 0
     },
     "properties.forecastSliced.title": {
-        "value": "Displaying partial results.",
+        "value": "Showing partial forecast.",
         "comment": "",
         "limit": 0
     },
     "properties.forecastSliced.description": {
-        "value": "Try changing the visualization settings to display all results.",
+        "value": "The available data point don`t cover the entire selected period.",
         "comment": "",
         "limit": 0
     },


### PR DESCRIPTION
JIRA: F1-322
JIRA: F1-316

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** 🙏

---

Refer to [documentation](https://github.com/gooddata/gooddata-ui-sdk/blob/master/dev_docs/continuous_integration.md) to see how to run checks and tests in the pull request. This is the list of the most used commands:

```
extended test - backstop
```

```
extended test - tiger-cypress - integrated
extended test - tiger-cypress - isolated
extended test - tiger-cypress - record
```
