### PR TITLE
fix(sdk-backend-tiger): workspaces query - use fallback empty filter

### DIFF
--- a/libs/sdk-backend-tiger/src/backend/workspaces/index.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspaces/index.ts
@@ -71,7 +71,7 @@ class TigerWorkspaceQuery implements IWorkspacesQuery {
     }
 
     public withFilter(filter: IWorkspacesQueryFilter): IWorkspacesQuery {
-        this.filter = filter;
+        this.filter = filter ?? {};
         return this;
     }
 


### PR DESCRIPTION
JIRA: LX-248

When `withFilter` method was called with `undefined` in workspaces query, the query failed in `constructFilter` method on an undefined filter object. Now it uses a fallback empty filter instead, hence it is not failing anymore.

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** 🙏

---

Refer to [documentation](https://github.com/gooddata/gooddata-ui-sdk/blob/master/dev_docs/continuous_integration.md) to see how to run checks and tests in the pull request. This is the list of the most used commands:

```
extended test - backstop
```

```
extended test - tiger-cypress - integrated
extended test - tiger-cypress - isolated
extended test - tiger-cypress - record
```
