### PR TITLE
ci: switching a few commits to release branch

### DIFF
--- a/.github/workflows/checklist-cypress-ui-test.yaml
+++ b/.github/workflows/checklist-cypress-ui-test.yaml
@@ -1,6 +1,6 @@
 # (C) 2024 GoodData Corporation
 
-name: Test ~ run checklist e2e tests with ${{ inputs.CYPRESS_TEST_TAGS }}
+name: Test ~ run checklist e2e tests
 on:
   workflow_dispatch:
     inputs:
@@ -12,6 +12,7 @@ on:
       TEST_BACKEND:
         default: 'https://checklist.staging.stg11.panther.intgdc.com'
         required: true
+        type: string
       TIGER_DATASOURCES_NAME:
         description: 'Tiger DS name'
         default: 'vertica_staging-goodsales'
@@ -20,7 +21,7 @@ on:
       CYPRESS_TEST_TAGS:
         description: 'Test tags should be run. Tip: can get them inside each spec file'
         required: true
-        default: 'checklist_integrated_tiger, checklist_integrated_tiger_export'
+        default: 'checklist_integrated_tiger,checklist_integrated_tiger_export'
         type: string
       FILTER:
         type: string
@@ -35,6 +36,7 @@ on:
       TEST_BACKEND:
         default: 'https://checklist.staging.stg11.panther.intgdc.com'
         required: true
+        type: string
       TIGER_DATASOURCES_NAME:
         default: 'vertica_staging-goodsales'
         required: true
@@ -42,24 +44,108 @@ on:
       CYPRESS_TEST_TAGS:
         required: true
         type: string
+      FILTER:
+        required: false
+        description: "List of spec files to filter"
+        type: string
 
 jobs:
-  e2e-checklist:
-    permissions:
-      id-token: write
-      contents: read
-    secrets: inherit
-    timeout-minutes: 60
+  warm-up-cache:
+    runs-on:
+      group: infra1-runners-arc
+      labels: runners-cxa-xlarge
     steps:
-      - name: Get vault secrets
-        uses: hashicorp/vault-action@v3
-        id: secrets
+      - uses: actions/checkout@v4
         with:
-          url: https://vault.ord1.infra.intgdc.com
-          method: jwt
-          path: jwt/github
-          role: front-end
-          secrets: |-
-            secret/data/v3/dev/panther/qa-org-bootstrap-token token | TIGER_API_TOKEN ;
-      - name: e2e integrated tests
-        uses: ./.github/workflows/rw-rush-build-e2e-tests-integrated.yml
+          ref: ${{ inputs.GIT_REVISION }}
+          fetch-depth: 2
+      - name: Git config user
+        uses: snow-actions/git-config-user@v1.0.0
+        with:
+          name: git-action
+          email: git-action@gooddata.com
+      - name: Warmup rush
+        env:
+          NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        uses: ./.github/actions/rush/warm-up-rush
+    build:
+      needs: [ warm-up-cache ]
+      runs-on:
+        group: infra1-runners-arc
+        labels: runners-rxa-xlarge
+      steps:
+        - uses: actions/checkout@v4
+          with:
+            ref: ${{ inputs.GIT_REVISION }}
+            fetch-depth: 2
+        - name: Git config user
+          uses: snow-actions/git-config-user@v1.0.0
+          with:
+            name: git-action
+            email: git-action@gooddata.com
+        - name: Debug
+          run: git log -1
+        - name: Setup rush
+          env:
+            NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          uses: ./.github/actions/rush/set-up-rush
+        - name: Rush build
+          run: node common/scripts/install-run-rush.js build --to @gooddata/sdk-ui-tests-e2e
+    e2e:
+      needs: [ warm-up-cache,build ]
+      runs-on:
+        group: infra1-runners-arc
+        labels: runners-rxa-xlarge
+      permissions:
+        contents: read
+        id-token: write
+      steps:
+        - uses: actions/checkout@v4
+          with:
+            ref: ${{ inputs.GIT_REVISION }}
+            fetch-depth: 2
+        - name: Git config user
+          uses: snow-actions/git-config-user@v1.0.0
+          with:
+            name: git-action
+            email: git-action@gooddata.com
+        - name: Setup rush
+          env:
+            NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          uses: ./.github/actions/rush/set-up-rush
+        - name: Rush build
+          run: |
+            node common/scripts/install-run-rush.js build --to @gooddata/sdk-ui-tests-e2e
+        - name: Rush generate dynamic files related to build
+          run: node common/scripts/install-run-rush.js build-generate-version
+        - name: Get vault secrets
+          uses: hashicorp/vault-action@v3
+          id: secrets
+          with:
+            url: https://vault.ord1.infra.intgdc.com
+            method: jwt
+            path: jwt/github
+            role: front-end
+            secrets: |-
+              secret/data/v3/dev/panther/qa-org-bootstrap-token token | TIGER_API_TOKEN ;
+        - name: Run e2e tests
+          run: |
+            export TEST_BACKEND=${{ inputs.TEST_BACKEND }}
+            export TIGER_DATASOURCES_NAME=${{ inputs.TIGER_DATASOURCES_NAME }}
+            export EXECUTOR_NUMBER=$GH_RUN_ID
+            export CYPRESS_TEST_TAGS=${{ inputs.CYPRESS_TEST_TAGS }}
+            if [ -n "$USER_FILTER" ]; then
+              export FILTER=$USER_FILTER
+            fi
+            echo "Running with FILTER=$FILTER"
+            ./common/scripts/ci/run_cypress_integrated_tests.sh
+          env:
+            GH_RUN_ID: ${{ github.run_id }}
+            USER_FILTER: ${{ inputs.FILTER }}
+        - name: Archive the cypress test artifacts
+          uses: actions/upload-artifact@v4
+          if: ${{ !cancelled() }}
+          with:
+            name: cypress-test-artifacts
+            path: |
+              libs/sdk-ui-tests-e2e/cypress/videos/**/*.mp4

