### PR TITLE
feat: defer catalog loading until dashboard is fully executed

### DIFF
--- a/libs/sdk-backend-tiger/src/backend/workspace/attributes/index.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/attributes/index.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2022 GoodData Corporation
+// (C) 2019-2024 GoodData Corporation
 import {
     IElementsQueryFactory,
     IWorkspaceAttributesService,
@@ -28,7 +28,6 @@ import {
     AfmValidObjectsQuery,
     AttributeItem,
 } from "@gooddata/api-client-tiger";
-import flatMap from "lodash/flatMap.js";
 import { invariant } from "ts-invariant";
 
 import {
@@ -61,12 +60,37 @@ export class TigerWorkspaceAttributes implements IWorkspaceAttributesService {
     };
 
     public getAttributeDisplayForms(refs: ObjRef[]): Promise<IAttributeDisplayFormMetadataObject[]> {
-        return this.authCall(async (client) => {
-            const allAttributes = await loadAttributes(client, this.workspace);
+        if (refs.length === 0) {
+            return Promise.resolve([]);
+        }
 
-            return flatMap(allAttributes, (attr) => attr.displayForms).filter((df) =>
-                refs.find((ref) => areObjRefsEqual(ref, df.ref)),
-            );
+        return this.authCall(async (client) => {
+            const filter = refs.map((ref: any) => `id==${ref.identifier}`).join(",");
+            const allDisplayForms = await client.entities.getAllEntitiesLabels({
+                include: ["attribute"],
+                workspaceId: this.workspace,
+                origin: "ALL",
+                filter,
+            });
+            const result = allDisplayForms?.data?.data;
+
+            return result?.map((item) => ({
+                attribute: {
+                    identifier: item.relationships?.attribute?.data?.id || "",
+                    type: item.relationships?.attribute?.data?.type || "attribute",
+                },
+                ref: { identifier: item.id, type: "displayForm" },
+                title: item?.attributes?.title || "",
+                description: item?.attributes?.description || "",
+                tags: item?.attributes?.tags,
+                primary: item?.attributes?.primary,
+                deprecated: false,
+                uri: item.id,
+                type: "displayForm", // item.type is "label"
+                production: true,
+                unlisted: false,
+                id: item.id,
+            }));
         });
     }
 

--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -7185,6 +7185,9 @@ export const selectCatalogDateDatasets: DashboardSelector<ICatalogDateDataset[]>
 // @public (undocumented)
 export const selectCatalogFacts: DashboardSelector<ICatalogFact[]>;
 
+// @alpha (undocumented)
+export const selectCatalogIsLoaded: DashboardSelector<boolean>;
+
 // @public (undocumented)
 export const selectCatalogMeasures: DashboardSelector<ICatalogMeasure[]>;
 

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/initializeDashboardHandler/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/initializeDashboardHandler/index.ts
@@ -14,7 +14,6 @@ import { dateFilterConfigActions } from "../../../store/dateFilterConfig/index.j
 import { DateFilterMergeResult, mergeDateFilterConfigWithOverrides } from "./mergeDateFilterConfigs.js";
 import { resolvePermissions } from "./resolvePermissions.js";
 import { permissionsActions } from "../../../store/permissions/index.js";
-import { loadCatalog } from "./loadCatalog.js";
 import { loadDashboardAlerts } from "./loadDashboardAlerts.js";
 import { catalogActions } from "../../../store/catalog/index.js";
 import { alertsActions } from "../../../store/alerts/index.js";
@@ -41,7 +40,7 @@ import {
     actionsToInitializeNewDashboard,
 } from "../common/stateInitializers.js";
 import { executionResultsActions } from "../../../store/executionResults/index.js";
-import { createDisplayFormMapFromCatalog } from "../../../../_staging/catalog/displayFormMap.js";
+import { createDisplayFormMap } from "../../../../_staging/catalog/displayFormMap.js";
 import { getPrivateContext } from "../../../store/_infra/contexts.js";
 import { accessibleDashboardsActions } from "../../../store/accessibleDashboards/index.js";
 import { loadAccessibleDashboardList } from "./loadAccessibleDashboardList.js";
@@ -163,7 +162,6 @@ function* loadExistingDashboard(
         call(resolveDashboardConfig, ctx, cmd),
         call(resolvePermissions, ctx, cmd),
         call(resolveEntitlements, ctx),
-        call(loadCatalog, ctx, cmd),
         call(loadDashboardAlerts, ctx),
         call(loadUser, ctx),
         call(loadDashboardList, ctx),
@@ -182,7 +180,6 @@ function* loadExistingDashboard(
         config,
         permissions,
         entitlements,
-        catalog,
         alerts,
         user,
         listedDashboards,
@@ -196,7 +193,6 @@ function* loadExistingDashboard(
         SagaReturnType<typeof resolveDashboardConfig>,
         SagaReturnType<typeof resolvePermissions>,
         PromiseFnReturnType<typeof resolveEntitlements>,
-        PromiseFnReturnType<typeof loadCatalog>,
         PromiseFnReturnType<typeof loadDashboardAlerts>,
         PromiseFnReturnType<typeof loadUser>,
         PromiseFnReturnType<typeof loadDashboardList>,
@@ -229,8 +225,8 @@ function* loadExistingDashboard(
         insights,
         config.settings,
         effectiveDateFilterConfig.config,
-        catalog.dateDatasets(),
-        createDisplayFormMapFromCatalog(catalog),
+        [],
+        createDisplayFormMap([], []),
         cmd.payload.persistedDashboard,
     );
 
@@ -253,11 +249,6 @@ function* loadExistingDashboard(
             userActions.setUser(user),
             permissionsActions.setPermissions(permissions),
             catalogActions.setCatalogItems({
-                attributes: catalog.attributes(),
-                dateDatasets: catalog.dateDatasets(),
-                facts: catalog.facts(),
-                measures: catalog.measures(),
-                attributeHierarchies: catalog.attributeHierarchies(),
                 dateHierarchyTemplates: dateHierarchyTemplates,
             }),
             ...initActions,
@@ -306,32 +297,26 @@ function* initializeNewDashboard(
         config,
         permissions,
         entitlements,
-        catalog,
         user,
         listedDashboards,
         accessibleDashboards,
         legacyDashboards,
-        dateHierarchyTemplates,
     ]: [
         SagaReturnType<typeof resolveDashboardConfig>,
         SagaReturnType<typeof resolvePermissions>,
         PromiseFnReturnType<typeof resolveEntitlements>,
-        PromiseFnReturnType<typeof loadCatalog>,
         PromiseFnReturnType<typeof loadUser>,
         PromiseFnReturnType<typeof loadDashboardList>,
         PromiseFnReturnType<typeof loadAccessibleDashboardList>,
         PromiseFnReturnType<typeof loadLegacyDashboards>,
-        PromiseFnReturnType<typeof loadDateHierarchyTemplates>,
     ] = yield all([
         call(resolveDashboardConfig, ctx, cmd),
         call(resolvePermissions, ctx, cmd),
         call(resolveEntitlements, ctx),
-        call(loadCatalog, ctx, cmd),
         call(loadUser, ctx),
         call(loadDashboardList, ctx),
         call(loadAccessibleDashboardList, ctx),
         call(loadLegacyDashboards, ctx),
-        call(loadDateHierarchyTemplates, ctx),
         call(loadFilterViews, ctx),
     ]);
 
@@ -353,14 +338,6 @@ function* initializeNewDashboard(
             entitlementsActions.setEntitlements(entitlements),
             userActions.setUser(user),
             permissionsActions.setPermissions(permissions),
-            catalogActions.setCatalogItems({
-                attributes: catalog.attributes(),
-                dateDatasets: catalog.dateDatasets(),
-                facts: catalog.facts(),
-                measures: catalog.measures(),
-                attributeHierarchies: catalog.attributeHierarchies(),
-                dateHierarchyTemplates: dateHierarchyTemplates,
-            }),
             listedDashboardsActions.setListedDashboards(listedDashboards),
             accessibleDashboardsActions.setAccessibleDashboards(accessibleDashboards),
             legacyDashboardsActions.setLegacyDashboards(legacyDashboards),

--- a/libs/sdk-ui-dashboard/src/model/queryServices/queryWidgetFilters.ts
+++ b/libs/sdk-ui-dashboard/src/model/queryServices/queryWidgetFilters.ts
@@ -24,7 +24,7 @@ import {
     uriRef,
     isDashboardAttributeFilterReference,
     IKpiWidget,
-    ICatalogDateDataset,
+    //ICatalogDateDataset,
     IAttributeDisplayFormMetadataObject,
     IMetadataObject,
     isInsightWidget,
@@ -38,7 +38,7 @@ import { selectAllFiltersForWidgetByRef, selectWidgetByRef } from "../store/layo
 import { selectInsightByRef } from "../store/insights/insightsSelectors.js";
 import { invalidQueryArguments } from "../events/general.js";
 import compact from "lodash/compact.js";
-import { selectAllCatalogDateDatasetsMap } from "../store/catalog/catalogSelectors.js";
+//import { selectAllCatalogDateDatasetsMap } from "../store/catalog/catalogSelectors.js";
 import { DashboardState } from "../store/types.js";
 import { resolveDisplayFormMetadata } from "../utils/displayFormResolver.js";
 import { invariant } from "ts-invariant";
@@ -64,7 +64,7 @@ interface IFilterDisplayFormPair {
 
 interface IFilterDateDatasetPair {
     filter: IDateFilter;
-    dateDataset: ICatalogDateDataset | undefined;
+    dateDataset: ObjRef | undefined; //ICatalogDateDataset | undefined;
 }
 
 function* loadDisplayFormsForAttributeFilters(
@@ -91,16 +91,16 @@ function* loadDisplayFormsForAttributeFilters(
 }
 
 function selectDateDatasetsForDateFilters(
-    state: DashboardState,
+    _state: DashboardState,
     filters: IDateFilter[],
 ): IFilterDateDatasetPair[] {
-    const fromCatalog = selectAllCatalogDateDatasetsMap(state);
+    //    const fromCatalog = selectAllCatalogDateDatasetsMap(state);
 
     return filters.map((filter): IFilterDateDatasetPair => {
-        const dateDataset = fromCatalog.get(filterObjRef(filter));
+        //        const dateDataset = fromCatalog.get(filterObjRef(filter));
 
         return {
-            dateDataset,
+            dateDataset: filterObjRef(filter),
             filter,
         };
     });
@@ -218,9 +218,8 @@ function resolveWidgetDateFilterIgnore(
     const nonIgnoredCommonDateFilterDateDatasetPairs = commonDateFilterDateDatasetPairs.filter(
         ({ dateDataset }) => {
             return (
-                !!widget.dateDataSet &&
-                dateDataset &&
-                refMatchesMdObject(widget.dateDataSet, dateDataset.dataSet, "dataSet")
+                !!widget.dateDataSet && dateDataset && areObjRefsEqual(widget.dateDataSet, dateDataset)
+                //                refMatchesMdObject(widget.dateDataSet, dateDataset.dataSet, "dataSet")
             );
         },
     );
@@ -230,7 +229,8 @@ function resolveWidgetDateFilterIgnore(
                 dateDataset &&
                 widget.ignoreDashboardFilters
                     ?.filter(isDashboardDateFilterReference)
-                    .some((ignored) => refMatchesMdObject(ignored.dataSet, dateDataset.dataSet, "dataSet"));
+                    //.some((ignored) => refMatchesMdObject(ignored.dataSet, dateDataset.dataSet, "dataSet"));
+                    .some((ignored) => areObjRefsEqual(ignored.dataSet, dateDataset));
 
             return !matches;
         },
@@ -268,7 +268,8 @@ function resolveDateFilters(
         .filter((item) => !!item.dateDataset)
         .reduceRight((acc: IDateFilter[], curr) => {
             const alreadyPresent = acc.some((item) =>
-                refMatchesMdObject(filterObjRef(item), curr.dateDataset!.dataSet, "dataSet"),
+                //refMatchesMdObject(filterObjRef(item), curr.dateDataset!.dataSet, "dataSet"),
+                areObjRefsEqual(filterObjRef(item), curr.dateDataset),
             );
 
             if (!alreadyPresent) {

--- a/libs/sdk-ui-dashboard/src/model/store/catalog/catalogReducers.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/catalog/catalogReducers.ts
@@ -14,12 +14,12 @@ import { CatalogState } from "./catalogState.js";
 type CatalogReducer<A extends Action> = CaseReducer<CatalogState, A>;
 
 export interface SetCatalogItemsPayload {
-    attributes: ICatalogAttribute[];
-    measures: ICatalogMeasure[];
-    facts: ICatalogFact[];
-    dateDatasets: ICatalogDateDataset[];
-    attributeHierarchies: ICatalogAttributeHierarchy[];
-    dateHierarchyTemplates: IDateHierarchyTemplate[];
+    attributes?: ICatalogAttribute[];
+    measures?: ICatalogMeasure[];
+    facts?: ICatalogFact[];
+    dateDatasets?: ICatalogDateDataset[];
+    attributeHierarchies?: ICatalogAttributeHierarchy[];
+    dateHierarchyTemplates?: IDateHierarchyTemplate[];
 }
 
 const setCatalogItems: CatalogReducer<PayloadAction<SetCatalogItemsPayload>> = (state, action) => {

--- a/libs/sdk-ui-dashboard/src/model/store/catalog/catalogSelectors.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/catalog/catalogSelectors.ts
@@ -137,6 +137,13 @@ export const selectHasCatalogDateDatasets: DashboardSelector<boolean> = createSe
 );
 
 /**
+ * @alpha
+ */
+export const selectCatalogIsLoaded: DashboardSelector<boolean> = createSelector(selectSelf, (state) => {
+    return state.attributes !== undefined;
+});
+
+/**
  * @public
  */
 export const selectCatalogDateAttributes: DashboardSelector<ICatalogDateAttribute[]> = createSelector(

--- a/libs/sdk-ui-dashboard/src/model/store/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/index.ts
@@ -234,6 +234,7 @@ export {
 } from "./insights/insightsSelectors.js";
 export type { CatalogState } from "./catalog/catalogState.js";
 export {
+    selectCatalogIsLoaded,
     selectAttributesWithDrillDown,
     selectCatalogAttributes,
     selectCatalogAttributeDisplayForms,

--- a/libs/sdk-ui-dashboard/src/model/store/widgetDrills/widgetDrillSelectors.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/widgetDrills/widgetDrillSelectors.ts
@@ -72,6 +72,7 @@ import {
 } from "../backendCapabilities/backendCapabilitiesSelectors.js";
 import { existBlacklistHierarchyPredicate } from "../../utils/attributeHierarchyUtils.js";
 import { selectDisableDashboardCrossFiltering } from "../meta/metaSelectors.js";
+import { selectCatalogIsLoaded } from "../catalog/catalogSelectors.js";
 
 /**
  * @internal
@@ -628,17 +629,27 @@ export const selectConfiguredAndImplicitDrillsByWidgetRef: (
     ref: ObjRef,
 ) => DashboardSelector<IImplicitDrillWithPredicates[]> = createMemoizedSelector((ref: ObjRef) =>
     createSelector(
+        selectCatalogIsLoaded,
         selectValidConfiguredDrillsByWidgetRef(ref),
         selectImplicitDrillsDownByWidgetRef(ref),
         selectImplicitDrillsToUrlByWidgetRef(ref),
         selectCrossFilteringByWidgetRef(ref),
-        (configuredDrills, implicitDrillDownDrills, implicitDrillToUrlDrills, crossFiltering) => {
-            return compact([
-                ...configuredDrills,
-                ...implicitDrillDownDrills,
-                ...implicitDrillToUrlDrills,
-                crossFiltering,
-            ]);
+        (
+            catalogIsLoaded,
+            configuredDrills,
+            implicitDrillDownDrills,
+            implicitDrillToUrlDrills,
+            crossFiltering,
+        ) => {
+            // disable drilling until catalog is fully loaded
+            return catalogIsLoaded
+                ? compact([
+                      ...configuredDrills,
+                      ...implicitDrillDownDrills,
+                      ...implicitDrillToUrlDrills,
+                      crossFiltering,
+                  ])
+                : [];
         },
     ),
 );

--- a/libs/sdk-ui-dashboard/src/model/utils/displayFormResolver.ts
+++ b/libs/sdk-ui-dashboard/src/model/utils/displayFormResolver.ts
@@ -1,4 +1,4 @@
-// (C) 2021-2022 GoodData Corporation
+// (C) 2021-2024 GoodData Corporation
 import { ObjRef, IAttributeDisplayFormMetadataObject } from "@gooddata/sdk-model";
 import { SagaIterator } from "redux-saga";
 import { selectAllCatalogDisplayFormsMap } from "../store/catalog/catalogSelectors.js";

--- a/libs/sdk-ui-dashboard/src/presentation/dashboard/components/DashboardInner.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/dashboard/components/DashboardInner.tsx
@@ -6,6 +6,7 @@ import {
     useDashboardSelector,
     selectLocale,
     selectIsInEditMode,
+    selectCatalogIsLoaded,
     useDashboardAutomations,
 } from "../../../model/index.js";
 import { DashboardHeader } from "../DashboardHeader/DashboardHeader.js";
@@ -29,6 +30,7 @@ const overlayController = OverlayController.getInstance(DASHBOARD_HEADER_OVERLAY
 export const DashboardInner: React.FC<IDashboardProps> = (props) => {
     const locale = useDashboardSelector(selectLocale);
     const isEditMode = useDashboardSelector(selectIsInEditMode);
+    const isCatalogLoaded = useDashboardSelector(selectCatalogIsLoaded);
 
     const headerRef = useRef(null);
     const layoutRef = useRef(null);
@@ -47,6 +49,7 @@ export const DashboardInner: React.FC<IDashboardProps> = (props) => {
             <div
                 className={cx("component-root", {
                     "sdk-edit-mode-on": isEditMode,
+                    "catalog-is-loaded": isCatalogLoaded,
                 })}
             >
                 <DragLayerComponent />

--- a/libs/sdk-ui-dashboard/src/presentation/topBar/buttonBar/button/editButton/DefaultEditButton.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/topBar/buttonBar/button/editButton/DefaultEditButton.tsx
@@ -6,6 +6,7 @@ import { Bubble, BubbleHoverTrigger, Button, useMediaQuery } from "@gooddata/sdk
 import {
     selectIsDashboardLoading,
     selectIsInEditMode,
+    selectCatalogIsLoaded,
     switchToEditRenderMode,
     useDashboardDispatch,
     useDashboardSelector,
@@ -23,6 +24,7 @@ export function useEditButtonProps(): IEditButtonProps {
 
     const canEnterEdit = useDashboardSelector(selectCanEnterEditMode);
     const isDashboardLoading = useDashboardSelector(selectIsDashboardLoading);
+    const isCatalogLoaded = useDashboardSelector(selectCatalogIsLoaded);
     const isEditing = useDashboardSelector(selectIsInEditMode);
 
     const dispatch = useDashboardDispatch();
@@ -30,7 +32,7 @@ export function useEditButtonProps(): IEditButtonProps {
 
     return {
         isVisible: minWidthForEditing && !isEditing && canEnterEdit,
-        isEnabled: !isDashboardLoading,
+        isEnabled: !isDashboardLoading && isCatalogLoaded,
         onEditClick,
     };
 }

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/ViewModeDashboardInsight/Insight/useDashboardInsightDrills.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/ViewModeDashboardInsight/Insight/useDashboardInsightDrills.ts
@@ -1,4 +1,4 @@
-// (C) 2020-2022 GoodData Corporation
+// (C) 2020-2024 GoodData Corporation
 import { useCallback, useMemo } from "react";
 import isEqual from "lodash/isEqual.js";
 import {
@@ -10,6 +10,7 @@ import {
     selectConfiguredAndImplicitDrillsByWidgetRef,
     selectIsInEditMode,
     selectEnableKPIDashboardDrillFromAttribute,
+    selectCatalogIsLoaded,
 } from "../../../../../model/index.js";
 import { OnWidgetDrill } from "../../../../drill/types.js";
 import {
@@ -42,6 +43,7 @@ export const useDashboardInsightDrills = ({
     const drillTargets = useDashboardSelector(selectDrillTargetsByWidgetRef(widget.ref));
     const isDrillFromAttributeEnabled = useDashboardSelector(selectEnableKPIDashboardDrillFromAttribute);
     const disableDrillDownOnWidget = insight.insight.properties.controls?.disableDrillDown;
+    const isCatalogLoaded = useDashboardSelector(selectCatalogIsLoaded);
 
     const onPushData = useCallback(
         (data: IPushData): void => {
@@ -97,8 +99,9 @@ export const useDashboardInsightDrills = ({
           }
         : undefined;
 
+    // disable all drills until catalog is loaded
     return {
-        drillableItems,
+        drillableItems: isCatalogLoaded ? drillableItems : [],
         onPushData,
         onDrill,
     };


### PR DESCRIPTION
- replace full catalog loads on dash viewmode with targeted calls to
  only the displayforms needed
- defer drilling and edit mode switching until full catalog is loaded
- mark app with css class when catalog finishes loading (for e2e)

risk: high
JIRA: STL-851

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** 🙏

---

Refer to [documentation](https://github.com/gooddata/gooddata-ui-sdk/blob/master/dev_docs/continuous_integration.md) to see how to run checks and tests in the pull request. This is the list of the most used commands:

```
extended test - backstop
```

```
extended test - tiger-cypress - integrated
extended test - tiger-cypress - isolated
extended test - tiger-cypress - record
```