### PR TITLE
fix: dashboard export filter context

### DIFF
--- a/libs/sdk-backend-tiger/src/backend/workspace/dashboards/index.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/dashboards/index.ts
@@ -204,9 +204,15 @@ export class TigerWorkspaceDashboards implements IWorkspaceDashboardsService {
             return null;
         }
 
-        const { filters = [] } = convertFromBackendExportMetadata(metadata);
+        const convertedExportMetadata = convertFromBackendExportMetadata(metadata);
+
+        // Fallback to default filters if no filters are present in the export metadata
+        if (!convertedExportMetadata) {
+            return null;
+        }
+
         return {
-            filters,
+            filters: convertedExportMetadata.filters,
             title: `temp-filter-context-${exportId}`,
             description: "temp-filter-context-description",
             ref: { identifier: `identifier-${exportId}` },

--- a/libs/sdk-backend-tiger/src/convertors/fromBackend/ExportMetadataConverter.ts
+++ b/libs/sdk-backend-tiger/src/convertors/fromBackend/ExportMetadataConverter.ts
@@ -1,8 +1,14 @@
-// (C) 2023 GoodData Corporation
+// (C) 2023-2024 GoodData Corporation
 
 import { IExportMetadata } from "../../types/index.js";
-export const convertExportMetadata = (exportMetadata: any): IExportMetadata => {
+export const convertExportMetadata = (exportMetadata: any): IExportMetadata | null => {
+    // No filters === should use default filters
+    if (!exportMetadata?.filters) {
+        return null;
+    }
+
+    // Filters, or empty filters === override default filters
     return {
-        filters: exportMetadata?.filters,
+        filters: exportMetadata.filters,
     };
 };


### PR DESCRIPTION
If filters are missing in export definition,
use the default dashboard filters.

If filters are provided (even empty ones),
use these to override default dashboard filters.

Before, it worked because export metadata endpoint always failed with empty filters.

JIRA: F1-975

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** 🙏

---

Refer to [documentation](https://github.com/gooddata/gooddata-ui-sdk/blob/master/dev_docs/continuous_integration.md) to see how to run checks and tests in the pull request. This is the list of the most used commands:

```
extended test - backstop
```

```
extended test - integrated
extended test - isolated
extended test - record
```
