### PR TITLE
fix(pivot): render renamed row metric current name

### DIFF
--- a/libs/sdk-ui-pivot/src/impl/data/rowFactory.ts
+++ b/libs/sdk-ui-pivot/src/impl/data/rowFactory.ts
@@ -73,6 +73,7 @@ function getCell(
     rowIndex: number,
     rowHeader: SliceCol | SliceMeasureCol | MixedHeadersCol | MixedValuesCol,
     rowHeaderIndex: number,
+    tableDescriptor: TableDescriptor,
     intl: IntlShape,
 ): {
     field: string;
@@ -87,11 +88,20 @@ function getCell(
         isSubtotal: false,
     };
 
-    if (isResultAttributeHeader(rowHeaderDataItem) || isResultMeasureHeader(rowHeaderDataItem)) {
+    if (isResultAttributeHeader(rowHeaderDataItem)) {
         return {
             ...cell,
             value: valueWithEmptyHandling(
                 getMappingHeaderFormattedName(rowHeaderDataItem),
+                emptyHeaderTitleFromIntl(intl),
+            ),
+        };
+    } else if (isResultMeasureHeader(rowHeaderDataItem)) {
+        const measureDescriptor = tableDescriptor.getMeasures()[rowHeaderDataItem.measureHeaderItem.order];
+        return {
+            ...cell,
+            value: valueWithEmptyHandling(
+                measureDescriptor.measureHeaderItem.name,
                 emptyHeaderTitleFromIntl(intl),
             ),
         };
@@ -140,6 +150,7 @@ export function getRow(
             rowIndex,
             rowHeader,
             rowHeaderIndex,
+            tableDescriptor,
             intl,
         );
         if (isSubtotal) {
@@ -160,6 +171,7 @@ export function getRow(
             rowIndex,
             rowHeader,
             rowHeader.index,
+            tableDescriptor,
             intl,
         );
 


### PR DESCRIPTION
Name from measureHeaderItem.name was used to render the metric name when metrics are placed in rows dimension. The object contained the original metric name for metrics created via Metric editor. When user renamed the metric in AD bucket, the name alias was not used. The reason for the original metric being there is due to some complex logic in dataView facade mapper. The name is being resolved because Tiger backend returns only order index of the metric but for custom metrics, it returns also its name. This name then bubbled to the table row.

Instead, the name from tableDescriptor measure is used instead now. Descriptor contains the currently applicable name for the measure, either the one returned by backend or one resolved from buckets (title, then alias if set by user). The same approach is used by series column header renderer where the renamed custom metric name was rendered correctly.

JIRA: LX-508
risk: low

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** 🙏

---

Refer to [documentation](https://github.com/gooddata/gooddata-ui-sdk/blob/master/dev_docs/continuous_integration.md) to see how to run checks and tests in the pull request. This is the list of the most used commands:

```
extended test - backstop
```

```
extended test - tiger-cypress - integrated
extended test - tiger-cypress - isolated
extended test - tiger-cypress - record
```
