### PR TITLE
fix: hide drill down detail section in Repeater

### DIFF
--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/repeater/PluggableRepeater.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/repeater/PluggableRepeater.tsx
@@ -53,6 +53,7 @@ import compact from "lodash/compact.js";
 import { getValidProperties } from "../../../utils/colors.js";
 import { DASHBOARDS_ENVIRONMENT } from "../../../constants/properties.js";
 import { REPEATER_SUPPORTER_PROPERTIES_LIST } from "../../../constants/supportedProperties.js";
+import omit from "lodash/omit.js";
 
 /**
  * PluggableRepeater
@@ -392,7 +393,10 @@ export class PluggableRepeater extends AbstractPluggableVisualization {
                     isError={this.getIsError()}
                     isLoading={this.isLoading}
                     featureFlags={this.featureFlags}
-                    configurationPanelRenderers={options.custom?.configurationPanelRenderers}
+                    configurationPanelRenderers={omit(
+                        options.custom?.configurationPanelRenderers,
+                        "InteractionsDetailRenderer",
+                    )}
                 />,
                 configPanelElement,
             );


### PR DESCRIPTION
Repeater does not support drill down, so hide the drill down detail section with info about attribute hierarchies.

JIRA: F1-671

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** 🙏

---

Refer to [documentation](https://github.com/gooddata/gooddata-ui-sdk/blob/master/dev_docs/continuous_integration.md) to see how to run checks and tests in the pull request. This is the list of the most used commands:

```
extended test - backstop
```

```
extended test - tiger-cypress - integrated
extended test - tiger-cypress - isolated
extended test - tiger-cypress - record
```
