### PR TITLE
chore: fix isolated command comment check

### DIFF
--- a/.github/workflows/pull-request-comment.yaml
+++ b/.github/workflows/pull-request-comment.yaml
@@ -98,7 +98,7 @@ jobs:
 
   e2e-run-isolated:
     needs: [get-pr-info,extract-filter]
-    if: $${{ startsWith(github.event.comment.body, 'extended-test --isolated') }}
+    if: ${{ startsWith(github.event.comment.body, 'extended-test --isolated') }}
     permissions:
       id-token: write
       contents: read
@@ -165,16 +165,16 @@ jobs:
             const url = `https://github.com/${repository.owner}/${repository.repo}/actions/runs/${context.runId}`;
 
             let testResult = "'command not recognized'";
-            if (process.env.COMMENT.startsWith('extended-test --isolated')) {
+            if (process.env.COMMENT?.startsWith('extended-test --isolated')) {
                 testResult = process.env.TEST_RESULT_ISOLATED;
             }
-            if (process.env.COMMENT.startsWith('extended-test --record')) {
+            if (process.env.COMMENT?.startsWith('extended-test --record')) {
                 testResult = process.env.TEST_RESULT_RECORD;
             }
-            if (process.env.COMMENT.startsWith('extended-test --integrated')) {
+            if (process.env.COMMENT?.startsWith('extended-test --integrated')) {
                 testResult = process.env.TEST_RESULT_INTEGRATED;
             }
-            if (process.env.COMMENT.startsWith('extended-test --backstop')) {
+            if (process.env.COMMENT?.startsWith('extended-test --backstop')) {
                 testResult = process.env.TEST_RESULT_BACKSTOP;
             }
 


### PR DESCRIPTION
risk: nonprod

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** 🙏

---

Refer to [documentation](https://github.com/gooddata/gooddata-ui-sdk/blob/master/dev_docs/continuous_integration.md) to see how to run checks and tests in the pull request. This is the list of the most used commands:

### Run extended test by pull request comment

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests.
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```
