### PR TITLE
fix(dashboards): merge default filter view with dashboard correctly

### DIFF
--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/common/filterViews.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/common/filterViews.ts
@@ -1,0 +1,111 @@
+// (C) 2024 GoodData Corporation
+
+import {
+    IDashboard,
+    IDashboardFilterView,
+    isFilterContext,
+    ISettings,
+    isDashboardAttributeFilter,
+    IDashboardAttributeFilter,
+    FilterContextItem,
+    IDashboardDateFilter,
+    isDashboardDateFilter,
+    areObjRefsEqual,
+    IFilterContext,
+} from "@gooddata/sdk-model";
+import omit from "lodash/omit.js";
+import isEqual from "lodash/isEqual.js";
+
+const findMatchingAttributeFilterByLocalIdentifier = (
+    filter: IDashboardAttributeFilter,
+    viewFilters: FilterContextItem[],
+): IDashboardAttributeFilter | undefined =>
+    viewFilters.find(
+        (item) =>
+            isDashboardAttributeFilter(item) &&
+            item.attributeFilter.localIdentifier === filter.attributeFilter.localIdentifier,
+    ) as IDashboardAttributeFilter;
+
+// date filters do not have localIdentifier set, compare them by dataSet instead
+const findMatchingDateFilterByDataSet = (
+    filter: IDashboardDateFilter,
+    viewFilters: FilterContextItem[],
+): IDashboardDateFilter | undefined =>
+    viewFilters.find(
+        (item) =>
+            isDashboardDateFilter(item) &&
+            ((item.dateFilter.dataSet === undefined && filter.dateFilter.dataSet === undefined) ||
+                areObjRefsEqual(item.dateFilter.dataSet, filter.dateFilter.dataSet)),
+    ) as IDashboardDateFilter;
+
+const OMITTED_ATTRIBUTE_FILTER_PATHS = [
+    "attributeFilter.attributeElements",
+    "attributeFilter.negativeSelection",
+];
+
+const hasSameAttributeFilterConfiguration = (
+    filterA: IDashboardAttributeFilter,
+    filterB?: IDashboardAttributeFilter,
+) => {
+    return isEqual(
+        omit(filterA, OMITTED_ATTRIBUTE_FILTER_PATHS),
+        omit(filterB, OMITTED_ATTRIBUTE_FILTER_PATHS),
+    );
+};
+
+export const changeFilterContextSelection = (
+    filterContext: IFilterContext,
+    filterViewFilters: FilterContextItem[],
+): IFilterContext => {
+    return {
+        ...filterContext,
+        filters: filterContext.filters.map((filter) => {
+            if (isDashboardAttributeFilter(filter)) {
+                const viewFilter = findMatchingAttributeFilterByLocalIdentifier(filter, filterViewFilters);
+                if (viewFilter !== undefined && hasSameAttributeFilterConfiguration(filter, viewFilter)) {
+                    return {
+                        attributeFilter: {
+                            ...filter.attributeFilter,
+                            attributeElements: viewFilter.attributeFilter.attributeElements,
+                            negativeSelection: viewFilter.attributeFilter.negativeSelection,
+                        },
+                    };
+                }
+            } else {
+                const viewFilter = findMatchingDateFilterByDataSet(filter, filterViewFilters);
+                if (viewFilter) {
+                    return {
+                        dateFilter: {
+                            ...filter.dateFilter,
+                            from: viewFilter.dateFilter.from,
+                            to: viewFilter.dateFilter.to,
+                            granularity: viewFilter.dateFilter.granularity,
+                            type: viewFilter.dateFilter.type,
+                        },
+                    };
+                }
+            }
+            return filter;
+        }),
+    };
+};
+
+export function applyDefaultFilterView(
+    dashboard: IDashboard,
+    filterViews: IDashboardFilterView[],
+    settings: ISettings,
+): IDashboard {
+    // find first default filter view (in case metadata are not consistent and there are more than one)
+    const defaultFilterView = filterViews.find((view) => view.isDefault);
+    const areFilterViewsEnabled = settings.enableDashboardFilterViews;
+
+    return areFilterViewsEnabled && defaultFilterView && isFilterContext(dashboard.filterContext)
+        ? {
+              ...dashboard,
+              filterContext: changeFilterContextSelection(
+                  dashboard.filterContext,
+                  defaultFilterView.filterContext.filters,
+              ),
+          }
+        : dashboard;
+}

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/common/tests/__snapshots__/filterViews.test.ts.snap
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/common/tests/__snapshots__/filterViews.test.ts.snap
@@ -1,0 +1,110 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`filterViews > changeFilterContextSelection > should set selection of matching filters in provided filters context and leave the rest of its filters as is 1`] = `
+{
+  "description": "",
+  "filters": [
+    {
+      "dateFilter": {
+        "from": -1,
+        "granularity": "GDC.time.year",
+        "to": -1,
+        "type": "relative",
+      },
+    },
+    {
+      "attributeFilter": {
+        "attributeElements": {
+          "uris": [
+            "Content",
+          ],
+        },
+        "displayForm": {
+          "identifier": "campaign_channels.category",
+          "type": "displayForm",
+        },
+        "localIdentifier": "86e90c9b864e4701affced5e55b36b9c",
+        "negativeSelection": false,
+        "selectionMode": "single",
+      },
+    },
+    {
+      "attributeFilter": {
+        "attributeElements": {
+          "uris": [
+            "Midwest",
+          ],
+        },
+        "displayForm": {
+          "identifier": "region",
+          "type": "displayForm",
+        },
+        "localIdentifier": "a01fc28d9a8244b99179d3f7320b3400",
+        "negativeSelection": false,
+        "selectionMode": "multi",
+      },
+    },
+    {
+      "attributeFilter": {
+        "attributeElements": {
+          "uris": [
+            "C",
+          ],
+        },
+        "displayForm": {
+          "identifier": "negative-filter",
+          "type": "displayForm",
+        },
+        "localIdentifier": "b01fc28d9a8244b99179d3f7320b3400",
+        "negativeSelection": false,
+        "selectionMode": "multi",
+      },
+    },
+    {
+      "dateFilter": {
+        "dataSet": {
+          "identifier": "date",
+          "type": "dataSet",
+        },
+        "from": -1,
+        "granularity": "GDC.time.year",
+        "to": -1,
+        "type": "relative",
+      },
+    },
+    {
+      "dateFilter": {
+        "dataSet": {
+          "identifier": "ignored",
+          "type": "dataSet",
+        },
+        "from": "2023-06-10",
+        "granularity": "GDC.time.date",
+        "to": "2023-02-11",
+        "type": "absolute",
+      },
+    },
+    {
+      "attributeFilter": {
+        "attributeElements": {
+          "uris": [],
+        },
+        "displayForm": {
+          "identifier": "order_id",
+          "type": "displayForm",
+        },
+        "localIdentifier": "87fbd090f82a4425822ecf19f4f9e123",
+        "negativeSelection": true,
+        "selectionMode": "multi",
+      },
+    },
+  ],
+  "identifier": "1c07035a-d48c-48f9-97ac-ca6a146a1b17",
+  "ref": {
+    "identifier": "1c07035a-d48c-48f9-97ac-ca6a146a1b17",
+    "type": "filterContext",
+  },
+  "title": "filterContext",
+  "uri": "https://internal-testing.staging.stg11.panther.intgdc.com/api/v1/entities/workspaces/130ee9a3d69b4508aed431773a660706/filterContexts/1c07035a-d48c-48f9-97ac-ca6a146a1b17",
+}
+`;

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/common/tests/filterViews.mock.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/common/tests/filterViews.mock.ts
@@ -1,0 +1,75 @@
+// (C) 2024 GoodData Corporation
+
+import { IFilterContext } from "@gooddata/sdk-model";
+
+export const filterContext: IFilterContext = {
+    ref: { identifier: "1c07035a-d48c-48f9-97ac-ca6a146a1b17", type: "filterContext" },
+    identifier: "1c07035a-d48c-48f9-97ac-ca6a146a1b17",
+    uri: "https://internal-testing.staging.stg11.panther.intgdc.com/api/v1/entities/workspaces/130ee9a3d69b4508aed431773a660706/filterContexts/1c07035a-d48c-48f9-97ac-ca6a146a1b17",
+    title: "filterContext",
+    description: "",
+    filters: [
+        {
+            dateFilter: {
+                granularity: "GDC.time.date",
+                type: "absolute",
+                from: "2024-08-12",
+                to: "2024-09-12",
+            },
+        },
+        {
+            attributeFilter: {
+                attributeElements: { uris: ["Content"] },
+                displayForm: { identifier: "campaign_channels.category", type: "displayForm" },
+                negativeSelection: false,
+                localIdentifier: "86e90c9b864e4701affced5e55b36b9c",
+                selectionMode: "single",
+            },
+        },
+        {
+            attributeFilter: {
+                attributeElements: { uris: ["South"] },
+                displayForm: { identifier: "region", type: "displayForm" },
+                negativeSelection: false,
+                localIdentifier: "a01fc28d9a8244b99179d3f7320b3400",
+                selectionMode: "multi",
+            },
+        },
+        {
+            attributeFilter: {
+                attributeElements: { uris: ["A", "B"] },
+                displayForm: { identifier: "negative-filter", type: "displayForm" },
+                negativeSelection: true,
+                localIdentifier: "b01fc28d9a8244b99179d3f7320b3400",
+                selectionMode: "multi",
+            },
+        },
+        {
+            dateFilter: {
+                dataSet: { identifier: "date", type: "dataSet" },
+                type: "absolute",
+                granularity: "GDC.time.date",
+                from: "2021-08-12",
+                to: "2021-09-12",
+            },
+        },
+        {
+            dateFilter: {
+                dataSet: { identifier: "ignored", type: "dataSet" },
+                type: "absolute",
+                granularity: "GDC.time.date",
+                from: "2023-06-10",
+                to: "2023-02-11",
+            },
+        },
+        {
+            attributeFilter: {
+                attributeElements: { uris: [] },
+                displayForm: { identifier: "order_id", type: "displayForm" },
+                negativeSelection: true,
+                localIdentifier: "87fbd090f82a4425822ecf19f4f9e123",
+                selectionMode: "multi",
+            },
+        },
+    ],
+};

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/common/tests/filterViews.test.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/common/tests/filterViews.test.ts
@@ -1,0 +1,61 @@
+// (C) 2024 GoodData Corporation
+
+import { it, describe, expect } from "vitest";
+import { changeFilterContextSelection } from "../filterViews";
+import { FilterContextItem } from "@gooddata/sdk-model";
+import { filterContext } from "./filterViews.mock";
+
+describe("filterViews", () => {
+    describe("changeFilterContextSelection", () => {
+        it("should set selection of matching filters in provided filters context and leave the rest of its filters as is", () => {
+            const filters: FilterContextItem[] = [
+                {
+                    dateFilter: {
+                        granularity: "GDC.time.year",
+                        type: "relative",
+                        from: -1,
+                        to: -1,
+                    },
+                },
+                {
+                    attributeFilter: {
+                        attributeElements: { uris: ["Advertising"] },
+                        displayForm: { identifier: "campaign_channels.category", type: "displayForm" },
+                        negativeSelection: true,
+                        localIdentifier: "86e90c9b864e4701affced5e55b36b9c",
+                        // the filter setting no longer matches the one in the filter context, therefore will not be applied
+                        selectionMode: "multi",
+                    },
+                },
+                {
+                    attributeFilter: {
+                        attributeElements: { uris: ["Midwest"] },
+                        displayForm: { identifier: "region", type: "displayForm" },
+                        negativeSelection: false,
+                        localIdentifier: "a01fc28d9a8244b99179d3f7320b3400",
+                        selectionMode: "multi",
+                    },
+                },
+                {
+                    dateFilter: {
+                        dataSet: { identifier: "date", type: "dataSet" },
+                        type: "relative",
+                        granularity: "GDC.time.year",
+                        from: -1,
+                        to: -1,
+                    },
+                },
+                {
+                    attributeFilter: {
+                        attributeElements: { uris: ["C"] },
+                        displayForm: { identifier: "negative-filter", type: "displayForm" },
+                        negativeSelection: false,
+                        localIdentifier: "b01fc28d9a8244b99179d3f7320b3400",
+                        selectionMode: "multi",
+                    },
+                },
+            ];
+            expect(changeFilterContextSelection(filterContext, filters)).toMatchSnapshot();
+        });
+    });
+});


### PR DESCRIPTION
The current naive implementation removed filters from dashboard's filter context when they were missing in the filter view (when filter was added to dashboard later after the view was saved).

Also, the default view was not applied when user saved some changes in dashboard edit mode and render mode was switched from edit to view.

JIRA: LX-422
risk: low

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** 🙏

---

Refer to [documentation](https://github.com/gooddata/gooddata-ui-sdk/blob/master/dev_docs/continuous_integration.md) to see how to run checks and tests in the pull request. This is the list of the most used commands:

```
extended test - backstop
```

```
extended test - tiger-cypress - integrated
extended test - tiger-cypress - isolated
extended test - tiger-cypress - record
```
