### PR TITLE
chore: add rush cache support for publish

### DIFF
--- a/.github/workflows/pull-request-prerelease.yml
+++ b/.github/workflows/pull-request-prerelease.yml
@@ -2,14 +2,16 @@
 
 name: Pull request ~ Prerelease
 on:
-  push:    
+  push:
     branches:
       - master
       - release
 
 jobs:
   pull-request-info:
-    runs-on: [ubuntu-latest]
+    runs-on:
+      group: infra1-runners-arc
+      labels: runners-small
     outputs:
       should-prerelease: ${{ steps.should-prerelease.outputs.result }}
       author: ${{ steps.author.outputs.result }}
@@ -30,14 +32,14 @@ jobs:
       - uses: actions/github-script@v7
         id: author
         with:
-          script: |          
+          script: |
             const pullRequests = await github.rest.repos.listPullRequestsAssociatedWithCommit({
               commit_sha: context.sha,
               owner: context.repo.owner,
               repo: context.repo.repo,
             });
-    
-            return pullRequests?.data[0]?.user?.login;            
+
+            return pullRequests?.data[0]?.user?.login;
           result-encoding: string
       - name: Extract branch name
         env:
@@ -56,6 +58,6 @@ jobs:
     permissions:
       contents: write
       id-token: write
-    with:      
+    with:
       source-branch:  ${{ needs.pull-request-info.outputs.branch-name }}
       author-name: ${{ needs.pull-request-info.outputs.author }}

--- a/.github/workflows/rw-bump-version.yml
+++ b/.github/workflows/rw-bump-version.yml
@@ -35,14 +35,15 @@ on:
 jobs:
     get-version:
       if: ${{ inputs.skip-bump }}
-      runs-on: [ubuntu-latest]
+      runs-on:
+        group: infra1-runners-arc
+        labels: runners-small
       outputs:
         version: ${{ steps.version.outputs.version }}
       steps:
         - name: Setup node
-          uses: actions/setup-node@v4
-          with:
-            node-version: 18.17.0
+          uses: ./.github/actions/node/set-up-node
+          id: node-init
         - name: Checkout code
           uses: actions/checkout@v4
           with:
@@ -55,14 +56,12 @@ jobs:
 
     bump-version-and-commit:
         if: ${{ !inputs.skip-bump && inputs.bump }}
-        runs-on: [ubuntu-latest]
+        runs-on:
+            group: infra1-runners-arc
+            labels: runners-cxa-xlarge
         outputs:
             version: ${{ steps.version.outputs.version }}
         steps:
-            - name: Setup node
-              uses: actions/setup-node@v4
-              with:
-                node-version: 18.17.0
             - name: Checkout code
               uses: actions/checkout@v4
               with:
@@ -72,13 +71,15 @@ jobs:
             - name: Add repository to git safe directories to avoid dubious ownership issue
               run: git config --global --add safe.directory $GITHUB_WORKSPACE
 
-            - name: Install rush
-              run: npm install -g @microsoft/rush
-
-            - name: Config user
-              run: |
-                  git config --global user.email "git-action@gooddata.com"
-                  git config --global user.name "git-action"
+            - name: Git config user
+              uses: snow-actions/git-config-user@v1.0.0
+              with:
+                name: git-action
+                email: git-action@gooddata.com
+            - name: Setup rush
+              env:
+                NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+              uses: ./.github/actions/rush/set-up-rush
 
             - name: Rush bump version and override prerelease-id
               if: ${{ inputs.prerelease-id}}

--- a/.github/workflows/rw-publish-prerelease.yml
+++ b/.github/workflows/rw-publish-prerelease.yml
@@ -29,17 +29,17 @@ concurrency:
 
 jobs:
   check-version:
-    runs-on: [ubuntu-latest]
+    runs-on:
+        group: infra1-runners-arc
+        labels: runners-small
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.source-branch }}
       - name: Setup node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 18.17.0
-
+        uses: ./.github/actions/node/set-up-node
+        id: node-init
       - name: Get version from branch ${{ inputs.source-branch }}
         uses: gooddata/gooddata-ui-sdk/.github/actions/get-version-action@master
         id: get-version
@@ -63,7 +63,9 @@ jobs:
 
   setup-params:
     needs: [check-version]
-    runs-on: [ubuntu-latest]
+    runs-on:
+      group: infra1-runners-arc
+      labels: runners-small
     outputs:
       prerelease-id: ${{ steps.validate-params.outputs.prerelease-id }}
       prerelease-tag: ${{ steps.validate-params.outputs.prerelease-tag }}
@@ -113,7 +115,9 @@ jobs:
       release-tag: ${{ needs.setup-params.outputs.prerelease-tag }}
 
   slack-notification:
-    runs-on: [ubuntu-latest]
+    runs-on:
+      group: infra1-runners-arc
+      labels: runners-small
     needs: [bump-version, publish-prerelease,setup-params]
     steps:
       - name: Notify to slack with author name

--- a/.github/workflows/rw-publish-version.yml
+++ b/.github/workflows/rw-publish-version.yml
@@ -15,32 +15,33 @@ on:
 
 jobs:
     publish-version:
-        runs-on: [ubuntu-latest]
+        runs-on:
+            group: infra1-runners-arc
+            labels: runners-rxa-xlarge
         permissions:
             contents: read
         steps:
-            - name: Setup node
-              uses: actions/setup-node@v4
-              with:
-                  node-version: 18.17.0
-            - name: Checkout code
+            - name: Checkout repository
               uses: actions/checkout@v4
               with:
-                  ref: ${{ inputs.source-branch }}
+                ref: ${{inputs.source-branch}}
             - name: Add repository to git safe directories to avoid dubious ownership issue
               run: git config --global --add safe.directory $GITHUB_WORKSPACE
-            - name: Install rush
-              run: |
-                  npm install -g @microsoft/rush
-            - name: Rush install
-              run: |
-                  rush install
+            - name: Git config user
+              uses: snow-actions/git-config-user@v1.0.0
+              with:
+                name: git-action
+                email: git-action@gooddata.com
+            - name: Setup rush
+              env:
+                NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+              uses: ./.github/actions/rush/set-up-rush
             - name: Rush build
               run: |
-                  rush build
+                  node common/scripts/install-run-rush.js build
             - name: Rush publish dry run
               run: |
-                  rush publish --include-all --version-policy sdk --set-access-level public
+                  node common/scripts/install-run-rush.js publish --include-all --version-policy sdk --set-access-level public
             - name: Rush publish
               uses: nick-fields/retry@v3
               env:
@@ -52,10 +53,10 @@ jobs:
                   retry_on: error
                   retry_wait_seconds: 10
                   command: |
-                      rush publish --publish --include-all --version-policy sdk --tag $TAG --set-access-level public
+                      node common/scripts/install-run-rush.js publish --publish --include-all --version-policy sdk --tag $TAG --set-access-level public
 
     notify-publish-failed-to-slack:
-        if: ${{ always() && needs.publish-version.result == 'failure' }}
+        if: ${{ !cancelled() && needs.publish-version.result  == 'failure' }}
         needs: publish-version
         runs-on: [ubuntu-latest]
         steps:


### PR DESCRIPTION
risk: nonprod

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** 🙏

---

Refer to [documentation](https://github.com/gooddata/gooddata-ui-sdk/blob/master/dev_docs/continuous_integration.md) to see how to run checks and tests in the pull request. This is the list of the most used commands:

```
extended test - backstop
```

```
extended test - tiger-cypress - integrated
extended test - tiger-cypress - isolated
extended test - tiger-cypress - record
```
