### PR TITLE
feat: drill intersection filtering configuration

### DIFF
--- a/libs/sdk-backend-tiger/src/backend/features/feature.ts
+++ b/libs/sdk-backend-tiger/src/backend/features/feature.ts
@@ -436,6 +436,13 @@ export function mapFeatures(features: FeaturesMap): Partial<ITigerFeatureFlags> 
             "BOOLEAN",
             FeatureFlagsValues.enableAIFunctions,
         ),
+        ...loadFeature(
+            features,
+            TigerFeaturesNames.EnableDrillIntersectionIgnoredAttributes,
+            "enableDrillIntersectionIgnoredAttributes",
+            "BOOLEAN",
+            FeatureFlagsValues.enableDrillIntersectionIgnoredAttributes,
+        ),
     };
 }
 

--- a/libs/sdk-backend-tiger/src/backend/uiFeatures.ts
+++ b/libs/sdk-backend-tiger/src/backend/uiFeatures.ts
@@ -98,6 +98,7 @@ export enum TigerFeaturesNames {
     EnableRollupTotals = "enableRollupTotals",
     EnableWidgetIdentifiersRollout = "enableWidgetIdentifiersRollout",
     EnableAIFunctions = "enableAIFunctions",
+    EnableDrillIntersectionIgnoredAttributes = "enableDrillIntersectionIgnoredAttributes",
 }
 
 export type ITigerFeatureFlags = {
@@ -161,6 +162,7 @@ export type ITigerFeatureFlags = {
     enableRollupTotals: typeof FeatureFlagsValues["enableRollupTotals"][number];
     enableWidgetIdentifiersRollout: typeof FeatureFlagsValues["enableWidgetIdentifiersRollout"][number];
     enableAIFunctions: typeof FeatureFlagsValues["enableAIFunctions"][number];
+    enableDrillIntersectionIgnoredAttributes: typeof FeatureFlagsValues["enableDrillIntersectionIgnoredAttributes"][number];
 };
 
 export const DefaultFeatureFlags: ITigerFeatureFlags = {
@@ -224,6 +226,7 @@ export const DefaultFeatureFlags: ITigerFeatureFlags = {
     enableRollupTotals: false,
     enableWidgetIdentifiersRollout: false,
     enableAIFunctions: false,
+    enableDrillIntersectionIgnoredAttributes: false,
 };
 
 export const FeatureFlagsValues = {
@@ -291,4 +294,5 @@ export const FeatureFlagsValues = {
     enableRollupTotals: [true, false] as const,
     enableWidgetIdentifiersRollout: [true, false] as const,
     enableAIFunctions: [true, false] as const,
+    enableDrillIntersectionIgnoredAttributes: [true, false] as const,
 };

--- a/libs/sdk-model/api/sdk-model.api.md
+++ b/libs/sdk-model/api/sdk-model.api.md
@@ -1407,6 +1407,7 @@ export function idRef(identifier: Identifier, type?: ObjectType): IdentifierRef;
 
 // @public
 export interface IDrill {
+    drillIntersectionIgnoredAttributes?: string[];
     localIdentifier?: string;
     origin: DrillOrigin;
     transition: DrillTransition;
@@ -2792,6 +2793,7 @@ export interface ISettings {
     enableDataSection?: boolean;
     enableDescriptions?: boolean;
     enableDrilledInsightExport?: boolean;
+    enableDrillIntersectionIgnoredAttributes?: boolean;
     enableDuplicatedLabelValuesInAttributeFilter?: boolean;
     enableEmbedButtonInAD?: boolean;
     enableEmbedButtonInKD?: boolean;

--- a/libs/sdk-model/src/dashboard/drill.ts
+++ b/libs/sdk-model/src/dashboard/drill.ts
@@ -171,6 +171,15 @@ export interface IDrill {
      * Drill origin
      */
     origin: DrillOrigin;
+
+    /**
+     * Local identifiers of the attribute display forms to ignore
+     * in the drill intersection.
+     *
+     * Values of these display forms won't be included
+     * in the drill intersection.
+     */
+    drillIntersectionIgnoredAttributes?: string[];
 }
 
 /**

--- a/libs/sdk-model/src/settings/index.ts
+++ b/libs/sdk-model/src/settings/index.ts
@@ -425,6 +425,11 @@ export interface ISettings {
      */
     enableAIFunctions?: boolean;
 
+    /**
+     * Enable configuration of the drill intersection ignored attributes.
+     */
+    enableDrillIntersectionIgnoredAttributes?: boolean;
+
     [key: string]: number | boolean | string | object | undefined;
 }
 

--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -6871,6 +6871,9 @@ export const selectEnableClickableAttributeURL: DashboardSelector<boolean>;
 export const selectEnableCompanyLogoInEmbeddedUI: DashboardSelector<boolean>;
 
 // @internal
+export const selectEnableDrillIntersectionIgnoredAttributes: DashboardSelector<boolean>;
+
+// @internal
 export const selectEnableDuplicatedLabelValuesInAttributeFilter: DashboardSelector<boolean>;
 
 // @public

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/drill/common/intersectionUtils.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/drill/common/intersectionUtils.ts
@@ -6,7 +6,12 @@ import {
     IDrillIntersectionAttributeItem,
     isDrillIntersectionAttributeItem,
 } from "@gooddata/sdk-ui";
-import { areObjRefsEqual, ObjRef, IDashboardAttributeFilter } from "@gooddata/sdk-model";
+import {
+    areObjRefsEqual,
+    ObjRef,
+    IDashboardAttributeFilter,
+    isAttributeDescriptor,
+} from "@gooddata/sdk-model";
 
 /**
  *  For correct drill intersection that should be converted into AttributeFilters must be drill intersection:
@@ -59,4 +64,20 @@ export function convertIntersectionToAttributeFilters(
             });
             return result;
         }, [] as IConversionResult[]);
+}
+
+/**
+ * @internal
+ */
+export function removeIgnoredValuesFromDrillIntersection(
+    intersection: IDrillEventIntersectionElement[],
+    drillIntersectionIgnoredAttributes: string[],
+): IDrillEventIntersectionElement[] {
+    return intersection!.filter((i) => {
+        if (isAttributeDescriptor(i.header) || isDrillIntersectionAttributeItem(i.header)) {
+            return !drillIntersectionIgnoredAttributes?.includes(i.header.attributeHeader.localIdentifier);
+        }
+
+        return true;
+    });
 }

--- a/libs/sdk-ui-dashboard/src/model/store/config/configSelectors.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/config/configSelectors.ts
@@ -694,3 +694,15 @@ export const selectEnableRichTextDescriptions: DashboardSelector<boolean> = crea
         return state.settings?.enableRichTextDescriptions ?? false;
     },
 );
+
+/**
+ * Returns whether drill intersection ignored attributes is enabled.
+ *
+ * @internal
+ */
+export const selectEnableDrillIntersectionIgnoredAttributes: DashboardSelector<boolean> = createSelector(
+    selectConfig,
+    (state) => {
+        return state.settings?.enableDrillIntersectionIgnoredAttributes ?? false;
+    },
+);

--- a/libs/sdk-ui-dashboard/src/model/store/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/index.ts
@@ -83,6 +83,7 @@ export {
     selectIsDisabledCrossFiltering,
     selectIsDisableUserFilterReset,
     selectEnableScheduling,
+    selectEnableDrillIntersectionIgnoredAttributes,
 } from "./config/configSelectors.js";
 export { EntitlementsState } from "./entitlements/entitlementsState.js";
 export {

--- a/libs/sdk-ui-dashboard/src/presentation/drill/types.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/drill/types.ts
@@ -162,6 +162,10 @@ export interface IDrillConfigItemBase {
     warning?: string;
     attributes: IAvailableDrillTargetMeasure["attributes"];
     widgetRef: ObjRef;
+    /**
+     * Local identifiers of attribute display forms that should be ignored in drill intersection.
+     */
+    drillIntersectionIgnoredAttributes?: string[];
 }
 
 export type IDrillConfigItem =

--- a/libs/sdk-ui-dashboard/src/presentation/localization/bundles/en-US.json
+++ b/libs/sdk-ui-dashboard/src/presentation/localization/bundles/en-US.json
@@ -1651,6 +1651,31 @@
         "translate": false,
         "limit": 0
     },
+    "configurationPanel.drillConfig.drillIntersectionIgnoredAttributes.label": {
+        "value": "Pass as filter:",
+        "comment": "Label of the dropdown to select drill intersection ignored attributes.",
+        "limit": 0
+    },
+    "configurationPanel.drillConfig.drillIntersectionIgnoredAttributes.dropdown.title": {
+        "value": "Pass as filters",
+        "comment": "Title of the dropdown to select drill intersection ignored attributes.",
+        "limit": 0
+    },
+    "configurationPanel.drillConfig.drillIntersectionIgnoredAttributes.dropdown.tooltip": {
+        "value": "Disable the attribute or date to exclude its value from being passed as a filter to the drill destination.",
+        "comment": "Tooltip of the dropdown to select drill intersection ignored attributes.",
+        "limit": 0
+    },
+    "configurationPanel.drillConfig.drillIntersectionIgnoredAttributes.dropdown.all": {
+        "value": "All",
+        "comment": "Title of the dropdown, when all values are selected and none attribute is ignored.",
+        "limit": 0
+    },
+    "configurationPanel.drillConfig.drillIntersectionIgnoredAttributes.dropdown.none": {
+        "value": "None",
+        "comment": "Title of the dropdown, when no values are selected and all attributes are ignored.",
+        "limit": 0
+    },
     "configurationPanel.unlistedDashboardTab": {
         "value": "Unlisted dashboard",
         "comment": "",

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/configuration/DrillIntersectionIgnoredAttributes.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/configuration/DrillIntersectionIgnoredAttributes.tsx
@@ -1,0 +1,87 @@
+// (C) 2020-2024 GoodData Corporation
+import React from "react";
+import { bucketsAttributes, insightBuckets, areObjRefsEqual } from "@gooddata/sdk-model";
+import { DRILL_TARGET_TYPE, IDrillConfigItem } from "../../../drill/types.js";
+import {
+    selectCatalogAttributeDisplayForms,
+    selectCatalogDateDatasets,
+    selectInsightByWidgetRef,
+    useDashboardSelector,
+} from "../../../../model/index.js";
+import {
+    DrillIntersectionIgnoredAttributesSelect,
+    IDrillIntersectionIgnoredAttributesSelectOption,
+} from "./DrillIntersectionIgnoredAttributesSelect.js";
+import { FormattedMessage } from "react-intl";
+
+export interface IDrillIntersectionIgnoredAttributesProps {
+    item: IDrillConfigItem;
+    onChange: (ignoredAttributes: string[]) => void;
+    drillTargetType?: DRILL_TARGET_TYPE;
+}
+
+export const DrillIntersectionIgnoredAttributes = ({
+    item,
+    onChange,
+    drillTargetType,
+}: IDrillIntersectionIgnoredAttributesProps) => {
+    const insight = useDashboardSelector(selectInsightByWidgetRef(item.widgetRef));
+    const insightAttributes = bucketsAttributes(insight ? insightBuckets(insight) : []);
+    const allCatalogDisplayForms = useDashboardSelector(selectCatalogAttributeDisplayForms);
+    const allDateDatasets = useDashboardSelector(selectCatalogDateDatasets);
+    const allCatalogDateAttributeDisplayForms = allDateDatasets
+        .flatMap((ds) => ds.dateAttributes)
+        .flatMap((da) => da.defaultDisplayForm);
+
+    const displayForms = insightAttributes.map((idf) => {
+        const catalogAttr = allCatalogDisplayForms.find((df) =>
+            areObjRefsEqual(df.ref, idf.attribute.displayForm),
+        );
+        const catalogDateAttribute = allCatalogDateAttributeDisplayForms.find((df) =>
+            areObjRefsEqual(df.ref, idf.attribute.displayForm),
+        );
+        const type = catalogDateAttribute ? "date" : "attribute";
+
+        return {
+            insightAttr: idf,
+            catalogAttr: catalogAttr ?? catalogDateAttribute,
+            type,
+        };
+    });
+
+    const options = displayForms.map(
+        (df): IDrillIntersectionIgnoredAttributesSelectOption => ({
+            id: df.insightAttr.attribute.localIdentifier,
+            title: df.catalogAttr?.title ?? "",
+            type: df.type as "attribute" | "date",
+        }),
+    );
+
+    const selection =
+        item.drillIntersectionIgnoredAttributes?.map(
+            (id): IDrillIntersectionIgnoredAttributesSelectOption => {
+                const option = options.find((o) => o.id === id);
+                return {
+                    id,
+                    title: option?.title ?? "",
+                    type: option?.type ?? "attribute",
+                };
+            },
+        ) ?? [];
+
+    return (
+        <div className="gd-drill-intersection-ignored-attributes-select-section">
+            <div className="gd-drill-intersection-ignored-attributes-select-label">
+                <FormattedMessage id="configurationPanel.drillConfig.drillIntersectionIgnoredAttributes.label" />
+            </div>
+            <DrillIntersectionIgnoredAttributesSelect
+                drillTargetType={drillTargetType}
+                initialSelection={selection}
+                options={options}
+                onApply={(selection) => {
+                    onChange(selection.map((s) => s.id));
+                }}
+            />
+        </div>
+    );
+};

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/configuration/DrillIntersectionIgnoredAttributesSelect.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/configuration/DrillIntersectionIgnoredAttributesSelect.tsx
@@ -1,0 +1,182 @@
+// (C) 2020-2024 GoodData Corporation
+import React, { useState } from "react";
+import {
+    Dropdown,
+    Bubble,
+    BubbleHoverTrigger,
+    Button,
+    InvertableSelect,
+    InvertableSelectItem,
+    Icon,
+    IIconProps,
+} from "@gooddata/sdk-ui-kit";
+import differenceBy from "lodash/differenceBy.js";
+import cx from "classnames";
+import { DRILL_TARGET_TYPE } from "../../../drill/types.js";
+import { FormattedMessage } from "react-intl";
+
+const ALIGN_POINTS = [
+    { align: "cr tl", offset: { x: 3, y: 0 } },
+    { align: "bc tl", offset: { x: 3, y: 0 } },
+    { align: "tc bl", offset: { x: 3, y: 0 } },
+    { align: "tc br", offset: { x: 3, y: 0 } },
+    { align: "bc tr", offset: { x: 3, y: 0 } },
+];
+
+/**
+ * @internal
+ */
+export interface IDrillIntersectionIgnoredAttributesSelectOption {
+    id: string;
+    title: string;
+    type: "attribute" | "date";
+}
+
+/**
+ * @internal
+ */
+export interface IDrillIntersectionIgnoredAttributesSelectProps {
+    options: IDrillIntersectionIgnoredAttributesSelectOption[];
+    initialSelection?: IDrillIntersectionIgnoredAttributesSelectOption[];
+    onApply: (selection: IDrillIntersectionIgnoredAttributesSelectOption[]) => void;
+    drillTargetType?: DRILL_TARGET_TYPE;
+}
+
+/**
+ * @internal
+ */
+export function DrillIntersectionIgnoredAttributesSelect({
+    options,
+    initialSelection = [],
+    onApply,
+    drillTargetType,
+}: IDrillIntersectionIgnoredAttributesSelectProps) {
+    const [isInverted, setIsInverted] = useState(true);
+    const [selection, setSelection] =
+        useState<IDrillIntersectionIgnoredAttributesSelectOption[]>(initialSelection);
+
+    const appliedSelection = isInverted ? selection : differenceBy(options, selection, "id");
+    const shownSelection = isInverted ? differenceBy(options, appliedSelection, "id") : selection;
+
+    return (
+        <Dropdown
+            onOpenStateChanged={(open) => {
+                if (!open) {
+                    onApply(appliedSelection);
+                }
+            }}
+            renderBody={() => {
+                return (
+                    <InvertableSelect
+                        className="gd-drill-intersection-ignored-attributes-select"
+                        onSelect={(items, isInverted) => {
+                            setSelection(items);
+                            setIsInverted(isInverted);
+                        }}
+                        items={options}
+                        getItemTitle={(item) => item.title}
+                        getItemKey={(item) => item.id}
+                        isInverted={isInverted}
+                        selectedItems={selection}
+                        totalItemsCount={options.length}
+                        renderItem={({ title, item, onSelect, onDeselect, isSelected }) => {
+                            const isDisabled =
+                                item.type === "date" &&
+                                drillTargetType === DRILL_TARGET_TYPE.DRILL_TO_DASHBOARD;
+
+                            let IconComponent: React.ComponentType<IIconProps> = () => null;
+                            if (item.type === "date") {
+                                IconComponent = Icon.Date;
+                            } else if (item.type === "attribute") {
+                                IconComponent = Icon.Attribute;
+                            }
+                            return (
+                                <InvertableSelectItem
+                                    title={title}
+                                    renderOnly={() => <></>}
+                                    isDisabled={isDisabled}
+                                    isSelected={!isDisabled && isSelected}
+                                    icon={
+                                        <IconComponent
+                                            className={cx(
+                                                "gd-drill-intersection-ignored-attributes-select-item-icon",
+                                                `gd-drill-intersection-ignored-attributes-select-item-icon-${item.type}`,
+                                            )}
+                                        />
+                                    }
+                                    onClick={() => {
+                                        if (isDisabled) {
+                                            return;
+                                        }
+                                        if (isSelected) {
+                                            onDeselect();
+                                        } else {
+                                            onSelect();
+                                        }
+                                    }}
+                                />
+                            );
+                        }}
+                        renderStatusBar={() => <></>}
+                        renderSearchBar={() => (
+                            <div className="gd-drill-intersection-ignored-attributes-select-title">
+                                <FormattedMessage id="configurationPanel.drillConfig.drillIntersectionIgnoredAttributes.dropdown.title" />
+                                <BubbleHoverTrigger>
+                                    <Icon.QuestionMark
+                                        className="gd-drill-intersection-ignored-attributes-select-title-tooltip"
+                                        width={12}
+                                        height={12}
+                                    />
+                                    <Bubble alignPoints={ALIGN_POINTS}>
+                                        <div className="gd-drill-intersection-ignored-attributes-select-title-tooltip-content">
+                                            <FormattedMessage id="configurationPanel.drillConfig.drillIntersectionIgnoredAttributes.dropdown.tooltip" />
+                                        </div>
+                                    </Bubble>
+                                </BubbleHoverTrigger>
+                            </div>
+                        )}
+                    />
+                );
+            }}
+            renderButton={({ toggleDropdown, isOpen }) => {
+                let title: React.ReactNode = "";
+                if (isInverted && selection.length === 0) {
+                    title = (
+                        <FormattedMessage id="configurationPanel.drillConfig.drillIntersectionIgnoredAttributes.dropdown.all" />
+                    );
+                } else if (
+                    (!isInverted && selection.length === 0) ||
+                    (isInverted && selection.length === options.length)
+                ) {
+                    title = (
+                        <FormattedMessage id="configurationPanel.drillConfig.drillIntersectionIgnoredAttributes.dropdown.none" />
+                    );
+                } else {
+                    title = shownSelection.map((s) => s.title).join(", ");
+                }
+                return (
+                    <Button
+                        onClick={toggleDropdown}
+                        iconRight={isOpen ? "gd-icon-navigateup" : "gd-icon-navigatedown"}
+                        size="small"
+                        variant="primary"
+                        className={cx(
+                            "gd-drill-intersection-ignored-attributes-select-button",
+                            "button-dropdown",
+                            "dropdown-button",
+                            {
+                                "gd-is-open": isOpen,
+                                "is-active": isOpen,
+                            },
+                        )}
+                    >
+                        <BubbleHoverTrigger>
+                            {title}
+                            <Bubble>{title}</Bubble>
+                        </BubbleHoverTrigger>
+                    </Button>
+                );
+            }}
+        />
+    );
+}

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/configuration/DrillTargets/DrillTargets.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/configuration/DrillTargets/DrillTargets.tsx
@@ -62,6 +62,7 @@ export const DrillTargets: React.FunctionComponent<IDrillTargetsProps> = (props)
             origin: getOrigin(item),
             type: "drillToInsight",
             target: targetItem.insight.ref,
+            drillIntersectionIgnoredAttributes: item.drillIntersectionIgnoredAttributes,
         };
         props.onSetup(drillConfigItem, { ...item, insightRef: targetItem.insight.ref });
     };
@@ -74,6 +75,7 @@ export const DrillTargets: React.FunctionComponent<IDrillTargetsProps> = (props)
             origin: getOrigin(item),
             type: "drillToDashboard",
             target: dashboard,
+            drillIntersectionIgnoredAttributes: item.drillIntersectionIgnoredAttributes,
         };
         props.onSetup(drillConfigItem, { ...item, dashboard });
     };

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/configuration/InsightDrillConfigPanel/drillConfigMapper.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/configuration/InsightDrillConfigPanel/drillConfigMapper.ts
@@ -1,4 +1,4 @@
-// (C) 2022 GoodData Corporation
+// (C) 2022-2024 GoodData Corporation
 import {
     IDrillToDashboard,
     IDrillToInsight,
@@ -90,6 +90,7 @@ const createInsightConfig = (
         insightRef: drillData.target,
         complete: true,
         widgetRef: widgetRef,
+        drillIntersectionIgnoredAttributes: drillData.drillIntersectionIgnoredAttributes,
     };
 };
 
