### PR TITLE
feat: pdf export function support of visualizationObject as alternati…

### DIFF
--- a/common/changes/@gooddata/sdk-ui-all/xsh-997-pdf-export-using-visualization-object_2024-06-24-11-58.json
+++ b/common/changes/@gooddata/sdk-ui-all/xsh-997-pdf-export-using-visualization-object_2024-06-24-11-58.json
@@ -1,0 +1,10 @@
+{
+    "changes": [
+        {
+            "packageName": "@gooddata/sdk-ui-all",
+            "comment": "Using visualizationObject whenever provided as alternative to executionResult for export.",
+            "type": "none"
+        }
+    ],
+    "packageName": "@gooddata/sdk-ui-all"
+}

--- a/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
+++ b/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
@@ -584,6 +584,8 @@ export interface IExportConfig {
     pdfConfiguration?: IExportPdfConfig;
     showFilters?: boolean;
     title?: string;
+    visualizationObjectCustomFilters?: Array<object>;
+    visualizationObjectId?: string;
 }
 
 // @alpha

--- a/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
+++ b/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
@@ -584,7 +584,7 @@ export interface IExportConfig {
     pdfConfiguration?: IExportPdfConfig;
     showFilters?: boolean;
     title?: string;
-    visualizationObjectCustomFilters?: Array<object>;
+    visualizationObjectCustomFilters?: Array<IFilter>;
     visualizationObjectId?: string;
 }
 

--- a/libs/sdk-backend-spi/src/workspace/execution/export.ts
+++ b/libs/sdk-backend-spi/src/workspace/execution/export.ts
@@ -23,20 +23,30 @@ export interface IExportConfig {
     mergeHeaders?: boolean;
 
     /**
-     * Applicable for XLSX format; specifies filters to include as comments / metadata in
+     * Applicable for XLSX, and PDF format; specifies filters to include as comments / metadata in
      * the Excel sheet.
      *
      * @remarks
      * Filters provided here are purely to paint a better context for the
-     * person looking at the XLSX file. They serve no other purpose and are merely serialized
-     * into the XLSX in a human readable form.
+     * person looking at the exported file. They serve no other purpose and are merely serialized
+     * in the export in a human-readable form.
      */
     showFilters?: boolean;
 
     /**
-     *  Applicable for PDF format; specifies configuration for PDF export.
+     * Applicable for PDF format; specifies configuration for PDF export.
      */
     pdfConfiguration?: IExportPdfConfig;
+
+    /**
+     * Visualization object identifier. Used to ensure proper display of HTML/PDF documents. (HTML/PDF only)
+     */
+    visualizationObjectId?: string;
+
+    /**
+     * Optional custom filters (as array of IFilter objects defined in UI SDK) to be applied when visualizationObject is given. (HTML/PDF only)
+     */
+    visualizationObjectCustomFilters?: Array<object>;
 }
 
 /**

--- a/libs/sdk-backend-spi/src/workspace/execution/export.ts
+++ b/libs/sdk-backend-spi/src/workspace/execution/export.ts
@@ -3,7 +3,7 @@
 import { IFilter } from "@gooddata/sdk-model";
 
 /**
- * Configuration for exports of results into XLSX or CSV.
+ * Configuration for exports of results into tabular formats.
  *
  * @public
  */
@@ -32,7 +32,7 @@ export interface IExportConfig {
      * Filters provided here are purely to paint a better context for the
      * person looking at the exported file. They serve no other purpose and are merely serialized
      * in the export in a human-readable form.
-     * The {@link visualizationObjectId} has to be provided to make this work for PDF format.
+     * The visualizationObjectId has to be provided to make this work for PDF format.
      */
     showFilters?: boolean;
 

--- a/libs/sdk-backend-spi/src/workspace/execution/export.ts
+++ b/libs/sdk-backend-spi/src/workspace/execution/export.ts
@@ -1,5 +1,7 @@
 // (C) 2019-2024 GoodData Corporation
 
+import { IFilter } from "@gooddata/sdk-model";
+
 /**
  * Configuration for exports of results into XLSX or CSV.
  *
@@ -30,6 +32,7 @@ export interface IExportConfig {
      * Filters provided here are purely to paint a better context for the
      * person looking at the exported file. They serve no other purpose and are merely serialized
      * in the export in a human-readable form.
+     * The {@link visualizationObjectId} has to be provided to make this work for PDF format.
      */
     showFilters?: boolean;
 
@@ -39,14 +42,16 @@ export interface IExportConfig {
     pdfConfiguration?: IExportPdfConfig;
 
     /**
-     * Visualization object identifier. Used to ensure proper display of HTML/PDF documents. (HTML/PDF only)
+     * Visualization object identifier. Used to ensure the export result is generated based on
+     * existing visualization in the PDF document. (PDF only)
      */
     visualizationObjectId?: string;
 
     /**
-     * Optional custom filters (as array of IFilter objects defined in UI SDK) to be applied when visualizationObject is given. (HTML/PDF only)
+     * Optional custom filters (as array of IFilter objects defined in UI SDK) to be applied
+     * when visualizationObject is given. (PDF only)
      */
-    visualizationObjectCustomFilters?: Array<object>;
+    visualizationObjectCustomFilters?: Array<IFilter>;
 }
 
 /**

--- a/libs/sdk-backend-tiger/src/backend/workspace/execution/executionResult.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/execution/executionResult.ts
@@ -223,15 +223,13 @@ export class TigerExecutionResult implements IExecutionResult {
                 : {}),
         };
 
-        const useExecutionResult = !options.visualizationObjectId ? this.resultId : undefined;
-
         const payload: TabularExportRequest = {
             format,
-            executionResult: useExecutionResult,
+            executionResult: options.visualizationObjectId ? undefined : this.resultId, // use the visualizationObject for the export instead of the execution when provided
             fileName: options.title ?? "default",
             settings,
             customOverride: resolveCustomOverride(this.dimensions, this.definition),
-            visualizationObject: !useExecutionResult ? options.visualizationObjectId : undefined,
+            visualizationObject: options.visualizationObjectId,
             visualizationObjectCustomFilters: options.visualizationObjectCustomFilters,
         };
 

--- a/libs/sdk-backend-tiger/src/backend/workspace/execution/executionResult.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/execution/executionResult.ts
@@ -223,12 +223,16 @@ export class TigerExecutionResult implements IExecutionResult {
                 : {}),
         };
 
+        const useExecutionResult = !options.visualizationObjectId ? this.resultId : undefined;
+
         const payload: TabularExportRequest = {
             format,
-            executionResult: this.resultId,
+            executionResult: useExecutionResult,
             fileName: options.title ?? "default",
             settings,
             customOverride: resolveCustomOverride(this.dimensions, this.definition),
+            visualizationObject: !useExecutionResult ? options.visualizationObjectId : undefined,
+            visualizationObjectCustomFilters: options.visualizationObjectCustomFilters,
         };
 
         return this.authCall(async (client) => {


### PR DESCRIPTION
…ve of executionResult

JIRA: XSH-997

Using `visualizationObject` whenever provided as alternative to `executionResult` for export.

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** 🙏

---

Refer to [documentation](https://github.com/gooddata/gooddata-ui-sdk/blob/master/dev_docs/continuous_integration.md) to see how to run checks and tests in the pull request. This is the list of the most used commands:

```
extended test - backstop
```

```
extended test - tiger-cypress - integrated
extended test - tiger-cypress - isolated
extended test - tiger-cypress - record
```
