### PR TITLE
fix: make sure to use metric instead of measure

### DIFF
--- a/libs/sdk-ui-dashboard/src/model/store/config/configSelectors.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/config/configSelectors.ts
@@ -451,7 +451,7 @@ export const selectEnableRenamingProjectToWorkspace: DashboardSelector<boolean> 
 export const selectEnableRenamingMeasureToMetric: DashboardSelector<boolean> = createSelector(
     selectConfig,
     (state) => {
-        return !!(state.settings?.enableRenamingMeasureToMetric ?? false);
+        return state.settings?.enableRenamingMeasureToMetric ?? true;
     },
 );
 

--- a/libs/sdk-ui-ext/src/internal/components/configurationControls/comparison/calculation/tests/CalculationListItemInfo.test.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/configurationControls/comparison/calculation/tests/CalculationListItemInfo.test.tsx
@@ -1,4 +1,4 @@
-// (C) 2023 GoodData Corporation
+// (C) 2023-2024 GoodData Corporation
 import React from "react";
 import { describe, it, expect } from "vitest";
 import { render } from "@testing-library/react";
@@ -28,7 +28,7 @@ describe("CalculationListItemInfo", () => {
         [
             CalculateAs.CHANGE,
             "Change",
-            "Calculates the relative change between primary and secondary measure values.",
+            "Calculates the relative change between primary and secondary metric values.",
             "Formula",
             "(Primary - Secondary) / Secondary",
             "Example",
@@ -37,7 +37,7 @@ describe("CalculationListItemInfo", () => {
         [
             CalculateAs.CHANGE_DIFFERENCE,
             "Change (difference)",
-            "Calculates both the relative change and absolute difference between primary and secondary measure values.",
+            "Calculates both the relative change and absolute difference between primary and secondary metric values.",
             "Formula (relative change)",
             "(Primary - Secondary) / Secondary",
             "Formula (absolute difference)",
@@ -48,7 +48,7 @@ describe("CalculationListItemInfo", () => {
         [
             CalculateAs.RATIO,
             "Ratio",
-            "Quantifies the share of the primary measure value in the secondary measure value.",
+            "Quantifies the share of the primary metric value in the secondary metric value.",
             "Formula",
             "Primary / Secondary",
             "Example",
@@ -57,7 +57,7 @@ describe("CalculationListItemInfo", () => {
         [
             CalculateAs.DIFFERENCE,
             "Difference",
-            "Calculates the absolute difference between primary and secondary measure values.",
+            "Calculates the absolute difference between primary and secondary metric values.",
             "Formula",
             "Primary - Secondary",
             "Example",

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/areaChart/tests/__snapshots__/PluggableAreaChart.test.tsx.snap
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/areaChart/tests/__snapshots__/PluggableAreaChart.test.tsx.snap
@@ -350,8 +350,8 @@ exports[`PluggableAreaChart > optional stacking > should return reference point 
         "isShowInPercentEnabled": true,
         "isShowInPercentVisible": true,
         "itemsLimit": 40,
-        "title": "Measures",
-        "warningMessage": "To add additional measure, remove <span class="attr-field-icon" /> or <span class="date-field-icon" /> from <span class="stack-by">view by</span>",
+        "title": "Metrics",
+        "warningMessage": "To add additional metric, remove <span class="attr-field-icon" /> or <span class="date-field-icon" /> from <span class="stack-by">view by</span>",
       },
       "stack": {
         "accepts": [
@@ -520,7 +520,7 @@ exports[`PluggableAreaChart > optional stacking > should reuse all measures, onl
         "isShowInPercentEnabled": false,
         "isShowInPercentVisible": true,
         "itemsLimit": 40,
-        "title": "Measures",
+        "title": "Metrics",
       },
       "stack": {
         "accepts": [
@@ -534,7 +534,7 @@ exports[`PluggableAreaChart > optional stacking > should reuse all measures, onl
         "isShowInPercentEnabled": false,
         "itemsLimit": 1,
         "title": "Stack by",
-        "warningMessage": "To stack by an attribute, an visualization can have only one measure",
+        "warningMessage": "To stack by an attribute, an visualization can have only one metric",
       },
       "view": {
         "accepts": [
@@ -552,7 +552,7 @@ exports[`PluggableAreaChart > optional stacking > should reuse all measures, onl
           "date": 1,
         },
         "title": "View by",
-        "warningMessage": "To view by another attribute, an visualization can have only one measure",
+        "warningMessage": "To view by another attribute, an visualization can have only one metric",
       },
     },
     "exportConfig": {
@@ -691,8 +691,8 @@ exports[`PluggableAreaChart > optional stacking > should reuse one measure, only
         "isShowInPercentEnabled": false,
         "isShowInPercentVisible": true,
         "itemsLimit": 40,
-        "title": "Measures",
-        "warningMessage": "To add additional measure, remove <span class="attr-field-icon" /> from <span class="stack-by">stack by</span>",
+        "title": "Metrics",
+        "warningMessage": "To add additional metric, remove <span class="attr-field-icon" /> from <span class="stack-by">stack by</span>",
       },
       "stack": {
         "accepts": [
@@ -868,8 +868,8 @@ exports[`PluggableAreaChart > optional stacking > should reuse one measure, two 
         "isShowInPercentEnabled": true,
         "isShowInPercentVisible": true,
         "itemsLimit": 40,
-        "title": "Measures",
-        "warningMessage": "To add additional measure, remove <span class="attr-field-icon" /> from <span class="stack-by">view by</span>",
+        "title": "Metrics",
+        "warningMessage": "To add additional metric, remove <span class="attr-field-icon" /> from <span class="stack-by">view by</span>",
       },
       "stack": {
         "accepts": [
@@ -991,8 +991,8 @@ exports[`PluggableAreaChart > should cut out measures tail when getting nM 0Vb 1
         "isShowInPercentEnabled": false,
         "isShowInPercentVisible": true,
         "itemsLimit": 40,
-        "title": "Measures",
-        "warningMessage": "To add additional measure, remove <span class="attr-field-icon" /> from <span class="stack-by">stack by</span>",
+        "title": "Metrics",
+        "warningMessage": "To add additional metric, remove <span class="attr-field-icon" /> from <span class="stack-by">stack by</span>",
       },
       "stack": {
         "accepts": [
@@ -1113,8 +1113,8 @@ exports[`PluggableAreaChart > should return reference point when no categories a
         "isShowInPercentEnabled": false,
         "isShowInPercentVisible": true,
         "itemsLimit": 40,
-        "title": "Measures",
-        "warningMessage": "To add additional measure, remove <span class="attr-field-icon" /> from <span class="stack-by">stack by</span>",
+        "title": "Metrics",
+        "warningMessage": "To add additional metric, remove <span class="attr-field-icon" /> from <span class="stack-by">stack by</span>",
       },
       "stack": {
         "accepts": [

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/baseChart/tests/__snapshots__/PluggableBaseChart.test.tsx.snap
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/baseChart/tests/__snapshots__/PluggableBaseChart.test.tsx.snap
@@ -70,8 +70,8 @@ exports[`PluggableBaseChart > should cut out measures tail when getting nM 0Vb 1
         "isShowInPercentEnabled": false,
         "isShowInPercentVisible": true,
         "itemsLimit": 40,
-        "title": "Measures",
-        "warningMessage": "To add additional measure, remove <span class="attr-field-icon" /> from <span class="stack-by">stack by</span>",
+        "title": "Metrics",
+        "warningMessage": "To add additional metric, remove <span class="attr-field-icon" /> from <span class="stack-by">stack by</span>",
       },
       "stack": {
         "accepts": [
@@ -203,8 +203,8 @@ exports[`PluggableBaseChart > should handle wrong order of buckets in reference 
         "isShowInPercentEnabled": false,
         "isShowInPercentVisible": true,
         "itemsLimit": 40,
-        "title": "Measures",
-        "warningMessage": "To add additional measure, remove <span class="attr-field-icon" /> from <span class="stack-by">stack by</span>",
+        "title": "Metrics",
+        "warningMessage": "To add additional metric, remove <span class="attr-field-icon" /> from <span class="stack-by">stack by</span>",
       },
       "stack": {
         "accepts": [
@@ -373,7 +373,7 @@ exports[`PluggableBaseChart > should return ref. point with multiple metrics and
         "isShowInPercentEnabled": false,
         "isShowInPercentVisible": true,
         "itemsLimit": 40,
-        "title": "Measures",
+        "title": "Metrics",
       },
       "stack": {
         "accepts": [
@@ -387,7 +387,7 @@ exports[`PluggableBaseChart > should return ref. point with multiple metrics and
         "isShowInPercentEnabled": false,
         "itemsLimit": 1,
         "title": "Stack by",
-        "warningMessage": "To stack by, an visualization can have only one measure",
+        "warningMessage": "To stack by, an visualization can have only one metric",
       },
       "view": {
         "accepts": [
@@ -486,7 +486,7 @@ exports[`PluggableBaseChart > should return reference point with base recommenda
         "isShowInPercentEnabled": false,
         "isShowInPercentVisible": true,
         "itemsLimit": 40,
-        "title": "Measures",
+        "title": "Metrics",
       },
       "stack": {
         "accepts": [
@@ -647,7 +647,7 @@ exports[`PluggableBaseChart > should return reference point with multiple metric
         "isShowInPercentEnabled": false,
         "isShowInPercentVisible": true,
         "itemsLimit": 40,
-        "title": "Measures",
+        "title": "Metrics",
       },
       "stack": {
         "accepts": [
@@ -661,7 +661,7 @@ exports[`PluggableBaseChart > should return reference point with multiple metric
         "isShowInPercentEnabled": false,
         "itemsLimit": 1,
         "title": "Stack by",
-        "warningMessage": "To stack by, an visualization can have only one measure",
+        "warningMessage": "To stack by, an visualization can have only one metric",
       },
       "view": {
         "accepts": [
@@ -781,8 +781,8 @@ exports[`PluggableBaseChart > should return reference point with one metric and 
         "isShowInPercentEnabled": false,
         "isShowInPercentVisible": true,
         "itemsLimit": 40,
-        "title": "Measures",
-        "warningMessage": "To add additional measure, remove <span class="attr-field-icon" /> from <span class="stack-by">stack by</span>",
+        "title": "Metrics",
+        "warningMessage": "To add additional metric, remove <span class="attr-field-icon" /> from <span class="stack-by">stack by</span>",
       },
       "stack": {
         "accepts": [
@@ -959,8 +959,8 @@ exports[`PluggableBaseChart > should return reference point with one metric and 
         "isShowInPercentEnabled": false,
         "isShowInPercentVisible": true,
         "itemsLimit": 40,
-        "title": "Measures",
-        "warningMessage": "To add additional measure, remove <span class="attr-field-icon" /> from <span class="stack-by">stack by</span>",
+        "title": "Metrics",
+        "warningMessage": "To add additional metric, remove <span class="attr-field-icon" /> from <span class="stack-by">stack by</span>",
       },
       "stack": {
         "accepts": [
@@ -1137,8 +1137,8 @@ exports[`PluggableBaseChart > should return reference point with one metric, one
         "isShowInPercentEnabled": false,
         "isShowInPercentVisible": true,
         "itemsLimit": 40,
-        "title": "Measures",
-        "warningMessage": "To add additional measure, remove <span class="attr-field-icon" /> from <span class="stack-by">stack by</span>",
+        "title": "Metrics",
+        "warningMessage": "To add additional metric, remove <span class="attr-field-icon" /> from <span class="stack-by">stack by</span>",
       },
       "stack": {
         "accepts": [
@@ -1270,8 +1270,8 @@ exports[`PluggableBaseChart > should return reference point without Date in stac
         "isShowInPercentEnabled": false,
         "isShowInPercentVisible": true,
         "itemsLimit": 40,
-        "title": "Measures",
-        "warningMessage": "To add additional measure, remove <span class="attr-field-icon" /> from <span class="stack-by">stack by</span>",
+        "title": "Metrics",
+        "warningMessage": "To add additional metric, remove <span class="attr-field-icon" /> from <span class="stack-by">stack by</span>",
       },
       "stack": {
         "accepts": [
@@ -1403,8 +1403,8 @@ exports[`PluggableBaseChart > should use second non-date attribute when switchin
         "isShowInPercentEnabled": false,
         "isShowInPercentVisible": true,
         "itemsLimit": 40,
-        "title": "Measures",
-        "warningMessage": "To add additional measure, remove <span class="attr-field-icon" /> from <span class="stack-by">stack by</span>",
+        "title": "Metrics",
+        "warningMessage": "To add additional metric, remove <span class="attr-field-icon" /> from <span class="stack-by">stack by</span>",
       },
       "stack": {
         "accepts": [

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/bubbleChart/tests/__snapshots__/PluggableBubbleChart.test.tsx.snap
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/bubbleChart/tests/__snapshots__/PluggableBubbleChart.test.tsx.snap
@@ -116,7 +116,7 @@ exports[`PluggableBubbleChart > should return reference point with secondary met
         "isShowInPercentVisible": false,
         "itemsLimit": 1,
         "subtitle": "X-axis",
-        "title": "Measure",
+        "title": "Metric",
       },
       "secondary_measures": {
         "accepts": [
@@ -134,7 +134,7 @@ exports[`PluggableBubbleChart > should return reference point with secondary met
         "isShowInPercentVisible": false,
         "itemsLimit": 1,
         "subtitle": "Y-axis",
-        "title": "Measure",
+        "title": "Metric",
       },
       "tertiary_measures": {
         "accepts": [
@@ -152,7 +152,7 @@ exports[`PluggableBubbleChart > should return reference point with secondary met
         "isShowInPercentVisible": false,
         "itemsLimit": 1,
         "subtitle": "Size",
-        "title": "Measure",
+        "title": "Metric",
       },
       "view": {
         "accepts": [
@@ -269,7 +269,7 @@ exports[`PluggableBubbleChart > should return reference point with three measure
         "isShowInPercentVisible": false,
         "itemsLimit": 1,
         "subtitle": "X-axis",
-        "title": "Measure",
+        "title": "Metric",
       },
       "secondary_measures": {
         "accepts": [
@@ -287,7 +287,7 @@ exports[`PluggableBubbleChart > should return reference point with three measure
         "isShowInPercentVisible": false,
         "itemsLimit": 1,
         "subtitle": "Y-axis",
-        "title": "Measure",
+        "title": "Metric",
       },
       "tertiary_measures": {
         "accepts": [
@@ -305,7 +305,7 @@ exports[`PluggableBubbleChart > should return reference point with three measure
         "isShowInPercentVisible": false,
         "itemsLimit": 1,
         "subtitle": "Size",
-        "title": "Measure",
+        "title": "Metric",
       },
       "view": {
         "accepts": [
@@ -455,7 +455,7 @@ exports[`PluggableBubbleChart > should return reference point with three measure
         "isShowInPercentVisible": false,
         "itemsLimit": 1,
         "subtitle": "X-axis",
-        "title": "Measure",
+        "title": "Metric",
       },
       "secondary_measures": {
         "accepts": [
@@ -473,7 +473,7 @@ exports[`PluggableBubbleChart > should return reference point with three measure
         "isShowInPercentVisible": false,
         "itemsLimit": 1,
         "subtitle": "Y-axis",
-        "title": "Measure",
+        "title": "Metric",
       },
       "tertiary_measures": {
         "accepts": [
@@ -491,7 +491,7 @@ exports[`PluggableBubbleChart > should return reference point with three measure
         "isShowInPercentVisible": false,
         "itemsLimit": 1,
         "subtitle": "Size",
-        "title": "Measure",
+        "title": "Metric",
       },
       "view": {
         "accepts": [

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/bulletChart/tests/__snapshots__/PluggableBulletChart.test.tsx.snap
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/bulletChart/tests/__snapshots__/PluggableBulletChart.test.tsx.snap
@@ -510,7 +510,7 @@ exports[`PluggableBulletChart > should return reference point with target and co
         "isShowOnSecondaryAxisVisible": false,
         "itemsLimit": 1,
         "subtitle": "Primary",
-        "title": "Measure",
+        "title": "Metric",
       },
       "secondary_measures": {
         "accepts": [
@@ -529,7 +529,7 @@ exports[`PluggableBulletChart > should return reference point with target and co
         "isShowOnSecondaryAxisVisible": false,
         "itemsLimit": 1,
         "subtitle": "Target",
-        "title": "Measure",
+        "title": "Metric",
       },
       "tertiary_measures": {
         "accepts": [
@@ -548,7 +548,7 @@ exports[`PluggableBulletChart > should return reference point with target and co
         "isShowOnSecondaryAxisVisible": false,
         "itemsLimit": 1,
         "subtitle": "Comparative",
-        "title": "Measure",
+        "title": "Metric",
       },
       "view": {
         "accepts": [
@@ -569,8 +569,8 @@ exports[`PluggableBulletChart > should return reference point with target and co
       },
     },
     "customError": {
-      "heading": "No primary measure in your visualization",
-      "text": "Add a primary measure to your visualization, or switch to table.
+      "heading": "No primary metric in your visualization",
+      "text": "Add a primary metric to your visualization, or switch to table.
 Once done, you'll be able to save it.",
     },
     "exportConfig": {
@@ -674,7 +674,7 @@ exports[`PluggableBulletChart > should return reference point with three measure
         "isShowOnSecondaryAxisVisible": false,
         "itemsLimit": 1,
         "subtitle": "Primary",
-        "title": "Measure",
+        "title": "Metric",
       },
       "secondary_measures": {
         "accepts": [
@@ -693,7 +693,7 @@ exports[`PluggableBulletChart > should return reference point with three measure
         "isShowOnSecondaryAxisVisible": false,
         "itemsLimit": 1,
         "subtitle": "Target",
-        "title": "Measure",
+        "title": "Metric",
       },
       "tertiary_measures": {
         "accepts": [
@@ -712,7 +712,7 @@ exports[`PluggableBulletChart > should return reference point with three measure
         "isShowOnSecondaryAxisVisible": false,
         "itemsLimit": 1,
         "subtitle": "Comparative",
-        "title": "Measure",
+        "title": "Metric",
       },
       "view": {
         "accepts": [
@@ -897,7 +897,7 @@ exports[`PluggableBulletChart > should return reference point with three measure
         "isShowOnSecondaryAxisVisible": false,
         "itemsLimit": 1,
         "subtitle": "Primary",
-        "title": "Measure",
+        "title": "Metric",
       },
       "secondary_measures": {
         "accepts": [
@@ -916,7 +916,7 @@ exports[`PluggableBulletChart > should return reference point with three measure
         "isShowOnSecondaryAxisVisible": false,
         "itemsLimit": 1,
         "subtitle": "Target",
-        "title": "Measure",
+        "title": "Metric",
       },
       "tertiary_measures": {
         "accepts": [
@@ -935,7 +935,7 @@ exports[`PluggableBulletChart > should return reference point with three measure
         "isShowOnSecondaryAxisVisible": false,
         "itemsLimit": 1,
         "subtitle": "Comparative",
-        "title": "Measure",
+        "title": "Metric",
       },
       "view": {
         "accepts": [

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/dependencyWheelChart/tests/__snapshots__/PluggableDependencyWheelChart.test.tsx.snap
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/dependencyWheelChart/tests/__snapshots__/PluggableDependencyWheelChart.test.tsx.snap
@@ -140,7 +140,7 @@ exports[`PluggableDependencyWheelChart > dependency wheel should allow date attr
         "isShowInPercentEnabled": true,
         "isShowInPercentVisible": true,
         "itemsLimit": 1,
-        "title": "MEASURE",
+        "title": "METRIC",
       },
     },
     "exportConfig": {
@@ -275,7 +275,7 @@ exports[`PluggableDependencyWheelChart > should return reference point with one 
         "isShowInPercentEnabled": true,
         "isShowInPercentVisible": true,
         "itemsLimit": 1,
-        "title": "MEASURE",
+        "title": "METRIC",
       },
     },
     "exportConfig": {
@@ -462,7 +462,7 @@ exports[`PluggableDependencyWheelChart > should reuse one measure and order attr
         "isShowInPercentEnabled": true,
         "isShowInPercentVisible": true,
         "itemsLimit": 1,
-        "title": "MEASURE",
+        "title": "METRIC",
       },
     },
     "exportConfig": {

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/donutChart/tests/__snapshots__/PluggableDonutChart.test.tsx.snap
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/donutChart/tests/__snapshots__/PluggableDonutChart.test.tsx.snap
@@ -80,7 +80,7 @@ exports[`PluggableDonutChart > should return reference point with multiple metri
         "isShowInPercentEnabled": false,
         "isShowInPercentVisible": true,
         "itemsLimit": 20,
-        "title": "Measures",
+        "title": "Metrics",
       },
       "view": {
         "accepts": [
@@ -98,7 +98,7 @@ exports[`PluggableDonutChart > should return reference point with multiple metri
           "date": 1,
         },
         "title": "View by",
-        "warningMessage": "To view by, an visualization can have only one measure",
+        "warningMessage": "To view by, an visualization can have only one metric",
       },
     },
     "exportConfig": {
@@ -171,7 +171,7 @@ exports[`PluggableDonutChart > should return reference point with one metric and
         "isShowInPercentEnabled": false,
         "isShowInPercentVisible": true,
         "itemsLimit": 20,
-        "title": "Measures",
+        "title": "Metrics",
       },
       "view": {
         "accepts": [
@@ -294,7 +294,7 @@ exports[`PluggableDonutChart > should return reference point with only one metri
         "isShowInPercentEnabled": true,
         "isShowInPercentVisible": true,
         "itemsLimit": 1,
-        "title": "Measures",
+        "title": "Metrics",
       },
       "view": {
         "accepts": [

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/funnelChart/tests/__snapshots__/PluggableFunnelChart.test.tsx.snap
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/funnelChart/tests/__snapshots__/PluggableFunnelChart.test.tsx.snap
@@ -80,7 +80,7 @@ exports[`PluggableFunnelChart > should return reference point with multiple metr
         "isShowInPercentEnabled": false,
         "isShowInPercentVisible": false,
         "itemsLimit": 20,
-        "title": "Measures",
+        "title": "Metrics",
       },
       "view": {
         "accepts": [
@@ -98,7 +98,7 @@ exports[`PluggableFunnelChart > should return reference point with multiple metr
           "date": 1,
         },
         "title": "View by",
-        "warningMessage": "To view by, an visualization can have only one measure",
+        "warningMessage": "To view by, an visualization can have only one metric",
       },
     },
     "exportConfig": {
@@ -171,7 +171,7 @@ exports[`PluggableFunnelChart > should return reference point with one metric an
         "isShowInPercentEnabled": false,
         "isShowInPercentVisible": false,
         "itemsLimit": 20,
-        "title": "Measures",
+        "title": "Metrics",
       },
       "view": {
         "accepts": [
@@ -294,7 +294,7 @@ exports[`PluggableFunnelChart > should return reference point with only one metr
         "isShowInPercentEnabled": false,
         "isShowInPercentVisible": false,
         "itemsLimit": 1,
-        "title": "Measures",
+        "title": "Metrics",
       },
       "view": {
         "accepts": [

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/geoChart/tests/__snapshots__/PluggableGeoPushpinChart.test.tsx.snap
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/geoChart/tests/__snapshots__/PluggableGeoPushpinChart.test.tsx.snap
@@ -68,7 +68,7 @@ exports[`PluggableGeoPushpinChart > getExtendedReferencePoint > should return a 
       "isShowInPercentVisible": false,
       "itemsLimit": 1,
       "subtitle": "Color",
-      "title": "Measure",
+      "title": "Metric",
     },
     "filters": {
       "accepts": [
@@ -132,7 +132,7 @@ exports[`PluggableGeoPushpinChart > getExtendedReferencePoint > should return a 
       "isShowInPercentVisible": false,
       "itemsLimit": 1,
       "subtitle": "Size",
-      "title": "Measure",
+      "title": "Metric",
     },
   },
   "exportConfig": {

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/headline/tests/PluggableHeadline.test.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/headline/tests/PluggableHeadline.test.tsx
@@ -302,9 +302,9 @@ describe("PluggableHeadline", () => {
 
                 expect(extendedReferencePoint.buckets).toEqual(referencePoint.buckets);
                 expect(extendedReferencePoint.uiConfig.customError).toEqual({
-                    heading: "No primary measure in your visualization",
+                    heading: "No primary metric in your visualization",
                     text:
-                        "Add a primary measure to your visualization, or switch to table.\n" +
+                        "Add a primary metric to your visualization, or switch to table.\n" +
                         "Once done, you'll be able to save it.",
                 });
             });

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/headline/tests/PluggableHeadline2.test.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/headline/tests/PluggableHeadline2.test.tsx
@@ -425,9 +425,9 @@ describe("PluggableHeadline2", () => {
 
                 expect(extendedReferencePoint.buckets).toEqual(referencePoint.buckets);
                 expect(extendedReferencePoint.uiConfig.customError).toEqual({
-                    heading: "No primary measure in your visualization",
+                    heading: "No primary metric in your visualization",
                     text:
-                        "Add a primary measure to your visualization, or switch to table.\n" +
+                        "Add a primary metric to your visualization, or switch to table.\n" +
                         "Once done, you'll be able to save it.",
                 });
             });

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/headline/tests/__snapshots__/PluggableHeadline.test.tsx.snap
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/headline/tests/__snapshots__/PluggableHeadline.test.tsx.snap
@@ -48,7 +48,7 @@ exports[`PluggableHeadline > getExtendedReferencePoint > should correctly proces
         "isShowInPercentVisible": false,
         "itemsLimit": 1,
         "subtitle": "primary",
-        "title": "Measure",
+        "title": "Metric",
       },
       "secondary_measures": {
         "accepts": [
@@ -66,7 +66,7 @@ exports[`PluggableHeadline > getExtendedReferencePoint > should correctly proces
         "isShowInPercentVisible": false,
         "itemsLimit": 1,
         "subtitle": "secondary",
-        "title": "Measure",
+        "title": "Metric",
       },
     },
     "exportConfig": {
@@ -152,7 +152,7 @@ exports[`PluggableHeadline > getExtendedReferencePoint > should return proper ex
         "isShowInPercentVisible": false,
         "itemsLimit": 1,
         "subtitle": "primary",
-        "title": "Measure",
+        "title": "Metric",
       },
       "secondary_measures": {
         "accepts": [
@@ -170,7 +170,7 @@ exports[`PluggableHeadline > getExtendedReferencePoint > should return proper ex
         "isShowInPercentVisible": false,
         "itemsLimit": 1,
         "subtitle": "secondary",
-        "title": "Measure",
+        "title": "Metric",
       },
     },
     "exportConfig": {

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/headline/tests/__snapshots__/PluggableHeadline2.test.tsx.snap
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/headline/tests/__snapshots__/PluggableHeadline2.test.tsx.snap
@@ -48,7 +48,7 @@ exports[`PluggableHeadline2 > getExtendedReferencePoint > should correctly proce
         "isShowInPercentVisible": false,
         "itemsLimit": 1,
         "subtitle": "primary",
-        "title": "Measure",
+        "title": "Metric",
       },
       "secondary_measures": {
         "accepts": [
@@ -66,7 +66,7 @@ exports[`PluggableHeadline2 > getExtendedReferencePoint > should correctly proce
         "isShowInPercentVisible": false,
         "itemsLimit": 2,
         "subtitle": "secondary",
-        "title": "Measure",
+        "title": "Metric",
       },
     },
     "exportConfig": {
@@ -160,7 +160,7 @@ exports[`PluggableHeadline2 > getExtendedReferencePoint > should return proper e
         "isShowInPercentVisible": false,
         "itemsLimit": 1,
         "subtitle": "primary",
-        "title": "Measure",
+        "title": "Metric",
       },
       "secondary_measures": {
         "accepts": [
@@ -178,7 +178,7 @@ exports[`PluggableHeadline2 > getExtendedReferencePoint > should return proper e
         "isShowInPercentVisible": false,
         "itemsLimit": 2,
         "subtitle": "secondary",
-        "title": "Measure",
+        "title": "Metric",
       },
     },
     "exportConfig": {

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/heatMap/tests/__snapshots__/PluggableHeatmap.test.tsx.snap
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/heatMap/tests/__snapshots__/PluggableHeatmap.test.tsx.snap
@@ -213,7 +213,7 @@ exports[`PluggableHeatmap > heatmap should allow date attribute in column bucket
         "isShowInPercentEnabled": false,
         "isShowInPercentVisible": false,
         "itemsLimit": 1,
-        "title": "Measure",
+        "title": "Metric",
       },
       "stack": {
         "accepts": [
@@ -383,7 +383,7 @@ exports[`PluggableHeatmap > should return reference point with one metric, categ
         "isShowInPercentEnabled": false,
         "isShowInPercentVisible": false,
         "itemsLimit": 1,
-        "title": "Measure",
+        "title": "Metric",
       },
       "stack": {
         "accepts": [

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/lineChart/tests/__snapshots__/PluggableLineChart.test.tsx.snap
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/lineChart/tests/__snapshots__/PluggableLineChart.test.tsx.snap
@@ -324,8 +324,8 @@ exports[`PluggableLineChart > should cut out measures tail when getting nM 0Vb 1
         "isShowInPercentVisible": true,
         "isShowOnSecondaryAxisVisible": true,
         "itemsLimit": 40,
-        "title": "Measures",
-        "warningMessage": "To add additional measure, remove <span class="attr-field-icon" /> from <span class="stack-by">segment by</span>",
+        "title": "Metrics",
+        "warningMessage": "To add additional metric, remove <span class="attr-field-icon" /> from <span class="stack-by">segment by</span>",
       },
       "segment": {
         "accepts": [
@@ -456,8 +456,8 @@ exports[`PluggableLineChart > should handle wrong order of buckets in reference 
         "isShowInPercentVisible": true,
         "isShowOnSecondaryAxisVisible": true,
         "itemsLimit": 40,
-        "title": "Measures",
-        "warningMessage": "To add additional measure, remove <span class="attr-field-icon" /> from <span class="stack-by">segment by</span>",
+        "title": "Metrics",
+        "warningMessage": "To add additional metric, remove <span class="attr-field-icon" /> from <span class="stack-by">segment by</span>",
       },
       "segment": {
         "accepts": [
@@ -578,8 +578,8 @@ exports[`PluggableLineChart > should return reference point when no categories a
         "isShowInPercentVisible": true,
         "isShowOnSecondaryAxisVisible": true,
         "itemsLimit": 40,
-        "title": "Measures",
-        "warningMessage": "To add additional measure, remove <span class="attr-field-icon" /> from <span class="stack-by">segment by</span>",
+        "title": "Metrics",
+        "warningMessage": "To add additional metric, remove <span class="attr-field-icon" /> from <span class="stack-by">segment by</span>",
       },
       "segment": {
         "accepts": [
@@ -710,8 +710,8 @@ exports[`PluggableLineChart > should return reference point with Date in categor
         "isShowInPercentVisible": true,
         "isShowOnSecondaryAxisVisible": true,
         "itemsLimit": 40,
-        "title": "Measures",
-        "warningMessage": "To add additional measure, remove <span class="attr-field-icon" /> from <span class="stack-by">segment by</span>",
+        "title": "Metrics",
+        "warningMessage": "To add additional metric, remove <span class="attr-field-icon" /> from <span class="stack-by">segment by</span>",
       },
       "segment": {
         "accepts": [
@@ -842,8 +842,8 @@ exports[`PluggableLineChart > should return reference point with one category an
         "isShowInPercentVisible": true,
         "isShowOnSecondaryAxisVisible": true,
         "itemsLimit": 40,
-        "title": "Measures",
-        "warningMessage": "To add additional measure, remove <span class="attr-field-icon" /> from <span class="stack-by">segment by</span>",
+        "title": "Metrics",
+        "warningMessage": "To add additional metric, remove <span class="attr-field-icon" /> from <span class="stack-by">segment by</span>",
       },
       "segment": {
         "accepts": [
@@ -1021,7 +1021,7 @@ exports[`PluggableLineChart > should reuse all measures, only one category and n
         "isShowInPercentVisible": true,
         "isShowOnSecondaryAxisVisible": true,
         "itemsLimit": 40,
-        "title": "Measures",
+        "title": "Metrics",
       },
       "segment": {
         "accepts": [
@@ -1035,7 +1035,7 @@ exports[`PluggableLineChart > should reuse all measures, only one category and n
         "isShowInPercentEnabled": false,
         "itemsLimit": 1,
         "title": "Segment by",
-        "warningMessage": "To segment by, an visualization can have only one measure",
+        "warningMessage": "To segment by, an visualization can have only one metric",
       },
       "trend": {
         "accepts": [
@@ -1198,8 +1198,8 @@ exports[`PluggableLineChart > should reuse one measure, only one category and on
         "isShowInPercentVisible": true,
         "isShowOnSecondaryAxisVisible": true,
         "itemsLimit": 40,
-        "title": "Measures",
-        "warningMessage": "To add additional measure, remove <span class="attr-field-icon" /> from <span class="stack-by">segment by</span>",
+        "title": "Metrics",
+        "warningMessage": "To add additional metric, remove <span class="attr-field-icon" /> from <span class="stack-by">segment by</span>",
       },
       "segment": {
         "accepts": [

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pieChart/tests/__snapshots__/PluggablePieChart.test.tsx.snap
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pieChart/tests/__snapshots__/PluggablePieChart.test.tsx.snap
@@ -125,7 +125,7 @@ exports[`PluggablePieChart > should return reference point with multiple metrics
         "isShowInPercentEnabled": false,
         "isShowInPercentVisible": true,
         "itemsLimit": 20,
-        "title": "Measures",
+        "title": "Metrics",
       },
       "view": {
         "accepts": [
@@ -143,7 +143,7 @@ exports[`PluggablePieChart > should return reference point with multiple metrics
           "date": 1,
         },
         "title": "View by",
-        "warningMessage": "To view by, an visualization can have only one measure",
+        "warningMessage": "To view by, an visualization can have only one metric",
       },
     },
     "exportConfig": {
@@ -216,7 +216,7 @@ exports[`PluggablePieChart > should return reference point with one metric and n
         "isShowInPercentEnabled": false,
         "isShowInPercentVisible": true,
         "itemsLimit": 20,
-        "title": "Measures",
+        "title": "Metrics",
       },
       "view": {
         "accepts": [
@@ -315,7 +315,7 @@ exports[`PluggablePieChart > should return reference point with one metric and o
         "isShowInPercentEnabled": true,
         "isShowInPercentVisible": true,
         "itemsLimit": 1,
-        "title": "Measures",
+        "title": "Metrics",
       },
       "view": {
         "accepts": [
@@ -438,7 +438,7 @@ exports[`PluggablePieChart > should return reference point with only one metric 
         "isShowInPercentEnabled": true,
         "isShowInPercentVisible": true,
         "itemsLimit": 1,
-        "title": "Measures",
+        "title": "Metrics",
       },
       "view": {
         "accepts": [

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/tests/__snapshots__/PluggablePivotTable.test.tsx.snap
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/tests/__snapshots__/PluggablePivotTable.test.tsx.snap
@@ -67,7 +67,7 @@ exports[`PluggablePivotTable > getExtendedReferencePoint > given an empty refere
       "isShowInPercentEnabled": false,
       "isShowInPercentVisible": true,
       "itemsLimit": 40,
-      "title": "Measures",
+      "title": "Metrics",
     },
   },
   "exportConfig": {
@@ -153,7 +153,7 @@ exports[`PluggablePivotTable > getExtendedReferencePoint > given multipleMetrics
       "isShowInPercentEnabled": false,
       "isShowInPercentVisible": true,
       "itemsLimit": 40,
-      "title": "Measures",
+      "title": "Metrics",
     },
   },
   "exportConfig": {
@@ -239,7 +239,7 @@ exports[`PluggablePivotTable > getExtendedReferencePoint > given simpleStackedRe
       "isShowInPercentEnabled": true,
       "isShowInPercentVisible": true,
       "itemsLimit": 40,
-      "title": "Measures",
+      "title": "Metrics",
     },
   },
   "exportConfig": {
@@ -390,7 +390,7 @@ exports[`PluggablePivotTable > getExtendedReferencePoint > given simpleStackedRe
         "isShowInPercentEnabled": false,
         "isShowInPercentVisible": true,
         "itemsLimit": 100,
-        "title": "Measures",
+        "title": "Metrics",
       },
     },
     "exportConfig": {
@@ -868,7 +868,7 @@ exports[`PluggablePivotTable > getExtendedReferencePoint > given simpleStackedRe
         "isShowInPercentEnabled": false,
         "isShowInPercentVisible": true,
         "itemsLimit": 40,
-        "title": "Measures",
+        "title": "Metrics",
         "warningMessage": "To add up to 60 more, remove all items from columns section",
       },
     },
@@ -1338,7 +1338,7 @@ exports[`PluggablePivotTable > getExtendedReferencePoint > given simpleStackedRe
         "isShowInPercentEnabled": false,
         "isShowInPercentVisible": true,
         "itemsLimit": 40,
-        "title": "Measures",
+        "title": "Metrics",
       },
     },
     "exportConfig": {
@@ -1784,7 +1784,7 @@ exports[`PluggablePivotTable > getExtendedReferencePoint > given simpleStackedRe
           "date": 1,
         },
         "title": "Columns",
-        "warningMessage": "Cannot add columns: limit is 40 measures and 20 rows. Follow the limits to add more",
+        "warningMessage": "Cannot add columns: limit is 40 metrics and 20 rows. Follow the limits to add more",
       },
       "filters": {
         "accepts": [
@@ -1814,7 +1814,7 @@ exports[`PluggablePivotTable > getExtendedReferencePoint > given simpleStackedRe
         "isShowInPercentEnabled": false,
         "isShowInPercentVisible": true,
         "itemsLimit": 100,
-        "title": "Measures",
+        "title": "Metrics",
       },
     },
     "exportConfig": {
@@ -1901,7 +1901,7 @@ exports[`PluggablePivotTable > getExtendedReferencePoint > should return a new r
       "isShowInPercentEnabled": true,
       "isShowInPercentVisible": true,
       "itemsLimit": 40,
-      "title": "Measures",
+      "title": "Metrics",
     },
   },
   "exportConfig": {
@@ -1988,7 +1988,7 @@ exports[`PluggablePivotTable > getExtendedReferencePoint > should return a new r
       "isShowInPercentVisible": true,
       "itemsLimit": 40,
       "subtitle": "in columns",
-      "title": "Measures",
+      "title": "Metrics",
     },
   },
   "exportConfig": {

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/sankeyChart/tests/__snapshots__/PluggableSankeyChart.test.tsx.snap
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/sankeyChart/tests/__snapshots__/PluggableSankeyChart.test.tsx.snap
@@ -140,7 +140,7 @@ exports[`PluggableSankeyChart > sankey should allow date attribute in attribute 
         "isShowInPercentEnabled": true,
         "isShowInPercentVisible": true,
         "itemsLimit": 1,
-        "title": "MEASURE",
+        "title": "METRIC",
       },
     },
     "exportConfig": {
@@ -275,7 +275,7 @@ exports[`PluggableSankeyChart > should return reference point with one metric, a
         "isShowInPercentEnabled": true,
         "isShowInPercentVisible": true,
         "itemsLimit": 1,
-        "title": "MEASURE",
+        "title": "METRIC",
       },
     },
     "exportConfig": {
@@ -462,7 +462,7 @@ exports[`PluggableSankeyChart > should reuse one measure and order attribute typ
         "isShowInPercentEnabled": true,
         "isShowInPercentVisible": true,
         "itemsLimit": 1,
-        "title": "MEASURE",
+        "title": "METRIC",
       },
     },
     "exportConfig": {

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/scatterPlot/tests/__snapshots__/PluggableScatterPlot.test.tsx.snap
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/scatterPlot/tests/__snapshots__/PluggableScatterPlot.test.tsx.snap
@@ -104,7 +104,7 @@ exports[`PluggableScatterPlot > should return reference point after switching fr
         "isShowInPercentVisible": false,
         "itemsLimit": 1,
         "subtitle": "X-axis",
-        "title": "Measure",
+        "title": "Metric",
       },
       "secondary_measures": {
         "accepts": [
@@ -122,7 +122,7 @@ exports[`PluggableScatterPlot > should return reference point after switching fr
         "isShowInPercentVisible": false,
         "itemsLimit": 1,
         "subtitle": "Y-axis",
-        "title": "Measure",
+        "title": "Metric",
       },
       "segment": {
         "accepts": [
@@ -240,7 +240,7 @@ exports[`PluggableScatterPlot > should return reference point with one secondary
         "isShowInPercentVisible": false,
         "itemsLimit": 1,
         "subtitle": "X-axis",
-        "title": "Measure",
+        "title": "Metric",
       },
       "secondary_measures": {
         "accepts": [
@@ -258,7 +258,7 @@ exports[`PluggableScatterPlot > should return reference point with one secondary
         "isShowInPercentVisible": false,
         "itemsLimit": 1,
         "subtitle": "Y-axis",
-        "title": "Measure",
+        "title": "Metric",
       },
       "segment": {
         "accepts": [
@@ -385,7 +385,7 @@ exports[`PluggableScatterPlot > should return reference point with primary and s
         "isShowInPercentVisible": false,
         "itemsLimit": 1,
         "subtitle": "X-axis",
-        "title": "Measure",
+        "title": "Metric",
       },
       "secondary_measures": {
         "accepts": [
@@ -403,7 +403,7 @@ exports[`PluggableScatterPlot > should return reference point with primary and s
         "isShowInPercentVisible": false,
         "itemsLimit": 1,
         "subtitle": "Y-axis",
-        "title": "Measure",
+        "title": "Metric",
       },
       "segment": {
         "accepts": [
@@ -521,7 +521,7 @@ exports[`PluggableScatterPlot > should return reference point with primary measu
         "isShowInPercentVisible": false,
         "itemsLimit": 1,
         "subtitle": "X-axis",
-        "title": "Measure",
+        "title": "Metric",
       },
       "secondary_measures": {
         "accepts": [
@@ -539,7 +539,7 @@ exports[`PluggableScatterPlot > should return reference point with primary measu
         "isShowInPercentVisible": false,
         "itemsLimit": 1,
         "subtitle": "Y-axis",
-        "title": "Measure",
+        "title": "Metric",
       },
       "segment": {
         "accepts": [
@@ -666,7 +666,7 @@ exports[`PluggableScatterPlot > should return reference point with two measures 
         "isShowInPercentVisible": false,
         "itemsLimit": 1,
         "subtitle": "X-axis",
-        "title": "Measure",
+        "title": "Metric",
       },
       "secondary_measures": {
         "accepts": [
@@ -684,7 +684,7 @@ exports[`PluggableScatterPlot > should return reference point with two measures 
         "isShowInPercentVisible": false,
         "itemsLimit": 1,
         "subtitle": "Y-axis",
-        "title": "Measure",
+        "title": "Metric",
       },
       "segment": {
         "accepts": [

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/tests/__snapshots__/PluggableColumnBarCharts.test.tsx.snap
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/tests/__snapshots__/PluggableColumnBarCharts.test.tsx.snap
@@ -71,8 +71,8 @@ exports[`PluggableColumnBarCharts > optional stacking > should cut out measures 
         "isShowInPercentVisible": true,
         "isShowOnSecondaryAxisVisible": true,
         "itemsLimit": 40,
-        "title": "Measures",
-        "warningMessage": "To add additional measure, remove <span class="attr-field-icon" /> from <span class="stack-by">stack by</span>",
+        "title": "Metrics",
+        "warningMessage": "To add additional metric, remove <span class="attr-field-icon" /> from <span class="stack-by">stack by</span>",
       },
       "stack": {
         "accepts": [
@@ -281,8 +281,8 @@ exports[`PluggableColumnBarCharts > optional stacking > should place third attri
         "isShowInPercentVisible": true,
         "isShowOnSecondaryAxisVisible": true,
         "itemsLimit": 40,
-        "title": "Measures",
-        "warningMessage": "To add additional measure, remove <span class="attr-field-icon" /> from <span class="stack-by">stack by</span>",
+        "title": "Metrics",
+        "warningMessage": "To add additional metric, remove <span class="attr-field-icon" /> from <span class="stack-by">stack by</span>",
       },
       "stack": {
         "accepts": [
@@ -422,7 +422,7 @@ exports[`PluggableColumnBarCharts > optional stacking > should return reference 
         "isShowInPercentVisible": true,
         "isShowOnSecondaryAxisVisible": true,
         "itemsLimit": 40,
-        "title": "Measures",
+        "title": "Metrics",
       },
       "stack": {
         "accepts": [
@@ -640,7 +640,7 @@ exports[`PluggableColumnBarCharts > optional stacking > should reuse all measure
         "isShowInPercentVisible": true,
         "isShowOnSecondaryAxisVisible": true,
         "itemsLimit": 40,
-        "title": "Measures",
+        "title": "Metrics",
       },
       "stack": {
         "accepts": [
@@ -654,7 +654,7 @@ exports[`PluggableColumnBarCharts > optional stacking > should reuse all measure
         "isShowInPercentEnabled": false,
         "itemsLimit": 1,
         "title": "Stack by",
-        "warningMessage": "To stack by an attribute, an visualization can have only one measure",
+        "warningMessage": "To stack by an attribute, an visualization can have only one metric",
       },
       "view": {
         "accepts": [
@@ -850,8 +850,8 @@ exports[`PluggableColumnBarCharts > optional stacking > should reuse one measure
         "isShowInPercentVisible": true,
         "isShowOnSecondaryAxisVisible": true,
         "itemsLimit": 40,
-        "title": "Measures",
-        "warningMessage": "To add additional measure, remove <span class="attr-field-icon" /> from <span class="stack-by">stack by</span>",
+        "title": "Metrics",
+        "warningMessage": "To add additional metric, remove <span class="attr-field-icon" /> from <span class="stack-by">stack by</span>",
       },
       "stack": {
         "accepts": [

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/treeMap/tests/__snapshots__/PluggableTreemap.test.tsx.snap
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/treeMap/tests/__snapshots__/PluggableTreemap.test.tsx.snap
@@ -125,8 +125,8 @@ exports[`PluggableTreemap > should return ref. point with 1 M, 1 Vb, 1 Sb and on
         "isShowInPercentEnabled": false,
         "isShowInPercentVisible": true,
         "itemsLimit": 1,
-        "title": "Measures",
-        "warningMessage": "To add additional measure, remove <span class="attr-field-icon" /> from <span class="stack-by">view by</span>",
+        "title": "Metrics",
+        "warningMessage": "To add additional metric, remove <span class="attr-field-icon" /> from <span class="stack-by">view by</span>",
       },
       "segment": {
         "accepts": [
@@ -254,8 +254,8 @@ exports[`PluggableTreemap > should return ref. point with 1 M, 1 Vb, 1 Sb and on
         "isShowInPercentEnabled": false,
         "isShowInPercentVisible": true,
         "itemsLimit": 1,
-        "title": "Measures",
-        "warningMessage": "To add additional measure, remove <span class="date-field-icon" /> from <span class="stack-by">view by</span>",
+        "title": "Metrics",
+        "warningMessage": "To add additional metric, remove <span class="date-field-icon" /> from <span class="stack-by">view by</span>",
       },
       "segment": {
         "accepts": [
@@ -427,8 +427,8 @@ exports[`PluggableTreemap > should return ref. point with 1 M, 1 Vb, 1 Sb and on
         "isShowInPercentEnabled": false,
         "isShowInPercentVisible": true,
         "itemsLimit": 1,
-        "title": "Measures",
-        "warningMessage": "To add additional measure, remove <span class="attr-field-icon" /> from <span class="stack-by">view by</span>",
+        "title": "Metrics",
+        "warningMessage": "To add additional metric, remove <span class="attr-field-icon" /> from <span class="stack-by">view by</span>",
       },
       "segment": {
         "accepts": [
@@ -559,7 +559,7 @@ exports[`PluggableTreemap > should return ref. point with n M, 0 Vb, 0 Sb for n 
         "isShowInPercentEnabled": false,
         "isShowInPercentVisible": true,
         "itemsLimit": 40,
-        "title": "Measures",
+        "title": "Metrics",
       },
       "segment": {
         "accepts": [
@@ -590,7 +590,7 @@ exports[`PluggableTreemap > should return ref. point with n M, 0 Vb, 0 Sb for n 
           "date": 1,
         },
         "title": "View by",
-        "warningMessage": "To view by, an visualization can have only one measure",
+        "warningMessage": "To view by, an visualization can have only one metric",
       },
     },
     "exportConfig": {
@@ -701,7 +701,7 @@ exports[`PluggableTreemap > should return ref. point with n M, 0 Vb, 1 Sb for n 
         "isShowInPercentEnabled": false,
         "isShowInPercentVisible": true,
         "itemsLimit": 40,
-        "title": "Measures",
+        "title": "Metrics",
       },
       "segment": {
         "accepts": [
@@ -732,7 +732,7 @@ exports[`PluggableTreemap > should return ref. point with n M, 0 Vb, 1 Sb for n 
           "date": 1,
         },
         "title": "View by",
-        "warningMessage": "To view by, an visualization can have only one measure",
+        "warningMessage": "To view by, an visualization can have only one metric",
       },
     },
     "exportConfig": {
@@ -809,7 +809,7 @@ exports[`PluggableTreemap > should return reference point with 1 M, 0 Vb, 0 Sb f
         "isShowInPercentEnabled": false,
         "isShowInPercentVisible": true,
         "itemsLimit": 40,
-        "title": "Measures",
+        "title": "Metrics",
       },
       "segment": {
         "accepts": [

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/waterfallChart/tests/__snapshots__/PluggableWaterfallChart.test.tsx.snap
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/waterfallChart/tests/__snapshots__/PluggableWaterfallChart.test.tsx.snap
@@ -94,7 +94,7 @@ exports[`PluggableWaterfallChart > should return reference point after switching
         "isTotalMeasureEnabled": false,
         "isTotalMeasureVisible": true,
         "itemsLimit": 1,
-        "title": "Measures",
+        "title": "Metrics",
       },
       "view": {
         "accepts": [
@@ -214,7 +214,7 @@ exports[`PluggableWaterfallChart > should return reference point with multi meas
         "isTotalMeasureEnabled": true,
         "isTotalMeasureVisible": true,
         "itemsLimit": 40,
-        "title": "Measures",
+        "title": "Metrics",
       },
       "view": {
         "accepts": [
@@ -232,7 +232,7 @@ exports[`PluggableWaterfallChart > should return reference point with multi meas
           "date": 1,
         },
         "title": "View by",
-        "warningMessage": "To view by, an visualization can have only one measure",
+        "warningMessage": "To view by, an visualization can have only one metric",
       },
     },
     "exportConfig": {
@@ -321,7 +321,7 @@ exports[`PluggableWaterfallChart > should return reference point with one measur
         "isTotalMeasureEnabled": false,
         "isTotalMeasureVisible": true,
         "itemsLimit": 1,
-        "title": "Measures",
+        "title": "Metrics",
       },
       "view": {
         "accepts": [

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/xirr/tests/__snapshots__/PluggableXirr.test.ts.snap
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/xirr/tests/__snapshots__/PluggableXirr.test.ts.snap
@@ -60,12 +60,12 @@ exports[`PluggableXirr > getExtendedReferencePoint > should correctly process em
         "isShowInPercentEnabled": false,
         "isShowInPercentVisible": false,
         "itemsLimit": 1,
-        "title": "Measure",
+        "title": "Metric",
       },
     },
     "customError": {
       "heading": "Incomplete configuration",
-      "text": "Make sure you have selected one measure and one date attribute",
+      "text": "Make sure you have selected one metric and one date attribute",
     },
     "exportConfig": {
       "supported": false,
@@ -161,7 +161,7 @@ exports[`PluggableXirr > getExtendedReferencePoint > should return proper extend
         "isShowInPercentEnabled": false,
         "isShowInPercentVisible": false,
         "itemsLimit": 1,
-        "title": "Measure",
+        "title": "Metric",
       },
     },
     "customError": undefined,

--- a/libs/sdk-ui-ext/src/internal/utils/tests/bucketHelper.test.ts
+++ b/libs/sdk-ui-ext/src/internal/utils/tests/bucketHelper.test.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2022 GoodData Corporation
+// (C) 2019-2024 GoodData Corporation
 import cloneDeep from "lodash/cloneDeep.js";
 import set from "lodash/set.js";
 import { IBucket } from "@gooddata/sdk-model";
@@ -197,7 +197,7 @@ describe("Bucket title", () => {
         const intl = createInternalIntl(DefaultLocale);
         const expectedUiconfig: IUiConfig = cloneDeep(DEFAULT_BASE_CHART_UICONFIG);
 
-        set(expectedUiconfig, ["buckets", "measures", "title"], "Measures");
+        set(expectedUiconfig, ["buckets", "measures", "title"], "Metrics");
         set(expectedUiconfig, ["buckets", "view", "title"], "View by");
         set(expectedUiconfig, ["buckets", "stack", "title"], "Stack by");
 
@@ -232,7 +232,7 @@ describe("Bucket title", () => {
         const intl = createInternalIntl(DefaultLocale);
         const expectedUiconfig: IUiConfig = cloneDeep(DEFAULT_BASE_CHART_UICONFIG);
 
-        set(expectedUiconfig, ["buckets", "measures", "title"], "Measures");
+        set(expectedUiconfig, ["buckets", "measures", "title"], "Metrics");
         set(expectedUiconfig, ["buckets", "view", "title"], "View by");
         set(expectedUiconfig, ["buckets", "stack", "enabled"], false);
 

--- a/libs/sdk-ui-ext/src/internal/utils/uiConfigHelpers/tests/__snapshots__/bulletChartUiConfigHelper.test.ts.snap
+++ b/libs/sdk-ui-ext/src/internal/utils/uiConfigHelpers/tests/__snapshots__/bulletChartUiConfigHelper.test.ts.snap
@@ -93,7 +93,7 @@ exports[`bulletChartUiConfigHelper > getBulletChartUiConfig > should return bull
         "isShowOnSecondaryAxisVisible": false,
         "itemsLimit": 1,
         "subtitle": "Primary",
-        "title": "Measure",
+        "title": "Metric",
       },
       "secondary_measures": {
         "accepts": [
@@ -112,7 +112,7 @@ exports[`bulletChartUiConfigHelper > getBulletChartUiConfig > should return bull
         "isShowOnSecondaryAxisVisible": false,
         "itemsLimit": 1,
         "subtitle": "Target",
-        "title": "Measure",
+        "title": "Metric",
       },
       "tertiary_measures": {
         "accepts": [
@@ -131,7 +131,7 @@ exports[`bulletChartUiConfigHelper > getBulletChartUiConfig > should return bull
         "isShowOnSecondaryAxisVisible": false,
         "itemsLimit": 1,
         "subtitle": "Comparative",
-        "title": "Measure",
+        "title": "Metric",
       },
       "view": {
         "accepts": [

--- a/libs/sdk-ui-ext/src/internal/utils/uiConfigHelpers/tests/comboChartUiConfigHelper.test.ts
+++ b/libs/sdk-ui-ext/src/internal/utils/uiConfigHelpers/tests/comboChartUiConfigHelper.test.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2020 GoodData Corporation
+// (C) 2019-2024 GoodData Corporation
 import { DefaultLocale, VisualizationTypes } from "@gooddata/sdk-ui";
 import * as referencePointMock from "../../../tests/mocks/referencePointMocks.js";
 import { setComboChartUiConfig } from "../comboChartUiConfigHelper.js";
@@ -21,8 +21,8 @@ describe("comboChartUiConfigHelper", () => {
             const secondaryMeasureBucket = referencePoint?.uiConfig?.buckets?.secondary_measures;
             const viewBucket = referencePoint?.uiConfig?.buckets?.view;
 
-            expect(primaryMeasureBucket.title).toEqual("Measures");
-            expect(secondaryMeasureBucket.title).toEqual("Measures");
+            expect(primaryMeasureBucket.title).toEqual("Metrics");
+            expect(secondaryMeasureBucket.title).toEqual("Metrics");
             expect(viewBucket.title).toEqual("View by");
         });
 

--- a/libs/sdk-ui-ext/src/internal/utils/uiConfigHelpers/tests/comboChartUiConfigHelperDeprecated.test.ts
+++ b/libs/sdk-ui-ext/src/internal/utils/uiConfigHelpers/tests/comboChartUiConfigHelperDeprecated.test.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2020 GoodData Corporation
+// (C) 2019-2024 GoodData Corporation
 import { DefaultLocale, VisualizationTypes } from "@gooddata/sdk-ui";
 import * as referencePointMock from "../../../tests/mocks/referencePointMocks.js";
 import { setComboChartUiConfigDeprecated } from "../comboChartUiConfigHelperDeprecated.js";
@@ -24,8 +24,8 @@ describe("comboChartUiConfigHelper", () => {
             const secondaryMeasureBucket = referencePoint?.uiConfig?.buckets?.secondary_measures;
             const viewBucket = referencePoint?.uiConfig?.buckets?.view;
 
-            expect(primaryMeasureBucket.title).toEqual("Measures");
-            expect(secondaryMeasureBucket.title).toEqual("Measures");
+            expect(primaryMeasureBucket.title).toEqual("Metrics");
+            expect(secondaryMeasureBucket.title).toEqual("Metrics");
             expect(viewBucket.title).toEqual("View by");
         });
 

--- a/libs/sdk-ui-ext/src/internal/utils/uiConfigHelpers/tests/headlineUiConfigHelper.test.ts
+++ b/libs/sdk-ui-ext/src/internal/utils/uiConfigHelpers/tests/headlineUiConfigHelper.test.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2020 GoodData Corporation
+// (C) 2019-2024 GoodData Corporation
 import { describe, expect, it } from "vitest";
 import cloneDeep from "lodash/cloneDeep.js";
 
@@ -75,8 +75,8 @@ describe("headlineUiConfigHelper", () => {
                     referencePointMocks.headlineWithMeasureInPrimaryBucket,
                     intl,
                 );
-                expect(uiConfig.buckets.measures.title).toEqual("Measure");
-                expect(uiConfig.buckets.secondary_measures.title).toEqual("Measure");
+                expect(uiConfig.buckets.measures.title).toEqual("Metric");
+                expect(uiConfig.buckets.secondary_measures.title).toEqual("Metric");
             });
         });
     });

--- a/libs/sdk-ui/src/base/localization/TranslationsCustomizationProvider/utils.ts
+++ b/libs/sdk-ui/src/base/localization/TranslationsCustomizationProvider/utils.ts
@@ -1,4 +1,4 @@
-// (C) 2007-2023 GoodData Corporation
+// (C) 2007-2024 GoodData Corporation
 import memoize from "memoize-one";
 import { IWorkspaceSettings } from "@gooddata/sdk-backend-spi";
 import { defaultImport } from "default-import";
@@ -76,7 +76,7 @@ export const pickCorrectMetricWording = (
     translations: Record<string, string>,
     settings?: IWorkspaceSettings,
 ): Record<string, string> => {
-    const isEnabledRenamingMeasureToMetric = !!settings?.enableRenamingMeasureToMetric;
+    const isEnabledRenamingMeasureToMetric = settings?.enableRenamingMeasureToMetric ?? true;
 
     return memoizedPickCorrectMetricWordingInner(translations, isEnabledRenamingMeasureToMetric);
 };


### PR DESCRIPTION
default enableRenamingMeasureToMetric was not true in some cases after reload

this might be related to latest React 18 upgrade in AD where it was spotted first

JIRA: F1-684
risk: low

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** 🙏

---

Refer to [documentation](https://github.com/gooddata/gooddata-ui-sdk/blob/master/dev_docs/continuous_integration.md) to see how to run checks and tests in the pull request. This is the list of the most used commands:

```
extended test - backstop
```

```
extended test - tiger-cypress - integrated
extended test - tiger-cypress - isolated
extended test - tiger-cypress - record
```