@@ -112,6 +113,7 @@ const createDashboardConfig = (
         dashboard: drillData.target,
         complete: true,
         widgetRef: widgetRef,
+        drillIntersectionIgnoredAttributes: drillData.drillIntersectionIgnoredAttributes,
     };
 };
 

--- a/libs/sdk-ui-dashboard/styles/scss/drillConfigPanel.scss
+++ b/libs/sdk-ui-dashboard/styles/scss/drillConfigPanel.scss
@@ -1,4 +1,4 @@
-// (C) 2019-2022 GoodData Corporation
+// (C) 2019-2024 GoodData Corporation
 @use "@gooddata/sdk-ui-kit/styles/scss/mixins";
 @use "variables";
 @use "@gooddata/sdk-ui-kit/styles/scss/Button/variables" as button-variables;
@@ -786,4 +786,82 @@ $gd-gd-drill-to-url-body-width: 230px;
 
 .attribute-hierarchy-list-footer {
     padding: 0 0 10px;
+}
+
+.gd-drill-intersection-ignored-attributes-select-section {
+    display: flex;
+    align-items: center;
+    margin-top: 5px;
+}
+.gd-drill-intersection-ignored-attributes-select-label {
+    white-space: nowrap;
+    overflow: hidden;
+    width: 100%;
+    text-overflow: ellipsis;
+    font-size: 12px;
+    line-height: 16.4px;
+    color: kit-variables.$gd-color-link;
+}
+
+.gd-drill-intersection-ignored-attributes-select {
+    .input-radio-label .input-label-text,
+    .input-checkbox-label .input-label-text {
+        display: inline;
+        font-size: 12px;
+    }
+
+    .gd-drill-intersection-ignored-attributes-select-item-icon {
+        margin-right: 5px;
+        vertical-align: middle;
+        width: 14px;
+        height: 14px;
+
+        &-date {
+            path {
+                fill: kit-variables.$gd-palette-primary-base;
+            }
+        }
+    }
+}
+
+.gd-drill-intersection-ignored-attributes-select-title {
+    padding: 5px 10px;
+    width: 100%;
+    background-color: kit-variables.$is-focused-background;
+    color: kit-variables.$gd-color-state-blank;
+    line-height: 15px;
+    font-size: 11px;
+    font-weight: 700;
+    height: 35px;
+    display: flex;
+    align-items: center;
+    text-transform: uppercase;
+    margin-bottom: 5px;
+}
+
+.gd-drill-intersection-ignored-attributes-select-title-tooltip {
+    margin-left: 5px;
+    margin-top: 2px;
+
+    path {
+        fill: kit-variables.$gd-color-state-blank;
+    }
+}
+
+.gd-drill-intersection-ignored-attributes-select-title-tooltip-content {
+    width: 190px;
+}
+
+.drill-config-target .gd-button-small.gd-drill-intersection-ignored-attributes-select-button {
+    margin-top: 0;
+    width: 95px;
+
+    &:not(&.gd-is-open, &:hover, &:active, &:focus) {
+        box-shadow: none;
+        border-color: transparent;
+    }
+
+    &:not(&.gd-is-open, &:active, &:focus) {
+        background: transparent;
+    }
 }