--- a/.github/workflows/checklist-integrated-staging.yaml
+++ b/.github/workflows/checklist-integrated-staging.yaml
@@ -14,6 +14,16 @@ on:
         required: false
         default: true
         type: boolean
+      test-branch:
+        description: 'Test branch to run tests'
+        required: false
+        default: master
+        type: string
+      send_message_to_slack_channel:
+        description: 'Notify result to slack'
+        required: false
+        default: true
+        type: boolean
 jobs:
   setup-stage:
     name: Setup env variables
@@ -23,19 +33,25 @@ jobs:
     outputs:
       run-cypress-sdk: ${{ steps.test-suite-options.outputs.run-cypress-sdk }}
       run-export: ${{ steps.test-suite-options.outputs.run-export }}
+      send_message_to_slack_channel: ${{ steps.test-suite-options.outputs.send_message_to_slack_channel }}
     steps:
       - name: Set test suite options
         id: test-suite-options
         run: |
           if [ -z "${{ inputs.run-cypress-sdk }}" ]; then
-            echo 'run-cypress-sdk=false' >> $GITHUB_OUTPUT
+            echo 'run-cypress-sdk=true' >> $GITHUB_OUTPUT
           else
             echo "run-cypress-sdk=${{ inputs.run-cypress-sdk }}" >> $GITHUB_OUTPUT
           fi
           if [ -z "${{ inputs.run-export }}" ]; then
-            echo 'run-export=false' >> $GITHUB_OUTPUT
+            echo 'run-export=true' >> $GITHUB_OUTPUT
           else
             echo "run-export=${{ inputs.run-export }}" >> $GITHUB_OUTPUT
+          fi
+          if [ -z "${{ inputs.send_message_to_slack_channel }}" ]; then
+            echo 'send_message_to_slack_channel=true' >> $GITHUB_OUTPUT
+          else
+            echo "send_message_to_slack_channel=${{ inputs.send_message_to_slack_channel }}" >> $GITHUB_OUTPUT
           fi
   checklist-SDK:
     name: Cypress SDK on top of Tiger
@@ -48,6 +64,9 @@ jobs:
     if: ${{ needs.setup-stage.outputs.run-cypress-sdk == 'true'}}
     with:
       CYPRESS_TEST_TAGS: 'checklist_integrated_tiger'
