### PR TITLE
fix: drill down intersection ignored attributes

### DIFF
--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -183,6 +183,7 @@ import { IDateHierarchyTemplate } from '@gooddata/sdk-model';
 import { Identifier } from '@gooddata/sdk-model';
 import { IdentifierRef } from '@gooddata/sdk-model';
 import { IDrillDownDefinition as IDrillDownDefinition_2 } from '../../../types.js';
+import { IDrillDownIntersectionIgnoredAttributes } from '@gooddata/sdk-model';
 import { IDrillDownReference } from '@gooddata/sdk-model';
 import { IDrillEvent } from '@gooddata/sdk-ui';
 import { IDrillEventIntersectionElement } from '@gooddata/sdk-ui';
@@ -3561,7 +3562,7 @@ export function getDefaultInsightMenuItems(intl: IntlShape, config: {
 }): IInsightMenuItem[];
 
 // @internal (undocumented)
-export function getDrillDownAttributeTitle(localIdentifier: string, drillEvent: IDrillEvent): string | null;
+export function getDrillDownTitle(drillDefinition: IDrillDownDefinition, drillEvent: IDrillEvent, drillDownIntersectionIgnoredAttributes?: IDrillDownIntersectionIgnoredAttributes[], drillTargetDisplayForm?: IAttributeDisplayFormMetadataObject): string | null;
 
 // @internal (undocumented)
 export class HeadlessDashboard {
@@ -4382,6 +4383,9 @@ export interface IDrillTargets {
     ref: ObjRef;
     uri: string;
 }
+
+// @internal (undocumented)
+export type IDrillToUrl = IDrillToCustomUrl | IDrillToAttributeUrl;
 
 // @internal (undocumented)
 export interface IDrillToUrlPlaceholder {
@@ -6932,6 +6936,9 @@ export const selectCanViewDashboardPermission: DashboardSelector<boolean>;
 
 // @public (undocumented)
 export const selectCatalogAttributeDisplayForms: DashboardSelector<IAttributeDisplayFormMetadataObject[]>;
+
+// @public (undocumented)
+export const selectCatalogAttributeDisplayFormsById: DashboardSelector<Record<string, IAttributeDisplayFormMetadataObject>>;
 
 // @beta (undocumented)
 export const selectCatalogAttributeHierarchies: DashboardSelector<ICatalogAttributeHierarchy[]>;

--- a/libs/sdk-ui-dashboard/src/_staging/drills/drillingUtils.ts
+++ b/libs/sdk-ui-dashboard/src/_staging/drills/drillingUtils.ts
@@ -9,6 +9,11 @@ import {
     isMeasureDescriptor,
     IAttributeDescriptor,
     isCrossFiltering,
+    IDrillDownIntersectionIgnoredAttributes,
+    ObjRef,
+    drillDownReferenceHierarchyRef,
+    isIdentifierRef,
+    areObjRefsEqual,
 } from "@gooddata/sdk-model";
 import { getMappingHeaderLocalIdentifier, IDrillEvent, IAvailableDrillTargets } from "@gooddata/sdk-ui";
 import first from "lodash/first.js";
@@ -144,4 +149,28 @@ export function getValidDrillOriginAttributes(
     );
 
     return attributeSupportedItems?.intersectionAttributes ?? [];
+}
+
+/**
+ * Check whether drill intersection ignored attributes belong to a particular hierarchy.
+ *
+ * Date drill down does not contain a proper date attribute reference (date hierarchy is global),
+ * so we just check that the hierarchy and its reference are date hierarchies.
+ *
+ * For other drill downs, we check reference equality as usual.
+ *
+ * @internal
+ */
+export function isDrillDownIntersectionIgnoredAttributesForHierarchy(
+    drillDownIgnoredDrillIntersection: IDrillDownIntersectionIgnoredAttributes,
+    targetHierarchyRef: ObjRef,
+) {
+    const hierarchyRef = drillDownReferenceHierarchyRef(drillDownIgnoredDrillIntersection.drillDownReference);
+    const targetRefType = isIdentifierRef(targetHierarchyRef) ? targetHierarchyRef.type : undefined;
+    const isDateDrillDown = targetRefType === "dateAttributeHierarchy";
+    const isDateDrillDownReference =
+        drillDownIgnoredDrillIntersection.drillDownReference.type === "dateHierarchyReference";
+    return isDateDrillDown && isDateDrillDownReference
+        ? true
+        : areObjRefsEqual(hierarchyRef, targetHierarchyRef);
 }

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/drill/drillDownHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/drill/drillDownHandler.ts
@@ -10,8 +10,9 @@ import {
     selectEnableDuplicatedLabelValuesInAttributeFilter,
 } from "../../store/config/configSelectors.js";
 import { selectWidgetByRef } from "../../store/layout/layoutSelectors.js";
-import { areObjRefsEqual, isInsightWidget, drillDownReferenceHierarchyRef } from "@gooddata/sdk-model";
+import { isInsightWidget } from "@gooddata/sdk-model";
 import { removeIgnoredValuesFromDrillIntersection } from "./common/intersectionUtils.js";
+import { isDrillDownIntersectionIgnoredAttributesForHierarchy } from "../../../_staging/drills/drillingUtils.js";
 
 export function* drillDownHandler(
     ctx: DashboardContext,
@@ -41,12 +42,12 @@ export function* drillDownHandler(
             : undefined;
 
         const drillDownIntersectionIgnoredAttributesForCurrentHierarchy =
-            drillDownIntersectionIgnoredAttributes?.find((ignored) =>
-                areObjRefsEqual(
-                    drillDownReferenceHierarchyRef(ignored.drillDownReference),
-                    drillDefinition.hierarchyRef,
-                ),
-            );
+            drillDownIntersectionIgnoredAttributes?.find((ignored) => {
+                return isDrillDownIntersectionIgnoredAttributesForHierarchy(
+                    ignored,
+                    drillDefinition.hierarchyRef!,
+                );
+            });
 
         const ignoredAttributesLocalIdentifiers =
             drillDownIntersectionIgnoredAttributesForCurrentHierarchy?.ignoredAttributes ?? [];

--- a/libs/sdk-ui-dashboard/src/model/store/catalog/catalogSelectors.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/catalog/catalogSelectors.ts
@@ -76,6 +76,18 @@ export const selectCatalogAttributeDisplayForms: DashboardSelector<IAttributeDis
 /**
  * @public
  */
+export const selectCatalogAttributeDisplayFormsById: DashboardSelector<
+    Record<string, IAttributeDisplayFormMetadataObject>
+> = createSelector(selectCatalogAttributeDisplayForms, (displayForms) => {
+    return displayForms.reduce((acc, displayForm) => {
+        acc[displayForm.id] = displayForm;
+        return acc;
+    }, {} as Record<string, IAttributeDisplayFormMetadataObject>);
+});
+
+/**
+ * @public
+ */
 export const selectCatalogMeasures: DashboardSelector<ICatalogMeasure[]> = createSelector(
     selectSelf,
     (state) => {

--- a/libs/sdk-ui-dashboard/src/model/store/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/index.ts
@@ -244,6 +244,7 @@ export {
     selectDateHierarchyTemplates,
     selectAdhocDateHierarchies,
     selectAllCatalogAttributeHierarchies,
+    selectCatalogAttributeDisplayFormsById,
 } from "./catalog/catalogSelectors.js";
 export { catalogActions } from "./catalog/index.js";
 export { drillActions } from "./drill/index.js";

--- a/libs/sdk-ui-dashboard/src/presentation/drill/index.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/drill/index.ts
@@ -1,4 +1,4 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2024 GoodData Corporation
 export { useDrill, UseDrillProps } from "./hooks/useDrill.js";
 export { useDrillDown, UseDrillDownProps } from "./hooks/useDrillDown.js";
 export { useDrillToInsight, UseDrillToInsightProps } from "./hooks/useDrillToInsight.js";
@@ -28,5 +28,6 @@ export {
     OnDrillToInsightSuccess,
     OnDrillToLegacyDashboard,
     OnDrillToLegacyDashboardSuccess,
+    IDrillToUrl,
 } from "./types.js";
-export { getDrillDownAttributeTitle } from "./utils/drillDownUtils.js";
+export { getDrillDownTitle } from "./utils/drillDownUtils.js";

--- a/libs/sdk-ui-dashboard/src/presentation/drill/types.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/drill/types.ts
@@ -139,6 +139,9 @@ export type OnCrossFilteringError = OnDashboardDrillError;
 
 /////
 
+/**
+ * @internal
+ */
 export type IDrillToUrl = IDrillToCustomUrl | IDrillToAttributeUrl;
 
 export function isDrillToUrl(drillDefinition: unknown): drillDefinition is IDrillToUrl {

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/configuration/InsightDrillConfigPanel/drillConfigMapper.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/configuration/InsightDrillConfigPanel/drillConfigMapper.ts
@@ -12,7 +12,6 @@ import {
     ObjRef,
     objRefToString,
     areObjRefsEqual,
-    drillDownReferenceHierarchyRef,
     drillDownReferenceAttributeRef,
 } from "@gooddata/sdk-model";
 import { IAvailableDrillTargets } from "@gooddata/sdk-ui";
@@ -21,6 +20,7 @@ import {
     getDrillOriginLocalIdentifier,
     getLocalIdentifierOrDie,
     getValidDrillOriginAttributes,
+    isDrillDownIntersectionIgnoredAttributesForHierarchy,
 } from "../../../../../_staging/drills/drillingUtils.js";
 import {
     DRILL_TARGET_TYPE,
@@ -231,28 +231,16 @@ function getIntersectionIgnoredAttributeLocalIdentifiersForDrillDown(
 
     const drillIntersectionIgnoredAttributes = attribute
         ? widget.drillDownIntersectionIgnoredAttributes?.find((drillDownIgnoredDrillIntersection) => {
-              const hierarchyRef = drillDownReferenceHierarchyRef(
-                  drillDownIgnoredDrillIntersection.drillDownReference,
-              );
               const attributeRef = drillDownReferenceAttributeRef(
                   drillDownIgnoredDrillIntersection.drillDownReference,
               );
 
-              // Global date drill down origin does not contain proper date attribute,
-              // so we need to check it differently
-              const isDateGlobalDrillDown =
-                  (globalDrillDownDefinition.target as { type: string; identifier: string }).type ===
-                  "dateAttributeHierarchy";
-              const isDateDrillDownReference =
-                  drillDownIgnoredDrillIntersection.drillDownReference.type === "dateHierarchyReference";
-              const isSameHierarchy =
-                  isDateGlobalDrillDown && isDateDrillDownReference
-                      ? true
-                      : areObjRefsEqual(hierarchyRef, globalDrillDownDefinition.target);
-
               return (
                   areObjRefsEqual(attributeRef, attribute.attribute.attributeHeader.formOf.ref) &&
-                  isSameHierarchy
+                  isDrillDownIntersectionIgnoredAttributesForHierarchy(
+                      drillDownIgnoredDrillIntersection,
+                      globalDrillDownDefinition.target,
+                  )
               );
           })
         : undefined;


### PR DESCRIPTION
Fix issue with date hierarchies matching - now, configured intersection ignored attributes should be correctly applied for date drill downs.

Display drill title (or label title) in the drill dialog instead of the attribute element title in case the attribute is ignored, as it was leading to confusing user experience.

JIRA: F1-591

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** 🙏

---

Refer to [documentation](https://github.com/gooddata/gooddata-ui-sdk/blob/master/dev_docs/continuous_integration.md) to see how to run checks and tests in the pull request. This is the list of the most used commands:

```
extended test - backstop
```

```
extended test - tiger-cypress - integrated
extended test - tiger-cypress - isolated
extended test - tiger-cypress - record
```