--- a/libs/sdk-ui-kit/api/sdk-ui-kit.api.md
+++ b/libs/sdk-ui-kit/api/sdk-ui-kit.api.md
@@ -2198,6 +2198,10 @@ export interface IInvertableSelectAllCheckboxProps {
 // @internal (undocumented)
 export interface IInvertableSelectItem {
     // (undocumented)
+    icon?: JSX.Element;
+    // (undocumented)
+    isDisabled?: boolean;
+    // (undocumented)
     isSelected?: boolean;
     // (undocumented)
     onClick?: () => void;
@@ -2208,7 +2212,15 @@ export interface IInvertableSelectItem {
     // (undocumented)
     onOnly?: () => void;
     // (undocumented)
+    renderOnly?: (props: IInvertableSelectItemRenderOnlyProps) => JSX.Element;
+    // (undocumented)
     title?: string;
+}
+
+// @internal (undocumented)
+export interface IInvertableSelectItemRenderOnlyProps {
+    // (undocumented)
+    onOnly?: () => void;
 }
 
 // @internal (undocumented)

--- a/libs/sdk-ui-kit/src/List/InvertableSelect/InvertableSelectItem.tsx
+++ b/libs/sdk-ui-kit/src/List/InvertableSelect/InvertableSelectItem.tsx
@@ -1,4 +1,4 @@
-// (C) 2007-2022 GoodData Corporation
+// (C) 2007-2024 GoodData Corporation
 import React, { useCallback } from "react";
 import { FormattedMessage } from "react-intl";
 import cx from "classnames";
@@ -8,26 +8,40 @@ import { stringUtils } from "@gooddata/util";
 /**
  * @internal
  */
+export interface IInvertableSelectItemRenderOnlyProps {
+    onOnly?: () => void;
+}
+
+/**
+ * @internal
+ */
 export interface IInvertableSelectItem {
     title?: string;
+    icon?: JSX.Element;
     isSelected?: boolean;
     onMouseOut?: () => void;
     onMouseOver?: () => void;
     onOnly?: () => void;
     onClick?: () => void;
+    renderOnly?: (props: IInvertableSelectItemRenderOnlyProps) => JSX.Element;
+    isDisabled?: boolean;
 }
 
 /**
  * @internal
  */
 export function InvertableSelectItem(props: IInvertableSelectItem) {
-    const { title, onClick, onMouseOver, onMouseOut, isSelected, onOnly } = props;
+    const { title, onClick, onMouseOver, onMouseOut, isSelected, onOnly, renderOnly, icon, isDisabled } =
+        props;
     const handleOnly = useCallback(
         (e: React.MouseEvent<HTMLSpanElement, MouseEvent>) => {
+            if (isDisabled) {
+                return;
+            }
             e.stopPropagation();
             onOnly?.();
         },
-        [onOnly],
+        [onOnly, isDisabled],
     );
 
     return (
@@ -37,20 +51,28 @@ export function InvertableSelectItem(props: IInvertableSelectItem) {
                 [`s-${stringUtils.simplifyText(title)}`]: true,
                 "has-only-visible": true,
                 "is-selected": isSelected,
+                "is-disabled": isDisabled,
             })}
-            onClick={onClick}
+            onClick={isDisabled ? () => {} : onClick}
             onMouseOver={onMouseOver}
             onMouseOut={onMouseOut}
         >
             <label className="input-checkbox-label">
-                <input type="checkbox" className="input-checkbox" readOnly={true} checked={isSelected} />
+                <input
+                    type="checkbox"
+                    className="input-checkbox"
+                    readOnly={true}
+                    checked={isSelected}
+                    disabled={isDisabled}
+                />
+                {icon ?? null}
                 <span className="input-label-text">{title}</span>
             </label>
-            {
+            {renderOnly?.({ onOnly: onOnly }) ?? (
                 <span className="gd-list-item-only" onClick={handleOnly}>
                     <FormattedMessage id="gs.list.only" />
                 </span>
-            }
+            )}
         </div>
     );
 }

