### PR TITLE
refactor: switch to secondary x axis for bar chart default sort

### DIFF
--- a/libs/sdk-ui-ext/src/internal/utils/sort.ts
+++ b/libs/sdk-ui-ext/src/internal/utils/sort.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2022 GoodData Corporation
+// (C) 2019-2025 GoodData Corporation
 import { IntlShape } from "react-intl";
 import isEmpty from "lodash/isEmpty.js";
 import isNil from "lodash/isNil.js";
@@ -169,7 +169,10 @@ export function createSorts(
         case VisualizationTypes.LINE:
             return [];
         case VisualizationTypes.BAR:
-            return getDefaultBarChartSort(insight, canSortStackTotalValue(insight, supportedControls));
+            return getDefaultBarChartSort(
+                insight,
+                canSortStackBarChartTotalValue(insight, supportedControls),
+            );
         case VisualizationTypes.TREEMAP:
             return getDefaultTreemapSort(insight);
         case VisualizationTypes.HEATMAP:
@@ -186,18 +189,18 @@ export function createSorts(
     return [];
 }
 
-function areAllMeasuresOnSingleAxis(insight: IInsightDefinition, secondaryYAxis: IAxisConfig): boolean {
+function areAllMeasuresOnSingleAxis(insight: IInsightDefinition, secondaryAxis: IAxisConfig): boolean {
     const measureCount = insightMeasures(insight).length;
-    const numberOfMeasureOnSecondaryAxis = secondaryYAxis.measures?.length ?? 0;
+    const numberOfMeasureOnSecondaryAxis = secondaryAxis.measures?.length ?? 0;
     return numberOfMeasureOnSecondaryAxis === 0 || measureCount === numberOfMeasureOnSecondaryAxis;
 }
 
-function canSortStackTotalValue(
+function canSortStackBarChartTotalValue(
     insight: IInsightDefinition,
     supportedControls: IVisualizationProperties,
 ): boolean {
     const stackMeasures = supportedControls?.stackMeasures ?? false;
-    const secondaryAxis: IAxisConfig = supportedControls?.secondary_yaxis ?? { measures: [] };
+    const secondaryAxis: IAxisConfig = supportedControls?.secondary_xaxis ?? { measures: [] };
     const allMeasuresOnSingleAxis = areAllMeasuresOnSingleAxis(insight, secondaryAxis);
 
     return stackMeasures && allMeasuresOnSingleAxis;


### PR DESCRIPTION
When the default Bar chart sorting is being generated, the secondary_yaxis property is attempted to be retrieved from the properties mapping.
Based on current behavior of UI, as well as the supportedProperties definitions, it seems like the only secondary axis supported for the bar chart is on the X axis, instead of the Y axis.

risk: low
JIRA: CQ-987

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests.
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```
