### PR TITLE
chore: remove the enableFlexConnectNaming FF

### DIFF
--- a/libs/sdk-backend-tiger/src/backend/features/feature.ts
+++ b/libs/sdk-backend-tiger/src/backend/features/feature.ts
@@ -592,13 +592,6 @@ export function mapFeatures(features: FeaturesMap): Partial<ITigerFeatureFlags> 
         ),
         ...loadFeature(
             features,
-            TigerFeaturesNames.EnableFlexConnectNaming,
-            "enableFlexConnectNaming",
-            "BOOLEAN",
-            FeatureFlagsValues.enableFlexConnectNaming,
-        ),
-        ...loadFeature(
-            features,
             TigerFeaturesNames.EnableInPlatformNotifications,
             "enableInPlatformNotifications",
             "BOOLEAN",

--- a/libs/sdk-backend-tiger/src/backend/uiFeatures.ts
+++ b/libs/sdk-backend-tiger/src/backend/uiFeatures.ts
@@ -121,7 +121,6 @@ export enum TigerFeaturesNames {
     EnableDashboardFlexibleLayout = "enableDashboardFlexibleLayout",
     EnableNumberSeparators = "enableNumberSeparators",
     EnableNewUserCreationFlow = "enableNewUserCreationFlow",
-    EnableFlexConnectNaming = "enableFlexConnectNaming",
     EnableDestinationTesting = "enableDestinationTesting",
     EnableInPlatformNotifications = "enableInPlatformNotifications",
 }
@@ -208,7 +207,6 @@ export type ITigerFeatureFlags = {
     enableDashboardFlexibleLayout: typeof FeatureFlagsValues["enableDashboardFlexibleLayout"][number];
     enableNumberSeparators: typeof FeatureFlagsValues["enableNumberSeparators"][number];
     enableNewUserCreationFlow: typeof FeatureFlagsValues["enableNewUserCreationFlow"][number];
-    enableFlexConnectNaming: typeof FeatureFlagsValues["enableFlexConnectNaming"][number];
     enableDestinationTesting: typeof FeatureFlagsValues["enableDestinationTesting"][number];
     enableInPlatformNotifications: typeof FeatureFlagsValues["enableInPlatformNotifications"][number];
 };
@@ -295,7 +293,6 @@ export const DefaultFeatureFlags: ITigerFeatureFlags = {
     enableDashboardFlexibleLayout: false,
     enableNumberSeparators: true,
     enableNewUserCreationFlow: false,
-    enableFlexConnectNaming: false,
     enableDestinationTesting: false,
     enableInPlatformNotifications: false,
 };
@@ -386,7 +383,6 @@ export const FeatureFlagsValues = {
     enableDashboardFlexibleLayout: [true, false] as const,
     enableNumberSeparators: [true, false] as const,
     enableNewUserCreationFlow: [true, false] as const,
-    enableFlexConnectNaming: [true, false] as const,
     enableDestinationTesting: [true, false] as const,
     enableInPlatformNotifications: [true, false] as const,
 };

--- a/libs/sdk-model/api/sdk-model.api.md
+++ b/libs/sdk-model/api/sdk-model.api.md
@@ -3213,7 +3213,6 @@ export interface ISettings {
     enableEarlyAccessFeaturesRollout?: boolean;
     enableEmbedButtonInAD?: boolean;
     enableEmbedButtonInKD?: boolean;
-    enableFlexConnectNaming?: boolean;
     enableFlightRpcDataSource?: boolean;
     enableGenAIChat?: boolean;
     enableGenAIChatRollout?: boolean;

--- a/libs/sdk-model/src/settings/index.ts
+++ b/libs/sdk-model/src/settings/index.ts
@@ -552,11 +552,6 @@ export interface ISettings {
     enableNewUserCreationFlow?: boolean;
 
     /**
-     * Enable the use of the new FlexConnect naming (instead of FlexFunctions).
-     */
-    enableFlexConnectNaming?: boolean;
-
-    /**
      * Enable the possibility to test destinations (emails, webhooks) in the UI.
      */
     enableDestinationTesting?: boolean;


### PR DESCRIPTION
This flag is no longer used by the apps, so let's get rid of it.

JIRA: CQ-953
risk: low

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** 🙏

---

Refer to [documentation](https://github.com/gooddata/gooddata-ui-sdk/blob/master/dev_docs/continuous_integration.md) to see how to run checks and tests in the pull request. This is the list of the most used commands:

```
extended test - backstop
```

```
extended test - tiger-cypress - integrated
extended test - tiger-cypress - isolated
extended test - tiger-cypress - record
```
