### PR TITLE
fix: fetch only filterView from current WS

### DIFF
--- a/libs/sdk-backend-tiger/src/backend/workspace/dashboards/index.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/dashboards/index.ts
@@ -644,6 +644,8 @@ export class TigerWorkspaceDashboards implements IWorkspaceDashboardsService {
                     workspaceId: this.workspace,
                     include: ["user", "analyticalDashboard"],
                     filter: `analyticalDashboard.id==${dashboardId};user.id==${profile.userId}`,
+                    origin: "NATIVE",
+
                     // sort: ["name"], // TODO LX-422 remove comment and array sort below once sort is supported
                 });
             });
@@ -761,6 +763,7 @@ export class TigerWorkspaceDashboards implements IWorkspaceDashboardsService {
             workspaceId: this.workspace,
             include: ["user", "analyticalDashboard"],
             filter: `analyticalDashboard.id==${dashboardId};user.id==${profile.userId};filterView.isDefault==true`,
+            origin: "NATIVE",
         });
         await Promise.all(
             defaultFilterViewsForDashboard.data.data.map((view) =>


### PR DESCRIPTION
Ignore filterViews from parents, as these can not be deleted nor set as default from child WS.

JIRA: LX-514
risk: low

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** 🙏

---

Refer to [documentation](https://github.com/gooddata/gooddata-ui-sdk/blob/master/dev_docs/continuous_integration.md) to see how to run checks and tests in the pull request. This is the list of the most used commands:

```
extended test - backstop
```

```
extended test - tiger-cypress - integrated
extended test - tiger-cypress - isolated
extended test - tiger-cypress - record
```
