### PR TITLE
feat: secondary label during cross filtering

### DIFF
--- a/libs/sdk-backend-tiger/src/convertors/fromBackend/afm/dimensions.ts
+++ b/libs/sdk-backend-tiger/src/convertors/fromBackend/afm/dimensions.ts
@@ -53,6 +53,7 @@ function transformDimension(
                         granularity: h.attributeHeader.granularity,
                         format: h.attributeHeader.format,
                         labelType: convertLabelType(h.attributeHeader.valueType),
+                        primaryLabel: idRef(h.attributeHeader.primaryLabel.id, "displayForm"),
                     },
                 };
             } else {

--- a/libs/sdk-backend-tiger/src/convertors/fromBackend/afm/tests/__snapshots__/dimensions.test.ts.snap
+++ b/libs/sdk-backend-tiger/src/convertors/fromBackend/afm/tests/__snapshots__/dimensions.test.ts.snap
@@ -21,6 +21,10 @@ exports[`transformResultDimensions > should fill in totals 1`] = `
           "labelType": undefined,
           "localIdentifier": "localAttr1",
           "name": "event_date - Quarter/Year",
+          "primaryLabel": {
+            "identifier": "event_date.quarter",
+            "type": "displayForm",
+          },
           "ref": {
             "identifier": "event_date.quarter.label",
             "type": "displayForm",
@@ -52,6 +56,10 @@ exports[`transformResultDimensions > should fill in totals 1`] = `
           "labelType": undefined,
           "localIdentifier": "localAttr2",
           "name": "event_date - Quarter/Year",
+          "primaryLabel": {
+            "identifier": "event_date.quarter",
+            "type": "displayForm",
+          },
           "ref": {
             "identifier": "event_date.quarter.label",
             "type": "displayForm",
@@ -106,6 +114,10 @@ exports[`transformResultDimensions > should fill in totals 1`] = `
           "labelType": undefined,
           "localIdentifier": "localAttr3",
           "name": "event_date - Quarter/Year",
+          "primaryLabel": {
+            "identifier": "event_date.quarter",
+            "type": "displayForm",
+          },
           "ref": {
             "identifier": "event_date.quarter.label",
             "type": "displayForm",
@@ -141,6 +153,10 @@ exports[`transformResultDimensions > should fill in totals 1`] = `
           "labelType": "GDC.link",
           "localIdentifier": "localAttr4",
           "name": "Hyperlink",
+          "primaryLabel": {
+            "identifier": "hyperlink.label",
+            "type": "displayForm",
+          },
           "ref": {
             "identifier": "hyperlink.label",
             "type": "displayForm",
@@ -170,6 +186,10 @@ exports[`transformResultDimensions > should fill in totals 1`] = `
           "labelType": "GDC.image",
           "localIdentifier": "localAttr5",
           "name": "Image",
+          "primaryLabel": {
+            "identifier": "image.label",
+            "type": "displayForm",
+          },
           "ref": {
             "identifier": "image.label",
             "type": "displayForm",
@@ -204,6 +224,10 @@ exports[`transformResultDimensions > should fill in totals with multiple totals 
           "labelType": undefined,
           "localIdentifier": "localAttr1",
           "name": "event_date - Quarter/Year",
+          "primaryLabel": {
+            "identifier": "event_date.quarter",
+            "type": "displayForm",
+          },
           "ref": {
             "identifier": "event_date.quarter.label",
             "type": "displayForm",
@@ -235,6 +259,10 @@ exports[`transformResultDimensions > should fill in totals with multiple totals 
           "labelType": undefined,
           "localIdentifier": "localAttr2",
           "name": "event_date - Quarter/Year",
+          "primaryLabel": {
+            "identifier": "event_date.quarter",
+            "type": "displayForm",
+          },
           "ref": {
             "identifier": "event_date.quarter.label",
             "type": "displayForm",
@@ -289,6 +317,10 @@ exports[`transformResultDimensions > should fill in totals with multiple totals 
           "labelType": undefined,
           "localIdentifier": "localAttr3",
           "name": "event_date - Quarter/Year",
+          "primaryLabel": {
+            "identifier": "event_date.quarter",
+            "type": "displayForm",
+          },
           "ref": {
             "identifier": "event_date.quarter.label",
             "type": "displayForm",
@@ -324,6 +356,10 @@ exports[`transformResultDimensions > should fill in totals with multiple totals 
           "labelType": "GDC.link",
           "localIdentifier": "localAttr4",
           "name": "Hyperlink",
+          "primaryLabel": {
+            "identifier": "hyperlink.label",
+            "type": "displayForm",
+          },
           "ref": {
             "identifier": "hyperlink.label",
             "type": "displayForm",
@@ -353,6 +389,10 @@ exports[`transformResultDimensions > should fill in totals with multiple totals 
           "labelType": "GDC.image",
           "localIdentifier": "localAttr5",
           "name": "Image",
+          "primaryLabel": {
+            "identifier": "image.label",
+            "type": "displayForm",
+          },
           "ref": {
             "identifier": "image.label",
             "type": "displayForm",
@@ -406,6 +446,10 @@ exports[`transformResultDimensions > should fill in uris and refs for attribute 
           "labelType": undefined,
           "localIdentifier": "fd48e8fd32b54b1baba3e3ccdd719f26",
           "name": "event_date - Quarter/Year",
+          "primaryLabel": {
+            "identifier": "event_date.quarter",
+            "type": "displayForm",
+          },
           "ref": {
             "identifier": "event_date.quarter.label",
             "type": "displayForm",
@@ -462,6 +506,10 @@ exports[`transformResultDimensions > should fill in uris and refs for attribute 
           "labelType": undefined,
           "localIdentifier": "fd48e8fd32b54b1baba3e3ccdd719f26",
           "name": "event_date - Quarter/Year",
+          "primaryLabel": {
+            "identifier": "event_date.quarter",
+            "type": "displayForm",
+          },
           "ref": {
             "identifier": "event_date.quarter.label",
             "type": "displayForm",

--- a/libs/sdk-model/api/sdk-model.api.md
+++ b/libs/sdk-model/api/sdk-model.api.md
@@ -625,6 +625,7 @@ export interface IAttributeDescriptorBody {
     labelType?: AttributeDisplayFormType;
     localIdentifier: string;
     name: string;
+    primaryLabel: ObjRef;
     ref: ObjRef;
     // (undocumented)
     totalItems?: ITotalDescriptor[];

--- a/libs/sdk-model/src/execution/results/index.ts
+++ b/libs/sdk-model/src/execution/results/index.ts
@@ -233,6 +233,11 @@ export interface IAttributeDescriptorBody {
         locale: string;
         pattern: string;
     };
+
+    /**
+     * Primary label of the attribute from formOf
+     */
+    primaryLabel: ObjRef;
 }
 
 /**


### PR DESCRIPTION
- propagate primaryLabel from execution to the drill
- create new virtual filter from primary label and primary values
- displayAsLabel for virtual filter is defined automatically

JIRA: LX-318
risk: low

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** 🙏

---

Refer to [documentation](https://github.com/gooddata/gooddata-ui-sdk/blob/master/dev_docs/continuous_integration.md) to see how to run checks and tests in the pull request. This is the list of the most used commands:

```
extended test - backstop
```

```
extended test - tiger-cypress - integrated
extended test - tiger-cypress - isolated
extended test - tiger-cypress - record
```
