### PR TITLE
fix: heatmap coloring

### DIFF
--- a/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartOptions/chartOptionsBuilder.ts
+++ b/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartOptions/chartOptionsBuilder.ts
@@ -164,7 +164,6 @@ function getStackingConfig(
 }
 
 export const HEAT_MAP_CATEGORIES_COUNT = 7;
-export const HIGHCHARTS_PRECISION = 15;
 export const DEFAULT_HEATMAP_COLOR_INDEX = 1;
 
 export function getHeatmapDataClasses(
@@ -184,8 +183,6 @@ export function getHeatmapDataClasses(
 
     const min = Math.min(...values);
     const max = Math.max(...values);
-    const safeMin = parseFloat(Number(min).toPrecision(HIGHCHARTS_PRECISION));
-    const safeMax = parseFloat(Number(max).toPrecision(HIGHCHARTS_PRECISION));
     const dataClasses = [];
 
     if (min === max) {
@@ -195,12 +192,12 @@ export function getHeatmapDataClasses(
             color: colorStrategy.getColorByIndex(DEFAULT_HEATMAP_COLOR_INDEX),
         });
     } else {
-        const step = (safeMax - safeMin) / HEAT_MAP_CATEGORIES_COUNT;
-        let currentSum = safeMin;
+        const step = (max - min) / HEAT_MAP_CATEGORIES_COUNT;
+        let currentSum = min;
         for (let i = 0; i < HEAT_MAP_CATEGORIES_COUNT; i += 1) {
             dataClasses.push({
                 from: currentSum,
-                to: i === HEAT_MAP_CATEGORIES_COUNT - 1 ? safeMax : currentSum + step,
+                to: i === HEAT_MAP_CATEGORIES_COUNT - 1 ? max : currentSum + step,
                 color: colorStrategy.getColorByIndex(i),
             });
             currentSum += step;


### PR DESCRIPTION
Fix heatmap coloring issue.

Max value was out of the range specified for coloring, because the applied number precision cut off the last few digits.

It seems that the number precision is not needed anymore, Highcharts seems to handle the coloring correctly without it, so remove it.

risk: low
JIRA: F1-344

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** 🙏

---

Refer to [documentation](https://github.com/gooddata/gooddata-ui-sdk/blob/master/dev_docs/continuous_integration.md) to see how to run checks and tests in the pull request. This is the list of the most used commands:

```
extended test - backstop
```

```
extended test - tiger-cypress - integrated
extended test - tiger-cypress - isolated
extended test - tiger-cypress - record
```
