### PR TITLE
fix(docker): use numeric user id

### DIFF
--- a/libs/sdk-ui-web-components/Dockerfile
+++ b/libs/sdk-ui-web-components/Dockerfile
@@ -13,7 +13,7 @@ USER 0
 RUN /usr/bin/rm -rf /etc/crontab /etc/cron.d /etc/cron.hourly /etc/cron.daily /etc/cron.weekly /etc/cron.monthly ; \
     /usr/bin/sed -i '/^CREATE_HOME/ s/^CREATE_HOME.*/CREATE_HOME yes/; t; $ aCREATE_HOME yes' /etc/login.defs
 ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-USER nginx
+USER 101
 # END OF Mastercard security compliance
 
 #COPY readme.txt / # TODO - There are some auto-generated license files in the bundle, do we need to add extra onces?


### PR DESCRIPTION
When running on k8s with runAsNonRoot option turned on,
we must use numeric id to make sure it can be recognized
by kubelet as non-zero (non-root) uid.

risk: low
JIRA: INFRA-3687

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** 🙏

---

Refer to [documentation](https://github.com/gooddata/gooddata-ui-sdk/blob/master/dev_docs/continuous_integration.md) to see how to run checks and tests in the pull request. This is the list of the most used commands:

```
extended test - backstop
```

```
extended test - tiger-cypress - integrated
extended test - tiger-cypress - isolated
extended test - tiger-cypress - record
```
