### PR TITLE
feat: enable forecasting and segmentation in AIO

### DIFF
--- a/libs/sdk-backend-tiger/src/backend/uiFeatures.ts
+++ b/libs/sdk-backend-tiger/src/backend/uiFeatures.ts
@@ -193,7 +193,7 @@ export const DefaultFeatureFlags: ITigerFeatureFlags = {
     enableAlerting: false,
     enableScheduling: false,
     enableLabsSmartFunctions: false,
-    enableSmartFunctions: false,
+    enableSmartFunctions: true,
     enableKeyDriverAnalysis: false,
     enableDataProfiling: false,
     enableFlexAi: false,
@@ -203,7 +203,7 @@ export const DefaultFeatureFlags: ITigerFeatureFlags = {
     enableDuplicatedLabelValuesInAttributeFilter: false,
     enableWorkspacesHierarchyView: false,
     enableMultipleDataSourcesInWorkspace: false,
-    enableScatterPlotSegmentation: false,
+    enableScatterPlotSegmentation: true,
 };
 
 export const FeatureFlagsValues = {


### PR DESCRIPTION
Enable forecasting and segmentation feature flags
by default for GoodData.CN all in one image.

JIRA: F1-345, F1-156

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** 🙏

---

Refer to [documentation](https://github.com/gooddata/gooddata-ui-sdk/blob/master/dev_docs/continuous_integration.md) to see how to run checks and tests in the pull request. This is the list of the most used commands:

```
extended test - backstop
```

```
extended test - tiger-cypress - integrated
extended test - tiger-cypress - isolated
extended test - tiger-cypress - record
```
