### PR TITLE
fix: comparative alert on vis can not trigger

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/configuration/InsightAlertConfig/test/transform.test.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/configuration/InsightAlertConfig/test/transform.test.ts
@@ -438,6 +438,43 @@ describe("alert transforms", () => {
             },
         ],
     };
+    const previousPeriodMetric2: AlertMetric = {
+        measure: {
+            measure: {
+                localIdentifier: "localPPMetric2",
+                title: "metric2",
+                format: "#,##0.00",
+                definition: {
+                    measureDefinition: {
+                        filters: [],
+                        item: {
+                            type: "measure",
+                            identifier: "simple_metric_2",
+                        },
+                    },
+                },
+            },
+        },
+        isPrimary: true,
+        comparators: [
+            {
+                comparator: AlertMetricComparatorType.PreviousPeriod,
+                isPrimary: true,
+                measure: {
+                    measure: {
+                        localIdentifier: "localMetric_pp_1",
+                        title: "metric_pp_1",
+                        definition: {
+                            previousPeriodMeasure: {
+                                measureIdentifier: "localMetric2",
+                                dateDataSets: [{ dataSet: { uri: "dateDataSetUri" }, periodsAgo: 1 }],
+                            },
+                        },
+                    },
+                },
+            },
+        ],
+    };
 
     const allMetrics = [
         simpleMetric1,
@@ -546,7 +583,7 @@ describe("alert transforms", () => {
             });
         });
 
-        it("transformAlertByMetric, relative and provide comparison metric", () => {
+        it("transformAlertByMetric, relative and provide comparison metric, relative isSecondary", () => {
             const res = transformAlertByMetric(allMetrics, baseRelative, previousPeriodMetric);
             expect(res).toEqual({
                 ...baseRelative,
@@ -605,6 +642,40 @@ describe("alert transforms", () => {
                         measures: [
                             previousPeriodMetric1.measure,
                             previousPeriodMetric1.comparators[0].measure,
+                        ],
+                    },
+                },
+            });
+        });
+
+        it("transformAlertByMetric, relative and provide comparison metric, normal and relative are isPrimary", () => {
+            const res = transformAlertByMetric(allMetrics, baseRelative, previousPeriodMetric2);
+            expect(res).toEqual({
+                ...baseRelative,
+                title: "metric2",
+                alert: {
+                    ...baseRelative.alert,
+                    condition: {
+                        ...baseRelative.alert.condition,
+                        measure: {
+                            operator: "CHANGE",
+                            left: {
+                                format: "#,##0.00",
+                                id: "localPPMetric2",
+                                title: "metric2",
+                            },
+                            right: {
+                                format: "#,##0.00",
+                                id: "localMetric_pp_1",
+                                title: "metric_pp_1",
+                            },
+                        },
+                    },
+                    execution: {
+                        ...baseRelative.alert.execution,
+                        measures: [
+                            previousPeriodMetric2.measure,
+                            previousPeriodMetric2.comparators[0].measure,
                         ],
                     },
                 },

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/configuration/InsightAlertConfig/utils/transformation.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/configuration/InsightAlertConfig/utils/transformation.ts
@@ -452,8 +452,13 @@ function transformRelativeCondition(
     periodMeasure: AlertMetricComparator | undefined,
     catalogMeasures?: ICatalogMeasure[],
 ) {
-    return {
-        ...(periodMeasure?.isPrimary && {
+    const isNormalSetup = measure.isPrimary && !periodMeasure?.isPrimary;
+    const isReverseSetup = !measure.isPrimary && periodMeasure?.isPrimary;
+
+    //NOTE: This is case primary for headline where normal measure is in secondary bucket
+    // and period measure is in primary bucket
+    if (isReverseSetup) {
+        return {
             left: {
                 id: periodMeasure.measure.measure.localIdentifier,
                 format: getMeasureFormat(periodMeasure.measure, catalogMeasures),
@@ -464,8 +469,13 @@ function transformRelativeCondition(
                 format: getMeasureFormat(measure.measure, catalogMeasures),
                 title: getMeasureTitle(measure.measure),
             },
-        }),
-        ...(!periodMeasure?.isPrimary && {
+        };
+    }
+
+    //NOTE: This is case for normal setup where normal measure is in primary bucket
+    // and period measure is in secondary bucket
+    if (isNormalSetup) {
+        return {
             left: {
                 id: measure.measure.measure.localIdentifier,
                 format: getMeasureFormat(measure.measure, catalogMeasures),
@@ -476,7 +486,22 @@ function transformRelativeCondition(
                 format: getMeasureFormat(periodMeasure?.measure, catalogMeasures),
                 title: periodMeasure?.measure ? getMeasureTitle(periodMeasure?.measure) : undefined,
             },
-        }),
+        };
+    }
+
+    //NOTE: This is case for normal setup where normal measure and period measure are
+    // in same bucket, primary or secondary, but same bucket
+    return {
+        left: {
+            id: measure.measure.measure.localIdentifier,
+            format: getMeasureFormat(measure.measure, catalogMeasures),
+            title: getMeasureTitle(measure.measure),
+        },
+        right: {
+            id: periodMeasure?.measure.measure.localIdentifier,
+            format: getMeasureFormat(periodMeasure?.measure, catalogMeasures),
+            title: periodMeasure?.measure ? getMeasureTitle(periodMeasure?.measure) : undefined,
+        },
     };
 }
 


### PR DESCRIPTION
Some comparative alert on Visualizations  can not trigger

risk: low
JIRA: F1-931

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** 🙏

---

Refer to [documentation](https://github.com/gooddata/gooddata-ui-sdk/blob/master/dev_docs/continuous_integration.md) to see how to run checks and tests in the pull request. This is the list of the most used commands:

```
extended test - backstop
```

```
extended test - tiger-cypress - integrated
extended test - tiger-cypress - isolated
extended test - tiger-cypress - record
```
