### PR TITLE
fix: propagate SDK version to FeatureHub

### DIFF
--- a/libs/api-client-tiger/api/api-client-tiger.api.md
+++ b/libs/api-client-tiger/api/api-client-tiger.api.md
@@ -7646,6 +7646,7 @@ export type FeatureContext = {
     organizationId: string;
     earlyAccessValues: string[];
     tier: string;
+    jsSdkVersion: string;
 };
 
 // @public

--- a/libs/api-client-tiger/src/profile.ts
+++ b/libs/api-client-tiger/src/profile.ts
@@ -6,6 +6,7 @@ export type FeatureContext = {
     organizationId: string;
     earlyAccessValues: string[];
     tier: string;
+    jsSdkVersion: string;
 };
 
 export interface ILiveFeatures {

--- a/libs/sdk-backend-tiger/src/backend/features/hub.ts
+++ b/libs/sdk-backend-tiger/src/backend/features/hub.ts
@@ -104,6 +104,10 @@ async function getFeatureHubData(
         featureHubFlags.push(`tier=${encodeURIComponent(context.tier)}`);
     }
 
+    if (context.jsSdkVersion) {
+        featureHubFlags.push(`jsSdkVersion=${encodeURIComponent(context.jsSdkVersion)}`);
+    }
+
     return axios.get("/features", {
         method: "GET",
         baseURL: host,

--- a/libs/sdk-backend-tiger/src/backend/features/index.ts
+++ b/libs/sdk-backend-tiger/src/backend/features/index.ts
@@ -14,9 +14,12 @@ import { ITigerFeatureFlags, DefaultFeatureFlags } from "../uiFeatures.js";
 
 import { getFeatureHubFeatures } from "./hub.js";
 import { getStaticFeatures } from "./static.js";
+import { LIB_VERSION } from "../../__version.js";
 
 const getKeyFromContext = (wsContext?: Partial<FeatureContext>): string => {
-    return `${wsContext?.organizationId}-${wsContext?.earlyAccessValues?.join(",")}`;
+    return `${wsContext?.organizationId}-${wsContext?.tier}-${
+        wsContext?.jsSdkVersion
+    }-${wsContext?.earlyAccessValues?.join(",")}`;
 };
 const responseMap: LRUCache<string, Promise<ITigerFeatureFlags>> = new LRUCache<
     string,
@@ -32,20 +35,24 @@ export class TigerFeaturesService {
         profile?: IUserProfile,
         wsContext?: Partial<FeatureContext>,
     ): Promise<ITigerFeatureFlags> {
-        const cachedResponse = responseMap.get(getKeyFromContext(wsContext));
+        const contextWithVersion: Partial<FeatureContext> = {
+            ...wsContext,
+            jsSdkVersion: LIB_VERSION,
+        };
+        const cachedResponse = responseMap.get(getKeyFromContext(contextWithVersion));
         if (cachedResponse) {
             return cachedResponse;
         }
         const response = this.authCall(async (client) => {
             const prof = profile || (await client.profile.getCurrent());
-            const results = await loadFeatures(prof, wsContext);
+            const results = await loadFeatures(prof, contextWithVersion);
 
             return {
                 ...DefaultFeatureFlags,
                 ...results,
             };
         });
-        responseMap.set(getKeyFromContext(wsContext), response);
+        responseMap.set(getKeyFromContext(contextWithVersion), response);
         return response;
     }
 }
@@ -78,8 +85,12 @@ export function pickContext(
     attributes: Partial<DeclarativeWorkspace> | undefined,
     organizationId: string | undefined,
     entitlements: ApiEntitlement[],
+    jsSdkVersion?: string,
 ): Partial<FeatureContext> {
-    const context: Partial<FeatureContext> = {};
+    const context: Partial<FeatureContext> = {
+        jsSdkVersion: jsSdkVersion ?? LIB_VERSION,
+    };
+
     const tier = getOrganizationTier(entitlements);
 
     if (attributes?.earlyAccessValues !== undefined) {

--- a/libs/sdk-backend-tiger/src/backend/features/test/hub.test.ts
+++ b/libs/sdk-backend-tiger/src/backend/features/test/hub.test.ts
@@ -21,10 +21,11 @@ describe("live features", () => {
         earlyAccessValues: string[] = [],
         organizationId = "",
         tier = "",
+        jsSdkVersion = "",
     ): ILiveFeatures["live"] {
         return {
             configuration: { host: "/", key: "" },
-            context: { earlyAccessValues, organizationId, tier },
+            context: { earlyAccessValues, organizationId, tier, jsSdkVersion },
         };
     }
 
@@ -75,13 +76,13 @@ describe("live features", () => {
 
         await getFeatureHubFeatures(
             createFeatures(),
-            pickContext({ earlyAccessValues: ["omega"] }, "test-org", []),
+            pickContext({ earlyAccessValues: ["omega"] }, "test-org", [], "1.0.0"),
         );
         expect(axiosGetSpy).toHaveBeenCalledWith("/features", {
             baseURL: "/",
             headers: {
                 "Content-type": "application/json",
-                "X-FeatureHub": "organizationId=test-org,earlyAccess=omega",
+                "X-FeatureHub": "organizationId=test-org,earlyAccess=omega,jsSdkVersion=1.0.0",
                 "if-none-match": expect.anything(),
             },
             method: "GET",
@@ -94,12 +95,12 @@ describe("live features", () => {
     it("call axios with context filled", async () => {
         mockReturn([]);
 
-        await getFeatureHubFeatures(createFeatures(["beta"], "org"));
+        await getFeatureHubFeatures(createFeatures(["beta"], "org", "", "1.0.0"));
         expect(axiosGetSpy).toHaveBeenCalledWith("/features", {
             baseURL: "/",
             headers: {
                 "Content-type": "application/json",
-                "X-FeatureHub": "organizationId=org,earlyAccess=beta",
+                "X-FeatureHub": "organizationId=org,earlyAccess=beta,jsSdkVersion=1.0.0",
                 "if-none-match": expect.anything(),
             },
             method: "GET",
@@ -114,13 +115,13 @@ describe("live features", () => {
 
         await getFeatureHubFeatures(
             createFeatures(["beta"], "org"),
-            pickContext({ earlyAccessValues: ["omega"] }, "test-org", entitlements),
+            pickContext({ earlyAccessValues: ["omega"] }, "test-org", entitlements, "1.0.0"),
         );
         expect(axiosGetSpy).toHaveBeenCalledWith("/features", {
             baseURL: "/",
             headers: {
                 "Content-type": "application/json",
-                "X-FeatureHub": "organizationId=test-org,earlyAccess=omega,tier=TRIAL",
+                "X-FeatureHub": "organizationId=test-org,earlyAccess=omega,tier=TRIAL,jsSdkVersion=1.0.0",
                 "if-none-match": expect.anything(),
             },
             method: "GET",

--- a/libs/sdk-backend-tiger/src/backend/workspace/settings/index.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/settings/index.ts
@@ -13,6 +13,7 @@ import { unwrapSettingContent } from "../../../convertors/fromBackend/SettingsCo
 import { TigerSettingsService, mapTypeToKey } from "../../settings/index.js";
 import { GET_OPTIMIZED_WORKSPACE_PARAMS } from "../constants.js";
 import { FeatureContext, isLiveFeatures, isStaticFeatures } from "@gooddata/api-client-tiger";
+import { LIB_VERSION } from "../../../__version.js";
 
 export class TigerWorkspaceSettings
     extends TigerSettingsService<IWorkspaceSettings>
@@ -191,7 +192,9 @@ export function getSettingsForCurrentUser(
 
         const resolvedSettings: ISettings = await resolveSettings(authCall, workspace);
 
-        const context: Partial<FeatureContext> = {};
+        const context: Partial<FeatureContext> = {
+            jsSdkVersion: LIB_VERSION,
+        };
 
         const staticFeaturesEarlyAccess = isStaticFeatures(profile.features)
             ? profile.features?.static?.context?.earlyAccessValues ?? []


### PR DESCRIPTION
Propagate GoodData.UI SDK version to FeatureHub, so we can use it as a split rule.

JIRA: F1-815

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** 🙏

---

Refer to [documentation](https://github.com/gooddata/gooddata-ui-sdk/blob/master/dev_docs/continuous_integration.md) to see how to run checks and tests in the pull request. This is the list of the most used commands:

```
extended test - backstop
```

```
extended test - tiger-cypress - integrated
extended test - tiger-cypress - isolated
extended test - tiger-cypress - record
```
