### PR TITLE
fix: better handling of fast changing filter prop

### DIFF
--- a/libs/sdk-ui-filters/src/AttributeFilter/hooks/useAttributeFilterController.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilter/hooks/useAttributeFilterController.ts
@@ -12,6 +12,7 @@ import {
     IAbsoluteDateFilter,
     IAttributeDisplayFormMetadataObject,
     IAttributeElement,
+    IAttributeElements,
     IAttributeFilter,
     IRelativeDateFilter,
     isAttributeElementsByRef,
@@ -233,6 +234,17 @@ function useOnError(
 
 const EMPTY_LIMITING_VALIDATION_ITEMS: ObjRef[] = [];
 
+const areElementsEqual = (elementsA: IAttributeElements, elementsB: IAttributeElements) => {
+    return (
+        (isAttributeElementsByRef(elementsA) &&
+            isAttributeElementsByRef(elementsB) &&
+            isEqual([...elementsA.uris].sort(), [...elementsB.uris].sort())) ||
+        (isAttributeElementsByValue(elementsA) &&
+            isAttributeElementsByValue(elementsB) &&
+            isEqual([...elementsA.values].sort(), [...elementsB.values].sort()))
+    );
+};
+
 // omit local identifier and sort elements because they order may change depending on current displayAsLabel order
 const areFiltersEqual = (filterA: IAttributeFilter, filterB: IAttributeFilter) => {
     if (!filterA || !filterB) {
@@ -242,13 +254,8 @@ const areFiltersEqual = (filterA: IAttributeFilter, filterB: IAttributeFilter) =
     const dfsEqual = areObjRefsEqual(filterObjRef(filterA), filterObjRef(filterB));
     const elementsA = filterAttributeElements(filterA);
     const elementsB = filterAttributeElements(filterB);
-    const elementsEqual =
-        (isAttributeElementsByRef(elementsA) &&
-            isAttributeElementsByRef(elementsB) &&
-            isEqual([...elementsA.uris].sort(), [...elementsB.uris].sort())) ||
-        (isAttributeElementsByValue(elementsA) &&
-            isAttributeElementsByValue(elementsB) &&
-            isEqual([...elementsA.values].sort(), [...elementsB.values].sort()));
+    const elementsEqual = areElementsEqual(elementsA, elementsB);
+
     return typeEqual && dfsEqual && elementsEqual;
 };
 
@@ -324,7 +331,6 @@ function useInitOrReload(
         ) => {
             if (enableDuplicatedLabelValuesInAttributeFilter) {
                 return (
-                    handler.getInitStatus() !== "loading" &&
                     !areFiltersEqual(filter, handler.getFilter()) &&
                     !areFiltersEqual(filter, handler.getFilterToDisplay())
                 );


### PR DESCRIPTION
Remove check for status as it skipped fast changing filter prop. In AD metric filter is taken from extended ref. point. So it is out of sync for short time when filter is changed (waiting for PV loop). This fast changing filter prop was ignored because status check.

JIRA: LX-615
risk: low

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** 🙏

---

Refer to [documentation](https://github.com/gooddata/gooddata-ui-sdk/blob/master/dev_docs/continuous_integration.md) to see how to run checks and tests in the pull request. This is the list of the most used commands:

```
extended test - backstop
```

```
extended test - tiger-cypress - integrated
extended test - tiger-cypress - isolated
extended test - tiger-cypress - record
```
