### PR TITLE
fix: convert displayAsLabel from IdentifierRef to idRef

### DIFF
--- a/libs/sdk-embedding/src/internal/filterConvertors.ts
+++ b/libs/sdk-embedding/src/internal/filterConvertors.ts
@@ -23,7 +23,7 @@ import {
     isRemoveDateFilter,
     isRemoveRankingFilter,
 } from "../iframe/index.js";
-import { ObjRef } from "@gooddata/sdk-model";
+import { ObjRef, idRef } from "@gooddata/sdk-model";
 
 export const EXTERNAL_DATE_FILTER_FORMAT = "YYYY-MM-DD";
 
@@ -272,12 +272,15 @@ function transformAttributeFilterItem(
             displayAsLabel,
         } = attributeFilterItem;
         const { uri: dfUri, identifier: dfIdentifier } = getObjectUriIdentifier(displayForm);
+        const { identifier: displayAsLabelIdentifier } = getObjectUriIdentifier(displayAsLabel);
         return {
             negativeSelection: false,
             attributeElements,
             dfIdentifier,
             dfUri,
-            ...(displayAsLabel ? { displayAsLabel } : {}),
+            ...(displayAsLabelIdentifier
+                ? { displayAsLabel: idRef(displayAsLabelIdentifier, "displayForm") }
+                : {}),
         };
     } else {
         const {
@@ -285,12 +288,15 @@ function transformAttributeFilterItem(
             displayAsLabel,
         } = attributeFilterItem;
         const { uri: dfUri, identifier: dfIdentifier } = getObjectUriIdentifier(displayForm);
+        const { identifier: displayAsLabelIdentifier } = getObjectUriIdentifier(displayAsLabel);
         return {
             negativeSelection: true,
             attributeElements,
             dfIdentifier,
             dfUri,
-            ...(displayAsLabel ? { displayAsLabel } : {}),
+            ...(displayAsLabelIdentifier
+                ? { displayAsLabel: idRef(displayAsLabelIdentifier, "displayForm") }
+                : {}),
         };
     }
 }


### PR DESCRIPTION
The type used for refs in postMessages is missing type of object and thus can not be directly saved in MD.

JIRA: LX-430
risk: low

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** 🙏

---

Refer to [documentation](https://github.com/gooddata/gooddata-ui-sdk/blob/master/dev_docs/continuous_integration.md) to see how to run checks and tests in the pull request. This is the list of the most used commands:

```
extended test - backstop
```

```
extended test - tiger-cypress - integrated
extended test - tiger-cypress - isolated
extended test - tiger-cypress - record
```
