### PR TITLE
feat: allow rollup totals if enableRollupTotals is true

### DIFF
--- a/libs/sdk-model/api/sdk-model.api.md
+++ b/libs/sdk-model/api/sdk-model.api.md
@@ -2776,6 +2776,7 @@ export interface ISettings {
     enableRenamingMeasureToMetric?: boolean;
     enableReversedStacking?: boolean;
     enableRichTextDescriptions?: boolean;
+    enableRollupTotals?: boolean;
     enableScatterPlotClustering?: boolean;
     enableScatterPlotSegmentation?: boolean;
     enableScheduling?: boolean;

--- a/libs/sdk-model/src/settings/index.ts
+++ b/libs/sdk-model/src/settings/index.ts
@@ -402,6 +402,11 @@ export interface ISettings {
      */
     enableScheduling?: boolean;
 
+    /**
+     * Enables rollup (native) totals.
+     */
+    enableRollupTotals?: boolean;
+
     [key: string]: number | boolean | string | object | undefined;
 }
 

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/PluggablePivotTable.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/PluggablePivotTable.tsx
@@ -1,4 +1,4 @@
-// (C) 2019-2023 GoodData Corporation
+// (C) 2019-2024 GoodData Corporation
 
 import {
     addIntersectionFiltersToInsight,
@@ -677,14 +677,24 @@ export function createPivotTableConfig(
     };
 
     const enableTableTotalRows = settings.enableTableTotalRows;
+    const enableRollupTotals = settings.enableRollupTotals;
 
     if (environment !== DASHBOARDS_ENVIRONMENT) {
         tableConfig = {
             ...tableConfig,
-            menu: pivotTableMenuForCapabilities(capabilities, {
-                aggregations: true,
-                aggregationsSubMenu: true,
-            }),
+            menu: pivotTableMenuForCapabilities(
+                {
+                    ...capabilities,
+                    // allow the enableRollupTotals to override the capabilities for now
+                    // we are in the process of adding the capability to the tiger backend
+                    // TODO: remove this once the tiger backend has the canCalculateNativeTotals capability
+                    canCalculateNativeTotals: capabilities.canCalculateNativeTotals || !!enableRollupTotals,
+                },
+                {
+                    aggregations: true,
+                    aggregationsSubMenu: true,
+                },
+            ),
         };
     }
 


### PR DESCRIPTION
This allows us to test the rollup totals on the UI without enabling the canCalculateNativeTotals capability on tiger backends yet.

risk: low
JIRA: CQ-603

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** 🙏

---

Refer to [documentation](https://github.com/gooddata/gooddata-ui-sdk/blob/master/dev_docs/continuous_integration.md) to see how to run checks and tests in the pull request. This is the list of the most used commands:

```
extended test - backstop
```

```
extended test - tiger-cypress - integrated
extended test - tiger-cypress - isolated
extended test - tiger-cypress - record
```
