### PR TITLE
feat: cleanup backstopjs artifacts

### DIFF
--- a/.github/workflows/rw-rush-build-e2e-tests-backstop.yml
+++ b/.github/workflows/rw-rush-build-e2e-tests-backstop.yml
@@ -80,10 +80,14 @@ jobs:
           ./common/scripts/ci/run_backstop_tests.sh
         env:
           GH_RUN_ID: ${{ github.run_id }}
+      - name: Cleanup backstop artifacts
+        if: ${{ !cancelled() && failure() }}
+        run: |
+          node libs/sdk-ui-tests/backstop/backstop-cleanup-artifacts.cjs
       - name: Archive the cypress test artifacts
         uses: actions/upload-artifact@v4
         if: ${{ !cancelled() && failure() }}
         with:
-          name: backstop-test-artifacts
+          name: backstop-test-artifacts-failed
           path: |
             libs/sdk-ui-tests/backstop/output/**/*

--- a/libs/sdk-ui-tests/backstop/backstop-cleanup-artifacts.cjs
+++ b/libs/sdk-ui-tests/backstop/backstop-cleanup-artifacts.cjs
@@ -1,0 +1,81 @@
+/**
+ * Process backstop output results.
+ *
+ * Adjust config so that the html report is correctly displayed and contains only failed tests.
+ *
+ * For "passed" tests, remove the screenshot from output to minimize artifact size
+ * (when test passes, they're identical to reference images so no need to archive them).
+ *
+ * For "failed" tests, keep the screenshot from test output and also copy reference
+ * image to output.
+ *
+ **/
+const fs = require("fs");
+const path = require("path");
+
+const currentDir = __dirname;
+const references = "reference";
+
+console.log(`Cleaning artifacts from ${currentDir}/output`);
+
+const outputPath = path.join(currentDir, "output");
+const htmlReportPath = path.join(outputPath, "html-report");
+const outputConfig = path.join(htmlReportPath, "config.js");
+
+if (!fs.existsSync(outputConfig)) {
+    console.log("No backstop output, skipping cleanup of test artifacts");
+    process.exit(1);
+}
+
+// this will be the newly added directory to output, to which we copy
+// reference screenshots for failed tests
+const referenceDirectory = path.join(outputPath, references);
+fs.mkdirSync(referenceDirectory, { recursive: true });
+
+const configData = fs.readFileSync(outputConfig, "utf8");
+
+// the config json we're interested in is wrapped with report({...});
+const configJson = configData.slice("report(".length, -2);
+const data = JSON.parse(configJson);
+
+data.tests.forEach((test) => {
+    if (test.status === "pass") {
+        const testFile = test.pair?.test;
+        const testFilePath = path.join(htmlReportPath, testFile);
+
+        if (fs.existsSync(testFilePath)) {
+            fs.unlinkSync(testFilePath);
+        }
+    } else if (test.status === "fail") {
+        const referenceFile = test.pair?.reference;
+        const referencePath = path.join(htmlReportPath, referenceFile);
+        const baseReferenceFilename = path.basename(referencePath);
+        const destReference = path.join(referenceDirectory, baseReferenceFilename);
+
+        if (fs.existsSync(referencePath)) {
+            fs.copyFileSync(referencePath, destReference);
+        }
+    } else {
+        console.log(`Processing "${test.pair?.label}", unrecognized test status: "${test.status}"`);
+    }
+});
+
+const updatedTests = data.tests
+    .filter((test) => test.status === "fail")
+    .map((test) => ({
+        ...test,
+        pair: {
+            ...test.pair,
+            reference: test.pair?.reference?.replace(`../../${references}`, `../${references}`),
+        },
+    }));
+
+const replacedConfig = {
+    ...data,
+    tests: updatedTests,
+};
+const stringified = JSON.stringify(replacedConfig, null, 2);
+
+// replace original config with adjusted one
+const result = `report(${stringified});`;
+fs.writeFileSync(outputConfig, result, "utf8");

--- a/libs/sdk-ui-tests/backstop/run-backstop-compose.sh
+++ b/libs/sdk-ui-tests/backstop/run-backstop-compose.sh
@@ -3,10 +3,8 @@
 # Absolute root dir .. for the docker volumes
 ROOT_DIR=$(echo $(cd $(dirname $0)/.. && pwd -P))
 
-if [[ "$GITHUB_ACTIONS" != "true" ]]; then
-    export USER_UID=$(id -u)
-    export USER_GID=$(id -g)
-fi
+export USER_UID=$(id -u)
+export USER_GID=$(id -g)
 
 cd $ROOT_DIR
 


### PR DESCRIPTION
After test is finished with failure, postprocess the results to include
only failed test screenshots in the report to decrease artifact size.
Also include reference images in the output for visibility in the html
report.

risk: low
JIRA: STL-1006

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests.
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```