### PR TITLE
fix: scatter plot legend configuration

### DIFF
--- a/libs/sdk-ui-ext/src/internal/components/configurationPanels/ScatterPlotConfigurationPanel.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/configurationPanels/ScatterPlotConfigurationPanel.tsx
@@ -50,6 +50,7 @@ export default class ScatterPlotConfigurationPanel extends ConfigurationPanelCon
             <BubbleHoverTrigger showDelay={SHOW_DELAY_DEFAULT} hideDelay={HIDE_DELAY_DEFAULT}>
                 <div>
                     {this.renderColorSection()}
+                    {this.renderLegendSection()}
                     <ConfigSection
                         id="xaxis_section"
                         title={messages.xaxisTitle.id}

--- a/libs/sdk-ui-ext/src/internal/constants/supportedProperties.ts
+++ b/libs/sdk-ui-ext/src/internal/constants/supportedProperties.ts
@@ -184,6 +184,7 @@ export const BUBBLE_CHART_SUPPORTED_PROPERTIES = [
 
 export const SCATTERPLOT_SUPPORTED_PROPERTIES = [
     "dataLabels.visible",
+    "legend",
     "grid",
     "xaxis.rotation",
     "xaxis.labelsEnabled",


### PR DESCRIPTION
Add the ability to configure the legend
in the scatter plot configuration panel.

JIRA: F1-379

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** 🙏

---

Refer to [documentation](https://github.com/gooddata/gooddata-ui-sdk/blob/master/dev_docs/continuous_integration.md) to see how to run checks and tests in the pull request. This is the list of the most used commands:

```
extended test - backstop
```

```
extended test - tiger-cypress - integrated
extended test - tiger-cypress - isolated
extended test - tiger-cypress - record
```
