### PR TITLE
fix: do not use resize observer when threshold not specified

### DIFF
--- a/libs/sdk-ui-kit/src/Overlay/Overlay.tsx
+++ b/libs/sdk-ui-kit/src/Overlay/Overlay.tsx
@@ -100,7 +100,7 @@ export class Overlay<T = HTMLElement> extends React.Component<IOverlayProps<T>, 
     private alignmentTimeoutId: number;
     static contextType = OverlayContext;
     declare context: React.ContextType<typeof OverlayContext>;
-    private observer: ResizeObserver;
+    private observer: ResizeObserver | undefined;
 
     constructor(props: IOverlayProps<T>) {
         super(props);
@@ -140,7 +140,7 @@ export class Overlay<T = HTMLElement> extends React.Component<IOverlayProps<T>, 
 
         window.addEventListener("resize", this.resizeHandler);
 
-        this.observer.observe(this.overlayRef.current);
+        this.observer?.observe(this.overlayRef.current);
 
         this.addListeners(this.props);
 
@@ -172,7 +172,7 @@ export class Overlay<T = HTMLElement> extends React.Component<IOverlayProps<T>, 
 
         window.removeEventListener("resize", this.resizeHandler);
 
-        this.observer.disconnect();
+        this.observer?.disconnect();
 
         this.removeListeners(this.props);
 
@@ -459,7 +459,12 @@ export class Overlay<T = HTMLElement> extends React.Component<IOverlayProps<T>, 
         );
     };
 
-    private createResizeObserver() {
+    private createResizeObserver(): ResizeObserver | undefined {
+        // With 100% or more threshold, don't use ResizeObserver
+        if (this.props.resizeObserverThreshold >= 1) {
+            return undefined;
+        }
+
         return new ResizeObserver((entries) => {
             const newHeightCandidate = entries[0].contentRect.height;
             const heightDiffersByThreshold =


### PR DESCRIPTION
JIRA: F1-837
risk: low

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** 🙏

---

Refer to [documentation](https://github.com/gooddata/gooddata-ui-sdk/blob/master/dev_docs/continuous_integration.md) to see how to run checks and tests in the pull request. This is the list of the most used commands:

```
extended test - backstop
```

```
extended test - tiger-cypress - integrated
extended test - tiger-cypress - isolated
extended test - tiger-cypress - record
```