--- a/libs/sdk-ui-kit/src/List/InvertableSelect/index.ts
+++ b/libs/sdk-ui-kit/src/List/InvertableSelect/index.ts
@@ -15,7 +15,11 @@ export {
     InvertableSelectLimitWarning,
     IInvertableSelectLimitWarningProps,
 } from "./InvertableSelectLimitWarning.js";
-export { IInvertableSelectItem, InvertableSelectItem } from "./InvertableSelectItem.js";
+export {
+    IInvertableSelectItem,
+    InvertableSelectItem,
+    IInvertableSelectItemRenderOnlyProps,
+} from "./InvertableSelectItem.js";
 export { InvertableSelectSearchBar, IInvertableSelectSearchBarProps } from "./InvertableSelectSearchBar.js";
 export {
     InvertableSelectAllCheckbox,

--- a/libs/sdk-ui-kit/src/List/index.ts
+++ b/libs/sdk-ui-kit/src/List/index.ts
@@ -47,6 +47,7 @@ export {
     IInvertableSelectStatusProps,
     InvertableSelectStatus,
     useInvertableSelectionStatusText,
+    IInvertableSelectItemRenderOnlyProps,
 } from "./InvertableSelect/index.js";
 export {
     SingleSelectListItem,


### PR DESCRIPTION
This features enables possibility to ignore specified attributes in the drill intersection for selected drill definitions. Ignored attributes are not transferred as filters during the drill.

Only drill to insight and drill to dashboards are supported.

- Add new feature flag `enableDrillIntersectionIgnoredAttributes` to enable/disable drill intersection filtering configuration
- Add new components for drill intersection filtering configuration
- Apply new configuration in relevant command handlers
- Validate that ignored attributes are still present in target insight, if not, remove the drill and show warning toast message
- Update some ui-kit components to support more customizations

risk: low
JIRA: F1-521

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** 🙏

---

Refer to [documentation](https://github.com/gooddata/gooddata-ui-sdk/blob/master/dev_docs/continuous_integration.md) to see how to run checks and tests in the pull request. This is the list of the most used commands:

```
extended test - backstop
```

```
extended test - tiger-cypress - integrated
extended test - tiger-cypress - isolated
extended test - tiger-cypress - record
```
