### PR TITLE
feat: scatter plot clustering

### DIFF
--- a/libs/sdk-backend-base/src/decoratedBackend/execution.ts
+++ b/libs/sdk-backend-base/src/decoratedBackend/execution.ts
@@ -258,4 +258,12 @@ export abstract class DecoratedDataView implements IDataView {
     public forecast(): IForecastView {
         return this.decorated.forecast();
     }
+
+    clustering(): IClusteringResult {
+        return this.decorated.clustering();
+    }
+
+    withClustering(config?: IClusteringConfig, result?: IClusteringResult): IDataView {
+        return this.decorated.withClustering(config, result);
+    }
 }

--- a/libs/sdk-backend-base/src/dummyBackend/index.ts
+++ b/libs/sdk-backend-base/src/dummyBackend/index.ts
@@ -70,6 +70,7 @@ import {
     IAnomalyDetectionResult,
     IClusteringResult,
     IOrganizationNotificationChannelService,
+    IClusteringConfig,
 } from "@gooddata/sdk-backend-spi";
 import {
     defFingerprint,
@@ -276,6 +277,12 @@ export function dummyDataView(
         },
         withForecast(_config: IForecastConfig, _result?: IForecastResult): IDataView {
             throw new NotSupported("not supported");
+        },
+        clustering(): IClusteringResult {
+            throw new NotSupported("clustering is not supported in this dummy backend");
+        },
+        withClustering(_config?: IClusteringConfig, _result?: IClusteringResult): IDataView {
+            throw new NotSupported("clustering is not supported in this dummy backend");
         },
     };
 }

--- a/libs/sdk-backend-base/src/normalizingBackend/index.ts
+++ b/libs/sdk-backend-base/src/normalizingBackend/index.ts
@@ -202,6 +202,8 @@ class DenormalizedDataView implements IDataView {
     public readonly result: IExecutionResult;
     public readonly forecastConfig?: IForecastConfig;
     public readonly forecastResult?: IForecastResult;
+    public readonly clusteringConfig?: IClusteringConfig;
+    public readonly clusteringResult?: IClusteringResult;
 
     public readonly data: DataValue[][] | DataValue[];
     public readonly headerItems: IResultHeader[][][];
@@ -220,12 +222,16 @@ class DenormalizedDataView implements IDataView {
         denormalizer: Denormalizer,
         forecastConfig?: IForecastConfig,
         forecastResult?: IForecastResult,
+        clusteringConfig?: IClusteringConfig,
+        clusteringResult?: IClusteringResult,
     ) {
         this._denormalizer = denormalizer;
 
         this.result = result;
         this.forecastConfig = forecastConfig;
         this.forecastResult = forecastResult;
+        this.clusteringConfig = clusteringConfig;
+        this.clusteringResult = clusteringResult;
 
         this.definition = this.result.definition;
         this.count = cloneDeep(this.normalizedDataView.count);
@@ -256,6 +262,10 @@ class DenormalizedDataView implements IDataView {
         };
     }
 
+    public clustering(): IClusteringResult {
+        return this.normalizedDataView.clustering();
+    }
+
     public withForecast(config?: IForecastConfig, result?: IForecastResult): IDataView {
         const normalizedDataView = this.normalizedDataView.withForecast(config, result);
         return new DenormalizedDataView(
@@ -264,6 +274,21 @@ class DenormalizedDataView implements IDataView {
             this._denormalizer,
             normalizedDataView.forecastConfig,
             normalizedDataView.forecastResult,
+            normalizedDataView.clusteringConfig,
+            normalizedDataView.clusteringResult,
+        );
+    }
+
+    public withClustering(config?: IClusteringConfig, result?: IClusteringResult): IDataView {
+        const normalizedDataView = this.normalizedDataView.withClustering(config, result);
+        return new DenormalizedDataView(
+            this.result as DenormalizingExecutionResult,
+            normalizedDataView,
+            this._denormalizer,
+            normalizedDataView.forecastConfig,
+            normalizedDataView.forecastResult,
+            normalizedDataView.clusteringConfig,
+            normalizedDataView.clusteringResult,
         );
     }
 }

--- a/libs/sdk-backend-mockingbird/src/legacyRecordedBackend/index.ts
+++ b/libs/sdk-backend-mockingbird/src/legacyRecordedBackend/index.ts
@@ -51,6 +51,7 @@ import {
     IForecastView,
     IAnomalyDetectionResult,
     IClusteringResult,
+    IClusteringConfig,
 } from "@gooddata/sdk-backend-spi";
 import {
     defFingerprint,
@@ -318,6 +319,12 @@ function recordedDataView(
                 prediction: [],
                 loading: false,
             };
+        },
+        clustering(): IClusteringResult {
+            throw new NotSupported("Clustering is not supported by the legacy recorded backend.");
+        },
+        withClustering(_config?: IClusteringConfig, _result?: IClusteringResult): IDataView {
+            throw new NotSupported("Clustering is not supported by the legacy recorded backend.");
         },
     };
 }

--- a/libs/sdk-backend-mockingbird/src/recordedBackend/execution.ts
+++ b/libs/sdk-backend-mockingbird/src/recordedBackend/execution.ts
@@ -16,6 +16,7 @@ import {
     IForecastView,
     IAnomalyDetectionResult,
     IClusteringResult,
+    IClusteringConfig,
 } from "@gooddata/sdk-backend-spi";
 import {
     defFingerprint,
@@ -333,6 +334,8 @@ class RecordedDataView implements IDataView {
         private readonly denormalizer?: Denormalizer,
         public readonly forecastConfig?: IForecastConfig,
         public readonly forecastResult?: IForecastResult,
+        public readonly clusteringConfig?: IClusteringConfig,
+        public readonly clusteringResult?: IClusteringResult,
     ) {
         this.data = recordedDataView.data;
         this.headerItems = denormalizer
@@ -366,6 +369,8 @@ class RecordedDataView implements IDataView {
             this.denormalizer,
             config,
             result,
+            this.clusteringConfig,
+            this.clusteringResult,
         );
     }
 
@@ -377,6 +382,30 @@ class RecordedDataView implements IDataView {
                 high: [],
                 prediction: [],
             }
+        );
+    }
+
+    clustering(): IClusteringResult {
+        return (
+            this.recordedDataView.clusteringResult ?? {
+                attribute: [],
+                clusters: [],
+                xcoord: [],
+                ycoord: [],
+            }
+        );
+    }
+
+    withClustering(config?: IClusteringConfig, result?: IClusteringResult): IDataView {
+        return new RecordedDataView(
+            this.result,
+            this.definition,
+            this.recordedDataView,
+            this.denormalizer,
+            this.forecastConfig,
+            this.forecastResult,
+            config,
+            result,
         );
     }
 }

