### PR TITLE
trivial: keep dashboard component in playground by default

### DIFF
--- a/examples/playground/src/App.tsx
+++ b/examples/playground/src/App.tsx
@@ -1,11 +1,14 @@
 // (C) 2019-2024 GoodData Corporation
 import React, { useMemo } from "react";
 import { BackendProvider, WorkspaceProvider } from "@gooddata/sdk-ui";
+import { Dashboard } from "@gooddata/sdk-ui-dashboard";
 import { createBackend } from "./createBackend.js";
 
 function hasCredentialsSetup(): boolean {
     return !!import.meta.env.VITE_TIGER_API_TOKEN;
 }
+
+const dashboard = import.meta.env.VITE_DASHBOARD;
 
 const AppWithBackend: React.FC = () => {
     // only create the backend instance once
@@ -17,13 +20,14 @@ const AppWithBackend: React.FC = () => {
         <BackendProvider backend={backend}>
             <WorkspaceProvider workspace={import.meta.env.VITE_WORKSPACE}>
                 {/* Build your playground components under the playground directory.*/}
-                {/*<Dashboard*/}
-                {/*    dashboard={import.meta.env.VITE_DASHBOARD}*/}
-                {/*    backend={backend}*/}
-                {/*    config={{*/}
-                {/*        initialRenderMode: "view",*/}
-                {/*    }}*/}
-                {/*/>*/}
+                {dashboard ? (
+                    <Dashboard
+                        dashboard={dashboard}
+                        config={{
+                            initialRenderMode: "view",
+                        }}
+                    />
+                ) : undefined}
             </WorkspaceProvider>
         </BackendProvider>
     );


### PR DESCRIPTION
risk: nonprod

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** 🙏

---

Refer to [documentation](https://github.com/gooddata/gooddata-ui-sdk/blob/master/dev_docs/continuous_integration.md) to see how to run checks and tests in the pull request. This is the list of the most used commands:

```
extended test - backstop
```

```
extended test - tiger-cypress - integrated
extended test - tiger-cypress - isolated
extended test - tiger-cypress - record
```
