### PR TITLE
RELATED: CQ-582 search closing bugfix

### DIFF
--- a/libs/sdk-ui-semantic-search/src/internal/SearchOverlay.tsx
+++ b/libs/sdk-ui-semantic-search/src/internal/SearchOverlay.tsx
@@ -190,7 +190,7 @@ const SearchOverlayCore: React.FC<
             }
 
             // Trigger the dialog closing unless it's opening in a new tab
-            if (newTab) {
+            if (!newTab) {
                 toggleOpen();
             }
         },


### PR DESCRIPTION
Fix a bug when search drop-down closing for __blank but not for __self links.

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** 🙏

---

Refer to [documentation](https://github.com/gooddata/gooddata-ui-sdk/blob/master/dev_docs/continuous_integration.md) to see how to run checks and tests in the pull request. This is the list of the most used commands:

```
extended test - backstop
```

```
extended test - tiger-cypress - integrated
extended test - tiger-cypress - isolated
extended test - tiger-cypress - record
```
