### PR TITLE
fix: schedule widget not selecting attachment

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/DefaultScheduledEmailDialog.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/DefaultScheduledEmailDialog.tsx
@@ -163,9 +163,11 @@ export function ScheduledMailDialogRenderer(props: IScheduledEmailDialogProps) {
 
     const isValid = (automation.recipients?.length ?? 0) <= maxAutomationsRecipients && isCronValid;
     const isDestinationEmpty = !automation.notificationChannel;
+    const isAttachmentsEmpty = !automation.exportDefinitions?.length;
     const isSubmitDisabled =
         !isValid ||
         isDestinationEmpty ||
+        isAttachmentsEmpty ||
         (editSchedule && areAutomationsEqual(automation, originalAutomation));
 
     const startDate = parseISO(


### PR DESCRIPTION
[Scheduling M3] schedule widget not selecting attachment, reopening it displays attachment PDF

JIRA: F1-571

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** 🙏

---

Refer to [documentation](https://github.com/gooddata/gooddata-ui-sdk/blob/master/dev_docs/continuous_integration.md) to see how to run checks and tests in the pull request. This is the list of the most used commands:

```
extended test - backstop
```

```
extended test - tiger-cypress - integrated
extended test - tiger-cypress - isolated
extended test - tiger-cypress - record
```
