### PR TITLE
fix: scatter plot bucket helper

### DIFF
--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/scatterPlot/bucketHelper.ts
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/scatterPlot/bucketHelper.ts
@@ -29,12 +29,12 @@ export const transformBuckets = (buckets: IBucketOfFun[]): IBucketOfFun[] => {
 
     const attributeBucket = {
         localIdentifier: BucketNames.ATTRIBUTE,
-        items: viewByAttributes,
+        items: viewByAttributes.slice(0, 1),
     };
 
     const segmentBucket = {
         localIdentifier: BucketNames.SEGMENT,
-        items: segmentByAttributes,
+        items: segmentByAttributes.slice(0, 1),
     };
 
     return [...measureBuckets, attributeBucket, segmentBucket];


### PR DESCRIPTION
Scatter plot: remove items from the viewBy and segmentBy bucket that do not belong there (both can contain a maximum of 1 item).

This fix ensures that switching from different visualization to scatter plot in AD will not cause the scatter plot to contain invalid items in the viewBy and segmentBy bucket.

JIRA: F1-346

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** 🙏

---

Refer to [documentation](https://github.com/gooddata/gooddata-ui-sdk/blob/master/dev_docs/continuous_integration.md) to see how to run checks and tests in the pull request. This is the list of the most used commands:

```
extended test - backstop
```

```
extended test - tiger-cypress - integrated
extended test - tiger-cypress - isolated
extended test - tiger-cypress - record
```
