### PR TITLE
feat: store dashboard filters with export definition

### DIFF
--- a/libs/sdk-backend-tiger/src/convertors/fromBackend/ExportDefinitionsConverter.ts
+++ b/libs/sdk-backend-tiger/src/convertors/fromBackend/ExportDefinitionsConverter.ts
@@ -6,6 +6,7 @@ import {
     VisualExportRequest,
 } from "@gooddata/api-client-tiger";
 import {
+    FilterContextItem,
     idRef,
     IExportDefinitionMetadataObject,
     IExportDefinitionRequestPayload,
@@ -74,6 +75,7 @@ const convertExportDefinitionRequestPayload = (
             format: "PDF",
             content: {
                 dashboard: exportRequest.dashboardId,
+                filters: (exportRequest.metadata as any)?.filters as FilterContextItem[],
             },
         };
     } else {

--- a/libs/sdk-backend-tiger/src/convertors/toBackend/ExportDefinitionsConverter.ts
+++ b/libs/sdk-backend-tiger/src/convertors/toBackend/ExportDefinitionsConverter.ts
@@ -55,9 +55,14 @@ const convertExportDefinitionRequestPayload = (
     exportRequest: IExportDefinitionRequestPayload,
 ): TabularExportRequest | VisualExportRequest => {
     if (isExportDefinitionDashboardContent(exportRequest.content)) {
+        const metadataObj = exportRequest.content.filters
+            ? { metadata: { filters: exportRequest.content.filters } }
+            : {};
+
         return {
             fileName: exportRequest.fileName,
             dashboardId: exportRequest.content.dashboard,
+            ...metadataObj,
         };
     }
 

--- a/libs/sdk-model/api/sdk-model.api.md
+++ b/libs/sdk-model/api/sdk-model.api.md
@@ -1536,7 +1536,7 @@ export interface IExportDefinitionDashboardContent {
     // (undocumented)
     dashboard: string;
     // (undocumented)
-    filters?: IFilter[];
+    filters?: FilterContextItem[];
 }
 
 // @alpha
@@ -2834,6 +2834,9 @@ export function isFilterContext(obj: unknown): obj is IFilterContext;
 
 // @alpha
 export function isFilterContextDefinition(obj: unknown): obj is IFilterContextDefinition;
+
+// @alpha
+export function isFilterContextItem(obj: unknown): obj is FilterContextItem;
 
 // @alpha
 export const isGranularAccess: (obj: unknown) => obj is IGranularUserAccess | IGranularUserGroupAccess;

--- a/libs/sdk-model/src/dashboard/filterContext.ts
+++ b/libs/sdk-model/src/dashboard/filterContext.ts
@@ -328,6 +328,14 @@ export function isAllTimeDashboardDateFilter(obj: unknown): boolean {
 export type FilterContextItem = IDashboardAttributeFilter | IDashboardDateFilter;
 
 /**
+ * Type-guard testing whether the provided object is an instance of {@link FilterContextItem}.
+ * @alpha
+ */
+export function isFilterContextItem(obj: unknown): obj is FilterContextItem {
+    return isDashboardDateFilter(obj) || isDashboardAttributeFilter(obj);
+}
+
+/**
  * Common filter context properties
  *
  * @alpha

--- a/libs/sdk-model/src/exportDefinitions/index.ts
+++ b/libs/sdk-model/src/exportDefinitions/index.ts
@@ -6,6 +6,7 @@ import { IFilter } from "../execution/filter/index.js";
 import { IMetadataObject, IMetadataObjectDefinition } from "../ldm/metadata/index.js";
 import { IAuditable } from "../base/metadata.js";
 import isEmpty from "lodash/isEmpty.js";
+import { FilterContextItem } from "../dashboard/filterContext.js";
 
 /**
  * Export definition PDF Options
@@ -42,11 +43,13 @@ export function isExportDefinitionVisualizationObjectContent(
 /**
  * Export definition dashboard content configuration.
  *
+ * @remarks Filter has to be in FilterContextItem shape so that dashboard can easily consume it.
+ *
  * @alpha
  */
 export interface IExportDefinitionDashboardContent {
     dashboard: string;
-    filters?: IFilter[];
+    filters?: FilterContextItem[];
 }
 
 /**

--- a/libs/sdk-model/src/index.ts
+++ b/libs/sdk-model/src/index.ts
@@ -495,6 +495,7 @@ export {
     newAbsoluteDashboardDateFilter,
     newAllTimeDashboardDateFilter,
     newRelativeDashboardDateFilter,
+    isFilterContextItem,
 } from "./dashboard/filterContext.js";
 
 export {

--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -1018,11 +1018,11 @@ export interface CreateScheduledEmail extends IDashboardCommand {
 }
 
 // @beta
-export function createScheduledEmail(scheduledEmail: IAutomationMetadataObjectDefinition, filterContext?: IFilterContextDefinition, correlationId?: string): CreateScheduledEmail;
+export function createScheduledEmail(scheduledEmail: IAutomationMetadataObjectDefinition, filters?: FilterContextItem[], correlationId?: string): CreateScheduledEmail;
 
 // @beta
 export interface CreateScheduledEmailPayload {
-    readonly filterContext?: IFilterContextDefinition;
+    readonly filters?: FilterContextItem[];
     readonly scheduledEmail: IAutomationMetadataObjectDefinition;
 }
 
@@ -6412,11 +6412,11 @@ export interface SaveScheduledEmail extends IDashboardCommand {
 }
 
 // @beta
-export function saveScheduledEmail(scheduledEmail: IAutomationMetadataObject, filterContextRef?: ObjRef, correlationId?: string): SaveScheduledEmail;
+export function saveScheduledEmail(scheduledEmail: IAutomationMetadataObject, filters?: FilterContextItem[], correlationId?: string): SaveScheduledEmail;
 
 // @beta
 export interface SaveScheduledEmailPayload {
-    readonly filterContextRef?: ObjRef;
+    readonly filters?: FilterContextItem[];
     readonly scheduledEmail: IAutomationMetadataObject;
 }
 

--- a/libs/sdk-ui-dashboard/src/_staging/sharedHooks/useCommonDateFilterTitle.ts
+++ b/libs/sdk-ui-dashboard/src/_staging/sharedHooks/useCommonDateFilterTitle.ts
@@ -2,7 +2,7 @@
 
 import { IntlShape } from "react-intl";
 
-import { selectDateFilterConfigOverrides, useDashboardSelector } from "../../../model/index.js";
+import { selectDateFilterConfigOverrides, useDashboardSelector } from "../../model/index.js";
 
 export const useCommonDateFilterTitle = (intl: IntlShape) => {
     const filterConfig = useDashboardSelector(selectDateFilterConfigOverrides);

--- a/libs/sdk-ui-dashboard/src/_staging/sharedHooks/useDateFiltersTitles.ts
+++ b/libs/sdk-ui-dashboard/src/_staging/sharedHooks/useDateFiltersTitles.ts
@@ -1,0 +1,37 @@
+// (C) 2024 GoodData Corporation
+
+import { areObjRefsEqual, IDashboardDateFilter, serializeObjRef } from "@gooddata/sdk-model";
+import { IntlShape } from "react-intl";
+import {
+    selectCatalogDateDatasets,
+    selectDateFilterConfigsOverrides,
+    useDashboardSelector,
+} from "../../model/index.js";
+
+export const useDateFiltersTitles = (filters: IDashboardDateFilter[], intl: IntlShape) => {
+    const allDateDatasets = useDashboardSelector(selectCatalogDateDatasets);
+    const allDateOverrides = useDashboardSelector(selectDateFilterConfigsOverrides);
+
+    return filters.reduce((acc, filter) => {
+        if (!filter.dateFilter.dataSet) {
+            return acc;
+        }
+        const key = serializeObjRef(filter.dateFilter.dataSet);
+
+        const customFilterName = allDateOverrides.find((config) =>
+            areObjRefsEqual(config.dateDataSet, filter.dateFilter.dataSet),
+        )?.config?.filterName;
+        const dateDataSetName = allDateDatasets.find((ds) =>
+            areObjRefsEqual(ds.dataSet.ref, filter?.dateFilter.dataSet),
+        )?.dataSet?.title;
+
+        const title =
+            customFilterName || dateDataSetName || intl.formatMessage({ id: "dateFilterDropdown.title" });
+
+        if (title) {
+            acc[key] = title;
+        }
+
+        return acc;
+    }, {} as Record<string, string>);
+};

--- a/libs/sdk-ui-dashboard/src/model/commands/scheduledEmail.ts
+++ b/libs/sdk-ui-dashboard/src/model/commands/scheduledEmail.ts
@@ -1,10 +1,9 @@
 // (C) 2021-2024 GoodData Corporation
 
 import {
-    IFilterContextDefinition,
     IAutomationMetadataObjectDefinition,
     IAutomationMetadataObject,
-    ObjRef,
+    FilterContextItem,
 } from "@gooddata/sdk-model";
 import { IDashboardCommand } from "./base.js";
 
@@ -18,9 +17,9 @@ export interface CreateScheduledEmailPayload {
      */
     readonly scheduledEmail: IAutomationMetadataObjectDefinition;
     /**
-     * Filter context to use for the scheduled email. If no filter context is provided, stored dashboard filter context will be used.
+     * Filter context filters to use for the scheduled email. If no filters are provided, stored dashboard filters will be used.
      */
-    readonly filterContext?: IFilterContextDefinition;
+    readonly filters?: FilterContextItem[];
 }
 
 /**
@@ -39,7 +38,7 @@ export interface CreateScheduledEmail extends IDashboardCommand {
  * Dispatching this command will result in the creating scheduled email on the backend.
  *
  * @param scheduledEmail - specify scheduled email to create.
- * @param filterContext - specify filter context to use for the scheduled email. If no filter context is provided, stored dashboard filter context will be used.
+ * @param filters - specify filter context filters to use for the scheduled email. If no filters are provided, stored dashboard filters will be used.
  * @param correlationId - specify correlation id to use for this command. this will be included in all
  *  events that will be emitted during the command processing
 
@@ -47,7 +46,7 @@ export interface CreateScheduledEmail extends IDashboardCommand {
  */
 export function createScheduledEmail(
     scheduledEmail: IAutomationMetadataObjectDefinition,
-    filterContext?: IFilterContextDefinition,
+    filters?: FilterContextItem[],
     correlationId?: string,
 ): CreateScheduledEmail {
     return {
@@ -55,7 +54,7 @@ export function createScheduledEmail(
         correlationId,
         payload: {
             scheduledEmail,
-            filterContext,
+            filters,
         },
     };
 }
@@ -80,16 +79,16 @@ export interface SaveScheduledEmailPayload {
      */
     readonly scheduledEmail: IAutomationMetadataObject;
     /**
-     * optionally specify existing filter context reference to be used for all attachments
+     * optionally specify existing filter context filters to be used for all attachments
      */
-    readonly filterContextRef?: ObjRef;
+    readonly filters?: FilterContextItem[];
 }
 
 /**
  * Saves existing SaveScheduledEmail command. Dispatching this command will result in saving scheduled email on the backend.
  *
  * @param scheduledEmail - specify scheduled email to save.
- * @param filterContextRef - optionally specify existing filter context reference to be used for all attachments
+ * @param filters - optionally specify existing filter context filters to be used for all attachments
  * @param correlationId - optionally specify correlation id to use for this command. this will be included in all
  *  events that will be emitted during the command processing
 
@@ -97,7 +96,7 @@ export interface SaveScheduledEmailPayload {
  */
 export function saveScheduledEmail(
     scheduledEmail: IAutomationMetadataObject,
-    filterContextRef?: ObjRef,
+    filters?: FilterContextItem[],
     correlationId?: string,
 ): SaveScheduledEmail {
     return {
@@ -105,7 +104,7 @@ export function saveScheduledEmail(
         correlationId,
         payload: {
             scheduledEmail,
-            filterContextRef,
+            filters,
         },
     };
 }

--- a/libs/sdk-ui-dashboard/src/model/react/useDashboardScheduledEmails.ts
+++ b/libs/sdk-ui-dashboard/src/model/react/useDashboardScheduledEmails.ts
@@ -29,9 +29,8 @@ import { messages } from "../../locales.js";
 export const useDashboardScheduledEmails = ({ onReload }: { onReload?: () => void } = {}) => {
     const { addSuccess, addError } = useToastMessage();
     const isScheduleEmailingDialogOpen = useDashboardSelector(selectIsScheduleEmailDialogOpen);
-    const isScheduleEmailingManagementDialogOpen = useDashboardSelector(
-        selectIsScheduleEmailManagementDialogOpen,
-    );
+    const isScheduleEmailingManagementDialogOpen =
+        useDashboardSelector(selectIsScheduleEmailManagementDialogOpen) || false;
     const dispatch = useDashboardDispatch();
     const dashboardRef = useDashboardSelector(selectDashboardRef);
     const isReadOnly = useDashboardSelector(selectIsReadOnly);

--- a/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/dashboardDropdownBody/configuration/limitValues/LimitValuesConfiguration.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/dashboardDropdownBody/configuration/limitValues/LimitValuesConfiguration.tsx
@@ -26,7 +26,7 @@ import {
     isDashboardDependentDateFilter,
 } from "../../../../../../model/index.js";
 import { IntlWrapper } from "../../../../../localization/index.js";
-import { useCommonDateFilterTitle } from "../../../../dateFilter/useCommonDateFilterTitle.js";
+import { useCommonDateFilterTitle } from "../../../../../../_staging/sharedHooks/useCommonDateFilterTitle.js";
 
 import { LimitingItem } from "./shared/LimitingItem.js";
 import { useLimitingItems } from "./shared/limitingItemsHook.js";

--- a/libs/sdk-ui-dashboard/src/presentation/localization/bundles/en-US.json
+++ b/libs/sdk-ui-dashboard/src/presentation/localization/bundles/en-US.json
@@ -716,9 +716,44 @@
         "comment": "Translate only uppercase in '{n, plural, one {# RECIPIENT} other {# RECIPIENTS}}'.",
         "limit": 0
     },
-    "dialogs.schedule.management.recipients.onlyYou": {
-        "value": "Only you",
-        "comment": "There is no other recipient than you.",
+    "dialogs.schedule.management.attachments.filters.title": {
+        "value": "Dashboard filters",
+        "comment": "Title of dropdown for selected type of dashboard filters for attachment",
+        "limit": 0
+    },
+    "dialogs.schedule.management.attachments.filters.using": {
+        "value": "using",
+        "comment": "Describes which filters will be used in the attachment",
+        "limit": 0
+    },
+    "dialogs.schedule.management.attachments.filters.default": {
+        "value": "default dashboard filters",
+        "comment": "Attachment filters type title",
+        "limit": 0
+    },
+    "dialogs.schedule.management.attachments.filters.edited": {
+        "value": "edited dashboard filters",
+        "comment": "Attachment filters type title",
+        "limit": 0
+    },
+    "dialogs.schedule.management.attachments.filters.item.default": {
+        "value": "Use default filters",
+        "comment": "Attachment filters type item",
+        "limit": 0
+    },
+    "dialogs.schedule.management.attachments.filters.item.edited": {
+        "value": "Use edited filters",
+        "comment": "Attachment filters type item",
+        "limit": 0
+    },
+    "dialogs.schedule.management.attachments.filters.item.tooltip": {
+        "value": "Default state of dashboard filters will be used in the scheduled export, even if the default values change in the future.",
+        "comment": "Attachment filters type tooltip",
+        "limit": 0
+    },
+    "dialogs.schedule.management.attachments.message": {
+        "value": "<strong>Note</strong>. Cross-filtering will not be applied in the scheduled export.",
+        "comment": "Message about used filters. Do not translate HTML tags.",
         "limit": 0
     },
     "dialogs.schedule.management.attachments.dashboard": {
@@ -790,6 +825,11 @@
     },
     "cancel": {
         "value": "Cancel",
+        "comment": "",
+        "limit": 0
+    },
+    "save": {
+        "value": "Save",
         "comment": "",
         "limit": 0
     },

--- a/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/DefaultScheduledEmailDialog.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/DefaultScheduledEmailDialog.tsx
@@ -249,6 +249,7 @@ export function ScheduledMailDialogRenderer(props: IScheduledEmailDialogProps) {
                             dashboardTitle={dashboardTitle}
                             dashboardSelected={isDashboardExportSelected}
                             onAttachmentsSelectionChanged={onAttachmentsChange}
+                            editSchedule={editSchedule}
                         />
                         {savingErrorMessage ? (
                             <Message type="error" className="gd-schedule-email-dialog-error">

--- a/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/components/Attachments/AttachmentFilters.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/components/Attachments/AttachmentFilters.tsx
@@ -1,0 +1,177 @@
+// (C) 2024 GoodData Corporation
+
+import React, { useState } from "react";
+import {
+    Bubble,
+    BubbleHoverTrigger,
+    Button,
+    ContentDivider,
+    Dropdown,
+    IAlignPoint,
+} from "@gooddata/sdk-ui-kit";
+import { FormattedMessage, useIntl } from "react-intl";
+import { AttachmentFiltersList } from "./AttachmentFiltersList.js";
+import { IAttachmentFilterInfo } from "../../hooks/useAttachmentDashboardFilters.js";
+
+const DROPDOWN_ALIGN_POINTS: IAlignPoint[] = [
+    {
+        align: "bl tl",
+        offset: { x: 0, y: 0 },
+    },
+    {
+        align: "tl bl",
+        offset: { x: 0, y: 0 },
+    },
+];
+
+const TOOLTIP_ALIGN_POINTS: IAlignPoint[] = [
+    {
+        align: "cr cl",
+        offset: { x: 0, y: -2 },
+    },
+    {
+        align: "cl cr",
+        offset: { x: 0, y: -2 },
+    },
+];
+
+interface IAttachmentFiltersProps {
+    filterType: AttachmentFilterType;
+    onChange: (type: AttachmentFilterType) => void;
+    /**
+     * Whole attachment content is hidden
+     */
+    hidden?: boolean;
+    /**
+     * We do not allow changing the filter type when disabled
+     */
+    disabled?: boolean;
+    /**
+     * Determines whether dropdown is available or not
+     */
+    useDropdown?: boolean;
+    /**
+     * Information about attachment filters
+     */
+    filters?: IAttachmentFilterInfo[];
+}
+
+/**
+ * edited - ad-hoc changed dashboard filters
+ * default - default dashboard filters stored in its filter context definition
+ */
+export type AttachmentFilterType = "edited" | "default";
+
+const buttonTitle = {
+    edited: "dialogs.schedule.management.attachments.filters.edited",
+    default: "dialogs.schedule.management.attachments.filters.default",
+};
+
+export const AttachmentFilters: React.FC<IAttachmentFiltersProps> = (props) => {
+    const { filterType, onChange, hidden = false, disabled = false, useDropdown = true, filters } = props;
+    const [selectedType, setSelectedType] = useState<AttachmentFilterType>(filterType);
+    const intl = useIntl();
+
+    const handleTypeChange = (type: AttachmentFilterType) => {
+        !disabled && setSelectedType(type);
+    };
+
+    const filtersButtonValue = intl.formatMessage({ id: buttonTitle[filterType] });
+    const filtersUsingMessage = intl.formatMessage({
+        id: "dialogs.schedule.management.attachments.filters.using",
+    });
+
+    if (hidden) {
+        return null;
+    }
+
+    return (
+        <div>
+            {useDropdown ? (
+                <Dropdown
+                    alignPoints={DROPDOWN_ALIGN_POINTS}
+                    renderButton={({ toggleDropdown }) => (
+                        <div className="gd-attachment-filters-dropdown-button">
+                            {filtersUsingMessage}
+                            <Button
+                                className="gd-button-link-dimmed s-attachment-filters-dropdown-button"
+                                value={intl.formatMessage({ id: buttonTitle[filterType] })}
+                                onClick={toggleDropdown}
+                            />
+                        </div>
+                    )}
+                    renderBody={({ closeDropdown }) => (
+                        <div className="gd-attachment-filters-dropdown">
+                            <div className="gd-list-title">
+                                <FormattedMessage id="dialogs.schedule.management.attachments.filters.title" />
+                                <div className="gd-close-button">
+                                    <Button
+                                        className="gd-button-link gd-button-icon-only gd-icon-cross s-dialog-close-button"
+                                        value=""
+                                        onClick={closeDropdown}
+                                    />
+                                </div>
+                            </div>
+                            <div className="gd-attachment-filters-dropdown-content">
+                                <label className="input-radio-label">
+                                    <input
+                                        type="radio"
+                                        className="input-radio"
+                                        name="filterType"
+                                        onChange={() => handleTypeChange("edited")}
+                                        checked={selectedType === "edited"}
+                                        disabled={selectedType !== "edited" && disabled}
+                                    />
+                                    <span className="input-label-text">
+                                        <FormattedMessage id="dialogs.schedule.management.attachments.filters.item.edited" />
+                                    </span>
+                                </label>
+                                <AttachmentFiltersList filters={filters} />
+                                <label className="input-radio-label">
+                                    <input
+                                        type="radio"
+                                        className="input-radio"
+                                        name="filterType"
+                                        onChange={() => handleTypeChange("default")}
+                                        checked={selectedType === "default"}
+                                        disabled={selectedType !== "default" && disabled}
+                                    />
+                                    <span className="input-label-text">
+                                        <FormattedMessage id="dialogs.schedule.management.attachments.filters.item.default" />
+                                        <BubbleHoverTrigger>
+                                            <span className="gd-icon-circle-question" />
+                                            <Bubble alignPoints={TOOLTIP_ALIGN_POINTS}>
+                                                <FormattedMessage id="dialogs.schedule.management.attachments.filters.item.tooltip" />
+                                            </Bubble>
+                                        </BubbleHoverTrigger>
+                                    </span>
+                                </label>
+                            </div>
+                            <ContentDivider className="gd-divider-without-margin" />
+                            <div className="gd-attachment-filters-dropdown-footer">
+                                <Button
+                                    value={intl.formatMessage({ id: "cancel" })}
+                                    className="gd-button-secondary"
+                                    onClick={closeDropdown}
+                                />
+                                <Button
+                                    value={intl.formatMessage({ id: "save" })}
+                                    className="gd-button-action"
+                                    onClick={() => {
+                                        onChange(selectedType);
+                                        closeDropdown();
+                                    }}
+                                    disabled={selectedType === filterType}
+                                />
+                            </div>
+                        </div>
+                    )}
+                />
+            ) : (
+                <span>
+                    {filtersUsingMessage}&nbsp;{filtersButtonValue}
+                </span>
+            )}
+        </div>
+    );
+};

--- a/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/components/Attachments/AttachmentFiltersList.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/components/Attachments/AttachmentFiltersList.tsx
@@ -1,0 +1,33 @@
+// (C) 2024 GoodData Corporation
+
+import React from "react";
+import { IAttachmentFilterInfo } from "../../hooks/useAttachmentDashboardFilters.js";
+
+interface IAttachmentFiltersListProps {
+    filters?: IAttachmentFilterInfo[];
+}
+
+export const AttachmentFiltersList: React.FC<IAttachmentFiltersListProps> = ({ filters }) => {
+    if (!filters) {
+        return null;
+    }
+
+    return (
+        <div className="gd-attachment-filters-list">
+            {filters.map((filter) => (
+                <FilterListItem key={filter.id} title={filter.title} subtitle={filter.subtitle} />
+            ))}
+        </div>
+    );
+};
+
+const FilterListItem: React.FC<{ title: string; subtitle: string }> = ({ title, subtitle }) => {
+    return (
+        <div className="gd-attachment-filters-list-item">
+            <div className="gd-attachment-filters-list-item-title">{title}</div>
+            <div className="gd-attachment-filters-list-item-subtitle" title={subtitle}>
+                {subtitle}
+            </div>
+        </div>
+    );
+};

--- a/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/components/Attachments/Attachments.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/components/Attachments/Attachments.tsx
@@ -1,11 +1,17 @@
 // (C) 2019-2024 GoodData Corporation
-import * as React from "react";
+import React, { ReactNode, useState } from "react";
 import { FormattedMessage } from "react-intl";
+import { FilterContextItem, IAutomationMetadataObject } from "@gooddata/sdk-model";
+import { Message } from "@gooddata/sdk-ui-kit";
+import { AttachmentFilters, AttachmentFilterType } from "./AttachmentFilters.js";
+import { useAttachmentDashboardFilters } from "../../hooks/useAttachmentDashboardFilters.js";
+import { getAutomationDashboardFilters } from "../../utils/getAutomationFilters.js";
 
 export interface IAttachmentsProps {
     dashboardTitle: string;
     dashboardSelected: boolean;
-    onAttachmentsSelectionChanged(dashboardSelected: boolean): void;
+    onAttachmentsSelectionChanged(dashboardSelected: boolean, filters?: FilterContextItem[]): void;
+    editSchedule?: IAutomationMetadataObject;
 }
 
 const AttachmentItem: React.FC<{ format: string; children?: React.ReactNode }> = ({ format, children }) => (
@@ -16,28 +22,77 @@ const AttachmentItem: React.FC<{ format: string; children?: React.ReactNode }> =
 );
 
 export const Attachments = (props: IAttachmentsProps) => {
-    const { dashboardTitle, dashboardSelected, onAttachmentsSelectionChanged } = props;
+    const { dashboardTitle, dashboardSelected, onAttachmentsSelectionChanged, editSchedule } = props;
+
+    /**
+     * When editing a schedule, we need to get the filters from the export definition and we don't care
+     * about the actual filters on the dashboard.
+     */
+    const dashboardEditFilters = getAutomationDashboardFilters(editSchedule);
+    const { areFiltersChanged, isCrossFiltering, filtersToStore, filtersToDisplayInfo } =
+        useAttachmentDashboardFilters({
+            customFilters: dashboardEditFilters,
+        });
+    const isEditing = !!editSchedule;
+
+    const [attachmentFilterType, setAttachmentFilterType] = useState<AttachmentFilterType>(
+        /**
+         * We use "edited" by default when creating a new schedule or editing
+         * an existing schedule with filters.
+         * "default" is used when editing without filters.
+         */
+        !isEditing || dashboardEditFilters ? "edited" : "default",
+    );
+    const showAttachmentFilters = isEditing || (areFiltersChanged && dashboardSelected);
+    const disableDropdown = isEditing && attachmentFilterType === "default";
+
+    const handleAttachmentFilterTypeChange = (type: AttachmentFilterType) => {
+        const includeFilters = type === "edited" && areFiltersChanged;
+        setAttachmentFilterType(type);
+        onAttachmentsSelectionChanged(dashboardSelected, includeFilters ? filtersToStore : undefined);
+    };
+
+    const handleAttachmentSelectionChange = () => {
+        const includeFilters = attachmentFilterType === "edited" && areFiltersChanged;
+        onAttachmentsSelectionChanged(!dashboardSelected, includeFilters ? filtersToStore : undefined);
+    };
 
     return (
         <div className="gd-input-component gd-schedule-email-attachments s-schedule-email-attachments">
             <label className="gd-label">
                 <FormattedMessage id="dialogs.schedule.email.attachments.label" />
             </label>
-            <div className="gd-dashboard-attachment-list">
-                <div className="gd-dashboard-attachment-list-content">
-                    <label className="gd-schedule-mail-attachment-checkbox input-checkbox-label">
-                        <input
-                            type="checkbox"
-                            className="input-checkbox"
-                            checked={props.dashboardSelected}
-                            onChange={() => onAttachmentsSelectionChanged(!dashboardSelected)}
+            <div className="gd-attachment-list">
+                <label className="gd-schedule-mail-attachment-checkbox input-checkbox-label">
+                    <input
+                        type="checkbox"
+                        className="input-checkbox"
+                        checked={props.dashboardSelected}
+                        onChange={handleAttachmentSelectionChange}
+                    />
+                    <span className="input-label-text" />
+                    <AttachmentItem format="pdf">
+                        <span className="shortened-name">{dashboardTitle}</span>
+                    </AttachmentItem>
+                </label>
+                <AttachmentFilters
+                    filterType={attachmentFilterType}
+                    onChange={handleAttachmentFilterTypeChange}
+                    hidden={!showAttachmentFilters}
+                    disabled={isEditing}
+                    useDropdown={!disableDropdown}
+                    filters={filtersToDisplayInfo}
+                />
+                {isCrossFiltering && props.dashboardSelected ? (
+                    <Message type="progress" className="gd-attachment-list-message">
+                        <FormattedMessage
+                            id="dialogs.schedule.management.attachments.message"
+                            values={{
+                                strong: (chunks: ReactNode) => <strong>{chunks}</strong>,
+                            }}
                         />
-                        <span className="input-label-text" />
-                        <AttachmentItem format="pdf">
-                            <span className="shortened-name">{dashboardTitle}</span>
-                        </AttachmentItem>
-                    </label>
-                </div>
+                    </Message>
+                ) : null}
             </div>
         </div>
     );

--- a/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/constants.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/constants.ts
@@ -2,6 +2,8 @@
 
 export const PLATFORM_DATE_FORMAT = "yyyy-MM-dd";
 
+export const DEFAULT_DATE_FILTER_DATE_FORMAT = "MM/dd/yyyy";
+
 export const DEFAULT_DROPDOWN_ALIGN_POINTS = [
     {
         align: "bl tl",

--- a/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/hooks/useAttachmentDashboardFilters.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/hooks/useAttachmentDashboardFilters.ts
@@ -1,0 +1,223 @@
+// (C) 2024 GoodData Corporation
+
+import { v4 as uuidv4 } from "uuid";
+import {
+    DashboardAttributeFilterConfigMode,
+    DashboardAttributeFilterConfigModeValues,
+    DashboardDateFilterConfigMode,
+    DashboardDateFilterConfigModeValues,
+    FilterContextItem,
+    getAttributeElementsItems,
+    IAttributeElement,
+    isDashboardAttributeFilter,
+    isDashboardCommonDateFilter,
+    isDashboardDateFilter,
+    isDashboardDateFilterWithDimension,
+    serializeObjRef,
+} from "@gooddata/sdk-model";
+import { invariant } from "ts-invariant";
+import isEqual from "lodash/isEqual.js";
+import { useIntl } from "react-intl";
+import {
+    ICrossFilteringItem,
+    selectAllCatalogAttributesMap,
+    selectAttributeFilterDisplayFormsMap,
+    selectCrossFilteringItems,
+    selectEffectiveAttributeFiltersModeMap,
+    selectEffectiveDateFilterMode,
+    selectEffectiveDateFiltersModeMap,
+    selectFilterContextFilters,
+    selectLocale,
+    selectOriginalFilterContextFilters,
+    selectSettings,
+    useDashboardSelector,
+} from "../../../../model/index.js";
+import { matchDateFilterToDateFilterOptionWithPreference } from "../../../../_staging/dateFilterConfig/dateFilterOptionMapping.js";
+import { defaultDateFilterConfig } from "../../../../_staging/dateFilterConfig/defaultConfig.js";
+import {
+    DateFilterHelpers,
+    DateFilterOption,
+    getAttributeFilterSubtitle,
+    getLocalizedIcuDateFormatPattern,
+} from "@gooddata/sdk-ui-filters";
+import { useCommonDateFilterTitle } from "../../../../_staging/sharedHooks/useCommonDateFilterTitle.js";
+import { useDateFiltersTitles } from "../../../../_staging/sharedHooks/useDateFiltersTitles.js";
+
+export interface IAttachmentFilterInfo {
+    id: string;
+    title: string;
+    subtitle: string;
+    attributeFilterValues?: (string | null)[];
+    isAttributeFilterNegative?: boolean;
+    dateFilterOption?: DateFilterOption;
+}
+
+interface IUseAttachmentDashboardFilters {
+    /**
+     * Is there some ad-hoc change of filters on the dashboard compared to original filters state?
+     *
+     * @remarks Excluding cross-filtering.
+     */
+    areFiltersChanged: boolean;
+    /**
+     * Is cross filtering currently in action?
+     */
+    isCrossFiltering: boolean;
+    /**
+     * Dashboard filters without cross-filtering intended for metadata storing.
+     */
+    filtersToStore: FilterContextItem[];
+    /**
+     * Information about dashboard filters without cross-filtering and hidden filters intended for UI usage.
+     */
+    filtersToDisplayInfo: IAttachmentFilterInfo[];
+}
+
+export const useAttachmentDashboardFilters = ({
+    customFilters,
+}: {
+    /**
+     * Custom filters from metadata object to use instead of the current dashboard filters.
+     */
+    customFilters?: FilterContextItem[];
+}): IUseAttachmentDashboardFilters => {
+    const intl = useIntl();
+    const locale = useDashboardSelector(selectLocale);
+    const settings = useDashboardSelector(selectSettings);
+
+    const dateFormat = settings.formatLocale
+        ? getLocalizedIcuDateFormatPattern(settings.formatLocale)
+        : settings.responsiveUiDateFormat;
+
+    const dashboardFilters = useDashboardSelector(selectFilterContextFilters);
+    const effectiveFilters = customFilters ? [...customFilters] : [...dashboardFilters];
+
+    // remove cross-filtering to get filters for storing
+    const crossFilteringItems = useDashboardSelector(selectCrossFilteringItems);
+    const isCrossFiltering = crossFilteringItems.length > 0;
+    const filtersToStore = removeCrossFilteringFilters(effectiveFilters, crossFilteringItems);
+
+    // compare stored dashboard filters with filters to store
+    const originalFilters = useDashboardSelector(selectOriginalFilterContextFilters);
+    const areFiltersChanged = !isEqual(filtersToStore, originalFilters);
+
+    // additionaly remove hidden filters to get filters suitable for display
+    const commonDateFilterMode = useDashboardSelector(selectEffectiveDateFilterMode);
+    const dateFiltersModeMap = useDashboardSelector(selectEffectiveDateFiltersModeMap);
+    const attributeFiltersModeMap = useDashboardSelector(selectEffectiveAttributeFiltersModeMap);
+    const filtersToDisplay = removeHiddenFilters(
+        filtersToStore,
+        commonDateFilterMode,
+        dateFiltersModeMap,
+        attributeFiltersModeMap,
+    );
+
+    // collect information for visual list of filters
+    const dfMap = useDashboardSelector(selectAttributeFilterDisplayFormsMap);
+    const attrMap = useDashboardSelector(selectAllCatalogAttributesMap);
+    const dateFiltersToDisplay = filtersToDisplay.filter(isDashboardDateFilterWithDimension);
+    const commonDateFilterTitle = useCommonDateFilterTitle(intl);
+    const allDateFiltersTitlesObj = useDateFiltersTitles(dateFiltersToDisplay, intl);
+
+    const filtersToDisplayInfo = filtersToDisplay.map((filter) => {
+        if (isDashboardAttributeFilter(filter)) {
+            const displayForm = dfMap.get(filter.attributeFilter.displayForm);
+            invariant(displayForm, "Inconsistent state in catalog");
+            const attribute = attrMap.get(displayForm.attribute);
+            invariant(attribute, "Inconsistent state in catalog");
+
+            const valuesAsAttributeElements: IAttributeElement[] = getAttributeElementsItems(
+                filter.attributeFilter.attributeElements,
+            )?.map((element) => ({
+                title: element,
+                uri: element,
+            }));
+            const subtitle = getAttributeFilterSubtitle(
+                filter.attributeFilter.negativeSelection,
+                valuesAsAttributeElements,
+                intl,
+            );
+
+            return {
+                id: filter.attributeFilter.localIdentifier!,
+                title: filter.attributeFilter.title ?? attribute.attribute.title,
+                subtitle,
+            };
+        } else {
+            /**
+             * Shenanigans inspired by core date filter and dashboard date filter implementation
+             * to get the date filter option for its subtitle.
+             */
+            const dateFilterOptionInfo = matchDateFilterToDateFilterOptionWithPreference(
+                filter,
+                defaultDateFilterConfig,
+                undefined,
+            );
+            const dateFilterOption = DateFilterHelpers.applyExcludeCurrentPeriod(
+                dateFilterOptionInfo.dateFilterOption,
+                dateFilterOptionInfo.excludeCurrentPeriod,
+            );
+            const subtitle = DateFilterHelpers.getDateFilterTitle(dateFilterOption, locale, dateFormat);
+
+            if (isDashboardDateFilterWithDimension(filter)) {
+                const key = serializeObjRef(filter.dateFilter.dataSet!);
+                return {
+                    id: uuidv4(), // used just for React keys
+                    title: allDateFiltersTitlesObj[key],
+                    subtitle,
+                };
+            } else {
+                return {
+                    id: uuidv4(), // used just for React keys
+                    title: commonDateFilterTitle || intl.formatMessage({ id: "dateFilterDropdown.title" }),
+                    subtitle,
+                };
+            }
+        }
+    });
+
+    return {
+        areFiltersChanged,
+        isCrossFiltering,
+        filtersToStore,
+        filtersToDisplayInfo,
+    };
+};
+
+const removeCrossFilteringFilters = (
+    filters: FilterContextItem[],
+    crossFilteringItems: ICrossFilteringItem[],
+) => {
+    const crossFilteringFilterLocalIdentifiers = crossFilteringItems.flatMap(
+        (item) => item.filterLocalIdentifiers,
+    );
+
+    return filters.filter((filter) => {
+        if (isDashboardAttributeFilter(filter) && filter.attributeFilter.localIdentifier) {
+            return !crossFilteringFilterLocalIdentifiers.includes(filter.attributeFilter.localIdentifier);
+        }
+
+        return true;
+    });
+};
+
+const removeHiddenFilters = (
+    filters: FilterContextItem[],
+    commonDateFilterMode: DashboardDateFilterConfigMode,
+    dateFiltersModeMap: Map<string, DashboardDateFilterConfigMode>,
+    attributeFiltersModeMap: Map<string, DashboardAttributeFilterConfigMode>,
+) => {
+    return filters.filter((filter) => {
+        if (isDashboardCommonDateFilter(filter)) {
+            return commonDateFilterMode !== DashboardDateFilterConfigModeValues.HIDDEN;
+        } else if (isDashboardDateFilter(filter) && filter.dateFilter.localIdentifier) {
+            const mode = dateFiltersModeMap.get(filter.dateFilter.localIdentifier);
+            return mode !== DashboardDateFilterConfigModeValues.HIDDEN;
+        } else if (isDashboardAttributeFilter(filter) && filter.attributeFilter.localIdentifier) {
+            const mode = attributeFiltersModeMap.get(filter.attributeFilter.localIdentifier);
+            return mode !== DashboardAttributeFilterConfigModeValues.HIDDEN;
+        }
+
+        return true;
+    });
+};

--- a/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/hooks/useCreateScheduledEmail.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/hooks/useCreateScheduledEmail.ts
@@ -2,7 +2,6 @@
 import { useCallback } from "react";
 import {
     FilterContextItem,
-    IFilterContextDefinition,
     IAutomationMetadataObject,
     IAutomationMetadataObjectDefinition,
 } from "@gooddata/sdk-model";
@@ -42,19 +41,14 @@ export const useCreateScheduledEmail = ({
             onSuccess?.(event.payload.scheduledEmail);
         },
         onBeforeRun: (cmd) => {
-            onBeforeRun?.(cmd.payload.scheduledEmail, cmd.payload.filterContext?.filters);
+            onBeforeRun?.(cmd.payload.scheduledEmail, cmd.payload.filters);
         },
     });
 
     const create = useCallback(
         (scheduledEmailToCreate: IAutomationMetadataObjectDefinition, filters?: FilterContextItem[]) => {
-            const filterContext: IFilterContextDefinition | undefined = filters && {
-                title: "filterContext",
-                description: "",
-                filters: ensureAllTimeFilterForExport(filters),
-            };
-
-            scheduledEmailCommandProcessing.run(scheduledEmailToCreate, filterContext);
+            const sanitizedFilters = filters && ensureAllTimeFilterForExport(filters);
+            scheduledEmailCommandProcessing.run(scheduledEmailToCreate, sanitizedFilters);
         },
         [scheduledEmailCommandProcessing],
     );

--- a/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/hooks/useSaveScheduledEmailToBackend.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/hooks/useSaveScheduledEmailToBackend.ts
@@ -1,12 +1,17 @@
 // (C) 2019-2024 GoodData Corporation
 import { useCallback, useState } from "react";
-import { ObjRef, IAutomationMetadataObject, IAutomationMetadataObjectDefinition } from "@gooddata/sdk-model";
+import {
+    IAutomationMetadataObject,
+    IAutomationMetadataObjectDefinition,
+    FilterContextItem,
+} from "@gooddata/sdk-model";
 import { GoodDataSdkError } from "@gooddata/sdk-ui";
 import { useCreateScheduledEmail } from "./useCreateScheduledEmail.js";
 import { useUpdateScheduledEmail } from "./useUpdateScheduledEmail.js";
 import { IScheduledEmailDialogProps } from "../../types.js";
 import { IntlShape, useIntl } from "react-intl";
 import omit from "lodash/omit.js";
+import { getAutomationDashboardFilters } from "../utils/getAutomationFilters.js";
 
 export function useSaveScheduledEmailToBackend(
     automation: IAutomationMetadataObject | IAutomationMetadataObjectDefinition,
@@ -33,8 +38,11 @@ export function useSaveScheduledEmailToBackend(
         },
     });
     const handleCreateScheduledEmail = useCallback(
-        (scheduledEmail: IAutomationMetadataObject | IAutomationMetadataObjectDefinition) => {
-            scheduledEmailCreator.create(scheduledEmail as IAutomationMetadataObjectDefinition);
+        (
+            scheduledEmail: IAutomationMetadataObject | IAutomationMetadataObjectDefinition,
+            filters?: FilterContextItem[],
+        ) => {
+            scheduledEmailCreator.create(scheduledEmail as IAutomationMetadataObjectDefinition, filters);
         },
         [scheduledEmailCreator],
     );
@@ -61,19 +69,23 @@ export function useSaveScheduledEmailToBackend(
     const handleUpdateScheduledEmail = useCallback(
         (
             scheduledEmail: IAutomationMetadataObject | IAutomationMetadataObjectDefinition,
-            filterContextRef?: ObjRef,
+            filters?: FilterContextItem[],
         ) => {
-            scheduledEmailUpdater.save(scheduledEmail as IAutomationMetadataObject, filterContextRef);
+            scheduledEmailUpdater.save(scheduledEmail as IAutomationMetadataObject, filters);
         },
         [scheduledEmailUpdater],
     );
 
     const handleSaveScheduledEmail = (): void => {
         const sanitizedAutomation = sanitizeAutomation(automation, intl);
+
+        // Only filters from dashboard export definition are relevant for scheduled email for now
+        const filters = getAutomationDashboardFilters(sanitizedAutomation);
+
         if (sanitizedAutomation.id) {
-            handleUpdateScheduledEmail(sanitizedAutomation);
+            handleUpdateScheduledEmail(sanitizedAutomation, filters);
         } else {
-            handleCreateScheduledEmail(sanitizedAutomation);
+            handleCreateScheduledEmail(sanitizedAutomation, filters);
         }
     };
 

--- a/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/hooks/useUpdateScheduledEmail.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/hooks/useUpdateScheduledEmail.ts
@@ -1,6 +1,6 @@
 // (C) 2020-2024 GoodData Corporation
 import { useCallback } from "react";
-import { IAutomationMetadataObject, ObjRef } from "@gooddata/sdk-model";
+import { FilterContextItem, IAutomationMetadataObject } from "@gooddata/sdk-model";
 import {
     CommandProcessingStatus,
     saveScheduledEmail,
@@ -16,7 +16,7 @@ export const useUpdateScheduledEmail = ({
     onSuccess?: () => void;
     onError?: (error: any) => void;
 } = {}): {
-    save: (scheduledEmailToSave: IAutomationMetadataObject, filterContextRef?: ObjRef) => void;
+    save: (scheduledEmailToSave: IAutomationMetadataObject, filters?: FilterContextItem[]) => void;
     savingStatus?: CommandProcessingStatus;
 } => {
     const scheduledEmailCommandProcessing = useDashboardCommandProcessing({
@@ -35,8 +35,8 @@ export const useUpdateScheduledEmail = ({
     });
 
     const save = useCallback(
-        (scheduledEmailToSave: IAutomationMetadataObject, filterContextRef?: ObjRef) => {
-            scheduledEmailCommandProcessing.run(scheduledEmailToSave, filterContextRef);
+        (scheduledEmailToSave: IAutomationMetadataObject, filters?: FilterContextItem[]) => {
+            scheduledEmailCommandProcessing.run(scheduledEmailToSave, filters);
         },
         [scheduledEmailCommandProcessing],
     );

--- a/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/utils/getAutomationFilters.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/utils/getAutomationFilters.ts
@@ -1,0 +1,22 @@
+// (C) 2024 GoodData Corporation
+
+import {
+    IAutomationMetadataObject,
+    IAutomationMetadataObjectDefinition,
+    isExportDefinitionDashboardContent,
+    isFilterContextItem,
+} from "@gooddata/sdk-model";
+
+export const getAutomationDashboardFilters = (
+    automation: IAutomationMetadataObject | IAutomationMetadataObjectDefinition | undefined,
+) => {
+    if (!automation) {
+        return undefined;
+    }
+
+    return automation.exportDefinitions
+        ?.find((exportDefinition) => {
+            return isExportDefinitionDashboardContent(exportDefinition.requestPayload.content);
+        })
+        ?.requestPayload?.content.filters?.filter(isFilterContextItem);
+};

--- a/libs/sdk-ui-dashboard/styles/scss/scheduled_mail.scss
+++ b/libs/sdk-ui-dashboard/styles/scss/scheduled_mail.scss
@@ -145,10 +145,14 @@ $min-content-height: 110px;
         margin: 10px 20px 0 0;
     }
 
-    .gd-dashboard-attachment-list {
+    .gd-attachment-list {
+        display: flex;
+        flex-direction: row;
+        align-items: baseline;
         flex: 1;
         overflow: hidden;
         margin: -2px 0;
+        flex-wrap: wrap;
 
         @media #{kit-variables.$small-only} {
             max-width: none;
@@ -159,6 +163,23 @@ $min-content-height: 110px;
             flex-wrap: wrap;
             overflow: hidden;
             margin: 0 -5px;
+        }
+    }
+
+    .gd-attachment-list-message {
+        display: flex;
+        flex-basis: 100%;
+        margin-top: 10px;
+    }
+
+    .gd-attachment-filters-dropdown-button {
+        display: flex;
+        align-items: baseline;
+        height: 28px;
+
+        .gd-button-link-dimmed {
+            border: none;
+            box-shadow: none;
         }
     }
 
@@ -205,6 +226,84 @@ $min-content-height: 110px;
                 margin-left: 7px;
             }
         }
+    }
+}
+
+.gd-attachment-filters-dropdown {
+    width: 245px;
+    max-height: 350px;
+
+    .gd-list-title {
+        line-height: normal;
+    }
+
+    .gd-close-button {
+        position: absolute;
+        top: 5px;
+        right: 5px;
+        outline: none;
+
+        .gd-button-link.gd-button-icon-only::before {
+            font-size: 14px;
+        }
+    }
+
+    .gd-attachment-filters-dropdown-content {
+        display: flex;
+        flex-direction: column;
+        padding: 10px;
+
+        > :first-child {
+            margin-bottom: 5px;
+        }
+
+        > :last-child {
+            margin-top: 5px;
+        }
+
+        .gd-icon-circle-question {
+            position: relative;
+            top: 2px;
+            padding: 5px;
+            color: kit-variables.$gd-color-state-blank;
+        }
+
+        .gd-attachment-filters-list {
+            display: flex;
+            flex-direction: column;
+            gap: 10px;
+            border-left: 2px dotted kit-variables.$gd-border-color;
+            padding: 0 10px;
+            margin-left: 6px;
+            max-height: 190px;
+            overflow-y: auto;
+            margin-right: -10px;
+        }
+
+        .gd-attachment-filters-list-item-title {
+            color: kit-variables.$gd-color-link;
+            font-size: 12px;
+            font-style: normal;
+            font-weight: 400;
+            line-height: normal;
+        }
+
+        .gd-attachment-filters-list-item-subtitle {
+            text-overflow: ellipsis;
+            white-space: nowrap;
+            overflow: hidden;
+            color: kit-variables.$gd-color-text;
+            font-size: 12px;
+            font-style: normal;
+            font-weight: bold;
+            line-height: normal;
+        }
+    }
+
+    .gd-attachment-filters-dropdown-footer {
+        display: flex;
+        justify-content: end;
+        padding: 10px;
     }
 }
 
@@ -844,8 +943,14 @@ $min-content-height: 110px;
     margin-bottom: $vertical-space;
 }
 
+.gd-divider-without-margin {
+    margin-top: 0;
+    margin-bottom: 0;
+}
+
 .gd-divider-full-row {
-    margin: 0 (-$dialog-padding) $vertical-space;
+    margin-left: -$dialog-padding;
+    margin-right: -$dialog-padding;
 }
 
 .gd-schedule-email-dialog-destination-empty {

--- a/libs/sdk-ui-filters/api/sdk-ui-filters.api.md
+++ b/libs/sdk-ui-filters/api/sdk-ui-filters.api.md
@@ -262,6 +262,9 @@ export const EmptyElementsSearchBar: React_2.VFC<IAttributeFilterElementsSearchB
 // @public
 export function filterVisibleDateFilterOptions(dateFilterOptions: IDateFilterOptionsByType): IDateFilterOptionsByType;
 
+// @internal (undocumented)
+export function getAttributeFilterSubtitle(isCommittedSelectionInverted: boolean, committedSelectionElements: IAttributeElement[], intl: IntlShape): string;
+
 // @internal
 export const getLocalizedIcuDateFormatPattern: (locale: string) => string;
 

--- a/libs/sdk-ui-filters/src/AttributeFilter/hooks/useResolveAttributeFilterSubtitle.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilter/hooks/useResolveAttributeFilterSubtitle.ts
@@ -1,7 +1,7 @@
-// (C) 2022 GoodData Corporation
+// (C) 2022-2024 GoodData Corporation
 import { useIntl } from "react-intl";
 import { IAttributeElement } from "@gooddata/sdk-model";
-import { getElementTitles } from "../utils.js";
+import { getAttributeFilterSubtitle } from "../utils.js";
 
 /**
  * @internal
@@ -11,22 +11,5 @@ export function useResolveAttributeFilterSubtitle(
     committedSelectionElements: IAttributeElement[],
 ) {
     const intl = useIntl();
-    const isCommittedSelectionEmpty = committedSelectionElements.length === 0;
-
-    const isNone = isCommittedSelectionEmpty && !isCommittedSelectionInverted;
-    const isNegativeSelection = !isCommittedSelectionEmpty && isCommittedSelectionInverted;
-    const isPositiveSelection = !isCommittedSelectionEmpty && !isCommittedSelectionInverted;
-
-    let subtitle = intl.formatMessage({ id: "gs.list.all" });
-    if (isNegativeSelection) {
-        subtitle = `${intl.formatMessage({ id: "gs.list.all" })} ${intl.formatMessage({
-            id: "gs.list.except",
-        })} ${getElementTitles(committedSelectionElements, intl)}`;
-    } else if (isPositiveSelection) {
-        subtitle = getElementTitles(committedSelectionElements, intl);
-    } else if (isNone) {
-        subtitle = intl.formatMessage({ id: "gs.filterLabel.none" });
-    }
-
-    return subtitle;
+    return getAttributeFilterSubtitle(isCommittedSelectionInverted, committedSelectionElements, intl);
 }

--- a/libs/sdk-ui-filters/src/AttributeFilter/index.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilter/index.ts
@@ -83,3 +83,5 @@ export {
     IUseAttributeFilterSearchProps,
     useAttributeFilterSearch,
 } from "./hooks/useAttributeFilterSearch.js";
+
+export { getAttributeFilterSubtitle } from "./utils.js";

--- a/libs/sdk-ui-filters/src/AttributeFilter/utils.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilter/utils.ts
@@ -117,3 +117,31 @@ export function isValidSingleSelectionFilter(
     }
     return true;
 }
+
+/**
+ * @internal
+ */
+export function getAttributeFilterSubtitle(
+    isCommittedSelectionInverted: boolean,
+    committedSelectionElements: IAttributeElement[],
+    intl: IntlShape,
+) {
+    const isCommittedSelectionEmpty = committedSelectionElements.length === 0;
+
+    const isNone = isCommittedSelectionEmpty && !isCommittedSelectionInverted;
+    const isNegativeSelection = !isCommittedSelectionEmpty && isCommittedSelectionInverted;
+    const isPositiveSelection = !isCommittedSelectionEmpty && !isCommittedSelectionInverted;
+
+    let subtitle = intl.formatMessage({ id: "gs.list.all" });
+    if (isNegativeSelection) {
+        subtitle = `${intl.formatMessage({ id: "gs.list.all" })} ${intl.formatMessage({
+            id: "gs.list.except",
+        })} ${getElementTitles(committedSelectionElements, intl)}`;
+    } else if (isPositiveSelection) {
+        subtitle = getElementTitles(committedSelectionElements, intl);
+    } else if (isNone) {
+        subtitle = intl.formatMessage({ id: "gs.filterLabel.none" });
+    }
+
+    return subtitle;
+}

--- a/libs/sdk-ui-filters/src/index.ts
+++ b/libs/sdk-ui-filters/src/index.ts
@@ -202,6 +202,7 @@ export {
     AttributeFilterControllerCallbacks,
     AttributeFilterDependencyTooltip,
     IAttributeFilterDependencyTooltipProps,
+    getAttributeFilterSubtitle,
 } from "./AttributeFilter/index.js";
 
 export { IFilterButtonCustomIcon, VisibilityMode } from "./shared/index.js";


### PR DESCRIPTION
- export definition for dashboard uses FilterContextItem in opposed to export definition for visualization objects due to differences in BE consumption
- do not store cross-filtering in export definition
- do not show hidden filters in the list of edited filters

JIRA: F1-437
risk: low

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** 🙏

---

Refer to [documentation](https://github.com/gooddata/gooddata-ui-sdk/blob/master/dev_docs/continuous_integration.md) to see how to run checks and tests in the pull request. This is the list of the most used commands:

```
extended test - backstop
```

```
extended test - tiger-cypress - integrated
extended test - tiger-cypress - isolated
extended test - tiger-cypress - record
```
