### PR TITLE
feat: multiple early access flags for ws and org

### DIFF
--- a/libs/api-client-tiger/api/api-client-tiger.api.md
+++ b/libs/api-client-tiger/api/api-client-tiger.api.md
@@ -6617,7 +6617,7 @@ export interface FactsApiInterface {
 // @public (undocumented)
 export type FeatureContext = {
     organizationId: string;
-    earlyAccess: string;
+    earlyAccessValues: string[];
 };
 
 // @public

--- a/libs/api-client-tiger/src/profile.ts
+++ b/libs/api-client-tiger/src/profile.ts
@@ -4,7 +4,7 @@ import { ApiEntitlement } from "./generated/metadata-json-api/index.js";
 
 export type FeatureContext = {
     organizationId: string;
-    earlyAccess: string;
+    earlyAccessValues: string[];
 };
 
 export interface ILiveFeatures {

--- a/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
+++ b/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
@@ -1249,7 +1249,9 @@ export interface IWorkspaceDescriptor {
     childWorkspacesCount?: number;
     // (undocumented)
     description: string;
+    // @deprecated
     earlyAccess?: string;
+    earlyAccessValues?: string[];
     // (undocumented)
     id: string;
     // (undocumented)
@@ -1267,6 +1269,8 @@ export interface IWorkspaceDescriptorUpdate {
     description?: string;
     // (undocumented)
     earlyAccess?: string | null;
+    // (undocumented)
+    earlyAccessValues?: string[] | null;
     // (undocumented)
     prefix?: string | null;
     // (undocumented)

--- a/libs/sdk-backend-spi/src/workspace/index.ts
+++ b/libs/sdk-backend-spi/src/workspace/index.ts
@@ -195,8 +195,15 @@ export interface IWorkspaceDescriptor {
     parentPrefixes?: string[];
     /**
      * Early access attribute value of the workspace
+     * @deprecated - use earlyAccessValues instead
      */
     earlyAccess?: string;
+
+    /**
+     * Early access flags of the workspace
+     */
+    earlyAccessValues?: string[];
+
     /**
      * Number of child workspaces
      */
@@ -215,6 +222,7 @@ export interface IWorkspaceDescriptorUpdate {
     description?: string;
     prefix?: string | null;
     earlyAccess?: string | null;
+    earlyAccessValues?: string[] | null;
 }
 
 /**
@@ -253,6 +261,7 @@ export interface IWorkspacesQueryFilter {
      * Filter by earlyAccess property on the workspace
      */
     earlyAccess?: string;
+
     /**
      * Filter by entity identifiers prefix in the workspace
      */

--- a/libs/sdk-backend-tiger/src/backend/features/hub.ts
+++ b/libs/sdk-backend-tiger/src/backend/features/hub.ts
@@ -103,7 +103,12 @@ async function getFeatureHubData(
                     if (value === undefined || value === "") {
                         return prev;
                     }
-                    return [...prev, `${item}=${encodeURIComponent(value)}`];
+
+                    const parsed = Array.isArray(value)
+                        ? value.map((v) => `${item}[]=${encodeURIComponent(v)}`)
+                        : [`${item}=${encodeURIComponent(value)}`];
+
+                    return [...prev, ...parsed];
                 }, [] as Array<string>)
                 .join(","),
             ...(state ? { "if-none-match": state.etag } : {}),

--- a/libs/sdk-backend-tiger/src/backend/features/index.ts
+++ b/libs/sdk-backend-tiger/src/backend/features/index.ts
@@ -14,7 +14,7 @@ import { getFeatureHubFeatures } from "./hub.js";
 import { getStaticFeatures } from "./static.js";
 
 const getKeyFromContext = (wsContext?: Partial<FeatureContext>): string => {
-    return `${wsContext?.organizationId}-${wsContext?.earlyAccess}`;
+    return `${wsContext?.organizationId}-${wsContext?.earlyAccessValues?.join(",")}`;
 };
 const responseMap: LRUCache<string, Promise<ITigerFeatureFlags>> = new LRUCache<
     string,
@@ -78,8 +78,8 @@ export function pickContext(
 ): Partial<FeatureContext> {
     const context: Partial<FeatureContext> = {};
 
-    if (attributes?.earlyAccess !== undefined) {
-        context.earlyAccess = attributes.earlyAccess;
+    if (attributes?.earlyAccessValues !== undefined) {
+        context.earlyAccessValues = attributes.earlyAccessValues;
     }
 
     if (organizationId !== undefined) {

--- a/libs/sdk-backend-tiger/src/backend/features/test/hub.test.ts
+++ b/libs/sdk-backend-tiger/src/backend/features/test/hub.test.ts
@@ -10,8 +10,9 @@ import { describe, expect, it, vi } from "vitest";
 const axiosGetSpy = vi.spyOn(axios, "get");
 
 describe("live features", () => {
-    function createFeatures(earlyAccess = "", organizationId = ""): ILiveFeatures["live"] {
-        return { configuration: { host: "/", key: "" }, context: { earlyAccess, organizationId } };
+    // TODO:
+    function createFeatures(earlyAccessValues: string[] = [], organizationId = ""): ILiveFeatures["live"] {
+        return { configuration: { host: "/", key: "" }, context: { earlyAccessValues, organizationId } };
     }
 
     function createFeature(key: string, type: FeatureDef["type"], value: any): FeatureDef {
@@ -59,12 +60,15 @@ describe("live features", () => {
     it("call axios with ws context", async () => {
         mockReturn([]);
 
-        await getFeatureHubFeatures(createFeatures(), pickContext({ earlyAccess: "omega" }, "test-org"));
+        await getFeatureHubFeatures(
+            createFeatures(),
+            pickContext({ earlyAccessValues: ["omega"] }, "test-org"),
+        );
         expect(axiosGetSpy).toHaveBeenCalledWith("/features", {
             baseURL: "/",
             headers: {
                 "Content-type": "application/json",
-                "X-FeatureHub": "earlyAccess=omega,organizationId=test-org",
+                "X-FeatureHub": "earlyAccessValues[]=omega,organizationId=test-org",
                 "if-none-match": expect.anything(),
             },
             method: "GET",
@@ -77,12 +81,12 @@ describe("live features", () => {
     it("call axios with context filled", async () => {
         mockReturn([]);
 
-        await getFeatureHubFeatures(createFeatures("beta", "org"));
+        await getFeatureHubFeatures(createFeatures(["beta"], "org"));
         expect(axiosGetSpy).toHaveBeenCalledWith("/features", {
             baseURL: "/",
             headers: {
                 "Content-type": "application/json",
-                "X-FeatureHub": "earlyAccess=beta,organizationId=org",
+                "X-FeatureHub": "earlyAccessValues[]=beta,organizationId=org",
                 "if-none-match": expect.anything(),
             },
             method: "GET",
@@ -96,14 +100,14 @@ describe("live features", () => {
         mockReturn([]);
 
         await getFeatureHubFeatures(
-            createFeatures("beta", "org"),
-            pickContext({ earlyAccess: "omega" }, "test-org"),
+            createFeatures(["beta"], "org"),
+            pickContext({ earlyAccessValues: ["omega"] }, "test-org"),
         );
         expect(axiosGetSpy).toHaveBeenCalledWith("/features", {
             baseURL: "/",
             headers: {
                 "Content-type": "application/json",
-                "X-FeatureHub": "earlyAccess=omega,organizationId=test-org",
+                "X-FeatureHub": "earlyAccessValues[]=omega,organizationId=test-org",
                 "if-none-match": expect.anything(),
             },
             method: "GET",

--- a/libs/sdk-backend-tiger/src/backend/features/test/static.test.ts
+++ b/libs/sdk-backend-tiger/src/backend/features/test/static.test.ts
@@ -1,4 +1,4 @@
-// (C) 2020-2023 GoodData Corporation
+// (C) 2020-2024 GoodData Corporation
 
 import { IStaticFeatures } from "@gooddata/api-client-tiger";
 import { TigerFeaturesNames } from "../../uiFeatures.js";
@@ -6,8 +6,8 @@ import { getStaticFeatures } from "../static.js";
 import { describe, expect, it } from "vitest";
 
 describe("static features", () => {
-    function createFeatures(items = {}, earlyAccess = ""): IStaticFeatures["static"] {
-        return { items, context: { earlyAccess } };
+    function createFeatures(items = {}, earlyAccessValues: string[] = []): IStaticFeatures["static"] {
+        return { items, context: { earlyAccessValues, organizationId: "" } };
     }
 
     it("empty definition", async () => {
@@ -56,7 +56,7 @@ describe("static features", () => {
                     [TigerFeaturesNames.EnableSqlDatasets]: "TRUE",
                     [TigerFeaturesNames.EnableCompositeGrain]: "TRUE",
                 },
-                "beta",
+                ["beta"],
             ),
         );
         expect(results).toEqual({

--- a/libs/sdk-backend-tiger/src/backend/organization/index.ts
+++ b/libs/sdk-backend-tiger/src/backend/organization/index.ts
@@ -58,6 +58,7 @@ export class TigerOrganization implements IOrganization {
                 bootstrapUser: idRef(bootstrapUser.id, bootstrapUser.type),
                 bootstrapUserGroup: idRef(bootstrapUserGroup.id, bootstrapUserGroup.type),
                 earlyAccess: result.data.data.attributes?.earlyAccess ?? undefined,
+                earlyAccessValues: result.data.data.attributes?.earlyAccessValues ?? undefined,
             };
         }
 
@@ -83,6 +84,7 @@ export class TigerOrganization implements IOrganization {
                             // type casts are necessary because nulls are not allowed in the type definition,
                             // but backend expects them in case we want to delete the value
                             earlyAccess: descriptor.earlyAccess as string | undefined,
+                            earlyAccessValues: descriptor.earlyAccessValues as string[] | undefined,
                         },
                     },
                 },

--- a/libs/sdk-backend-tiger/src/backend/workspaces/index.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspaces/index.ts
@@ -126,7 +126,7 @@ class TigerWorkspaceQuery implements IWorkspacesQuery {
     private constructFilter(): string | undefined {
         const filterParam = compact([
             this.filter.description && `description==${this.filter.description}`,
-            this.filter.earlyAccess && `earlyAccess==${this.filter.earlyAccess}`,
+            this.filter.earlyAccess && `earlyAccessValues=containsic=${this.filter.earlyAccess}`,
             this.filter.prefix && `prefix==${this.filter.prefix}`,
             // get only workspaces that have no parent workspace
             this.filter.rootWorkspacesOnly && "parent.id=isnull=true",

--- a/libs/sdk-backend-tiger/src/convertors/fromBackend/WorkspaceConverter.ts
+++ b/libs/sdk-backend-tiger/src/convertors/fromBackend/WorkspaceConverter.ts
@@ -15,6 +15,7 @@ export const workspaceConverter = (
         parentWorkspace,
         parentPrefixes,
         earlyAccess: attributes?.earlyAccess ?? undefined,
+        earlyAccessValues: attributes?.earlyAccessValues ?? undefined,
         childWorkspacesCount: meta?.hierarchy?.childrenCount,
     };
 };

--- a/libs/sdk-backend-tiger/src/convertors/toBackend/WorkspaceConverter.ts
+++ b/libs/sdk-backend-tiger/src/convertors/toBackend/WorkspaceConverter.ts
@@ -17,6 +17,7 @@ export const convertWorkspaceUpdate = (
             // but backend expects them in case we want to delete the value
             prefix: descriptor.prefix as string | undefined,
             earlyAccess: descriptor.earlyAccess as string | undefined,
+            earlyAccessValues: descriptor.earlyAccessValues as string[] | undefined,
         },
     };
 };

--- a/libs/sdk-model/api/sdk-model.api.md
+++ b/libs/sdk-model/api/sdk-model.api.md
@@ -2185,8 +2185,10 @@ export interface IOrganizationDescriptor {
     bootstrapUser?: ObjRef;
     // (undocumented)
     bootstrapUserGroup?: ObjRef;
-    // (undocumented)
+    // @deprecated (undocumented)
     earlyAccess?: string;
+    // (undocumented)
+    earlyAccessValues?: string[];
     // (undocumented)
     id: string;
     // (undocumented)
@@ -2195,8 +2197,10 @@ export interface IOrganizationDescriptor {
 
 // @public
 export interface IOrganizationDescriptorUpdate {
-    // (undocumented)
+    // @deprecated (undocumented)
     earlyAccess?: string | null;
+    // (undocumented)
+    earlyAccessValues?: string[] | null;
     // (undocumented)
     title?: string;
 }

--- a/libs/sdk-model/src/organization/index.ts
+++ b/libs/sdk-model/src/organization/index.ts
@@ -12,7 +12,11 @@ export interface IOrganizationDescriptor {
     title: string;
     bootstrapUser?: ObjRef;
     bootstrapUserGroup?: ObjRef;
+    /**
+     * @deprecated - use early access values instead
+     */
     earlyAccess?: string;
+    earlyAccessValues?: string[];
 }
 
 /**
@@ -24,7 +28,11 @@ export interface IOrganizationDescriptor {
  */
 export interface IOrganizationDescriptorUpdate {
     title?: string;
+    /**
+     * @deprecated - use early access values instead
+     */
     earlyAccess?: string | null;
+    earlyAccessValues?: string[] | null;
 }
 
 /**


### PR DESCRIPTION
Enable usage of multiple simultaneous early access flags for workspaces and organizations.

Deprecate earlyAccess property in favor of earlyAccessValues.

risk: low
JIRA: F1-489

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** 🙏

---

Refer to [documentation](https://github.com/gooddata/gooddata-ui-sdk/blob/master/dev_docs/continuous_integration.md) to see how to run checks and tests in the pull request. This is the list of the most used commands:

```
extended test - backstop
```

```
extended test - tiger-cypress - integrated
extended test - tiger-cypress - isolated
extended test - tiger-cypress - record
```
