### PR TITLE
fix: earlyAccess flags

### DIFF
--- a/libs/sdk-backend-tiger/src/backend/features/test/hub.test.ts
+++ b/libs/sdk-backend-tiger/src/backend/features/test/hub.test.ts
@@ -68,7 +68,7 @@ describe("live features", () => {
             baseURL: "/",
             headers: {
                 "Content-type": "application/json",
-                "X-FeatureHub": "earlyAccessValues[]=omega,organizationId=test-org",
+                "X-FeatureHub": "organizationId=test-org,earlyAccess=omega",
                 "if-none-match": expect.anything(),
             },
             method: "GET",
@@ -86,7 +86,7 @@ describe("live features", () => {
             baseURL: "/",
             headers: {
                 "Content-type": "application/json",
-                "X-FeatureHub": "earlyAccessValues[]=beta,organizationId=org",
+                "X-FeatureHub": "organizationId=org,earlyAccess=beta",
                 "if-none-match": expect.anything(),
             },
             method: "GET",
@@ -107,7 +107,7 @@ describe("live features", () => {
             baseURL: "/",
             headers: {
                 "Content-type": "application/json",
-                "X-FeatureHub": "earlyAccessValues[]=omega,organizationId=test-org",
+                "X-FeatureHub": "organizationId=test-org,earlyAccess=omega",
                 "if-none-match": expect.anything(),
             },
             method: "GET",


### PR DESCRIPTION
Change how multiple earlyAccess flags are provided to FeatureHub, to keep it more backward compatible.

risk: low
JIRA: F1-491

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** 🙏

---

Refer to [documentation](https://github.com/gooddata/gooddata-ui-sdk/blob/master/dev_docs/continuous_integration.md) to see how to run checks and tests in the pull request. This is the list of the most used commands:

```
extended test - backstop
```

```
extended test - tiger-cypress - integrated
extended test - tiger-cypress - isolated
extended test - tiger-cypress - record
```
