### PR TITLE
fix: call onError when insight does not exist

### DIFF
--- a/libs/sdk-ui-ext/src/insightView/InsightView.tsx
+++ b/libs/sdk-ui-ext/src/insightView/InsightView.tsx
@@ -1,4 +1,4 @@
-// (C) 2019-2023 GoodData Corporation
+// (C) 2019-2024 GoodData Corporation
 import React, { useCallback, useMemo, useRef, useState } from "react";
 import { injectIntl, WrappedComponentProps } from "react-intl";
 import {
@@ -110,6 +110,10 @@ const InsightViewCore: React.FC<IInsightViewProps & WrappedComponentProps> = (pr
                     .workspace(workspace!)
                     .insights()
                     .getInsightWithAddedFilters(insightData, filters ?? []);
+            },
+            onError: (err) => {
+                const sdkError = convertError(err);
+                onError?.(sdkError);
             },
         },
         [insight, backend, workspace, executeByReference, filters, onInsightLoaded],

--- a/libs/sdk-ui/src/base/errors/GoodDataSdkError.ts
+++ b/libs/sdk-ui/src/base/errors/GoodDataSdkError.ts
@@ -202,7 +202,7 @@ export class NoDataSdkError extends GoodDataSdkError {
  */
 export class NotFoundSdkError extends GoodDataSdkError {
     constructor(message?: string, cause?: Error) {
-        super(ErrorCodes.NO_DATA as SdkErrorType, message, cause);
+        super(ErrorCodes.NOT_FOUND as SdkErrorType, message, cause);
     }
 }
 


### PR DESCRIPTION
Fix InsightView to call onError callback, when insight does not exist.

risk: low
JIRA: F1-442

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** 🙏

---

Refer to [documentation](https://github.com/gooddata/gooddata-ui-sdk/blob/master/dev_docs/continuous_integration.md) to see how to run checks and tests in the pull request. This is the list of the most used commands:

```
extended test - backstop
```

```
extended test - tiger-cypress - integrated
extended test - tiger-cypress - isolated
extended test - tiger-cypress - record
```
