### PR TITLE
feat: external recipients in home ui support

### DIFF
--- a/libs/sdk-backend-tiger/src/convertors/fromBackend/NotificationChannelsConvertor.ts
+++ b/libs/sdk-backend-tiger/src/convertors/fromBackend/NotificationChannelsConvertor.ts
@@ -1,4 +1,4 @@
-// (C) 2022-2024 GoodData Corporation
+// (C) 2022-2025 GoodData Corporation
 import {
     DeclarativeNotificationChannelDestinationTypeEnum,
     JsonApiNotificationChannelOut,
@@ -6,6 +6,7 @@ import {
     Smtp,
     JsonApiNotificationChannelOutAttributesAllowedRecipientsEnum,
     DefaultSmtp,
+    JsonApiNotificationChannelOutAttributesDashboardLinkVisibilityEnum,
 } from "@gooddata/api-client-tiger";
 import {
     assertNever,
@@ -53,7 +54,14 @@ function convertSharedNotificationChannelPropertiesFromBackend(
     channel: JsonApiNotificationChannelOut,
 ): Pick<
     INotificationChannelMetadataObject,
-    "id" | "type" | "title" | "description" | "customDashboardUrl" | "allowedRecipients" | "tags"
+    | "id"
+    | "type"
+    | "title"
+    | "description"
+    | "customDashboardUrl"
+    | "allowedRecipients"
+    | "tags"
+    | "dashboardLinkVisibility"
 > {
     return {
         type: "notificationChannel",
@@ -61,6 +69,7 @@ function convertSharedNotificationChannelPropertiesFromBackend(
         title: channel.attributes?.name ?? undefined,
         description: channel.attributes?.description ?? undefined,
         customDashboardUrl: channel.attributes?.customDashboardUrl,
+        dashboardLinkVisibility: convertDashboardLinkVisibility(channel.attributes?.dashboardLinkVisibility),
         allowedRecipients: convertAllowedRecipientsFromBackend(channel.attributes?.allowedRecipients),
         tags: [],
     };
@@ -157,6 +166,21 @@ function convertAllowedRecipientsFromBackend(
             return "external";
         default:
             assertNever(allowedRecipients);
+            return undefined;
+    }
+}
+
+function convertDashboardLinkVisibility(
+    type?: JsonApiNotificationChannelOutAttributesDashboardLinkVisibilityEnum,
+) {
+    switch (type) {
+        case JsonApiNotificationChannelOutAttributesDashboardLinkVisibilityEnum.HIDDEN:
+            return "hidden";
+        case JsonApiNotificationChannelOutAttributesDashboardLinkVisibilityEnum.ALL:
+            return "visible";
+        case JsonApiNotificationChannelOutAttributesDashboardLinkVisibilityEnum.INTERNAL_ONLY:
+            return "internalOnly";
+        default:
             return undefined;
     }
 }

--- a/libs/sdk-backend-tiger/src/convertors/toBackend/NotificationChannelsConvertor.ts
+++ b/libs/sdk-backend-tiger/src/convertors/toBackend/NotificationChannelsConvertor.ts
@@ -7,6 +7,7 @@ import {
     DefaultSmtp,
     Webhook,
     JsonApiNotificationChannelOutAttributesAllowedRecipientsEnum,
+    JsonApiNotificationChannelOutAttributesDashboardLinkVisibilityEnum,
 } from "@gooddata/api-client-tiger";
 import { UnexpectedError } from "@gooddata/sdk-backend-spi";
 import {
@@ -24,6 +25,7 @@ import {
     IWebhookNotificationChannelMetadataObjectDefinition,
     isNotificationChannelMetadataObject,
     NotificationChannelDestinationType,
+    NotificationChannelDashboardLinkVisibility,
 } from "@gooddata/sdk-model";
 
 type BackendReturnType<T> = T extends INotificationChannelMetadataObject
@@ -64,6 +66,7 @@ function convertSharedNotificationChannelPropertiesToBackend<
             name: channel.title,
             description: channel.description,
             customDashboardUrl: channel.customDashboardUrl,
+            dashboardLinkVisibility: convertDashboardLinkVisibility(channel.dashboardLinkVisibility),
             allowedRecipients: convertAllowedRecipientsToBackend(channel.allowedRecipients),
         },
     };
@@ -210,5 +213,18 @@ function convertNotificationChannelTypeToBackend(
         default:
             assertNever(type);
             return [DeclarativeNotificationChannelDestinationTypeEnum.WEBHOOK];
+    }
+}
+
+function convertDashboardLinkVisibility(type?: NotificationChannelDashboardLinkVisibility) {
+    switch (type) {
+        case "hidden":
+            return JsonApiNotificationChannelOutAttributesDashboardLinkVisibilityEnum.HIDDEN;
+        case "visible":
+            return JsonApiNotificationChannelOutAttributesDashboardLinkVisibilityEnum.ALL;
+        case "internalOnly":
+            return JsonApiNotificationChannelOutAttributesDashboardLinkVisibilityEnum.INTERNAL_ONLY;
+        default:
+            return undefined;
     }
 }

--- a/libs/sdk-model/api/sdk-model.api.md
+++ b/libs/sdk-model/api/sdk-model.api.md
@@ -2501,6 +2501,7 @@ export type INotificationChannelMetadataObject = IWebhookNotificationChannelMeta
 export interface INotificationChannelMetadataObjectBase {
     allowedRecipients?: NotificationChannelAllowedRecipients;
     customDashboardUrl?: string;
+    dashboardLinkVisibility?: NotificationChannelDashboardLinkVisibility;
     destinationType: NotificationChannelDestinationType;
     // (undocumented)
     type: "notificationChannel";
@@ -4623,6 +4624,9 @@ export function newVirtualArithmeticMeasure(measuresOrIds: ReadonlyArray<Measure
 
 // @beta
 export type NotificationChannelAllowedRecipients = "creator" | "internal" | "external";
+
+// @beta
+export type NotificationChannelDashboardLinkVisibility = "hidden" | "visible" | "internalOnly";
 
 // @beta
 export type NotificationChannelDestinationType = "webhook" | "smtp" | "inPlatform";

--- a/libs/sdk-model/src/index.ts
+++ b/libs/sdk-model/src/index.ts
@@ -49,6 +49,7 @@ export type {
     NotificationChannelDestinationType,
     INotificationChannelMetadataObject,
     INotificationChannelMetadataObjectDefinition,
+    NotificationChannelDashboardLinkVisibility,
     INotificationChannelTestResponse,
     ToNotificationChannelMetadataObject,
 } from "./notificationChannels/index.js";

--- a/libs/sdk-model/src/notificationChannels/index.ts
+++ b/libs/sdk-model/src/notificationChannels/index.ts
@@ -1,4 +1,4 @@
-// (C) 2024 GoodData Corporation
+// (C) 2024-2025 GoodData Corporation
 import { IMdObject, isMdObject, isMdObjectDefinition, ToMdObjectDefinition } from "../ldm/metadata/next.js";
 
 /**
@@ -7,6 +7,17 @@ import { IMdObject, isMdObject, isMdObjectDefinition, ToMdObjectDefinition } fro
  * @beta
  */
 export type NotificationChannelDestinationType = "webhook" | "smtp" | "inPlatform";
+
+/**
+ * Visibility of the dashboard link in the email notification.
+ *
+ * Hidden - the link is not visible
+ * Visible - the link is visible for all
+ * InternalOnly - the link is visible only for internal users
+ *
+ * @beta
+ */
+export type NotificationChannelDashboardLinkVisibility = "hidden" | "visible" | "internalOnly";
 
 /**
  * Allowed recipients of notifications from this channel.
@@ -43,6 +54,11 @@ export interface INotificationChannelMetadataObjectBase {
      * If not specified it is going to be deduced based on the context. Allowed placeholders are \{workspaceId\}, \{dashboardId\}.
      */
     customDashboardUrl?: string;
+
+    /**
+     * Dashboard link visibility.
+     */
+    dashboardLinkVisibility?: NotificationChannelDashboardLinkVisibility;
 }
 
 /**


### PR DESCRIPTION
Design propagate display of link for channels

risk: low
JIRA: F1-1017

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests.
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```
