### PR TITLE
fix: register for async render as early as possible

### DIFF
--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/render/renderingWorker.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/render/renderingWorker.ts
@@ -1,4 +1,4 @@
-// (C) 2021-2024 GoodData Corporation
+// (C) 2021-2025 GoodData Corporation
 import { Task, SagaIterator } from "redux-saga";
 import { put, delay, take, join, race, call, all, spawn, cancel, actionChannel } from "redux-saga/effects";
 import { v4 as uuidv4 } from "uuid";
@@ -68,6 +68,13 @@ export interface RenderingWorkerConfiguration {
      *
      */
     asyncRenderExpectedCount?: number;
+
+    /**
+     * Indicates whether rendering worker is triggered inside export mode
+     *
+     * Default: false
+     */
+    isExport?: boolean;
 }
 
 const baseConfig: RenderingWorkerConfiguration = {
@@ -75,6 +82,7 @@ const baseConfig: RenderingWorkerConfiguration = {
     asyncRenderResolvedTimeout: 2000,
     maxTimeout: 20 * 60000,
     correlationIdGenerator: uuidv4,
+    isExport: false,
 };
 export function newRenderingWorker(renderingWorkerConfig: Partial<RenderingWorkerConfiguration>) {
     return function* renderingWorker(ctx: DashboardContext): SagaIterator<void> {
@@ -121,6 +129,16 @@ function* collectAsyncRenderTasks(config: RenderingWorkerConfiguration): SagaIte
         });
 
         if (timeoutResolved) {
+            if (
+                config.asyncRenderExpectedCount !== undefined &&
+                config.asyncRenderExpectedCount !== 0 &&
+                config.isExport
+            ) {
+                // put as console.error in export mode to get to the exporter logs
+                console.error(
+                    `Rendering worker reached timeout with ${asyncRenderTasks.size} registered tasks, expected ${config.asyncRenderExpectedCount}`,
+                );
+            }
             break;
         }
 

--- a/libs/sdk-ui-dashboard/src/model/react/useInitializeDashboardStore.ts
+++ b/libs/sdk-ui-dashboard/src/model/react/useInitializeDashboardStore.ts
@@ -1,4 +1,4 @@
-// (C) 2021-2024 GoodData Corporation
+// (C) 2021-2025 GoodData Corporation
 import { useEffect, useRef, useState } from "react";
 import { useBackendStrict, useClientWorkspaceIdentifiers, usePrevious, useWorkspace } from "@gooddata/sdk-ui";
 import { useMapboxToken, enrichMapboxToken } from "@gooddata/sdk-ui-geo";
@@ -110,11 +110,16 @@ export const useInitializeDashboardStore = (
 
             let asyncRenderExpectedCount = undefined;
             if (isDashboard(dashboard) && dashboard.layout !== undefined && !dashboard.plugins) {
-                asyncRenderExpectedCount = getWidgetsOfType(dashboard.layout, ["kpi", "insight"]).length;
+                asyncRenderExpectedCount = getWidgetsOfType(dashboard.layout, [
+                    "kpi",
+                    "insight",
+                    "visualizationSwitcher",
+                ]).length;
             }
             const backgroundWorkers = [
                 newRenderingWorker({
                     asyncRenderExpectedCount,
+                    isExport: config?.isExport,
                 }),
             ];
 


### PR DESCRIPTION
- move registration to earlier stage (useEffect)
- fix async expected count for vis switcher widget

risk: low
JIRA: STL-982


<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests.
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```