### PR TITLE
fix: miss tooltip when hover the guest card

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/localization/bundles/en-US.json
+++ b/libs/sdk-ui-dashboard/src/presentation/localization/bundles/en-US.json
@@ -538,6 +538,11 @@
         "comment": "Message for recipients input when a user is external and not allowed.",
         "limit": 0
     },
+    "dialogs.schedule.email.user.used.external": {
+        "value": "The email “{email}” does not belong to this workspace. The recipient may receive sensitive data.",
+        "comment": "Message for recipients input when a user is external and allowed.",
+        "limit": 0
+    },
     "dialogs.schedule.email.user.warning.external": {
         "value": "This email address does not belong to this workspace. The recipient may receive sensitive data.",
         "comment": "Message for recipients input when a user is external",

--- a/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/components/RecipientsSelect/RecipientsSelectRenderer.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/components/RecipientsSelect/RecipientsSelectRenderer.tsx
@@ -355,6 +355,22 @@ export class RecipientsSelectRenderer extends React.PureComponent<
             );
         }
 
+        if (options.type === "externalUser") {
+            return (
+                <BubbleHoverTrigger>
+                    {render()}
+                    <Bubble className="bubble-primary" alignPoints={TOOLTIP_ALIGN_POINTS}>
+                        <FormattedMessage
+                            id="dialogs.schedule.email.user.used.external"
+                            values={{
+                                email: label,
+                            }}
+                        />
+                    </Bubble>
+                </BubbleHoverTrigger>
+            );
+        }
+
         return render();
     };
 


### PR DESCRIPTION
risk: low
JIRA: F1-1037

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests.
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```
