### PR TITLE
feat: adjust build scripts to be compatible with rush cache

### DIFF
--- a/libs/api-client-bear/src/__version.ts
+++ b/libs/api-client-bear/src/__version.ts
@@ -1,0 +1,6 @@
+// (C) 2021-2024 GoodData Corporation
+// The placeholders in this file are replaced by values
+// from package.json right after tsc build
+export const LIB_VERSION = "0.0.0";
+export const LIB_NAME = "LIB_NAME_PLACEHOLDER";
+export const LIB_DESCRIPTION = "LIB_DESCRIPTION_PLACEHOLDER";

--- a/libs/api-client-tiger/.gitignore
+++ b/libs/api-client-tiger/.gitignore
@@ -1,2 +1,0 @@
-# ignore the auxiliary file created during build to extract package version
-src/__version.ts

--- a/libs/api-client-tiger/scripts/build.sh
+++ b/libs/api-client-tiger/scripts/build.sh
@@ -2,19 +2,23 @@
 set -e
 
 _version() {
-    # prepare the auxiliary __version.ts file so that the code can read the package version as a constant
-    echo '// (C) 2021 GoodData Corporation' >src/__version.ts
-    echo '// DO NOT CHANGE THIS FILE, IT IS RE-GENERATED ON EVERY BUILD' >>src/__version.ts
-    node -p "'export const LIB_VERSION = ' + JSON.stringify(require('./package.json').version) + ';' +'\n\n' + 'export const LIB_NAME = ' + JSON.stringify(require('./package.json').name) + ';'" >>src/__version.ts
+    VERSION=$(node -p "require('./package.json').version")
+    NAME=$(node -p "require('./package.json').name")
+    DESCRIPTION=$(node -p "require('./package.json').description")
+    sed -i \
+        -e "s|\0.\0.\0|$VERSION|" \
+        -e "s|LIB_NAME_PLACEHOLDER|$NAME|" \
+        -e "s|LIB_DESCRIPTION_PLACEHOLDER|$DESCRIPTION|" \
+        esm/__version.js esm/__version.d.ts
 }
 
