### PR TITLE
fix: separators

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1916,8 +1916,8 @@ importers:
   ../../libs/sdk-ui:
     dependencies:
       '@gooddata/number-formatter':
-        specifier: ^1.0.5
-        version: 1.0.5
+        specifier: ^1.0.6
+        version: 1.0.6
       '@gooddata/sdk-backend-spi':
         specifier: workspace:*
         version: link:../sdk-backend-spi
@@ -2203,8 +2203,8 @@ importers:
         specifier: 27.3.0
         version: 27.3.0(@ag-grid-community/core@27.3.0)(react-dom@18.2.0)(react@18.2.0)
       '@gooddata/number-formatter':
-        specifier: ^1.0.5
-        version: 1.0.5
+        specifier: ^1.0.6
+        version: 1.0.6
       '@gooddata/sdk-backend-spi':
         specifier: workspace:*
         version: link:../sdk-backend-spi
@@ -2408,8 +2408,8 @@ importers:
   ../../libs/sdk-ui-dashboard:
     dependencies:
       '@gooddata/number-formatter':
-        specifier: ^1.0.5
-        version: 1.0.5
+        specifier: ^1.0.6
+        version: 1.0.6
       '@gooddata/sdk-backend-base':
         specifier: workspace:*
         version: link:../sdk-backend-base
@@ -3315,8 +3315,8 @@ importers:
   ../../libs/sdk-ui-geo:
     dependencies:
       '@gooddata/number-formatter':
-        specifier: ^1.0.5
-        version: 1.0.5
+        specifier: ^1.0.6
+        version: 1.0.6
       '@gooddata/sdk-backend-spi':
         specifier: workspace:*
         version: link:../sdk-backend-spi
@@ -3490,8 +3490,8 @@ importers:
         specifier: ^2.0.1
         version: 2.1.1(react-dom@18.2.0)(react@18.2.0)
       '@gooddata/number-formatter':
-        specifier: ^1.0.5
-        version: 1.0.5
+        specifier: ^1.0.6
+        version: 1.0.6
       '@gooddata/sdk-backend-spi':
         specifier: workspace:*
         version: link:../sdk-backend-spi
@@ -3891,8 +3891,8 @@ importers:
         specifier: 27.3.0
         version: 27.3.0(@ag-grid-community/core@27.3.0)(react-dom@18.2.0)(react@18.2.0)
       '@gooddata/number-formatter':
-        specifier: ^1.0.5
-        version: 1.0.5
+        specifier: ^1.0.6
+        version: 1.0.6
       '@gooddata/sdk-backend-spi':
         specifier: workspace:*
         version: link:../sdk-backend-spi
@@ -4344,7 +4344,7 @@ importers:
         version: 5.62.0(eslint@8.55.0)(typescript@5.3.3)
       babel-loader:
         specifier: ^8.0.5
-        version: 8.3.0(@babel/core@7.23.6)(webpack@4.47.0)
+        version: 8.3.0(@babel/core@7.23.6)(webpack@5.89.0)
       babel-plugin-require-context-hook:
         specifier: ^1.0.0
         version: 1.0.0
@@ -4878,8 +4878,8 @@ importers:
   ../../libs/sdk-ui-vis-commons:
     dependencies:
       '@gooddata/number-formatter':
-        specifier: ^1.0.5
-        version: 1.0.5
+        specifier: ^1.0.6
+        version: 1.0.6
       '@gooddata/sdk-backend-spi':
         specifier: workspace:*
         version: link:../sdk-backend-spi
@@ -9297,8 +9297,8 @@ packages:
       - encoding
     dev: true
 
-  /@gooddata/number-formatter@1.0.5:
-    resolution: {integrity: sha512-2FmOOcpmfm79mJiSPvHUx5Z1qI+NEgA6PER1UrxHOlKuWX21Kp18g2N7Fih3808q2LjXsjWTTmIIwshlqtDB5A==}
+  /@gooddata/number-formatter@1.0.6:
+    resolution: {integrity: sha512-16+Sqa6SChAR2fHGOe3/aIiXJdBMfB0eU9XzXGCxx93Lbxud1RjddbIo1/t5E1eodf4Ga5QmLMKiKZOWNaLAiQ==}
     dependencies:
       lru-cache: 10.1.0
       ts-invariant: 0.7.5

