### PR TITLE
fix: re-enable alerting / scheduling

### DIFF
--- a/libs/sdk-backend-tiger/src/backend/features/index.ts
+++ b/libs/sdk-backend-tiger/src/backend/features/index.ts
@@ -43,8 +43,7 @@ export class TigerFeaturesService {
             return {
                 ...DefaultFeatureFlags,
                 ...results,
-                enableScheduling: false,
-                enableAlerting: false,
+                // After conflict here when merge release->master, please remove hardcoded feature flags override
             };
         });
         responseMap.set(getKeyFromContext(wsContext), response);


### PR DESCRIPTION
Alerting and scheduling is currently disabled in release branch, we can re-enable it after release of 10.11.0.

risk: low
JIRA: F1-753

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** 🙏

---

Refer to [documentation](https://github.com/gooddata/gooddata-ui-sdk/blob/master/dev_docs/continuous_integration.md) to see how to run checks and tests in the pull request. This is the list of the most used commands:

```
extended test - backstop
```

```
extended test - tiger-cypress - integrated
extended test - tiger-cypress - isolated
extended test - tiger-cypress - record
```