-_common-build() {
+_post-build() {
     _version
 }
 
 build() {
-    _common-build
     tsc -p tsconfig.json
+    _post-build
     npm run api-extractor
 }
 

--- a/libs/api-client-tiger/src/__version.ts
+++ b/libs/api-client-tiger/src/__version.ts
@@ -1,0 +1,6 @@
+// (C) 2021-2024 GoodData Corporation
+// The placeholders in this file are replaced by values
+// from package.json right after tsc build
+export const LIB_VERSION = "0.0.0";
+export const LIB_NAME = "LIB_NAME_PLACEHOLDER";
+export const LIB_DESCRIPTION = "LIB_DESCRIPTION_PLACEHOLDER";

--- a/libs/sdk-backend-bear/src/__version.ts
+++ b/libs/sdk-backend-bear/src/__version.ts
@@ -1,0 +1,6 @@
+// (C) 2021-2024 GoodData Corporation
+// The placeholders in this file are replaced by values
+// from package.json right after tsc build
+export const LIB_VERSION = "0.0.0";
+export const LIB_NAME = "LIB_NAME_PLACEHOLDER";
+export const LIB_DESCRIPTION = "LIB_DESCRIPTION_PLACEHOLDER";

--- a/libs/sdk-backend-tiger/.gitignore
+++ b/libs/sdk-backend-tiger/.gitignore
@@ -1,5 +1,2 @@
 .wiremock_containerid
 .wiremock/
-
-# ignore the auxiliary file created during build to extract package version
-src/__version.ts

--- a/libs/sdk-backend-tiger/scripts/build.sh
+++ b/libs/sdk-backend-tiger/scripts/build.sh
@@ -2,19 +2,23 @@
 set -e
 
 _version() {
-    # prepare the auxiliary __version.ts file so that the code can read the package version as a constant
-    echo '// (C) 2021 GoodData Corporation' >src/__version.ts
-    echo '// DO NOT CHANGE THIS FILE, IT IS RE-GENERATED ON EVERY BUILD' >>src/__version.ts
-    node -p "'export const LIB_VERSION = ' + JSON.stringify(require('./package.json').version) + ';' +'\n\n' + 'export const LIB_NAME = ' + JSON.stringify(require('./package.json').name) + ';'" >>src/__version.ts
+    VERSION=$(node -p "require('./package.json').version")
+    NAME=$(node -p "require('./package.json').name")
+    DESCRIPTION=$(node -p "require('./package.json').description")
+    sed -i \
+        -e "s|\0.\0.\0|$VERSION|" \
+        -e "s|LIB_NAME_PLACEHOLDER|$NAME|" \
+        -e "s|LIB_DESCRIPTION_PLACEHOLDER|$DESCRIPTION|" \
+        esm/__version.js esm/__version.d.ts
 }
 
-_common-build() {
+_post-build() {
     _version
 }
 
 build() {
-    _common-build
     tsc -p tsconfig.json
+    _post-build
     npm run api-extractor
 }
 

--- a/libs/sdk-backend-tiger/src/__version.ts
+++ b/libs/sdk-backend-tiger/src/__version.ts
@@ -1,0 +1,6 @@
+// (C) 2021-2024 GoodData Corporation
+// The placeholders in this file are replaced by values
+// from package.json right after tsc build
+export const LIB_VERSION = "0.0.0";
+export const LIB_NAME = "LIB_NAME_PLACEHOLDER";
+export const LIB_DESCRIPTION = "LIB_DESCRIPTION_PLACEHOLDER";

--- a/libs/sdk-ui-dashboard/.gitignore
+++ b/libs/sdk-ui-dashboard/.gitignore
@@ -1,5 +1,3 @@
 styles/css
-# ignore the auxiliary file created during build to extract package version
-src/__version.ts
 # ignore the NOTICE that gets copied here on publish, the source of truth is the root of the repo
 NOTICE

--- a/libs/sdk-ui-dashboard/scripts/build.sh
+++ b/libs/sdk-ui-dashboard/scripts/build.sh
@@ -1,11 +1,20 @@
 #!/usr/bin/env bash
 set -e
 
+
 _version() {
-    # prepare the auxiliary __version.ts file so that the code can read the package version as a constant
-    echo '// (C) 2021 GoodData Corporation' >src/__version.ts
-    echo '// DO NOT CHANGE THIS FILE, IT IS RE-GENERATED ON EVERY BUILD' >>src/__version.ts
-    node -p "'export const LIB_VERSION = ' + JSON.stringify(require('./package.json').version) + ';'" >>src/__version.ts
+    VERSION=$(node -p "require('./package.json').version")
+    NAME=$(node -p "require('./package.json').name")
+    DESCRIPTION=$(node -p "require('./package.json').description")
+    sed -i \
+        -e "s|\0.\0.\0|$VERSION|" \
+        -e "s|LIB_NAME_PLACEHOLDER|$NAME|" \
+        -e "s|LIB_DESCRIPTION_PLACEHOLDER|$DESCRIPTION|" \
+        esm/__version.js esm/__version.d.ts
+}
+
+_post-build() {
+    _version
 }
 
 _build_styles() {
@@ -22,15 +31,13 @@ _assets() {
 
 _common-build() {
     _assets
-
     _build_styles
-
-    _version
 }
 
 build() {
     _common-build
     tsc -p tsconfig.json
+    _post-build
     npm run api-extractor
 }
 

--- a/libs/sdk-ui-dashboard/src/__version.ts
+++ b/libs/sdk-ui-dashboard/src/__version.ts
@@ -1,0 +1,6 @@
+// (C) 2021-2024 GoodData Corporation
+// The placeholders in this file are replaced by values
+// from package.json right after tsc build
+export const LIB_VERSION = "0.0.0";
+export const LIB_NAME = "LIB_NAME_PLACEHOLDER";
+export const LIB_DESCRIPTION = "LIB_DESCRIPTION_PLACEHOLDER";

--- a/libs/sdk-ui-gen-ai/.gitignore
+++ b/libs/sdk-ui-gen-ai/.gitignore
@@ -1,5 +1,3 @@
 styles/css
-# ignore the auxiliary file created during build to extract package version
-src/__version.ts
 # ignore the NOTICE that gets copied here on publish, the source of truth is the root of the repo
 NOTICE

--- a/tools/app-toolkit/.gitignore
+++ b/tools/app-toolkit/.gitignore
@@ -1,6 +1,5 @@
 build
 test-plugin*
-src/__version.ts
 # ignore the NOTICE that gets copied here on publish, the source of truth is the root of the repo
 NOTICE
 

--- a/tools/app-toolkit/scripts/build.sh
+++ b/tools/app-toolkit/scripts/build.sh
@@ -1,12 +1,17 @@
 #!/usr/bin/env bash
 set -e
 
-# prepare the auxiliary __version.ts file so that the code can read the package version as a constant
-echo '// (C) 2021 GoodData Corporation' >src/__version.ts
-echo '// DO NOT CHANGE THIS FILE, IT IS RE-GENERATED ON EVERY BUILD' >>src/__version.ts
-node -p "'export const LIB_VERSION = ' + JSON.stringify(require('./package.json').version) + ';' +'\n\n' + 'export const LIB_DESCRIPTION =' + '\n    ' + JSON.stringify(require('./package.json').description) + ';' +'\n\n' + 'export const LIB_NAME = ' + JSON.stringify(require('./package.json').name) + ';'" >>src/__version.ts
 
-set -e
+_version() {
+    VERSION=$(node -p "require('./package.json').version")
+    NAME=$(node -p "require('./package.json').name")
+    DESCRIPTION=$(node -p "require('./package.json').description")
+    sed -i \
+        -e "s|\0.\0.\0|$VERSION|" \
+        -e "s|LIB_NAME_PLACEHOLDER|$NAME|" \
+        -e "s|LIB_DESCRIPTION_PLACEHOLDER|$DESCRIPTION|" \
+        esm/__version.js esm/__version.d.ts
+}
 
 PACKAGE_DIR="$(echo $(cd $(dirname $0)/.. && pwd -P))"
 DIST_DIR="${PACKAGE_DIR}/esm"
@@ -14,6 +19,7 @@ BABEL_BIN="${PACKAGE_DIR}/node_modules/.bin/babel"
 PRETTIER_BIN="${PACKAGE_DIR}/node_modules/.bin/prettier"
 TSNODE_BIN="${PACKAGE_DIR}/node_modules/.bin/ts-node"
 PREPARE_PACKAGE_JSON="${TSNODE_BIN} --esm ${PACKAGE_DIR}/scripts/preparePackageJson.ts"
+
 
 REACT_APP_TEMPLATE_DIR="${PACKAGE_DIR}/../react-app-template"
 JS_CONFIG_TEMPLATES="${REACT_APP_TEMPLATE_DIR}/configTemplates/js"
@@ -32,6 +38,7 @@ mkdir "${BUILD_DIR}"
 
 # first build main Application Development Toolkit assets
 tsc -p tsconfig.json
+_version
 
 #######################################################################
 # Build react-app-template for Typescript

--- a/tools/app-toolkit/src/__version.ts
+++ b/tools/app-toolkit/src/__version.ts
@@ -1,0 +1,6 @@
+// (C) 2021-2024 GoodData Corporation
+// The placeholders in this file are replaced by values
+// from package.json right after tsc build
+export const LIB_VERSION = "0.0.0";
+export const LIB_NAME = "LIB_NAME_PLACEHOLDER";
+export const LIB_DESCRIPTION = "LIB_DESCRIPTION_PLACEHOLDER";

--- a/tools/catalog-export/.gitignore
+++ b/tools/catalog-export/.gitignore
@@ -1,4 +1,2 @@
 catalog*.ts
 catalog*.json
-# ignore the auxiliary file created during build to extract package version
-src/__version.ts

--- a/tools/catalog-export/scripts/build.sh
+++ b/tools/catalog-export/scripts/build.sh
@@ -2,20 +2,23 @@
 set -e
 
 _version() {
-    # prepare the auxiliary __version.ts file so that the code can read the package version as a constant
-    echo '// (C) 2021 GoodData Corporation' >src/__version.ts
-    echo '// DO NOT CHANGE THIS FILE, IT IS RE-GENERATED ON EVERY BUILD' >>src/__version.ts
-    node -p "'export const LIB_VERSION = ' + JSON.stringify(require('./package.json').version) + ';' +'\n\n' + 'export const LIB_DESCRIPTION = ' + JSON.stringify(require('./package.json').description) + ';' +'\n\n' + 'export const LIB_NAME = ' + JSON.stringify(require('./package.json').name) + ';'" >>src/__version.ts
+    VERSION=$(node -p "require('./package.json').version")
+    NAME=$(node -p "require('./package.json').name")
+    DESCRIPTION=$(node -p "require('./package.json').description")
+    sed -i \
+        -e "s|\0.\0.\0|$VERSION|" \
+        -e "s|LIB_NAME_PLACEHOLDER|$NAME|" \
+        -e "s|LIB_DESCRIPTION_PLACEHOLDER|$DESCRIPTION|" \
+        esm/__version.js esm/__version.d.ts
 }
 
-_common-build() {
+_post-build() {
    _version
 }
 
 build() {
-    _common-build
-
     tsc -p tsconfig.json
+    _post-build
 }
 
 build

--- a/tools/catalog-export/src/__version.ts
+++ b/tools/catalog-export/src/__version.ts
@@ -1,0 +1,6 @@
+// (C) 2021-2024 GoodData Corporation
+// The placeholders in this file are replaced by values
+// from package.json right after tsc build
+export const LIB_VERSION = "0.0.0";
+export const LIB_NAME = "LIB_NAME_PLACEHOLDER";
+export const LIB_DESCRIPTION = "LIB_DESCRIPTION_PLACEHOLDER";

--- a/tools/mock-handling/.gitignore
+++ b/tools/mock-handling/.gitignore
@@ -1,2 +1,0 @@
-# ignore the auxiliary file created during build to extract package version
-src/__version.ts

--- a/tools/mock-handling/scripts/build.sh
+++ b/tools/mock-handling/scripts/build.sh
@@ -2,20 +2,23 @@
 set -e
 
 _version() {
-    # prepare the auxiliary __version.ts file so that the code can read the package version as a constant
-    echo '// (C) 2021 GoodData Corporation' >src/__version.ts
-    echo '// DO NOT CHANGE THIS FILE, IT IS RE-GENERATED ON EVERY BUILD' >>src/__version.ts
-    node -p "'export const LIB_VERSION = ' + JSON.stringify(require('./package.json').version) + ';' +'\n\n' + 'export const LIB_NAME = ' + JSON.stringify(require('./package.json').name) + ';'" >>src/__version.ts
+    VERSION=$(node -p "require('./package.json').version")
+    NAME=$(node -p "require('./package.json').name")
+    DESCRIPTION=$(node -p "require('./package.json').description")
+    sed -i \
+        -e "s|\0.\0.\0|$VERSION|" \
+        -e "s|LIB_NAME_PLACEHOLDER|$NAME|" \
+        -e "s|LIB_DESCRIPTION_PLACEHOLDER|$DESCRIPTION|" \
+        esm/__version.js esm/__version.d.ts
 }
 
-_common-build() {
+_post-build() {
     _version
 }
 
 build() {
-    _common-build
-
     tsc -p tsconfig.json
+    _post-build
 }
 
 build

--- a/tools/mock-handling/src/__version.ts
+++ b/tools/mock-handling/src/__version.ts
@@ -1,0 +1,6 @@
+// (C) 2021-2024 GoodData Corporation
+// The placeholders in this file are replaced by values
+// from package.json right after tsc build
+export const LIB_VERSION = "0.0.0";
+export const LIB_NAME = "LIB_NAME_PLACEHOLDER";
+export const LIB_DESCRIPTION = "LIB_DESCRIPTION_PLACEHOLDER";

--- a/tools/plugin-toolkit/.gitignore
+++ b/tools/plugin-toolkit/.gitignore
@@ -1,5 +1,4 @@
 build
 test-plugin*
-src/__version.ts
 # ignore the NOTICE that gets copied here on publish, the source of truth is the root of the repo
 NOTICE

--- a/tools/plugin-toolkit/scripts/build.sh
+++ b/tools/plugin-toolkit/scripts/build.sh
@@ -1,12 +1,17 @@
 #!/usr/bin/env bash
 set -e
 
-# prepare the auxiliary __version.ts file so that the code can read the package version as a constant
-echo '// (C) 2021 GoodData Corporation' >src/__version.ts
-echo '// DO NOT CHANGE THIS FILE, IT IS RE-GENERATED ON EVERY BUILD' >>src/__version.ts
-node -p "'export const LIB_VERSION = ' + JSON.stringify(require('./package.json').version) + ';' +'\n\n' + 'export const LIB_DESCRIPTION = ' + JSON.stringify(require('./package.json').description) + ';' +'\n\n' + 'export const LIB_NAME = ' + JSON.stringify(require('./package.json').name) + ';'" >>src/__version.ts
+_version() {
+    VERSION=$(node -p "require('./package.json').version")
+    NAME=$(node -p "require('./package.json').name")
+    DESCRIPTION=$(node -p "require('./package.json').description")
+    sed -i \
+        -e "s|\0.\0.\0|$VERSION|" \
+        -e "s|LIB_NAME_PLACEHOLDER|$NAME|" \
+        -e "s|LIB_DESCRIPTION_PLACEHOLDER|$DESCRIPTION|" \
+        esm/__version.js esm/__version.d.ts
+}
 
-set -e
 
 PACKAGE_DIR="$(echo $(cd $(dirname $0)/.. && pwd -P))"
 DIST_DIR="${PACKAGE_DIR}/esm"
@@ -14,6 +19,7 @@ BABEL_BIN="${PACKAGE_DIR}/node_modules/.bin/babel"
 PRETTIER_BIN="${PACKAGE_DIR}/node_modules/.bin/prettier"
 TSNODE_BIN="${PACKAGE_DIR}/node_modules/.bin/ts-node"
 PREPARE_PACKAGE_JSON="${TSNODE_BIN} --esm ${PACKAGE_DIR}/scripts/preparePackageJson.ts"
+
 
 DASHBOARD_PLUGIN_TEMPLATE_DIR="${PACKAGE_DIR}/../dashboard-plugin-template"
 JS_CONFIG_TEMPLATES="${DASHBOARD_PLUGIN_TEMPLATE_DIR}/configTemplates/js/*"
@@ -34,6 +40,7 @@ mkdir "${BUILD_DIR}"
 
 # first build main Plugin Development Toolkit assets
 tsc -p tsconfig.json
+_version
 
 #######################################################################
 # Build dashboard-plugin-template for Typescript

--- a/tools/plugin-toolkit/src/__version.ts
+++ b/tools/plugin-toolkit/src/__version.ts
@@ -1,0 +1,6 @@
+// (C) 2021-2024 GoodData Corporation
+// The placeholders in this file are replaced by values
+// from package.json right after tsc build
+export const LIB_VERSION = "0.0.0";
+export const LIB_NAME = "LIB_NAME_PLACEHOLDER";
+export const LIB_DESCRIPTION = "LIB_DESCRIPTION_PLACEHOLDER";


### PR DESCRIPTION
The presence of placeholdered __version.ts files will make sure that these are correctly cached in rush cache.
The version will get updated in post-build

risk: low
JIRA: STL-931

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** 🙏

---

Refer to [documentation](https://github.com/gooddata/gooddata-ui-sdk/blob/master/dev_docs/continuous_integration.md) to see how to run checks and tests in the pull request. This is the list of the most used commands:

```
extended test - backstop
```

```
extended test - tiger-cypress - integrated
extended test - tiger-cypress - isolated
extended test - tiger-cypress - record
```