+      GIT_REVISION: ${{ inputs.test-branch || master }}
+      TEST_BACKEND: 'https://checklist.staging.stg11.panther.intgdc.com'
+      TIGER_DATASOURCES_NAME: 'vertica_staging-goodsales'
   checklist-export:
     name: Cypress SDK Export Test
     permissions:
@@ -55,7 +74,34 @@ jobs:
       pages: write
       id-token: write
     uses: ./.github/workflows/checklist-cypress-ui-test.yaml
-    needs: [ setup-stage ]
-    if: ${{ needs.setup-stage.outputs.run-export == 'true'}}
+    needs: [ setup-stage, checklist-SDK ]
+    if: ${{ !cancelled() && (needs.setup-stage.outputs.run-export == 'true') }}
     with:
       CYPRESS_TEST_TAGS: 'checklist_integrated_tiger_export'
+      GIT_REVISION: ${{ inputs.test-branch || master }}
+      TEST_BACKEND: 'https://checklist.staging.stg11.panther.intgdc.com'
+      TIGER_DATASOURCES_NAME: 'vertica_staging-goodsales'
+  status-check-notify-slack:
+    needs:
+      - setup-stage
+      - checklist-SDK
+      - checklist-export
+    if: ${{ !canceled() }}
+    runs-on:
+      group: infra1-runners-arc
+      labels: runners-small
+    steps:
+      - name: Decide whether the needed jobs succeeded or failed
+        id: alls-green
+        uses: re-actors/alls-green@release/v1
+        with:
+          allowed-skips: checklist-SDK, checklist-export
+          jobs: ${{ toJSON(needs) }}
+      - name: Send Slack notification
+        uses: slackapi/slack-github-action@v1.27.1
+        if: ${{ needs.setup-stage.outputs.send_message_to_slack_channel == 'true' }}
+        with:
+          channel-id: qa_tests
+          slack-message: "${{ steps.alls-green.outcome == 'success' &&  ':unicorn_face:' || ':robot_panic:' }} `checklist-SDK-${{ github.ref_name }}-branch: ` *${{ steps.alls-green.outcome == 'success' &&  'success' || 'failed' }}*; please check *<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|the logs>*."
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/checklist-run-boiler-app.yaml
+++ b/.github/workflows/checklist-run-boiler-app.yaml
@@ -1,0 +1,138 @@
+# (C) 2024 GoodData Corporation
+
+name: Test ~ run boiler app
+on:
+  workflow_dispatch:
+    inputs:
+      GIT_REVISION:
+        description: 'GIT REVISION'
+        default: master
+        required: true
+        type: string
+      TEST_BACKEND:
+        default: 'https://checklist.staging.stg11.panther.intgdc.com'
+        required: true
+        type: string
+      TIGER_DATASOURCES_NAME:
+        description: 'Tiger DS name'
+        default: 'vertica_staging-goodsales'
+        required: true
+        type: string
+      SDK_VERSION:
+        required: true
+        type: string
+        default: 'latest'
+      SDK_LANG:
+        description: 'Programming Language to be used'
+        type: choice
+        default: 'js'
+        options:
+          - js
+          - ts
+      FILTER:
+        type: string
+        required: true
+        description: 'Test files to be filtered'
+        default: 'boilerapp.spec.ts'
+  workflow_call:
+    inputs:
+      GIT_REVISION:
+        description: 'GIT REVISION'
+        default: master
+        required: true
+        type: string
+      TEST_BACKEND:
+        default: 'https://checklist.staging.stg11.panther.intgdc.com'
+        required: true
+        type: string
+      TIGER_DATASOURCES_NAME:
+        description: 'Tiger DS name'
+        default: 'vertica_staging-goodsales'
+        required: true
+        type: string
+      SDK_VERSION:
+        required: true
+        type: string
+        default: 'latest'
+      SDK_LANG:
+        description: 'Programming Language to be used'
+        type: choice
+        default: 'js'
+        options:
+          - js
+          - ts
+      FILTER:
+        type: string
+        required: true
+        description: 'Test files to be filtered'
+        default: 'boilerapp.spec.ts'
+
+jobs:
+  warm-up-cache:
+    runs-on:
+      group: infra1-runners-arc
+      labels: runners-cxa-xlarge
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.GIT_REVISION }}
+          fetch-depth: 2
+      - name: Git config user
+        uses: snow-actions/git-config-user@v1.0.0
+        with:
+          name: git-action
+          email: git-action@gooddata.com
+      - name: Warmup rush
+        env:
+          NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        uses: ./.github/actions/rush/warm-up-rush
+  e2e:
+    needs: [ warm-up-cache ]
+    runs-on:
+      group: infra1-runners-arc
+      labels: runners-rxa-xlarge
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.GIT_REVISION }}
+          fetch-depth: 2
+      - name: Git config user
+        uses: snow-actions/git-config-user@v1.0.0
+        with:
+          name: git-action
+          email: git-action@gooddata.com
+      - name: Get vault secrets
+        uses: hashicorp/vault-action@v3
+        id: secrets
+        with:
+          url: https://vault.ord1.infra.intgdc.com
+          method: jwt
+          path: jwt/github
+          role: front-end
+          secrets: |-
+            secret/data/v3/dev/panther/qa-org-bootstrap-token token | TIGER_API_TOKEN ;
+      - name: Run e2e tests
+        run: |
+          export HOST=${{ inputs.TEST_BACKEND }}
+          export TIGER_DATASOURCES_NAME=${{ inputs.TIGER_DATASOURCES_NAME }}
+          export SDK_LANG=${{ inputs.SDK_LANG }}
+          export FILTER=${{ inputs.FILTER }}
+          if [[ -z ${{ inputs.SDK_VERSION }} || ${{ inputs.SDK_VERSION }} == "latest" ]]; then
+            export SDK_VERSION=$(jq < libs/sdk-backend-spi/package.json -r '.["version"]')
+          else
+            export SDK_VERSION=${{ inputs.SDK_VERSION }}
+          fi
+          echo "The boiler app will be run with sdk version $SDK_VERSION"
+          ./common/scripts/ci/run_boiler_app_integration_tests_with_live_backend.sh
+      - name: Archive the cypress test artifacts
+        uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: cypress-test-artifacts
+          path: |
+            libs/sdk-ui-tests-e2e/cypress/videos/**/*.mp4
+            libs/sdk-ui-tests-e2e/cypress/screenshots/**/*
+            libs/sdk-ui-tests-e2e/cypress/results/**/*