--- a/libs/sdk-ui-charts/package.json
+++ b/libs/sdk-ui-charts/package.json
@@ -74,7 +74,7 @@
         "@ag-grid-community/all-modules": "27.3.0",
         "@ag-grid-community/core": "27.3.0",
         "@ag-grid-community/react": "27.3.0",
-        "@gooddata/number-formatter": "^1.0.5",
+        "@gooddata/number-formatter": "^1.0.6",
         "@gooddata/sdk-backend-spi": "workspace:*",
         "@gooddata/sdk-model": "workspace:*",
         "@gooddata/sdk-ui": "workspace:*",

--- a/libs/sdk-ui-dashboard/package.json
+++ b/libs/sdk-ui-dashboard/package.json
@@ -57,7 +57,7 @@
         "validate-locales-ci": "i18n-toolkit"
     },
     "dependencies": {
-        "@gooddata/number-formatter": "^1.0.5",
+        "@gooddata/number-formatter": "^1.0.6",
         "@gooddata/sdk-backend-base": "workspace:*",
         "@gooddata/sdk-backend-spi": "workspace:*",
         "@gooddata/sdk-model": "workspace:*",

--- a/libs/sdk-ui-geo/package.json
+++ b/libs/sdk-ui-geo/package.json
@@ -52,7 +52,7 @@
         "validate-locales-ci": "cd ../sdk-ui && npm run validate-locales-ci"
     },
     "dependencies": {
-        "@gooddata/number-formatter": "^1.0.5",
+        "@gooddata/number-formatter": "^1.0.6",
         "@gooddata/sdk-backend-spi": "workspace:*",
         "@gooddata/sdk-model": "workspace:*",
         "@gooddata/sdk-ui": "workspace:*",

--- a/libs/sdk-ui-kit/package.json
+++ b/libs/sdk-ui-kit/package.json
@@ -55,7 +55,7 @@
     },
     "dependencies": {
         "@aaronhayes/react-use-hubspot-form": "^2.0.1",
-        "@gooddata/number-formatter": "^1.0.5",
+        "@gooddata/number-formatter": "^1.0.6",
         "@gooddata/sdk-backend-spi": "workspace:*",
         "@gooddata/sdk-model": "workspace:*",
         "@gooddata/sdk-ui": "workspace:*",

--- a/libs/sdk-ui-pivot/package.json
+++ b/libs/sdk-ui-pivot/package.json
@@ -55,7 +55,7 @@
         "@ag-grid-community/all-modules": "27.3.0",
         "@ag-grid-community/core": "27.3.0",
         "@ag-grid-community/react": "27.3.0",
-        "@gooddata/number-formatter": "^1.0.5",
+        "@gooddata/number-formatter": "^1.0.6",
         "@gooddata/sdk-backend-spi": "workspace:*",
         "@gooddata/sdk-model": "workspace:*",
         "@gooddata/sdk-ui": "workspace:*",

--- a/libs/sdk-ui-vis-commons/package.json
+++ b/libs/sdk-ui-vis-commons/package.json
@@ -50,7 +50,7 @@
         "validate-locales-ci": "cd ../sdk-ui && npm run validate-locales-ci"
     },
     "dependencies": {
-        "@gooddata/number-formatter": "^1.0.5",
+        "@gooddata/number-formatter": "^1.0.6",
         "@gooddata/sdk-backend-spi": "workspace:*",
         "@gooddata/sdk-model": "workspace:*",
         "@gooddata/sdk-ui": "workspace:*",

--- a/libs/sdk-ui/package.json
+++ b/libs/sdk-ui/package.json
@@ -51,7 +51,7 @@
         "validate-locales-ci": "i18n-toolkit"
     },
     "dependencies": {
-        "@gooddata/number-formatter": "^1.0.5",
+        "@gooddata/number-formatter": "^1.0.6",
         "@gooddata/sdk-backend-spi": "workspace:*",
         "@gooddata/sdk-model": "workspace:*",
         "@gooddata/util": "workspace:*",


### PR DESCRIPTION
Do not reverse thousand separator string in the formatted result.

Empty strings should be considered as empty separators, and not fallback to default separators.

Default separators still should be used
in case of undefined/null separators.

risk: low
JIRA: F1-862

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** 🙏

---

Refer to [documentation](https://github.com/gooddata/gooddata-ui-sdk/blob/master/dev_docs/continuous_integration.md) to see how to run checks and tests in the pull request. This is the list of the most used commands:

```
extended test - backstop
```

```
extended test - tiger-cypress - integrated
extended test - tiger-cypress - isolated
extended test - tiger-cypress - record
```
