### PR TITLE
fix: alert afm contains alias field that is not allowed

### DIFF
--- a/libs/sdk-backend-tiger/src/convertors/toBackend/AutomationConverter.ts
+++ b/libs/sdk-backend-tiger/src/convertors/toBackend/AutomationConverter.ts
@@ -121,7 +121,9 @@ const convertAlert = (alert: IAutomationAlert): JsonApiAutomationInAttributesAle
             auxMeasures: execution.auxMeasures?.map((measure) => {
                 return omit(convertMeasure(measure), "alias", "format", "title");
             }),
-            attributes: execution.attributes?.map(convertAttribute),
+            attributes: execution.attributes?.map((attribute, i) => {
+                return omit(convertAttribute(attribute, i), "alias");
+            }),
         },
         trigger: alert.trigger.mode,
     };


### PR DESCRIPTION
Creating alert failed after changing name of attribute in visualization

JIRA: F1-878

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** 🙏

---

Refer to [documentation](https://github.com/gooddata/gooddata-ui-sdk/blob/master/dev_docs/continuous_integration.md) to see how to run checks and tests in the pull request. This is the list of the most used commands:

```
extended test - backstop
```

```
extended test - tiger-cypress - integrated
extended test - tiger-cypress - isolated
extended test - tiger-cypress - record
```
