### PR TITLE
feat: add retries to staging file uploads

### DIFF
--- a/common/config/rush/browser-approved-packages.json
+++ b/common/config/rush/browser-approved-packages.json
@@ -655,6 +655,10 @@
       "allowedCategories": [ "examples", "production", "tools" ]
     },
     {
+      "name": "exponential-backoff",
+      "allowedCategories": [ "production" ]
+    },
+    {
       "name": "fast-glob",
       "allowedCategories": [ "production", "tools" ]
     },

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1669,6 +1669,9 @@ importers:
       date-fns:
         specifier: ^2.22.1
         version: 2.30.0
+      exponential-backoff:
+        specifier: ^3.1.1
+        version: 3.1.1
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
@@ -14888,6 +14891,10 @@ packages:
       snapdragon: 0.8.2
       to-regex: 3.0.2
     dev: true
+
+  /exponential-backoff@3.1.1:
+    resolution: {integrity: sha512-dX7e/LHVJ6W3DE1MHWi9S1EYzDESENfLrYohG2G++ovZrYOkm4Knwa0mc1cn84xJOR4KEU0WSchhLbd0UklbHw==}
+    dev: false
 
   /express@4.18.2:
     resolution: {integrity: sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==}

--- a/libs/sdk-backend-tiger/package.json
+++ b/libs/sdk-backend-tiger/package.json
@@ -57,6 +57,7 @@
         "@gooddata/sdk-model": "workspace:*",
         "axios": "^1.4.0",
         "date-fns": "^2.22.1",
+        "exponential-backoff": "^3.1.1",
         "lodash": "^4.17.21",
         "spark-md5": "^3.0.0",
         "ts-invariant": "^0.7.5",


### PR DESCRIPTION
This handles temporary traffic spikes on the upload API: if there are
 too many requests happening, automatically retry after a backoff.

JIRA: CQ-378

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** 🙏

---

Refer to [documentation](https://github.com/gooddata/gooddata-ui-sdk/blob/master/dev_docs/continuous_integration.md) to see how to run checks and tests in the pull request. This is the list of the most used commands:

```
extended test - backstop
```

```
extended test - tiger-cypress - integrated
extended test - tiger-cypress - isolated
extended test - tiger-cypress - record
```
