### PR TITLE
fix: remove column rollup totals as well

### DIFF
--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/PluggablePivotTable.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/PluggablePivotTable.tsx
@@ -218,7 +218,7 @@ export class PluggablePivotTable extends AbstractPluggableVisualization {
             : [];
 
         const rowTotals = removeInvalidTotals(getTotalsFromBucket(buckets, BucketNames.ATTRIBUTE), filters);
-        const colTotals = getTotalsFromBucket(buckets, BucketNames.COLUMNS);
+        const colTotals = removeInvalidTotals(getTotalsFromBucket(buckets, BucketNames.COLUMNS), filters);
 
         newReferencePoint.buckets = removeDuplicateBucketItems([
             {

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/tests/PluggablePivotTable.test.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/tests/PluggablePivotTable.test.tsx
@@ -1,4 +1,4 @@
-// (C) 2019-2022 GoodData Corporation
+// (C) 2019-2024 GoodData Corporation
 import {
     createPivotTableConfig,
     getColumnAttributes,
@@ -561,9 +561,8 @@ describe("PluggablePivotTable", () => {
             });
         });
 
-        it("should not remove native total if ranking filter is present", () => {
+        it("should remove native total if ranking filter is present", () => {
             const pivotTable = createComponent();
-            const validColTotals = referencePointMocks.tableWithRowColTotalAndRankingFilter.buckets[2].totals;
 
             return pivotTable
                 .getExtendedReferencePoint(
@@ -572,7 +571,7 @@ describe("PluggablePivotTable", () => {
                 )
                 .then((extendedReferencePoint) => {
                     expect(extendedReferencePoint.buckets[1].totals).toBeUndefined();
-                    expect(extendedReferencePoint.buckets[2].totals).toEqual(validColTotals);
+                    expect(extendedReferencePoint.buckets[2].totals).toBeUndefined();
                 });
         });
 


### PR DESCRIPTION
There already was logic to remove row rollup totals when there is a ranking or measure value filter. We need the same logic for column totals, too.

JIRA: CQ-675
risk: low

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** 🙏

---

Refer to [documentation](https://github.com/gooddata/gooddata-ui-sdk/blob/master/dev_docs/continuous_integration.md) to see how to run checks and tests in the pull request. This is the list of the most used commands:

```
extended test - backstop
```

```
extended test - tiger-cypress - integrated
extended test - tiger-cypress - isolated
extended test - tiger-cypress - record
```
