### PR TITLE
fix: handle selection over limit

### DIFF
--- a/libs/sdk-ui-filters/src/AttributeFilterHandler/internal/redux/init/initSelectionSaga.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilterHandler/internal/redux/init/initSelectionSaga.ts
@@ -37,7 +37,7 @@ export function* initSelectionSaga(correlation: Correlation): SagaIterator<void>
             options: {
                 elements,
                 offset: 0,
-                limit: 550,
+                limit: Math.max(550, elementKeys.length),
                 search: undefined,
                 excludePrimaryLabel: shouldExcludePrimaryLabel(context, elementsForm),
             },


### PR DESCRIPTION
During migration of filter to new format using primary label it may happen that the number of elements in the selection will overflow the limit. API request needs to handle this. UI will force user to reduce selection to be able to save it

risk: low

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** 🙏

---

Refer to [documentation](https://github.com/gooddata/gooddata-ui-sdk/blob/master/dev_docs/continuous_integration.md) to see how to run checks and tests in the pull request. This is the list of the most used commands:

```
extended test - backstop
```

```
extended test - tiger-cypress - integrated
extended test - tiger-cypress - isolated
extended test - tiger-cypress - record
```