--- a/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
+++ b/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
@@ -419,6 +419,12 @@ export interface IDataSourcesService {
 
 // @public
 export interface IDataView {
+    // @beta
+    clustering(): IClusteringResult;
+    // @beta
+    readonly clusteringConfig?: IClusteringConfig;
+    // @beta
+    readonly clusteringResult?: IClusteringResult;
     readonly count: number[];
     readonly data: DataValue[][] | DataValue[];
     readonly definition: IExecutionDefinition;
@@ -437,6 +443,8 @@ export interface IDataView {
     readonly totals?: DataValue[][][];
     readonly totalTotals?: DataValue[][][];
     readonly warnings?: IResultWarning[];
+    // @beta
+    withClustering(config?: IClusteringConfig, result?: IClusteringResult): IDataView;
     // @beta
     withForecast(config?: IForecastConfig, result?: IForecastResult): IDataView;
 }

--- a/libs/sdk-backend-spi/src/workspace/execution/index.ts
+++ b/libs/sdk-backend-spi/src/workspace/execution/index.ts
@@ -526,6 +526,18 @@ export interface IDataView {
     readonly forecastResult?: IForecastResult;
 
     /**
+     * Configuration for the clustering, if available.
+     * @beta
+     */
+    readonly clusteringConfig?: IClusteringConfig;
+
+    /**
+     * Clustering result, if available.
+     * @beta
+     */
+    readonly clusteringResult?: IClusteringResult;
+
+    /**
      * Result warnings.
      *
      * @remarks
@@ -563,6 +575,13 @@ export interface IDataView {
     forecast(): IForecastView;
 
     /**
+     * Return clustering data view. This object is empty if `withClustering` was not called
+     * @see IDataView.withClustering
+     * @beta
+     */
+    clustering(): IClusteringResult;
+
+    /**
      * Adds forecast for this data view.
      *
      * @beta
@@ -571,6 +590,15 @@ export interface IDataView {
      * @returns new data view with forecasting enabled
      */
     withForecast(config?: IForecastConfig, result?: IForecastResult): IDataView;
+
+    /**
+     * Adds clustering for this data view.
+     * @beta
+     * @param config - clustering configuration
+     * @param result - clustering result
+     * @returns new data view with clustering enabled
+     */
+    withClustering(config?: IClusteringConfig, result?: IClusteringResult): IDataView;
 }
 
 /**

--- a/libs/sdk-backend-tiger/src/backend/features/feature.ts
+++ b/libs/sdk-backend-tiger/src/backend/features/feature.ts
@@ -387,6 +387,13 @@ export function mapFeatures(features: FeaturesMap): Partial<ITigerFeatureFlags> 
             "BOOLEAN",
             FeatureFlagsValues.enableScatterPlotSegmentation,
         ),
+        ...loadFeature(
+            features,
+            TigerFeaturesNames.EnableScatterPlotClustering,
+            "enableScatterPlotClustering",
+            "BOOLEAN",
+            FeatureFlagsValues.enableScatterPlotClustering,
+        ),
     };
 }
 

--- a/libs/sdk-backend-tiger/src/backend/uiFeatures.ts
+++ b/libs/sdk-backend-tiger/src/backend/uiFeatures.ts
@@ -92,6 +92,7 @@ export enum TigerFeaturesNames {
     EnableWorkspacesHierarchyView = "enableWorkspacesHierarchyView",
     EnableMultipleDataSourcesInWorkspace = "enableMultipleDataSourcesInWorkspace",
     EnableScatterPlotSegmentation = "enableScatterPlotSegmentation",
+    EnableScatterPlotClustering = "enableScatterPlotClustering",
 }
 
 export type ITigerFeatureFlags = {
@@ -148,6 +149,7 @@ export type ITigerFeatureFlags = {
     enableWorkspacesHierarchyView: typeof FeatureFlagsValues["enableWorkspacesHierarchyView"][number];
     enableMultipleDataSourcesInWorkspace: typeof FeatureFlagsValues["enableMultipleDataSourcesInWorkspace"][number];
     enableScatterPlotSegmentation: typeof FeatureFlagsValues["enableScatterPlotSegmentation"][number];
+    enableScatterPlotClustering: typeof FeatureFlagsValues["enableScatterPlotClustering"][number];
 };
 
 export const DefaultFeatureFlags: ITigerFeatureFlags = {
@@ -204,6 +206,7 @@ export const DefaultFeatureFlags: ITigerFeatureFlags = {
     enableWorkspacesHierarchyView: false,
     enableMultipleDataSourcesInWorkspace: false,
     enableScatterPlotSegmentation: true,
+    enableScatterPlotClustering: false,
 };
 
 export const FeatureFlagsValues = {
@@ -264,4 +267,5 @@ export const FeatureFlagsValues = {
     enableWorkspacesHierarchyView: [true, false] as const,
     enableMultipleDataSourcesInWorkspace: [true, false] as const,
     enableScatterPlotSegmentation: [true, false] as const,
+    enableScatterPlotClustering: [true, false] as const,
 };

--- a/libs/sdk-backend-tiger/src/backend/workspace/execution/executionResult.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/execution/executionResult.ts
@@ -311,6 +311,8 @@ class TigerDataView implements IDataView {
     public readonly totals?: DataValue[][][];
     public readonly forecastConfig?: IForecastConfig;
     public readonly forecastResult?: IForecastResult;
+    public readonly clusteringConfig?: IClusteringConfig;
+    public readonly clusteringResult?: IClusteringResult;
     public readonly totalTotals?: DataValue[][][];
     private readonly _fingerprint: string;
     private readonly _execResult: ExecutionResult;
@@ -322,11 +324,15 @@ class TigerDataView implements IDataView {
         dateFormatter: DateFormatter,
         forecastConfig?: IForecastConfig,
         forecastResult?: IForecastResult,
+        clusteringConfig?: IClusteringConfig,
+        clusteringResult?: IClusteringResult,
     ) {
         this.result = result;
         this.definition = result.definition;
         this.forecastConfig = forecastConfig;
         this.forecastResult = forecastResult;
+        this.clusteringConfig = clusteringConfig;
+        this.clusteringResult = clusteringResult;
 
         this._execResult = execResult;
         this._dateFormatter = dateFormatter;
@@ -384,6 +390,17 @@ class TigerDataView implements IDataView {
         );
     }
 
+    public clustering(): IClusteringResult {
+        return (
+            this.clusteringResult ?? {
+                attribute: [],
+                clusters: [],
+                xcoord: [],
+                ycoord: [],
+            }
+        );
+    }
+
     public withForecast(config?: IForecastConfig, result?: IForecastResult): IDataView {
         const normalizedConfig = config
             ? {
@@ -397,6 +414,20 @@ class TigerDataView implements IDataView {
             this._execResult,
             this._dateFormatter,
             normalizedConfig,
+            result,
+            this.clusteringConfig,
+            this.clusteringResult,
+        );
+    }
+
+    public withClustering(config?: IClusteringConfig, result?: IClusteringResult): IDataView {
+        return new TigerDataView(
+            this.result,
+            this._execResult,
+            this._dateFormatter,
+            this.forecastConfig,
+            this.forecastResult,
+            config,
             result,
         );
     }

--- a/libs/sdk-model/api/sdk-model.api.md
+++ b/libs/sdk-model/api/sdk-model.api.md
@@ -2656,6 +2656,7 @@ export interface ISettings {
     enablePushpinGeoChart?: boolean;
     enableRenamingMeasureToMetric?: boolean;
     enableReversedStacking?: boolean;
+    enableScatterPlotClustering?: boolean;
     enableScatterPlotSegmentation?: boolean;
     enableSeparateTotalLabels?: boolean;
     enableTableColumnsAutoResizing?: boolean;

--- a/libs/sdk-model/src/settings/index.ts
+++ b/libs/sdk-model/src/settings/index.ts
@@ -387,6 +387,11 @@ export interface ISettings {
      */
     enableScatterPlotSegmentation?: boolean;
 
+    /**
+     * Enable clustering in scatter plot.
+     */
+    enableScatterPlotClustering?: boolean;
+
     [key: string]: number | boolean | string | object | undefined;
 }
 

--- a/libs/sdk-ui-charts/api/sdk-ui-charts.api.md
+++ b/libs/sdk-ui-charts/api/sdk-ui-charts.api.md
@@ -19,6 +19,7 @@ import { IAnalyticalBackend } from '@gooddata/sdk-backend-spi';
 import { IAttribute } from '@gooddata/sdk-model';
 import { IAttributeOrMeasure } from '@gooddata/sdk-model';
 import { IBucket } from '@gooddata/sdk-model';
+import { IClusteringConfig } from '@gooddata/sdk-backend-spi';
 import { IColor } from '@gooddata/sdk-model';
 import { IColorMapping } from '@gooddata/sdk-ui-vis-commons';
 import { IColorPalette } from '@gooddata/sdk-model';
@@ -283,6 +284,12 @@ export interface IChartCallbacks extends IVisualizationCallbacks {
     onLegendReady?: OnLegendReady;
 }
 
+// @beta
+export interface IChartClusteringConfig {
+    enabled: boolean;
+    numberOfClusters: number;
+}
+
 // @public
 export interface IChartConfig {
     // @beta
@@ -293,6 +300,8 @@ export interface IChartConfig {
     cellVerticalAlign?: ChartCellVerticalAlign;
     // @internal
     chart?: any;
+    // @beta
+    clustering?: IChartClusteringConfig;
     colorMapping?: IColorMapping[];
     colorPalette?: IColorPalette;
     colors?: string[];
@@ -430,6 +439,7 @@ export interface IContinuousLineConfig {
 
 // @internal
 export interface ICoreChartProps extends ICommonChartProps {
+    clusteringConfig?: IClusteringConfig;
     execution: IPreparedExecution;
     forecastConfig?: IForecastConfig;
 }

--- a/libs/sdk-ui-charts/src/highcharts/ChartTransformation.tsx
+++ b/libs/sdk-ui-charts/src/highcharts/ChartTransformation.tsx
@@ -11,6 +11,7 @@ import {
     ExplicitDrill,
     emptyHeaderTitleFromIntl,
     totalColumnTitleFromIntl,
+    clusterTitleFromIntl,
 } from "@gooddata/sdk-ui";
 import { IChartConfig, OnLegendReady } from "../interfaces/index.js";
 import { getChartOptions } from "./chartTypes/_chartOptions/chartOptionsBuilder.js";
@@ -100,6 +101,7 @@ const ChartTransformationImpl = (props: IChartTransformationProps) => {
         emptyHeaderTitleFromIntl(intl),
         theme,
         totalColumnTitleFromIntl(intl),
+        clusterTitleFromIntl(intl),
     );
     const legendOptions: ILegendOptions = buildLegendOptions(config.legend, chartOptions, intl);
     const validationResult = validateData(config.limits, chartOptions);

--- a/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartOptions/chartOptionsBuilder.ts
+++ b/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartOptions/chartOptionsBuilder.ts
@@ -390,6 +390,7 @@ export function getChartOptions(
     emptyHeaderTitle: string,
     theme?: ITheme,
     totalColumnTitle?: string,
+    clusterTitle?: string,
 ): IChartOptions {
     const dv = DataViewFacade.for(dataView);
     const dimensions = dv.meta().dimensions();
@@ -419,6 +420,7 @@ export function getChartOptions(
         dv,
         type,
         theme,
+        clusterTitle,
     );
 
     const gridEnabled = config?.grid?.enabled ?? true;
@@ -547,7 +549,13 @@ export function getChartOptions(
                 categories,
             },
             actions: {
-                tooltip: generateTooltipScatterPlotFn(measures, stackByAttribute, viewByAttribute, config),
+                tooltip: generateTooltipScatterPlotFn(
+                    measures,
+                    stackByAttribute,
+                    viewByAttribute,
+                    config,
+                    clusterTitle,
+                ),
             },
             grid: {
                 enabled: gridEnabled,

--- a/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartOptions/chartTooltips.ts
+++ b/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartOptions/chartTooltips.ts
@@ -214,6 +214,7 @@ export function generateTooltipScatterPlotFn(
     stackByAttribute: IUnwrappedAttributeHeadersWithItems,
     viewByAttribute: IUnwrappedAttributeHeadersWithItems,
     config: IChartConfig = {},
+    clusterTitle?: string,
 ): ITooltipFactory {
     const { separators } = config;
 
@@ -221,6 +222,7 @@ export function generateTooltipScatterPlotFn(
         const textData = [];
         const viewByName = point.name ? point.name : point.series.name;
         const stackByName = point.segmentName ? point.segmentName : point.series.name;
+        const clusterName = point.clusterName ? point.clusterName : point.series.name;
 
         if (viewByAttribute) {
             textData.unshift([customEscape(viewByAttribute.formOf.name), customEscape(viewByName)]);
@@ -242,6 +244,10 @@ export function generateTooltipScatterPlotFn(
                 customEscape(measures[1].measureHeaderItem.name),
                 formatValueForTooltip(point.y, measures[1].measureHeaderItem.format, separators),
             ]);
+        }
+
+        if (config?.clustering?.enabled && clusterName) {
+            textData.unshift([clusterTitle, customEscape(clusterName)]);
         }
 
         return renderTooltipHTML(textData, maxTooltipContentWidth);

--- a/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartOptions/colorFactory.ts
+++ b/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartOptions/colorFactory.ts
@@ -54,6 +54,7 @@ export class ColorFactory {
         dv: DataViewFacade,
         type: string,
         theme?: ITheme,
+        clusterTitle?: string,
     ): IColorStrategy {
         if (isHeatmap(type)) {
             return new HeatmapColorStrategy(
@@ -85,6 +86,7 @@ export class ColorFactory {
                 stackByAttribute,
                 dv,
                 theme,
+                clusterTitle,
             );
         }
 

--- a/libs/sdk-ui-charts/src/highcharts/chartTypes/scatterPlot/scatterPlotSeries.ts
+++ b/libs/sdk-ui-charts/src/highcharts/chartTypes/scatterPlot/scatterPlotSeries.ts
@@ -3,7 +3,7 @@ import { BucketNames, DataViewFacade, getMappingHeaderFormattedName } from "@goo
 import { IColorStrategy, valueWithEmptyHandling } from "@gooddata/sdk-ui-vis-commons";
 import { IPointData, ISeriesItemConfig } from "../../typings/unsafe.js";
 import { parseValue } from "../_util/common.js";
-import { IResultAttributeHeader } from "@gooddata/sdk-model";
+import { IColorDescriptor, IResultAttributeHeader } from "@gooddata/sdk-model";
 import debounce from "lodash/debounce.js";
 
 function _decreaseOpacityOfOtherSegmentsOnMouseOver() {
@@ -28,6 +28,28 @@ function _resetOpacityOfOtherSegmentsOnMouseOut() {
 
 const resetOpacityOfOtherSegmentsOnMouseOut = debounce(_resetOpacityOfOtherSegmentsOnMouseOut, 50);
 
+function _decreaseOpacityOfOtherClustersOnMouseOver() {
+    const clusterName = this?.clusterName;
+    const allDataPoints = this?.series?.data;
+    const otherClustersDataPoints = allDataPoints?.filter((dp) => dp.clusterName !== clusterName);
+    otherClustersDataPoints?.forEach((dp) => {
+        dp.graphic?.attr({ opacity: 0.3 });
+    });
+}
+
+const decreaseOpacityOfOtherClustersOnMouseOver = debounce(_decreaseOpacityOfOtherClustersOnMouseOver, 50);
+
+function _resetOpacityOfOtherClustersOnMouseOut() {
+    const clusterName = this?.clusterName;
+    const allDataPoints = this?.series?.data;
+    const otherClustersDataPoints = allDataPoints?.filter((dp) => dp.clusterName !== clusterName);
+    otherClustersDataPoints?.forEach((dp) => {
+        dp.graphic?.attr({ opacity: 1 });
+    });
+}
+
+const resetOpacityOfOtherClustersOnMouseOut = debounce(_resetOpacityOfOtherClustersOnMouseOut, 50);
+
 export function getScatterPlotSeries(
     dv: DataViewFacade,
     // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
@@ -41,6 +63,11 @@ export function getScatterPlotSeries(
     const secondaryMeasuresBucketEmpty = dv.def().isBucketEmpty(BucketNames.SECONDARY_MEASURES);
     const colorAssignments = colorStrategy.getColorAssignment();
 
+    const isClustering = dv?.dataView?.clusteringConfig?.numberOfClusters > 0;
+    const isClusteringLoading = isClustering && !dv?.dataView?.clusteringResult;
+    const isClusteringError = isClustering && dv?.dataView?.clusteringResult?.clusters?.length === 0;
+    const isClusteringLoaded = isClustering && !!dv?.dataView?.clusteringResult && !isClusteringError;
+
     const data = dv
         .rawData()
         .twoDimData()
@@ -49,19 +76,25 @@ export function getScatterPlotSeries(
                 return parseValue(value);
             });
 
-            const colorAssignment = stackByAttribute
-                ? colorAssignments.find(
-                      (a) =>
-                          (stackByAttribute.items as IResultAttributeHeader[])[seriesIndex]
-                              .attributeHeaderItem.uri ===
-                          (a.headerItem as IResultAttributeHeader).attributeHeaderItem.uri,
-                  )
-                : colorAssignments[0];
+            let colorAssignment = colorAssignments[0];
+            if (stackByAttribute) {
+                colorAssignment = colorAssignments.find(
+                    (a) =>
+                        (stackByAttribute.items as IResultAttributeHeader[])[seriesIndex].attributeHeaderItem
+                            .uri === (a.headerItem as IResultAttributeHeader).attributeHeaderItem.uri,
+                );
+            } else if (isClusteringLoaded) {
+                const clusterIndex = dv?.dataView?.clusteringResult?.clusters?.[seriesIndex];
+                colorAssignment = colorAssignments.find(
+                    (a) => (a.headerItem as IColorDescriptor).colorHeaderItem.id === `${clusterIndex}`,
+                );
+            }
 
             const colorAssignmentIndex = colorAssignments.indexOf(colorAssignment);
             const assignedColor = colorStrategy.getColorByIndex(colorAssignmentIndex);
 
             return {
+                loading: isClustering ? isClusteringLoading : false,
                 x: !primaryMeasuresBucketEmpty ? values[0] : 0,
                 y: !secondaryMeasuresBucketEmpty ? (primaryMeasuresBucketEmpty ? values[0] : values[1]) : 0,
                 name: viewByAttribute
@@ -76,12 +109,27 @@ export function getScatterPlotSeries(
                           emptyHeaderTitle,
                       )
                     : "",
+                clusterName:
+                    isClusteringLoaded && colorAssignment
+                        ? valueWithEmptyHandling(
+                              getMappingHeaderFormattedName(colorAssignment.headerItem),
+                              emptyHeaderTitle,
+                          )
+                        : "",
                 color: assignedColor,
                 ...(stackByAttribute
                     ? {
                           events: {
                               mouseOver: decreaseOpacityOfOtherSegmentsOnMouseOver,
                               mouseOut: resetOpacityOfOtherSegmentsOnMouseOut,
+                          },
+                      }
+                    : {}),
+                ...(isClusteringLoaded
+                    ? {
+                          events: {
+                              mouseOver: decreaseOpacityOfOtherClustersOnMouseOver,
+                              mouseOut: resetOpacityOfOtherClustersOnMouseOut,
                           },
                       }
                     : {}),

--- a/libs/sdk-ui-charts/src/interfaces/chartConfig.ts
+++ b/libs/sdk-ui-charts/src/interfaces/chartConfig.ts
@@ -343,6 +343,28 @@ export interface IChartConfig {
      * @beta
      */
     forecast?: IForecast;
+
+    /**
+     * Configuration of the clustering.
+     * @beta
+     */
+    clustering?: IChartClusteringConfig;
+}
+
+/**
+ * @beta
+ * Forecast configuration
+ */
+export interface IChartClusteringConfig {
+    /**
+     * Indicates whether the clustering is enabled or not.
+     */
+    enabled: boolean;
+
+    /**
+     * Number of clusters.
+     */
+    numberOfClusters: number;
 }
 
 /**

--- a/libs/sdk-ui-charts/src/interfaces/chartProps.ts
+++ b/libs/sdk-ui-charts/src/interfaces/chartProps.ts
@@ -1,5 +1,10 @@
 // (C) 2019-2024 GoodData Corporation
-import { IAnalyticalBackend, IForecastConfig, IPreparedExecution } from "@gooddata/sdk-backend-spi";
+import {
+    IAnalyticalBackend,
+    IClusteringConfig,
+    IForecastConfig,
+    IPreparedExecution,
+} from "@gooddata/sdk-backend-spi";
 import { IVisualizationCallbacks, IVisualizationProps } from "@gooddata/sdk-ui";
 import { IExecutionConfig } from "@gooddata/sdk-model";
 import { IChartConfig } from "./chartConfig.js";
@@ -114,4 +119,9 @@ export interface ICoreChartProps extends ICommonChartProps {
      * Forecast configuration to apply to the chart data.
      */
     forecastConfig?: IForecastConfig;
+
+    /**
+     * Clustering configuration to apply to the chart data.
+     */
+    clusteringConfig?: IClusteringConfig;
 }

--- a/libs/sdk-ui-charts/src/interfaces/index.ts
+++ b/libs/sdk-ui-charts/src/interfaces/index.ts
@@ -27,6 +27,7 @@ export {
     ChartCellImageSizing,
     ChartInlineVisualizationType,
     IInlineVisualizationsConfig,
+    IChartClusteringConfig,
 } from "./chartConfig.js";
 
 export {

--- a/libs/sdk-ui-ext/src/internal/components/configurationControls/InputControl.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/configurationControls/InputControl.tsx
@@ -1,4 +1,4 @@
-// (C) 2019-2022 GoodData Corporation
+// (C) 2019-2024 GoodData Corporation
 import React from "react";
 import { WrappedComponentProps, injectIntl } from "react-intl";
 import noop from "lodash/noop.js";
@@ -28,6 +28,23 @@ export interface IInputControlProps {
     pushData?(data: any): void;
     validateAndPushDataCallback?(value: string): void;
     maxLength?: number;
+    /**
+     * Optional function to validate the input value.
+     * If the value is considered as invalid, it won't be set and emitted,
+     * and last valid value will be used instead.
+     *
+     * @param value - the value to validate
+     * @returns true if the value is valid, false otherwise
+     */
+    validateFn?: (value: string) => boolean;
+    /**
+     * Optional function to transform the input value, before it's sent via pushData callback.
+     * This callback will be called only for valid values (see validateFn property).
+     *
+     * @param value - the value to transform
+     * @returns the transformed value
+     */
+    transformFn?: (value: string) => string;
 }
 
 export interface IInputControlState {
@@ -126,6 +143,11 @@ export class InputControl extends React.Component<
     }
 
     private isValid(type: string, value: string) {
+        const { validateFn } = this.props;
+        if (validateFn) {
+            return validateFn(value);
+        }
+
         if (type === "number") {
             // allow only numbers, `-` and string doesn't starts with `.`
             return !value.startsWith(".") && (!isNaN(Number(value)) || value === "-");
@@ -150,7 +172,11 @@ export class InputControl extends React.Component<
     }
 
     private modifyDataForSending(value: string) {
-        const { type } = this.props;
+        const { type, transformFn } = this.props;
+
+        if (transformFn) {
+            return transformFn(value);
+        }
 
         if (type === "number") {
             return value.replace(/\.+$/, "");

--- a/libs/sdk-ui-ext/src/internal/components/configurationControls/clustering/NumberOfClustersControl.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/configurationControls/clustering/NumberOfClustersControl.tsx
@@ -1,0 +1,48 @@
+// (C) 2019-2024 GoodData Corporation
+import React from "react";
+import InputControl from "../InputControl.js";
+import { IVisualizationProperties } from "../../../interfaces/Visualization.js";
+import { messages } from "../../../../locales.js";
+import { DEFAULT_NUMBER_OF_CLUSTERS } from "../../../constants/scatter.js";
+
+export interface INumberOfClustersControlProps {
+    valuePath: string;
+    disabled: boolean;
+    properties: IVisualizationProperties;
+    pushData: (data: any) => any;
+}
+
+const validPositiveNumberHigherThanZero = /^[1-9][0-9]*$/;
+
+export const NumberOfClustersControl = ({
+    disabled,
+    valuePath,
+    properties,
+    pushData,
+}: INumberOfClustersControlProps) => {
+    return (
+        <InputControl
+            valuePath={valuePath}
+            labelText={messages.clusteringAmount.id}
+            placeholder={messages.clusteringAmountPlaceholder.id}
+            type="number"
+            value={properties?.controls?.clustering?.numberOfClusters ?? `${DEFAULT_NUMBER_OF_CLUSTERS}`}
+            disabled={disabled}
+            properties={properties}
+            pushData={pushData}
+            validateFn={(value) => {
+                // Only numbers or empty value is valid input
+                return value === "" || validPositiveNumberHigherThanZero.test(value);
+            }}
+            transformFn={(value) => {
+                const isValid = validPositiveNumberHigherThanZero.test(value);
+                // For invalid or empty input, transform to default value.
+                if (value === "" || !isValid) {
+                    return `${DEFAULT_NUMBER_OF_CLUSTERS}`;
+                }
+
+                return value;
+            }}
+        />
+    );
+};

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/AbstractPluggableVisualization.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/AbstractPluggableVisualization.tsx
@@ -34,6 +34,7 @@ import {
     isGoodDataSdkError,
     UnexpectedSdkError,
     isForecastNotReceived,
+    isClusteringNotReceived,
 } from "@gooddata/sdk-ui";
 import { IntlShape } from "react-intl";
 import { createInternalIntl } from "../../utils/internalIntlProvider.js";
@@ -259,7 +260,7 @@ export abstract class AbstractPluggableVisualization implements IVisualization {
         // EMPTY_AFM is handled in update as it can change on any render contrary to other error types
         // that have to be set manually or by loading
         // FORECAST_NOT_RECEIVED is not handled as an normal error, cause its not results in invalid chart
-        if (!isEmptyAfm(error) && !isForecastNotReceived(error)) {
+        if (!isEmptyAfm(error) && !isForecastNotReceived(error) && !isClusteringNotReceived(error)) {
             this.hasError = true;
         }
 

--- a/libs/sdk-ui-ext/src/internal/constants/scatter.ts
+++ b/libs/sdk-ui-ext/src/internal/constants/scatter.ts
@@ -1,0 +1,2 @@
+// (C) 2019-2024 GoodData Corporation
+export const DEFAULT_NUMBER_OF_CLUSTERS = 3;

--- a/libs/sdk-ui-ext/src/internal/constants/supportedProperties.ts
+++ b/libs/sdk-ui-ext/src/internal/constants/supportedProperties.ts
@@ -205,6 +205,8 @@ export const SCATTERPLOT_SUPPORTED_PROPERTIES = [
     "zoomInsight",
     "yaxis.format",
     "disableDrillDown",
+    "clustering.enabled",
+    "clustering.numberOfClusters",
 ];
 
 export const PIECHART_SUPPORTED_PROPERTIES = [

--- a/libs/sdk-ui-ext/src/internal/translations/en-US.json
+++ b/libs/sdk-ui-ext/src/internal/translations/en-US.json
@@ -1031,6 +1031,36 @@
         "comment": "",
         "limit": 0
     },
+    "properties.clustering.title": {
+        "value": "Cluster",
+        "comment": "Title of the clustering configuration section.",
+        "limit": 0
+    },
+    "properties.clustering.amount": {
+        "value": "Amount",
+        "comment": "Label of the input for configuring the number of clusters.",
+        "limit": 0
+    },
+    "properties.clustering.amount.placeholder": {
+        "value": "3",
+        "comment": "Placeholder of the input for configuring the number of clusters.",
+        "limit": 0
+    },
+    "properties.clustering.amount.partial.title": {
+        "value": "Showing partial clusters",
+        "comment": "Message title that is shown when clustering amount is higher than the number of visualization data points.",
+        "limit": 0
+    },
+    "properties.clustering.amount.partial.description": {
+        "value": "The available data points don't cover the entire selected amount.",
+        "comment": "Message description that is shown when clustering amount is higher than the number of visualization data points.",
+        "limit": 0
+    },
+    "properties.clustering.disabled": {
+        "value": "Clustering can be enabled only when the segmentBy bucket is empty.",
+        "comment": "Tooltip message of the disabled toggle that enables clustering",
+        "limit": 0
+    },
     "properties.canvas.totalLabels": {
         "value": "Total Labels",
         "comment": "",

--- a/libs/sdk-ui-ext/src/locales.ts
+++ b/libs/sdk-ui-ext/src/locales.ts
@@ -242,6 +242,9 @@ export const messages: Record<string, MessageDescriptor> = defineMessages({
     forecastConfidence95: { id: "properties.forecastConfidence.95" },
     forecastSlicedWarningTitle: { id: "properties.forecastSliced.title" },
     forecastSlicedWarningDescription: { id: "properties.forecastSliced.description" },
+    clusteringTitle: { id: "properties.clustering.title" },
+    clusteringAmount: { id: "properties.clustering.amount" },
+    clusteringAmountPlaceholder: { id: "properties.clustering.amount.placeholder" },
 });
 
 export const comparisonMessages: Record<string, MessageDescriptor> = defineMessages({

--- a/libs/sdk-ui-vis-commons/api/sdk-ui-vis-commons.api.md
+++ b/libs/sdk-ui-vis-commons/api/sdk-ui-vis-commons.api.md
@@ -38,9 +38,11 @@ export const ColorLegend: React_2.ComponentType<Omit<IColorLegendProps, "theme" 
 
 // @internal (undocumented)
 export abstract class ColorStrategy implements IColorStrategy {
-    constructor(colorPalette: IColorPalette, colorMapping: IColorMapping[], viewByAttribute: any, stackByAttribute: any, dv: DataViewFacade, theme?: ITheme);
+    constructor(colorPalette: IColorPalette, colorMapping: IColorMapping[], viewByAttribute: any, stackByAttribute: any, dv: DataViewFacade, theme?: ITheme, clusterTitle?: string);
     // (undocumented)
-    protected abstract createColorAssignment(colorPalette: IColorPalette, colorMapping: IColorMapping[], viewByAttribute: any, stackByAttribute: any, dv: DataViewFacade): ICreateColorAssignmentReturnValue;
+    protected clusterTitle?: string;
+    // (undocumented)
+    protected abstract createColorAssignment(colorPalette: IColorPalette, colorMapping: IColorMapping[], viewByAttribute: any, stackByAttribute: any, dv: DataViewFacade, clusterTitle?: string): ICreateColorAssignmentReturnValue;
     // (undocumented)
     protected createPalette(colorPalette: IColorPalette, colorAssignment: IColorAssignment[], _viewByAttribute: any, _stackByAttribute: any): string[];
     // (undocumented)

--- a/libs/sdk-ui-vis-commons/src/coloring/base.ts
+++ b/libs/sdk-ui-vis-commons/src/coloring/base.ts
@@ -1,4 +1,4 @@
-// (C) 2020-2022 GoodData Corporation
+// (C) 2020-2024 GoodData Corporation
 import { IColorAssignment, DataViewFacade } from "@gooddata/sdk-ui";
 import {
     IColor,
@@ -39,6 +39,7 @@ export abstract class ColorStrategy implements IColorStrategy {
     protected fullColorAssignment: IColorAssignment[];
     protected outputColorAssignment: IColorAssignment[];
     protected theme?: ITheme;
+    protected clusterTitle?: string;
 
     constructor(
         colorPalette: IColorPalette,
@@ -49,6 +50,7 @@ export abstract class ColorStrategy implements IColorStrategy {
         stackByAttribute: any,
         dv: DataViewFacade,
         theme?: ITheme,
+        clusterTitle?: string,
     ) {
         this.theme = theme;
 
@@ -58,6 +60,7 @@ export abstract class ColorStrategy implements IColorStrategy {
             viewByAttribute,
             stackByAttribute,
             dv,
+            clusterTitle,
         );
         this.fullColorAssignment = fullColorAssignment;
         this.outputColorAssignment = outputColorAssignment ? outputColorAssignment : fullColorAssignment;
@@ -106,6 +109,7 @@ export abstract class ColorStrategy implements IColorStrategy {
         // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
         stackByAttribute: any,
         dv: DataViewFacade,
+        clusterTitle?: string,
     ): ICreateColorAssignmentReturnValue;
 }
 

--- a/libs/sdk-ui/api/sdk-ui.api.md
+++ b/libs/sdk-ui/api/sdk-ui.api.md
@@ -18,6 +18,7 @@ import { IAttributeDescriptor } from '@gooddata/sdk-model';
 import { IAttributeFilter } from '@gooddata/sdk-model';
 import { IAttributeOrMeasure } from '@gooddata/sdk-model';
 import { IBucket } from '@gooddata/sdk-model';
+import { IClusteringConfig } from '@gooddata/sdk-backend-spi';
 import { IColor } from '@gooddata/sdk-model';
 import { IColorDescriptor } from '@gooddata/sdk-model';
 import { IColorPalette } from '@gooddata/sdk-model';
@@ -164,6 +165,14 @@ export type ChartType = "bar" | "column" | "pie" | "line" | "area" | "donut" | "
 
 // @alpha
 export const ClientWorkspaceProvider: React_2.FC<IClientWorkspaceProviderProps>;
+
+// @public
+export class ClusteringNotReceivedSdkError extends GoodDataSdkError {
+    constructor(message?: string, cause?: Error);
+}
+
+// @internal
+export function clusterTitleFromIntl(intl: IntlShape): string;
 
 // @public
 export function composedFromIdentifier(identifier: string): IHeaderPredicate;
@@ -360,6 +369,7 @@ export const ErrorCodes: {
     TIMEOUT_ERROR: string;
     VISUALIZATION_CLASS_UNKNOWN: string;
     FORECAST_NOT_RECEIVED: string;
+    CLUSTERING_NOT_RECEIVED: string;
 };
 
 // @public
@@ -661,6 +671,8 @@ export interface IDataSliceCollection extends Iterable<IDataSlice> {
 
 // @public
 export interface IDataVisualizationProps extends IVisualizationProps, IVisualizationCallbacks {
+    // @beta
+    clusteringConfig?: IClusteringConfig;
     execution: IPreparedExecution;
     // @beta
     forecastConfig?: IForecastConfig;
@@ -1183,6 +1195,9 @@ export const isCancelError: (obj: unknown) => obj is CancelError;
 
 // @public
 export function isCancelledSdkError(obj: unknown): obj is CancelledSdkError;
+
+// @public
+export function isClusteringNotReceived(obj: unknown): obj is ClusteringNotReceivedSdkError;
 
 // @public
 export function isComposedPlaceholder<TReturn, TValue extends any[], TContext>(obj: unknown): obj is IComposedPlaceholder<TReturn, TValue, TContext>;

--- a/libs/sdk-ui/src/base/errors/GoodDataSdkError.ts
+++ b/libs/sdk-ui/src/base/errors/GoodDataSdkError.ts
@@ -25,6 +25,7 @@ export const ErrorCodes = {
     TIMEOUT_ERROR: "TIMEOUT_ERROR",
     VISUALIZATION_CLASS_UNKNOWN: "VISUALIZATION_CLASS_UNKNOWN",
     FORECAST_NOT_RECEIVED: "FORECAST_NOT_RECEIVED",
+    CLUSTERING_NOT_RECEIVED: "CLUSTERING_NOT_RECEIVED",
 };
 
 /**
@@ -145,6 +146,17 @@ export class DataTooLargeToDisplaySdkError extends GoodDataSdkError {
 export class ForecastNotReceivedSdkError extends GoodDataSdkError {
     constructor(message?: string, cause?: Error) {
         super(ErrorCodes.FORECAST_NOT_RECEIVED as SdkErrorType, message, cause);
+    }
+}
+
+/**
+ * This error means that execution of forecast ended with error.
+ *
+ * @public
+ */
+export class ClusteringNotReceivedSdkError extends GoodDataSdkError {
+    constructor(message?: string, cause?: Error) {
+        super(ErrorCodes.CLUSTERING_NOT_RECEIVED as SdkErrorType, message, cause);
     }
 }
 
@@ -313,6 +325,15 @@ export function isDataTooLargeToCompute(obj: unknown): obj is DataTooLargeToComp
  */
 export function isForecastNotReceived(obj: unknown): obj is ForecastNotReceivedSdkError {
     return !isEmpty(obj) && (obj as GoodDataSdkError).seType === "FORECAST_NOT_RECEIVED";
+}
+
+/**
+ * Typeguard checking whether input is an instance of {@link ClusteringNotReceivedSdkError}
+ *
+ * @public
+ */
+export function isClusteringNotReceived(obj: unknown): obj is ClusteringNotReceivedSdkError {
+    return !isEmpty(obj) && (obj as GoodDataSdkError).seType === "CLUSTERING_NOT_RECEIVED";
 }
 
 /**

--- a/libs/sdk-ui/src/base/index.tsx
+++ b/libs/sdk-ui/src/base/index.tsx
@@ -15,6 +15,7 @@ export {
     SdkErrorType,
     ErrorCodes,
     ForecastNotReceivedSdkError,
+    ClusteringNotReceivedSdkError,
     GoodDataSdkError,
     UnauthorizedSdkError,
     NotFoundSdkError,
@@ -43,6 +44,7 @@ export {
     isUnauthorized,
     isUnknownSdkError,
     isForecastNotReceived,
+    isClusteringNotReceived,
     isDynamicScriptLoadSdkError,
 } from "./errors/GoodDataSdkError.js";
 export {
@@ -188,6 +190,7 @@ export {
     resolveLocale,
     emptyHeaderTitleFromIntl,
     totalColumnTitleFromIntl,
+    clusterTitleFromIntl,
     resolveLocaleDefaultMessages,
 } from "./localization/intlUtils.js";
 export {

--- a/libs/sdk-ui/src/base/localization/bundles/en-US.json
+++ b/libs/sdk-ui/src/base/localization/bundles/en-US.json
@@ -267,6 +267,11 @@
         "comment": "The default name for the waterfall total column",
         "limit": 0
     },
+    "visualization.cluster": {
+        "value": "Cluster",
+        "comment": "The default title for the cluster group",
+        "limit": 0
+    },
     "visualization.ErrorMessageGeneric|insight": {
         "value": "Sorry, we can't display this visualization",
         "comment": "",

--- a/libs/sdk-ui/src/base/localization/intlUtils.tsx
+++ b/libs/sdk-ui/src/base/localization/intlUtils.tsx
@@ -94,3 +94,12 @@ export function emptyHeaderTitleFromIntl(intl: IntlShape): string {
 export function totalColumnTitleFromIntl(intl: IntlShape): string {
     return intl.formatMessage({ id: "visualization.waterfall.total" });
 }
+
+/**
+ * Returns a string meant to represent a cluster group.
+ * @param intl - the source of i18n strings
+ * @internal
+ */
+export function clusterTitleFromIntl(intl: IntlShape): string {
+    return intl.formatMessage({ id: "visualization.cluster" });
+}

--- a/libs/sdk-ui/src/base/results/facade.ts
+++ b/libs/sdk-ui/src/base/results/facade.ts
@@ -1,6 +1,8 @@
 // (C) 2019-2024 GoodData Corporation
 import { defFingerprint, IExecutionDefinition, IResultWarning } from "@gooddata/sdk-model";
 import {
+    IClusteringConfig,
+    IClusteringResult,
     IDataView,
     IExecutionResult,
     IForecastConfig,
@@ -174,6 +176,8 @@ export function emptyDataViewForResult(
     result: IExecutionResult,
     forecastConfig?: IForecastConfig,
     forecastResult?: IForecastResult,
+    clusteringConfig?: IClusteringConfig,
+    clusteringResult?: IClusteringResult,
 ): IDataView {
     const { definition } = result;
     const fp = defFingerprint(definition) + "/emptyView";
@@ -195,7 +199,13 @@ export function emptyDataViewForResult(
             return fp === other.fingerprint();
         },
         withForecast(forecastConfig?: IForecastConfig, forecastResult?: IForecastResult): IDataView {
-            return emptyDataViewForResult(result, forecastConfig, forecastResult);
+            return emptyDataViewForResult(
+                result,
+                forecastConfig,
+                forecastResult,
+                clusteringConfig,
+                clusteringResult,
+            );
         },
         forecast(): IForecastView {
             return {
@@ -205,6 +215,26 @@ export function emptyDataViewForResult(
                 prediction: [],
                 loading: false,
             };
+        },
+        clustering(): IClusteringResult {
+            return {
+                attribute: [],
+                clusters: [],
+                xcoord: [],
+                ycoord: [],
+            };
+        },
+        withClustering(
+            clusteringConfig?: IClusteringConfig,
+            clusteringResult?: IClusteringResult,
+        ): IDataView {
+            return emptyDataViewForResult(
+                result,
+                forecastConfig,
+                forecastResult,
+                clusteringConfig,
+                clusteringResult,
+            );
         },
     };
 }

--- a/libs/sdk-ui/src/base/vis/VisualizationProps.ts
+++ b/libs/sdk-ui/src/base/vis/VisualizationProps.ts
@@ -5,7 +5,7 @@ import React from "react";
 import { IErrorProps } from "../react/ErrorComponent.js";
 import { ILoadingProps } from "../react/LoadingComponent.js";
 import { IPushData, OnError, OnExportReady, OnLoadingChanged } from "./Events.js";
-import { IForecastConfig, IPreparedExecution } from "@gooddata/sdk-backend-spi";
+import { IClusteringConfig, IForecastConfig, IPreparedExecution } from "@gooddata/sdk-backend-spi";
 
 /**
  * Super-interface for all visualization props.
@@ -110,4 +110,10 @@ export interface IDataVisualizationProps extends IVisualizationProps, IVisualiza
      * @beta
      */
     forecastConfig?: IForecastConfig;
+
+    /**
+     * Configuration for clustering.
+     * @beta
+     */
+    clusteringConfig?: IClusteringConfig;
 }


### PR DESCRIPTION
- Introduce new feature flag `enableScatterPlotClustering` to control whether clustering is enabled in scatter plot
- Add new section for clustering in scatter plot configuration panel
- Call clustering endpoints in `withEntireDataView`` hook to get clustering data
- Add support for clustering configuration and result to `IDataView`
- Adjust scatter plot coloring to be able to work with cluster groups
- Map cluster groups to correct data points in scatter plot series

JIRA: F1-346

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** 🙏

---

Refer to [documentation](https://github.com/gooddata/gooddata-ui-sdk/blob/master/dev_docs/continuous_integration.md) to see how to run checks and tests in the pull request. This is the list of the most used commands:

```
extended test - backstop
```

```
extended test - tiger-cypress - integrated
extended test - tiger-cypress - isolated
extended test - tiger-cypress - record
```
