### PR TITLE
fix: standalone ScatterPlot clsutering

### DIFF
--- a/libs/sdk-backend-tiger/src/backend/uiFeatures.ts
+++ b/libs/sdk-backend-tiger/src/backend/uiFeatures.ts
@@ -206,7 +206,7 @@ export const DefaultFeatureFlags: ITigerFeatureFlags = {
     enableWorkspacesHierarchyView: false,
     enableMultipleDataSourcesInWorkspace: false,
     enableScatterPlotSegmentation: true,
-    enableScatterPlotClustering: false,
+    enableScatterPlotClustering: true,
 };
 
 export const FeatureFlagsValues = {

--- a/libs/sdk-ui-charts/src/charts/scatterPlot/CoreScatterPlot.tsx
+++ b/libs/sdk-ui-charts/src/charts/scatterPlot/CoreScatterPlot.tsx
@@ -1,10 +1,14 @@
-// (C) 2007-2022 GoodData Corporation
+// (C) 2007-2024 GoodData Corporation
 import React from "react";
-import { BaseChart } from "../_base/BaseChart.js";
+import { BaseChart, IBaseChartProps } from "../_base/BaseChart.js";
 import { ICoreChartProps } from "../../interfaces/index.js";
 
 export class CoreScatterPlot extends React.PureComponent<ICoreChartProps, null> {
     public render() {
-        return <BaseChart type="scatter" {...this.props} />;
+        const { config } = this.props;
+        const clusteringConfig: Partial<IBaseChartProps> = config?.clustering
+            ? { clusteringConfig: config.clustering }
+            : {};
+        return <BaseChart type="scatter" {...this.props} {...clusteringConfig} />;
     }
 }


### PR DESCRIPTION
Propagate missing clustering configuration
in standalone ScatterPlot component.

Also enable `enableScutterPlotClustering`` feature flag by default.

risk: low
JIRA: F1-390

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** 🙏

---

Refer to [documentation](https://github.com/gooddata/gooddata-ui-sdk/blob/master/dev_docs/continuous_integration.md) to see how to run checks and tests in the pull request. This is the list of the most used commands:

```
extended test - backstop
```

```
extended test - tiger-cypress - integrated
extended test - tiger-cypress - isolated
extended test - tiger-cypress - record
```
