### PR TITLE
chore: remove the getStagingUploadLocation function

### DIFF
--- a/libs/api-client-tiger/api/api-client-tiger.api.md
+++ b/libs/api-client-tiger/api/api-client-tiger.api.md
@@ -327,11 +327,6 @@ export interface ActionsApiGetMetadataRequest {
 }
 
 // @public
-export interface ActionsApiGetStagingUploadLocationRequest {
-    readonly dataSourceId: string;
-}
-
-// @public
 export interface ActionsApiGetTabularExportRequest {
     readonly exportId: string;
     readonly workspaceId: string;
@@ -6308,7 +6303,6 @@ export interface GdStorageFile {
     name: string;
     size: number;
     type: GdStorageFileTypeEnum;
-    version: number;
 }
 
 // @public (undocumented)
@@ -13686,7 +13680,6 @@ export interface ResultActionsApiInterface {
     analyzeCsv(requestParameters: ActionsApiAnalyzeCsvRequest, options?: AxiosRequestConfig): AxiosPromise<Array<AnalyzeCsvResponse>>;
     collectCacheUsage(options?: AxiosRequestConfig): AxiosPromise<CacheUsageData>;
     deleteFiles(requestParameters: ActionsApiDeleteFilesRequest, options?: AxiosRequestConfig): AxiosPromise<void>;
-    getStagingUploadLocation(requestParameters: ActionsApiGetStagingUploadLocationRequest, options?: AxiosRequestConfig): AxiosPromise<StagingUploadLocation>;
     importCsv(requestParameters: ActionsApiImportCsvRequest, options?: AxiosRequestConfig): AxiosPromise<Array<ImportCsvResponse>>;
     listFiles(requestParameters: ActionsApiListFilesRequest, options?: AxiosRequestConfig): AxiosPromise<Array<GdStorageFile>>;
     readFileManifests(requestParameters: ActionsApiReadFileManifestsRequest, options?: AxiosRequestConfig): AxiosPromise<Array<ReadFileManifestsResponse>>;
@@ -14061,12 +14054,6 @@ export type SqlColumnDataTypeEnum = typeof SqlColumnDataTypeEnum[keyof typeof Sq
 // @public
 export interface SqlQuery {
     sql: string;
-}
-
-// @public
-export interface StagingUploadLocation {
-    location: string;
-    uploadUrl: string;
 }
 
 // @public

--- a/libs/api-client-tiger/src/generated/result-json-api/api.ts
+++ b/libs/api-client-tiger/src/generated/result-json-api/api.ts
@@ -477,12 +477,6 @@ export interface GdStorageFile {
      */
     name: string;
     /**
-     * Version of the file.
-     * @type {number}
-     * @memberof GdStorageFile
-     */
-    version: number;
-    /**
      * Size of the file in bytes.
      * @type {number}
      * @memberof GdStorageFile
@@ -730,25 +724,6 @@ export interface ReadFileManifestsResponse {
     manifest: CsvManifestBody;
 }
 /**
- * Information related to uploading a file to the staging area.
- * @export
- * @interface StagingUploadLocation
- */
-export interface StagingUploadLocation {
-    /**
-     * Location relative to the root of the storage.
-     * @type {string}
-     * @memberof StagingUploadLocation
-     */
-    location: string;
-    /**
-     * Pre-signed upload URL to PUT the file to.
-     * @type {string}
-     * @memberof StagingUploadLocation
-     */
-    uploadUrl: string;
-}
-/**
  * Information related to the file uploaded to the staging area.
  * @export
  * @interface UploadFileResponse
@@ -966,46 +941,6 @@ export const ActionsApiAxiosParamCreator = function (configuration?: Configurati
             localVarRequestOptions.data = needsSerialization
                 ? JSON.stringify(deleteFilesRequest !== undefined ? deleteFilesRequest : {})
                 : deleteFilesRequest || "";
-
-            return {
-                url: toPathString(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         * Provides a location for uploading staging files.
-         * @summary Get a staging upload location
-         * @param {string} dataSourceId
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getStagingUploadLocation: async (
-            dataSourceId: string,
-            options: AxiosRequestConfig = {},
-        ): Promise<RequestArgs> => {
-            // verify required parameter 'dataSourceId' is not null or undefined
-            assertParamExists("getStagingUploadLocation", "dataSourceId", dataSourceId);
-            const localVarPath = `/api/v1/actions/dataSources/{dataSourceId}/staging/upload`.replace(
-                `{${"dataSourceId"}}`,
-                encodeURIComponent(String(dataSourceId)),
-            );
-            // use dummy base URL string because the URL constructor only accepts absolute URLs.
-            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-            const localVarRequestOptions = { method: "POST", ...baseOptions, ...options };
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            setSearchParams(localVarUrlObj, localVarQueryParameter);
-            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {
-                ...localVarHeaderParameter,
-                ...headersFromBaseOptions,
-                ...options.headers,
-            };
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -1268,23 +1203,6 @@ export const ActionsApiFp = function (configuration?: Configuration) {
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
-         * Provides a location for uploading staging files.
-         * @summary Get a staging upload location
-         * @param {string} dataSourceId
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        async getStagingUploadLocation(
-            dataSourceId: string,
-            options?: AxiosRequestConfig,
-        ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<StagingUploadLocation>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.getStagingUploadLocation(
-                dataSourceId,
-                options,
-            );
-            return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
-        },
-        /**
          * Import the CSV files at the given locations in the staging area to the final location.
          * @summary Import CSV
          * @param {string} dataSourceId
@@ -1414,21 +1332,6 @@ export const ActionsApiFactory = function (
                 .then((request) => request(axios, basePath));
         },
         /**
-         * Provides a location for uploading staging files.
-         * @summary Get a staging upload location
-         * @param {ActionsApiGetStagingUploadLocationRequest} requestParameters Request parameters.
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getStagingUploadLocation(
-            requestParameters: ActionsApiGetStagingUploadLocationRequest,
-            options?: AxiosRequestConfig,
-        ): AxiosPromise<StagingUploadLocation> {
-            return localVarFp
-                .getStagingUploadLocation(requestParameters.dataSourceId, options)
-                .then((request) => request(axios, basePath));
-        },
-        /**
          * Import the CSV files at the given locations in the staging area to the final location.
          * @summary Import CSV
          * @param {ActionsApiImportCsvRequest} requestParameters Request parameters.
@@ -1537,19 +1440,6 @@ export interface ActionsApiInterface {
     ): AxiosPromise<void>;
 
     /**
-     * Provides a location for uploading staging files.
-     * @summary Get a staging upload location
-     * @param {ActionsApiGetStagingUploadLocationRequest} requestParameters Request parameters.
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof ActionsApiInterface
-     */
-    getStagingUploadLocation(
-        requestParameters: ActionsApiGetStagingUploadLocationRequest,
-        options?: AxiosRequestConfig,
-    ): AxiosPromise<StagingUploadLocation>;
-
-    /**
      * Import the CSV files at the given locations in the staging area to the final location.
      * @summary Import CSV
      * @param {ActionsApiImportCsvRequest} requestParameters Request parameters.
@@ -1642,20 +1532,6 @@ export interface ActionsApiDeleteFilesRequest {
      * @memberof ActionsApiDeleteFiles
      */
     readonly deleteFilesRequest: DeleteFilesRequest;
-}
-
-/**
- * Request parameters for getStagingUploadLocation operation in ActionsApi.
- * @export
- * @interface ActionsApiGetStagingUploadLocationRequest
- */
-export interface ActionsApiGetStagingUploadLocationRequest {
-    /**
-     *
-     * @type {string}
-     * @memberof ActionsApiGetStagingUploadLocation
-     */
-    readonly dataSourceId: string;
 }
 
 /**
@@ -1780,23 +1656,6 @@ export class ActionsApi extends BaseAPI implements ActionsApiInterface {
     public deleteFiles(requestParameters: ActionsApiDeleteFilesRequest, options?: AxiosRequestConfig) {
         return ActionsApiFp(this.configuration)
             .deleteFiles(requestParameters.dataSourceId, requestParameters.deleteFilesRequest, options)
-            .then((request) => request(this.axios, this.basePath));
-    }
-
-    /**
-     * Provides a location for uploading staging files.
-     * @summary Get a staging upload location
-     * @param {ActionsApiGetStagingUploadLocationRequest} requestParameters Request parameters.
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof ActionsApi
-     */
-    public getStagingUploadLocation(
-        requestParameters: ActionsApiGetStagingUploadLocationRequest,
-        options?: AxiosRequestConfig,
-    ) {
-        return ActionsApiFp(this.configuration)
-            .getStagingUploadLocation(requestParameters.dataSourceId, options)
             .then((request) => request(this.axios, this.basePath));
     }
 
@@ -2909,46 +2768,6 @@ export const DataSourceStagingLocationApiAxiosParamCreator = function (configura
     return {
         /**
          * Provides a location for uploading staging files.
-         * @summary Get a staging upload location
-         * @param {string} dataSourceId
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getStagingUploadLocation: async (
-            dataSourceId: string,
-            options: AxiosRequestConfig = {},
-        ): Promise<RequestArgs> => {
-            // verify required parameter 'dataSourceId' is not null or undefined
-            assertParamExists("getStagingUploadLocation", "dataSourceId", dataSourceId);
-            const localVarPath = `/api/v1/actions/dataSources/{dataSourceId}/staging/upload`.replace(
-                `{${"dataSourceId"}}`,
-                encodeURIComponent(String(dataSourceId)),
-            );
-            // use dummy base URL string because the URL constructor only accepts absolute URLs.
-            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-            const localVarRequestOptions = { method: "POST", ...baseOptions, ...options };
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            setSearchParams(localVarUrlObj, localVarQueryParameter);
-            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {
-                ...localVarHeaderParameter,
-                ...headersFromBaseOptions,
-                ...options.headers,
-            };
-
-            return {
-                url: toPathString(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         * Provides a location for uploading staging files.
          * @summary Upload a file to the staging area
          * @param {string} dataSourceId
          * @param {any} file The file to upload.
@@ -3011,23 +2830,6 @@ export const DataSourceStagingLocationApiFp = function (configuration?: Configur
     return {
         /**
          * Provides a location for uploading staging files.
-         * @summary Get a staging upload location
-         * @param {string} dataSourceId
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        async getStagingUploadLocation(
-            dataSourceId: string,
-            options?: AxiosRequestConfig,
-        ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<StagingUploadLocation>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.getStagingUploadLocation(
-                dataSourceId,
-                options,
-            );
-            return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
-        },
-        /**
-         * Provides a location for uploading staging files.
          * @summary Upload a file to the staging area
          * @param {string} dataSourceId
          * @param {any} file The file to upload.
@@ -3062,21 +2864,6 @@ export const DataSourceStagingLocationApiFactory = function (
     return {
         /**
          * Provides a location for uploading staging files.
-         * @summary Get a staging upload location
-         * @param {DataSourceStagingLocationApiGetStagingUploadLocationRequest} requestParameters Request parameters.
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getStagingUploadLocation(
-            requestParameters: DataSourceStagingLocationApiGetStagingUploadLocationRequest,
-            options?: AxiosRequestConfig,
-        ): AxiosPromise<StagingUploadLocation> {
-            return localVarFp
-                .getStagingUploadLocation(requestParameters.dataSourceId, options)
-                .then((request) => request(axios, basePath));
-        },
-        /**
-         * Provides a location for uploading staging files.
          * @summary Upload a file to the staging area
          * @param {DataSourceStagingLocationApiStagingUploadRequest} requestParameters Request parameters.
          * @param {*} [options] Override http request option.
@@ -3101,19 +2888,6 @@ export const DataSourceStagingLocationApiFactory = function (
 export interface DataSourceStagingLocationApiInterface {
     /**
      * Provides a location for uploading staging files.
-     * @summary Get a staging upload location
-     * @param {DataSourceStagingLocationApiGetStagingUploadLocationRequest} requestParameters Request parameters.
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof DataSourceStagingLocationApiInterface
-     */
-    getStagingUploadLocation(
-        requestParameters: DataSourceStagingLocationApiGetStagingUploadLocationRequest,
-        options?: AxiosRequestConfig,
-    ): AxiosPromise<StagingUploadLocation>;
-
-    /**
-     * Provides a location for uploading staging files.
      * @summary Upload a file to the staging area
      * @param {DataSourceStagingLocationApiStagingUploadRequest} requestParameters Request parameters.
      * @param {*} [options] Override http request option.
@@ -3124,20 +2898,6 @@ export interface DataSourceStagingLocationApiInterface {
         requestParameters: DataSourceStagingLocationApiStagingUploadRequest,
         options?: AxiosRequestConfig,
     ): AxiosPromise<UploadFileResponse>;
-}
-
-/**
- * Request parameters for getStagingUploadLocation operation in DataSourceStagingLocationApi.
- * @export
- * @interface DataSourceStagingLocationApiGetStagingUploadLocationRequest
- */
-export interface DataSourceStagingLocationApiGetStagingUploadLocationRequest {
-    /**
-     *
-     * @type {string}
-     * @memberof DataSourceStagingLocationApiGetStagingUploadLocation
-     */
-    readonly dataSourceId: string;
 }
 
 /**
@@ -3168,23 +2928,6 @@ export interface DataSourceStagingLocationApiStagingUploadRequest {
  * @extends {BaseAPI}
  */
 export class DataSourceStagingLocationApi extends BaseAPI implements DataSourceStagingLocationApiInterface {
-    /**
-     * Provides a location for uploading staging files.
-     * @summary Get a staging upload location
-     * @param {DataSourceStagingLocationApiGetStagingUploadLocationRequest} requestParameters Request parameters.
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof DataSourceStagingLocationApi
-     */
-    public getStagingUploadLocation(
-        requestParameters: DataSourceStagingLocationApiGetStagingUploadLocationRequest,
-        options?: AxiosRequestConfig,
-    ) {
-        return DataSourceStagingLocationApiFp(this.configuration)
-            .getStagingUploadLocation(requestParameters.dataSourceId, options)
-            .then((request) => request(this.axios, this.basePath));
-    }
-
     /**
      * Provides a location for uploading staging files.
      * @summary Upload a file to the staging area

--- a/libs/api-client-tiger/src/generated/result-json-api/openapi-spec.json
+++ b/libs/api-client-tiger/src/generated/result-json-api/openapi-spec.json
@@ -72,40 +72,6 @@
                 }
             }
         },
-        "/api/v1/actions/dataSources/{dataSourceId}/staging/upload": {
-            "post": {
-                "tags": ["Data source staging location", "actions"],
-                "summary": "Get a staging upload location",
-                "description": "Provides a location for uploading staging files.",
-                "operationId": "getStagingUploadLocation",
-                "parameters": [
-                    {
-                        "name": "dataSourceId",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Staging upload location was registered.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/StagingUploadLocation"
-                                }
-                            }
-                        }
-                    }
-                },
-                "x-gdc-security-info": {
-                    "permissions": ["MANAGE"],
-                    "description": "Minimal permission required to use this endpoint."
-                }
-            }
-        },
         "/api/v1/actions/dataSources/{dataSourceId}/readFileManifests": {
             "post": {
                 "tags": ["Data source files manifest read", "actions"],
@@ -359,21 +325,6 @@
                 },
                 "description": "Information related to the file uploaded to the staging area."
             },
-            "StagingUploadLocation": {
-                "required": ["location", "uploadUrl"],
-                "type": "object",
-                "properties": {
-                    "location": {
-                        "type": "string",
-                        "description": "Location relative to the root of the storage."
-                    },
-                    "uploadUrl": {
-                        "type": "string",
-                        "description": "Pre-signed upload URL to PUT the file to."
-                    }
-                },
-                "description": "Information related to uploading a file to the staging area."
-            },
             "ReadFileManifestsRequest": {
                 "required": ["manifestRequests"],
                 "type": "object",
@@ -622,17 +573,12 @@
                 "description": "Describes the results of a CSV manifest read of a single file."
             },
             "GdStorageFile": {
-                "required": ["modifiedAt", "name", "size", "type", "version"],
+                "required": ["modifiedAt", "name", "size", "type"],
                 "type": "object",
                 "properties": {
                     "name": {
                         "type": "string",
                         "description": "Name of the file."
-                    },
-                    "version": {
-                        "type": "integer",
-                        "description": "Version of the file.",
-                        "format": "int32"
                     },
                     "size": {
                         "type": "integer",

--- a/libs/api-client-tiger/src/index.ts
+++ b/libs/api-client-tiger/src/index.ts
@@ -262,7 +262,6 @@ export {
 export {
     ActionsApiAnalyzeCsvRequest,
     ActionsApiDeleteFilesRequest,
-    ActionsApiGetStagingUploadLocationRequest,
     ActionsApiImportCsvRequest,
     ActionsApiListFilesRequest,
     ActionsApiReadFileManifestsRequest,
@@ -294,7 +293,6 @@ export {
     ReadFileManifestsRequest,
     ReadFileManifestsRequestItem,
     ReadFileManifestsResponse,
-    StagingUploadLocation,
     UploadFileResponse,
     WorkspaceCacheSettings,
     WorkspaceCacheUsage,

--- a/libs/api-client-tiger/src/result.ts
+++ b/libs/api-client-tiger/src/result.ts
@@ -3,8 +3,6 @@ import { AxiosInstance } from "axios";
 import {
     ActionsApi,
     ActionsApiInterface,
-    ActionsApiGetStagingUploadLocationRequest,
-    StagingUploadLocation,
     ActionsApiAnalyzeCsvRequest,
     AnalyzeCsvResponse,
     AnalyzeCsvRequest,
@@ -23,8 +21,6 @@ export const tigerResultClientFactory = (axios: AxiosInstance): ActionsApiInterf
 
 export {
     ActionsApiInterface as ResultActionsApiInterface,
-    ActionsApiGetStagingUploadLocationRequest,
-    StagingUploadLocation,
     ActionsApiAnalyzeCsvRequest,
     AnalyzeCsvResponse,
     AnalyzeCsvRequest,

--- a/libs/sdk-backend-tiger/api/sdk-backend-tiger.api.md
+++ b/libs/sdk-backend-tiger/api/sdk-backend-tiger.api.md
@@ -50,7 +50,6 @@ import { PlatformUsage } from '@gooddata/api-client-tiger';
 import { ReadFileManifestsResponse } from '@gooddata/api-client-tiger';
 import { ScanResultPdm } from '@gooddata/api-client-tiger';
 import { ScanSqlResponse } from '@gooddata/api-client-tiger';
-import { StagingUploadLocation } from '@gooddata/api-client-tiger';
 import { TestDefinitionRequestTypeEnum } from '@gooddata/api-client-tiger';
 import { UploadFileResponse } from '@gooddata/api-client-tiger';
 
@@ -352,8 +351,6 @@ export type ScanSqlResult = ScanSqlResponse;
 // @alpha
 export type SetJwtCallback = (jwt: string, secondsBeforeTokenExpirationToCallReminder?: number) => void;
 
-export { StagingUploadLocation }
-
 // @public
 export type TigerAfmType = "label" | "metric" | "dataset" | "fact" | "attribute" | "prompt";
 
@@ -456,7 +453,6 @@ export type TigerSpecificFunctions = {
     getEntityUser?: (id: string) => Promise<IUser>;
     scanSql?: (dataSourceId: string, sql: string) => Promise<ScanSqlResult>;
     checkEntityOverrides?: (workspaceId: string, entities: Array<HierarchyObjectIdentification>) => Promise<Array<IdentifierDuplications>>;
-    getStagingUploadLocation?: (dataSourceId: string) => Promise<StagingUploadLocation>;
     stagingUpload?: (dataSourceId: string, file: File) => Promise<UploadFileResponse>;
     analyzeCsv?: (dataSourceId: string, analyzeCsvRequest: AnalyzeCsvRequest) => Promise<Array<AnalyzeCsvResponse>>;
     importCsv?: (dataSourceId: string, importCsvRequest: ImportCsvRequest) => Promise<Array<ImportCsvResponse>>;

--- a/libs/sdk-backend-tiger/src/backend/tigerSpecificFunctions.ts
+++ b/libs/sdk-backend-tiger/src/backend/tigerSpecificFunctions.ts
@@ -43,7 +43,6 @@ import {
     JsonApiWorkspaceDataFilterSettingOutDocument,
     JsonApiWorkspaceDataFilterSettingInDocument,
     ScanResultPdm,
-    StagingUploadLocation,
     AnalyzeCsvRequest,
     AnalyzeCsvResponse,
     ImportCsvRequest,
@@ -485,13 +484,6 @@ export type TigerSpecificFunctions = {
         workspaceId: string,
         entities: Array<HierarchyObjectIdentification>,
     ) => Promise<Array<IdentifierDuplications>>;
-
-    /**
-     * Get pre-signed S3 URL to upload a CSV file to the GDSTORAGE data source staging location
-     * @param dataSourceId - id of the data source
-     * @deprecated use stagingUpload instead
-     */
-    getStagingUploadLocation?: (dataSourceId: string) => Promise<StagingUploadLocation>;
 
     /**
      * Upload a CSV file to the GDSTORAGE data source staging location
@@ -1506,22 +1498,6 @@ export const buildTigerSpecificFunctions = (
                     .checkEntityOverrides({ workspaceId, hierarchyObjectIdentification })
                     .then((response) => {
                         return response.data as Array<IdentifierDuplications>;
-                    });
-            });
-        } catch (error: any) {
-            throw convertApiError(error);
-        }
-    },
-
-    getStagingUploadLocation: async (dataSourceId: string): Promise<StagingUploadLocation> => {
-        try {
-            return await authApiCall(async (sdk) => {
-                return await sdk.result
-                    .getStagingUploadLocation({
-                        dataSourceId: dataSourceId,
-                    })
-                    .then((res) => {
-                        return res?.data;
                     });
             });
         } catch (error: any) {

--- a/libs/sdk-backend-tiger/src/index.ts
+++ b/libs/sdk-backend-tiger/src/index.ts
@@ -53,7 +53,6 @@ export {
     GenerateLdmRequest,
     ApiEntitlement,
     ApiEntitlementNameEnum,
-    StagingUploadLocation,
     AnalyzeCsvRequest,
     AnalyzeCsvResponse,
     ImportCsvRequest,


### PR DESCRIPTION
The corresponding API was removed from the backend already. No client app should be using this anymore, so let's just remove this.

JIRA: CQ-383

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** 🙏

---

Refer to [documentation](https://github.com/gooddata/gooddata-ui-sdk/blob/master/dev_docs/continuous_integration.md) to see how to run checks and tests in the pull request. This is the list of the most used commands:

```
extended test - backstop
```

```
extended test - tiger-cypress - integrated
extended test - tiger-cypress - isolated
extended test - tiger-cypress - record
```
