### PR TITLE
fix: show % in alerts description

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/alerting/DefaultAlertingManagementDialog/DefaultAlertingManagementDialog.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/alerting/DefaultAlertingManagementDialog/DefaultAlertingManagementDialog.tsx
@@ -16,6 +16,7 @@ import { Alerts } from "./components/AlertsList.js";
 import { DeleteAlertConfirmDialog } from "./components/DeleteAlertConfirmDialog.js";
 import { PauseAlertRunner } from "./components/PauseAlertRunner.js";
 import { GoodDataSdkError } from "@gooddata/sdk-ui";
+import { useDashboardSelector, selectIsWhiteLabeled } from "../../../model/index.js";
 
 /**
  * @alpha
@@ -34,6 +35,7 @@ export const AlertingManagementDialog: React.FC<IAlertingManagementDialogProps> 
     const [alertToDelete, setAlertToDelete] = useState<IAutomationMetadataObject | null>(null);
     const [alertToPause, setAlertToPause] = useState<[IAutomationMetadataObject, boolean] | null>(null);
     const intl = useIntl();
+    const isWhiteLabeled = useDashboardSelector(selectIsWhiteLabeled);
 
     const handleAlertDelete = useCallback((alert: IAutomationMetadataObject) => {
         setAlertToDelete(alert);
@@ -109,11 +111,13 @@ export const AlertingManagementDialog: React.FC<IAlertingManagementDialogProps> 
                 </div>
                 <div className="gd-content-divider"></div>
                 <div className="gd-buttons">
-                    <Hyperlink
-                        text={intl.formatMessage({ id: helpTextId })}
-                        href="https://www.gooddata.com/docs/cloud/create-dashboards/automation/alerts/"
-                        iconClass="gd-icon-circle-question"
-                    />
+                    {!isWhiteLabeled ? (
+                        <Hyperlink
+                            text={intl.formatMessage({ id: helpTextId })}
+                            href="https://www.gooddata.com/docs/cloud/create-dashboards/automation/alerts/"
+                            iconClass="gd-icon-circle-question"
+                        />
+                    ) : null}
                     <Button
                         onClick={onClose}
                         className="gd-button-secondary s-close-button"

--- a/libs/sdk-ui-dashboard/src/presentation/alerting/DefaultAlertingManagementDialog/components/Alert.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/alerting/DefaultAlertingManagementDialog/components/Alert.tsx
@@ -19,6 +19,7 @@ import { useAlertValidation } from "../../../widget/insight/configuration/Insigh
 import {
     getAlertThreshold,
     getOperatorTitle,
+    getValueSuffix,
 } from "../../../widget/insight/configuration/InsightAlertConfig/utils.js";
 
 interface IAlertProps {
@@ -62,7 +63,8 @@ export const Alert: React.FC<IAlertProps> = (props) => {
     const insightWidget = isInsightWidget(widget) ? widget : undefined;
     const widgetName = insightWidget?.title ?? "";
 
-    const subtitle = [`${getOperatorTitle(intl, alert.alert)} ${threshold}`, widgetName]
+    const valueSuffix = getValueSuffix(alert.alert) ?? "";
+    const subtitle = [`${getOperatorTitle(intl, alert.alert)} ${threshold}${valueSuffix}`, widgetName]
         .filter(Boolean)
         .join(" • ");
 

--- a/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/DefaultScheduledEmailDialog.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/DefaultScheduledEmailDialog.tsx
@@ -28,6 +28,7 @@ import {
     selectEntitlementMaxAutomationRecipients,
     selectEntitlementMinimumRecurrenceMinutes,
     selectIsCrossFiltering,
+    selectIsWhiteLabeled,
 } from "../../../model/index.js";
 import { IScheduledEmailDialogProps } from "../types.js";
 import { getDefaultCronExpression, useEditScheduledEmail } from "./hooks/useEditScheduledEmail.js";
@@ -71,6 +72,8 @@ export function ScheduledMailDialogRenderer({
     const [scheduledEmailToDelete, setScheduledEmailToDelete] = useState<
         IAutomationMetadataObject | IAutomationMetadataObjectDefinition | null
     >(null);
+
+    const isWhiteLabeled = useDashboardSelector(selectIsWhiteLabeled);
 
     const handleScheduleDeleteSuccess = () => {
         onDeleteSuccess?.();
@@ -155,11 +158,13 @@ export function ScheduledMailDialogRenderer({
                         showProgressIndicator={isSavingScheduledEmail}
                         footerLeftRenderer={() => (
                             <div className="gd-notifications-channels-dialog-footer-link">
-                                <Hyperlink
-                                    text={intl.formatMessage({ id: helpTextId })}
-                                    href="https://www.gooddata.com/docs/cloud/create-dashboards/automation/scheduled-exports/#ScheduleExportsinDashboards-ScheduleExport"
-                                    iconClass="gd-icon-circle-question"
-                                />
+                                {!isWhiteLabeled ? (
+                                    <Hyperlink
+                                        text={intl.formatMessage({ id: helpTextId })}
+                                        href="https://www.gooddata.com/docs/cloud/create-dashboards/automation/scheduled-exports/#ScheduleExportsinDashboards-ScheduleExport"
+                                        iconClass="gd-icon-circle-question"
+                                    />
+                                ) : null}
                                 {scheduledExportToEdit ? (
                                     <Button
                                         className="gd-button-link-dimmed"

--- a/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailManagementDialog/DefaultScheduledEmailManagementDialog.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailManagementDialog/DefaultScheduledEmailManagementDialog.tsx
@@ -16,6 +16,7 @@ import {
     useDashboardSelector,
     DEFAULT_MAX_AUTOMATIONS,
     selectCanCreateAutomation,
+    selectIsWhiteLabeled,
 } from "../../../model/index.js";
 import { messages } from "../../../locales.js";
 import { isMobileView } from "../DefaultScheduledEmailDialog/utils/responsive.js";
@@ -41,6 +42,7 @@ export const ScheduledEmailManagementDialog: React.FC<IScheduledEmailManagementD
     const currentUser = useDashboardSelector(selectCurrentUser);
     const maxAutomationsEntitlement = useDashboardSelector(selectEntitlementMaxAutomations);
     const unlimitedAutomationsEntitlement = useDashboardSelector(selectEntitlementUnlimitedAutomations);
+    const isWhiteLabeled = useDashboardSelector(selectIsWhiteLabeled);
     const maxAutomations = parseInt(maxAutomationsEntitlement?.value ?? DEFAULT_MAX_AUTOMATIONS, 10);
     const intl = useIntl();
 
@@ -108,11 +110,13 @@ export const ScheduledEmailManagementDialog: React.FC<IScheduledEmailManagementD
                 </div>
                 <div className="gd-content-divider"></div>
                 <div className="gd-buttons">
-                    <Hyperlink
-                        text={intl.formatMessage({ id: helpTextId })}
-                        href="https://www.gooddata.com/docs/cloud/create-dashboards/automation/scheduled-exports/#ScheduleExportsinDashboards-ScheduleExport"
-                        iconClass="gd-icon-circle-question"
-                    />
+                    {!isWhiteLabeled ? (
+                        <Hyperlink
+                            text={intl.formatMessage({ id: helpTextId })}
+                            href="https://www.gooddata.com/docs/cloud/create-dashboards/automation/scheduled-exports/#ScheduleExportsinDashboards-ScheduleExport"
+                            iconClass="gd-icon-circle-question"
+                        />
+                    ) : null}
                     <Button
                         onClick={onClose}
                         className="gd-button-secondary s-close-button"

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/configuration/InsightAlertConfig/AlertsListItem.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/configuration/InsightAlertConfig/AlertsListItem.tsx
@@ -6,7 +6,7 @@ import { useTheme } from "@gooddata/sdk-ui-theme-provider";
 import { Icon } from "@gooddata/sdk-ui-kit";
 import cx from "classnames";
 import { AlertActionsDropdown } from "./AlertActionsDropdown.js";
-import { getAlertThreshold, getOperatorTitle } from "./utils.js";
+import { getAlertThreshold, getOperatorTitle, getValueSuffix } from "./utils.js";
 import { gdColorNegative } from "../../../../constants/colors.js";
 import { useAlertValidation } from "./hooks/useAlertValidation.js";
 import {
@@ -33,7 +33,10 @@ export const AlertsListItem: React.FC<IAlertsListItemProps> = ({
     const theme = useTheme();
     const intl = useIntl();
     const isPaused = alert.alert?.trigger?.state === "PAUSED";
-    const description = `${getOperatorTitle(intl, alert.alert)} ${getAlertThreshold(alert.alert)}`;
+    const valueSuffix = getValueSuffix(alert.alert) ?? "";
+    const description = `${getOperatorTitle(intl, alert.alert)} ${getAlertThreshold(
+        alert.alert,
+    )}${valueSuffix}`;
     const { isValid } = useAlertValidation(alert);
     const currentUser = useDashboardSelector(selectCurrentUser);
     const canManageWorkspace = useDashboardSelector(selectCanManageWorkspace);


### PR DESCRIPTION
If value of the alert represents percents,
show % in the description of the alert.

Do not show links in alerting / scheduling dialogs for white labeled domains.

risk: low
JIRA: F1-739

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** 🙏

---

Refer to [documentation](https://github.com/gooddata/gooddata-ui-sdk/blob/master/dev_docs/continuous_integration.md) to see how to run checks and tests in the pull request. This is the list of the most used commands:

```
extended test - backstop
```

```
extended test - tiger-cypress - integrated
extended test - tiger-cypress - isolated
extended test - tiger-cypress - record
```
