### PR TITLE
fix: do not offer displayAsLabel when same

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/drill/DrillConfigPanel/DrillToUrl/CustomUrlEditorParametersSections/DashboardParametersSection.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/drill/DrillConfigPanel/DrillToUrl/CustomUrlEditorParametersSections/DashboardParametersSection.tsx
@@ -50,6 +50,8 @@ export const DashboardParametersSection: React.FC<IDashboardParametersSectionPro
 
                 const filterSecondaryIdentifier = secondaryDf?.id;
 
+                const areDfsDifferent = filterIdentifier !== filterSecondaryIdentifier;
+
                 return (
                     <>
                         {df ? (
@@ -63,7 +65,7 @@ export const DashboardParametersSection: React.FC<IDashboardParametersSectionPro
                                 isFilter
                             />
                         ) : null}
-                        {enableDuplicatedLabelValuesInAttributeFilter && secondaryDf ? (
+                        {enableDuplicatedLabelValuesInAttributeFilter && secondaryDf && areDfsDifferent ? (
                             <DisplayFormParam
                                 key={`df_${index}_secondary`}
                                 item={secondaryDf}


### PR DESCRIPTION
When filter has primary label used also for UI do
not offer it twice in custom uri params

JIRA: LX-399
risk: low

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** 🙏

---

Refer to [documentation](https://github.com/gooddata/gooddata-ui-sdk/blob/master/dev_docs/continuous_integration.md) to see how to run checks and tests in the pull request. This is the list of the most used commands:

```
extended test - backstop
```

```
extended test - tiger-cypress - integrated
extended test - tiger-cypress - isolated
extended test - tiger-cypress - record
```