--- a/.github/workflows/rw-rush-build-e2e-tests-integrated.yml
+++ b/.github/workflows/rw-rush-build-e2e-tests-integrated.yml
@@ -83,6 +83,7 @@ jobs:
           export TEST_BACKEND=https://staging-automation.dev-latest.stg11.panther.intgdc.com
           export TIGER_DATASOURCES_NAME=pg_staging-goodsales
           export EXECUTOR_NUMBER=$GH_RUN_ID
+          export CYPRESS_TEST_TAGS=post-merge_integrated_tiger
           if [ -n "$USER_FILTER" ]; then
             export FILTER=$USER_FILTER
           fi

--- a/common/scripts/ci/run_cypress_integrated_tests.sh
+++ b/common/scripts/ci/run_cypress_integrated_tests.sh
@@ -16,7 +16,7 @@ export TEST_BACKEND_NO_PREFIX=$(sed <<< $TEST_BACKEND -E "s#^https?:\/\/##")
 
 export HOST=${TEST_BACKEND}
 export TEST_BACKEND=${TEST_BACKEND:-}
-export CYPRESS_TEST_TAGS=post-merge_integrated_tiger
+export CYPRESS_TEST_TAGS=${CYPRESS_TEST_TAGS:-}
 export FIXTURE_TYPE=goodsales
 export FILTER=${FILTER:-}
 export TIGER_API_TOKEN=${TIGER_API_TOKEN:?}


### PR DESCRIPTION
switching a few commits to release branch:
- https://github.com/gooddata/gooddata-ui-sdk/pull/5716/files
- https://github.com/gooddata/gooddata-ui-sdk/pull/5701/files
- https://github.com/gooddata/gooddata-ui-sdk/pull/5715/files

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests.
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```
