### PR TITLE
feat: pdf export function adjustments to support pdf options

### DIFF
--- a/common/changes/@gooddata/sdk-ui-all/xsh-997-pdf-export-config_2024-06-21-13-03.json
+++ b/common/changes/@gooddata/sdk-ui-all/xsh-997-pdf-export-config_2024-06-21-13-03.json
@@ -1,0 +1,10 @@
+{
+    "changes": [
+        {
+            "packageName": "@gooddata/sdk-ui-all",
+            "comment": "Adjusted export function to support pdf options.",
+            "type": "none"
+        }
+    ],
+    "packageName": "@gooddata/sdk-ui-all"
+}

--- a/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
+++ b/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
@@ -611,8 +611,9 @@ export type IExportDefinitionsQueryResult = IPagedResource<IExportDefinition>;
 
 // @public
 export interface IExportPdfConfig {
-    // (undocumented)
-    orientation: "portrait" | "landscape";
+    orientation?: string;
+    topLeftContent?: string;
+    topRightContent?: string;
 }
 
 // @public

--- a/libs/sdk-backend-spi/src/workspace/execution/export.ts
+++ b/libs/sdk-backend-spi/src/workspace/execution/export.ts
@@ -45,7 +45,12 @@ export interface IExportConfig {
  * @public
  */
 export interface IExportPdfConfig {
-    orientation: "portrait" | "landscape";
+    /** PDF document orientation */
+    orientation?: string;
+    /** PDF top left header content. */
+    topLeftContent?: string;
+    /** PDF top right header content. */
+    topRightContent?: string;
 }
 
 /**

--- a/libs/sdk-backend-tiger/src/backend/workspace/execution/executionResult.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/execution/executionResult.ts
@@ -7,6 +7,7 @@ import {
     ActionsApiGetTabularExportRequest,
     TabularExportRequest,
     TabularExportRequestFormatEnum,
+    Settings,
 } from "@gooddata/api-client-tiger";
 import {
     IDataView,
@@ -208,11 +209,18 @@ export class TigerExecutionResult implements IExecutionResult {
             ? TabularExportRequestFormatEnum[uppercaseFormat]
             : TabularExportRequestFormatEnum.CSV;
 
-        const settings = {
+        const settings: Settings = {
             ...(format === TabularExportRequestFormatEnum.XLSX
                 ? { mergeHeaders: Boolean(options.mergeHeaders), showFilters: Boolean(options.showFilters) }
                 : {}),
-            ...(format === TabularExportRequestFormatEnum.PDF ? options.pdfConfiguration : {}),
+            ...(format === TabularExportRequestFormatEnum.PDF
+                ? {
+                      showFilters: Boolean(options.showFilters),
+                      pdfPageSize: options.pdfConfiguration?.orientation,
+                      pdfTopLeftContent: options.pdfConfiguration?.topLeftContent,
+                      pdfTopRightContent: options.pdfConfiguration?.topRightContent,
+                  }
+                : {}),
         };
 
         const payload: TabularExportRequest = {


### PR DESCRIPTION
JIRA: XSH-997

Currently export function doesn't supports options like `pdfTopLeftContent` or `pdfTopRightContent`, this pr will add support for that. Also, `orientation` option from `IExportPdfConfig` was not working since the `Settings` interface doesn't support it, but it does support orientation through the `pdfPageSize` prop.

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** 🙏

---

Refer to [documentation](https://github.com/gooddata/gooddata-ui-sdk/blob/master/dev_docs/continuous_integration.md) to see how to run checks and tests in the pull request. This is the list of the most used commands:

```
extended test - backstop
```

```
extended test - tiger-cypress - integrated
extended test - tiger-cypress - isolated
extended test - tiger-cypress - record
```
