### PR TITLE
fix: alerts and scheduled exports permissions

### DIFF
--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/scheduledEmail/initializeAutomationsHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/scheduledEmail/initializeAutomationsHandler.ts
@@ -19,6 +19,7 @@ import {
     selectAutomationsIsInitialized,
     selectAutomationsIsLoading,
 } from "../../store/automations/automationsSelectors.js";
+import { selectCanManageWorkspace } from "../../store/permissions/permissionsSelectors.js";
 
 export function* initializeAutomationsHandler(
     ctx: DashboardContext,
@@ -26,6 +27,10 @@ export function* initializeAutomationsHandler(
 ): SagaIterator {
     const dashboardId: ReturnType<typeof selectDashboardId> = yield select(selectDashboardId);
     const user: ReturnType<typeof selectCurrentUser> = yield select(selectCurrentUser);
+    const canManageAutomations: ReturnType<typeof selectCanManageWorkspace> = yield select(
+        selectCanManageWorkspace,
+    );
+
     const enableAutomations: ReturnType<typeof selectEnableScheduling> = yield select(
         selectEnableAutomations,
     );
@@ -49,7 +54,7 @@ export function* initializeAutomationsHandler(
             PromiseFnReturnType<typeof loadNotificationChannels>,
             PromiseFnReturnType<typeof loadWorkspaceUsers>,
         ] = yield all([
-            call(loadDashboardUserAutomations, ctx, dashboardId, user.login),
+            call(loadDashboardUserAutomations, ctx, dashboardId, user.login, !canManageAutomations),
             call(loadWorkspaceAutomationsCount, ctx),
             call(loadNotificationChannels, ctx),
             call(loadWorkspaceUsers, ctx),

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/scheduledEmail/loadAutomations.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/scheduledEmail/loadAutomations.ts
@@ -14,15 +14,20 @@ export function loadDashboardUserAutomations(
     ctx: DashboardContext,
     dashboardId: string,
     userId: string,
+    filterByUser: boolean,
 ): Promise<IAutomationMetadataObject[]> {
     const { backend, workspace } = ctx;
 
-    return backend
+    let dashboardQuery = backend
         .workspace(workspace)
         .automations()
         .getAutomationsQuery()
-        .withDashboard(dashboardId)
-        .withUser(userId)
         .withSorting(["title,asc", "createdAt,asc"])
-        .queryAll();
+        .withDashboard(dashboardId);
+
+    if (filterByUser) {
+        dashboardQuery = dashboardQuery.withUser(userId);
+    }
+
+    return dashboardQuery.queryAll();
 }

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/scheduledEmail/refreshAutomationsHandlers.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/scheduledEmail/refreshAutomationsHandlers.ts
@@ -11,12 +11,16 @@ import { selectEnableAlerting, selectEnableScheduling } from "../../store/config
 import { automationsActions } from "../../store/automations/index.js";
 import { selectDashboardId } from "../../store/meta/metaSelectors.js";
 import { selectCurrentUser } from "../../store/user/userSelectors.js";
+import { selectCanManageWorkspace } from "../../store/permissions/permissionsSelectors.js";
 
 export function* refreshAutomationsHandlers(ctx: DashboardContext, _cmd: RefreshAutomations): SagaIterator {
     const dashboardId: ReturnType<typeof selectDashboardId> = yield select(selectDashboardId);
     const user: ReturnType<typeof selectCurrentUser> = yield select(selectCurrentUser);
     const enableScheduling: ReturnType<typeof selectEnableScheduling> = yield select(selectEnableScheduling);
     const enableAlerting: ReturnType<typeof selectEnableAlerting> = yield select(selectEnableAlerting);
+    const canManageAutomations: ReturnType<typeof selectCanManageWorkspace> = yield select(
+        selectCanManageWorkspace,
+    );
 
     const enableAutomations = enableScheduling || enableAlerting;
 
@@ -31,7 +35,7 @@ export function* refreshAutomationsHandlers(ctx: DashboardContext, _cmd: Refresh
             PromiseFnReturnType<typeof loadDashboardUserAutomations>,
             PromiseFnReturnType<typeof loadWorkspaceAutomationsCount>,
         ] = yield all([
-            call(loadDashboardUserAutomations, ctx, dashboardId, user.login),
+            call(loadDashboardUserAutomations, ctx, dashboardId, user.login, !canManageAutomations),
             call(loadWorkspaceAutomationsCount, ctx),
         ]);
 

--- a/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailManagementDialog/components/DeleteScheduleConfirmDialog.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailManagementDialog/components/DeleteScheduleConfirmDialog.tsx
@@ -5,7 +5,11 @@ import { FormattedMessage, useIntl } from "react-intl";
 import { IAutomationMetadataObject, IAutomationMetadataObjectDefinition } from "@gooddata/sdk-model";
 import { convertError, GoodDataSdkError, useBackendStrict, useWorkspaceStrict } from "@gooddata/sdk-ui";
 import { ConfirmDialog } from "@gooddata/sdk-ui-kit";
-import { selectCurrentUser, useDashboardSelector } from "../../../../model/index.js";
+import {
+    selectCanManageWorkspace,
+    selectCurrentUser,
+    useDashboardSelector,
+} from "../../../../model/index.js";
 
 interface IDeleteScheduleConfirmDialogProps {
     scheduledEmail: IAutomationMetadataObject | IAutomationMetadataObjectDefinition;
@@ -21,6 +25,7 @@ export const DeleteScheduleConfirmDialog: React.FC<IDeleteScheduleConfirmDialogP
     const effectiveWorkspace = useWorkspaceStrict();
     const intl = useIntl();
     const currentUser = useDashboardSelector(selectCurrentUser);
+    const canManageAutomations = useDashboardSelector(selectCanManageWorkspace);
 
     const handleDeleteScheduledMail = async () => {
         const alertCreatorId = scheduledEmail.createdBy?.login;
@@ -29,10 +34,11 @@ export const DeleteScheduleConfirmDialog: React.FC<IDeleteScheduleConfirmDialogP
             !!alertCreatorId && !!currentUserId && alertCreatorId === currentUserId;
         const automationService = effectiveBackend.workspace(effectiveWorkspace).automations();
 
-        // If schedule is created by current user, delete it, otherwise unsubscribe
-        const deleteMethod = isAlertCreatedByCurrentUser
-            ? automationService.deleteAutomation.bind(automationService)
-            : automationService.unsubscribeAutomation.bind(automationService);
+        // If schedule is created by current user, or user has permissions to manage automations, delete it, otherwise unsubscribe
+        const deleteMethod =
+            canManageAutomations || isAlertCreatedByCurrentUser
+                ? automationService.deleteAutomation.bind(automationService)
+                : automationService.unsubscribeAutomation.bind(automationService);
 
         try {
             await deleteMethod(scheduledEmail.id!);


### PR DESCRIPTION
For users with workspace management permissions:
1. Retrieve all alerts and schedules associated with the dashboard, including those created by other users or where the current user is not a recipient
2. Grant the ability to delete any alert or schedule, regardless of its creator

risk: low
JIRA: F1-710

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** 🙏

---

Refer to [documentation](https://github.com/gooddata/gooddata-ui-sdk/blob/master/dev_docs/continuous_integration.md) to see how to run checks and tests in the pull request. This is the list of the most used commands:

```
extended test - backstop
```

```
extended test - tiger-cypress - integrated
extended test - tiger-cypress - isolated
extended test - tiger-cypress - record
```
