### PR TITLE
fix: use proper ref from state

### DIFF
--- a/libs/sdk-ui-filters/api/sdk-ui-filters.api.md
+++ b/libs/sdk-ui-filters/api/sdk-ui-filters.api.md
@@ -303,6 +303,7 @@ export interface IAttributeElementLoader {
     cancelIrrelevantElementsLoad(correlation?: Correlation): void;
     cancelNextElementsPageLoad(): void;
     getAllElements(): IAttributeElement[];
+    getDisplayAsLabel(): ObjRef | undefined;
     getElementsByKey(keys: AttributeElementKey[]): IAttributeElement[];
     getInitialElementsPageError(): GoodDataSdkError | undefined;
     getInitialElementsPageStatus(): AsyncOperationStatus;

--- a/libs/sdk-ui-filters/src/AttributeFilterHandler/internal/bridge.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilterHandler/internal/bridge.ts
@@ -90,6 +90,7 @@ import {
     selectLimitingValidationItems,
     selectAttributeFilterToDisplay,
     selectOriginalFilter,
+    selectAttributeFilterDisplayAsLabel,
 } from "./redux/index.js";
 import { newAttributeFilterCallbacks } from "./callbacks.js";
 import { AttributeFilterHandlerConfig } from "./types.js";
@@ -391,6 +392,11 @@ export class AttributeFilterReduxBridge {
     setDisplayAsLabel = (displayAsLabel: ObjRef, correlation?: Correlation): void => {
         this.redux.dispatch(actions.setDisplayAsLabel({ displayAsLabel, correlation }));
     };
+
+    getDisplayAsLabel = (): ObjRef | undefined => {
+        return this.redux.select(selectAttributeFilterDisplayAsLabel);
+    };
+
     setDisplayForm = (displayForm: ObjRef, correlation?: Correlation): void => {
         this.redux.dispatch(actions.setDisplayFormRef({ displayForm, correlation }));
     };

--- a/libs/sdk-ui-filters/src/AttributeFilterHandler/internal/loader.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilterHandler/internal/loader.ts
@@ -360,6 +360,11 @@ export class AttributeFilterLoader implements IAttributeFilterLoader {
     setDisplayAsLabel = (displayAsLabel: ObjRef): void => {
         this.bridge.setDisplayAsLabel(displayAsLabel);
     };
+
+    getDisplayAsLabel = (): ObjRef | undefined => {
+        return this.bridge.getDisplayAsLabel();
+    };
+
     setDisplayForm = (label: ObjRef): void => {
         this.bridge.setDisplayForm(label);
     };

--- a/libs/sdk-ui-filters/src/AttributeFilterHandler/types/attributeFilterLoader.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilterHandler/types/attributeFilterLoader.ts
@@ -23,6 +23,7 @@ export interface IAttributeFilterLoader extends IAttributeLoader, IAttributeElem
 
     /**
      * Get the filter to display in component, including custom displayAsLabel applied.
+     * Note: This filter is not used for execution and can be completely the same as getFilter one.
      */
     getFilterToDisplay(): IAttributeFilter;
 

--- a/libs/sdk-ui-filters/src/AttributeFilterHandler/types/elementsLoader.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilterHandler/types/elementsLoader.ts
@@ -170,6 +170,11 @@ export interface IAttributeElementLoader {
     setDisplayAsLabel(displayAsLabel: ObjRef): void;
 
     /**
+     * Get the label used for representing the attribute filter elements visually if defined.
+     */
+    getDisplayAsLabel(): ObjRef | undefined;
+
+    /**
      * Set the limit for the upcoming attribute element loads.
      *
      * @remarks


### PR DESCRIPTION
- handler.getFilterToDisplay() always returns something even displayAsLabel is not defined
- it caused endless loop when comparing filter based on attribute with single label
- user real displayAsLabel value from state instead

JIRA: LX-368
risk: low

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** 🙏

---

Refer to [documentation](https://github.com/gooddata/gooddata-ui-sdk/blob/master/dev_docs/continuous_integration.md) to see how to run checks and tests in the pull request. This is the list of the most used commands:

```
extended test - backstop
```

```
extended test - tiger-cypress - integrated
extended test - tiger-cypress - isolated
extended test - tiger-cypress - record
```
