### PR TITLE
fix: show correct measure title in alert config

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/configuration/InsightAlertConfig/utils.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/configuration/InsightAlertConfig/utils.ts
@@ -38,7 +38,7 @@ import { messages } from "./messages.js";
  * @internal
  */
 export const getMeasureTitle = (measure: IMeasure) => {
-    return measure ? measureTitle(measure) ?? measureAlias(measure) : undefined;
+    return measure ? measureAlias(measure) ?? measureTitle(measure) : undefined;
 };
 
 export const getOperatorTitle = (intl: IntlShape, alert?: IAutomationAlert) => {


### PR DESCRIPTION
Show correct name for measures that were renamed in analytical designer. Alias now takes precedence over measure title.

risk: low
JIRA: F1-627

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** 🙏

---

Refer to [documentation](https://github.com/gooddata/gooddata-ui-sdk/blob/master/dev_docs/continuous_integration.md) to see how to run checks and tests in the pull request. This is the list of the most used commands:

```
extended test - backstop
```

```
extended test - tiger-cypress - integrated
extended test - tiger-cypress - isolated
extended test - tiger-cypress - record
```
