### PR TITLE
fix: more bug fixes

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/localization/bundles/en-US.json
+++ b/libs/sdk-ui-dashboard/src/presentation/localization/bundles/en-US.json
@@ -548,9 +548,9 @@
         "comment": "Message for recipients input when a user is external",
         "limit": 0
     },
-    "dialogs.schedule.email.user.quest": {
-        "value": "(quest)",
-        "comment": "Quest user label",
+    "dialogs.schedule.email.user.guest": {
+        "value": "(guest)",
+        "comment": "Guest user label",
         "limit": 0
     },
     "dialogs.schedule.email.subject.label": {

--- a/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/components/RecipientsSelect/RecipientsSelectRenderer.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/components/RecipientsSelect/RecipientsSelectRenderer.tsx
@@ -40,7 +40,6 @@ import { DASHBOARD_DIALOG_OVERS_Z_INDEX } from "../../../../constants/index.js";
 const MAXIMUM_RECIPIENTS_RECEIVE = 60;
 const DELAY_TIME = 500;
 const PADDING = 16;
-const REMOVE_ICON_WIDTH = 21;
 const LOADING_MENU_HEIGHT = 50;
 const CREATE_OPTION = "create-option";
 const SELECT_OPTION = "select-option";
@@ -240,9 +239,7 @@ export class RecipientsSelectRenderer extends React.PureComponent<
         const { width } = (!isEmpty(current) && current!.getBoundingClientRect()) || { width: undefined };
 
         return {
-            maxWidth: width
-                ? width - PADDING - REMOVE_ICON_WIDTH // label item width equal value item container - padding - remove icon
-                : "100%",
+            maxWidth: width ? width - PADDING : "100%",
             width,
         };
     }
@@ -282,7 +279,7 @@ export class RecipientsSelectRenderer extends React.PureComponent<
         const style = this.getStyle();
         return (
             <OverlayControllerProvider overlayController={overlayController}>
-                <Overlay alignTo={".gd-recipients__value-container"}>
+                <Overlay alignTo={".gd-recipients-container"} alignPoints={[{ align: "bc tc" }]}>
                     <div className="gd-recipients-overlay" style={{ width: style.width }}>
                         <Menu className="s-gd-recipients-menu-container" {...menuProps}>
                             {menuProps.children}
@@ -313,20 +310,19 @@ export class RecipientsSelectRenderer extends React.PureComponent<
         const render = () => {
             return (
                 <div
+                    style={{ maxWidth: style.maxWidth }}
                     className={cx("gd-recipient-value-item s-gd-recipient-value-item multiple-value", {
                         "invalid-email": !options.hasEmail,
                         "invalid-external": options.noExternal,
                     })}
                 >
-                    <div style={{ maxWidth: style.maxWidth }} className="gd-recipient-label">
-                        {label}
-                    </div>
+                    <div className="gd-recipient-label">{label}</div>
                     {options.type === "externalUser" ? (
                         <div className="gd-recipient-quest">
-                            <FormattedMessage id="dialogs.schedule.email.user.quest" />
+                            <FormattedMessage id="dialogs.schedule.email.user.guest" />
                         </div>
                     ) : null}
-                    <div aria-label="remove-icon" className="s-gd-recipient-remove">
+                    <div aria-label="remove-icon" className="gd-recipient-remove-icon s-gd-recipient-remove">
                         {removeIcon}
                     </div>
                 </div>

--- a/libs/sdk-ui-dashboard/styles/scss/scheduled_mail_recipients.scss
+++ b/libs/sdk-ui-dashboard/styles/scss/scheduled_mail_recipients.scss
@@ -127,10 +127,19 @@ $input-height: 28px;
             color: kit-variables.$gd-color-text;
             font-family: kit-variables.$gd-font-primary;
             font-size: 14px;
+            flex-grow: 0;
+            flex-shrink: 1;
         }
 
         .gd-recipient-quest {
             color: kit-variables.$gd-color-state-blank;
+            flex-grow: 0;
+            flex-shrink: 0;
+        }
+
+        .gd-recipient-remove-icon {
+            flex-grow: 0;
+            flex-shrink: 0;
         }
 
         // custom className from react-select rendered
@@ -191,8 +200,6 @@ $input-height: 28px;
 }
 
 .gd-recipients-overlay {
-    margin-top: 31px;
-
     // custom className from react-select rendered
     .gd-recipients__menu {
         padding: 0;


### PR DESCRIPTION
- Always show line cutting through the text when adding email that extends to the second line
- Wrong label "quest" and not show guest label in one line in field
- Miss tooltip when hover the guest card

risk: low
JIRA: F1-1038, F1-1040, F1-1037

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests.
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```
