### PR TITLE
fix: widgets on the first row of container are not aligned

### DIFF
--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -4581,6 +4581,8 @@ export interface IDashboardWidgetProps {
     parentLayoutItemSize?: IDashboardLayoutSizeByScreenSize;
     // @alpha
     parentLayoutPath?: ILayoutItemPath;
+    // @alpha
+    rowIndex?: number;
     // @alpha (undocumented)
     screen: ScreenSize;
     // @alpha
@@ -9808,6 +9810,8 @@ export interface WidthResizerDragItem {
     maxLimit: number;
     // (undocumented)
     minLimit: number;
+    // (undocumented)
+    rowIndex?: number;
     // (undocumented)
     sectionIndex: number;
     // (undocumented)

--- a/libs/sdk-ui-dashboard/src/_staging/layout/coordinates.ts
+++ b/libs/sdk-ui-dashboard/src/_staging/layout/coordinates.ts
@@ -305,14 +305,6 @@ export const hasParent = (path: ILayoutItemPath | ILayoutSectionPath): boolean =
     );
 };
 
-export const isFirstInContainer = (parentLayoutPath: ILayoutItemPath | undefined) => {
-    if (parentLayoutPath && parentLayoutPath.length > 1) {
-        const itemCoordinates = parentLayoutPath[parentLayoutPath.length - 1];
-        return itemCoordinates.itemIndex === 0 && itemCoordinates.sectionIndex === 0;
-    }
-    return false;
-};
-
 export const getParentPath = (
     path: ILayoutItemPath | ILayoutSectionPath | undefined,
 ): ILayoutItemPath | undefined => {

--- a/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/types.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/types.ts
@@ -1,4 +1,4 @@
-// (C) 2022-2024 GoodData Corporation
+// (C) 2022-2025 GoodData Corporation
 import { IDashboardAttributeFilter, IDashboardDateFilter, IInsight, IKpi } from "@gooddata/sdk-model";
 import { ICustomWidget } from "../../model/types/layoutTypes.js";
 import { ILayoutItemPath, ILayoutSectionPath } from "../../types.js";
@@ -409,6 +409,8 @@ export interface WidthResizerDragItem {
     initialLayoutDimensions: DOMRect;
     minLimit: number;
     maxLimit: number;
+    // TODO LX-608: make required
+    rowIndex?: number;
 }
 
 /**

--- a/libs/sdk-ui-dashboard/src/presentation/flexibleLayout/DashboardLayoutWidget.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/flexibleLayout/DashboardLayoutWidget.tsx
@@ -97,8 +97,8 @@ function getWidgetIndex(item: IDashboardLayoutItemFacade<ExtendedDashboardWidget
  */
 export const DashboardLayoutWidget: IDashboardLayoutWidgetRenderer<
     ExtendedDashboardWidget,
-    Pick<IDashboardWidgetProps, "onError" | "onDrill" | "onFiltersChange">
-> = ({ item, DefaultWidgetRenderer, onDrill, onFiltersChange, onError, getLayoutDimensions }) => {
+    Pick<IDashboardWidgetProps, "onError" | "onDrill" | "onFiltersChange" | "rowIndex">
+> = ({ item, DefaultWidgetRenderer, onDrill, onFiltersChange, onError, getLayoutDimensions, rowIndex }) => {
     const screen = useScreenSize();
     const dispatch = useDashboardDispatch();
     const insights = useDashboardSelector(selectInsightsMap);
@@ -200,6 +200,7 @@ export const DashboardLayoutWidget: IDashboardLayoutWidgetRenderer<
             className={className}
             contentRef={contentRef}
             getLayoutDimensions={getLayoutDimensions}
+            rowIndex={rowIndex}
         >
             <div
                 ref={dragRef}
@@ -232,6 +233,7 @@ export const DashboardLayoutWidget: IDashboardLayoutWidgetRenderer<
                             parentLayoutPath={item.index()}
                             ErrorComponent={ErrorComponent}
                             LoadingComponent={LoadingComponent}
+                            rowIndex={rowIndex}
                         />
                     </HoverDetector>
                 </DashboardItemPathAndSizeProvider>
@@ -269,6 +271,7 @@ export const DashboardLayoutWidget: IDashboardLayoutWidgetRenderer<
                                 getGridColumnHeightInPx={getHeightInPx}
                                 getGridColumnWidth={getGridColumnWidth}
                                 getLayoutDimensions={getLayoutDimensions}
+                                rowIndex={rowIndex}
                             />
                         </>
                     )}

--- a/libs/sdk-ui-dashboard/src/presentation/flexibleLayout/DefaultDashboardLayoutRenderer/DashboardLayoutEditSectionHeaderRenderer.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/flexibleLayout/DefaultDashboardLayoutRenderer/DashboardLayoutEditSectionHeaderRenderer.tsx
@@ -1,4 +1,4 @@
-// (C) 2019-2024 GoodData Corporation
+// (C) 2019-2025 GoodData Corporation
 import * as React from "react";
 
 import { isInitialPlaceholderWidget } from "../../../widgets/index.js";
@@ -28,6 +28,9 @@ export function DashboardLayoutEditSectionHeaderRenderer(
         <DashboardLayoutItemViewRenderer
             DefaultItemRenderer={DashboardLayoutItemViewRenderer}
             item={emptyItem}
+            // header is always at the top, this information is not usable by it but required by
+            // the shared interface with widget
+            rowIndex={-1}
         >
             <DashboardLayoutEditSectionHeader
                 section={section}

--- a/libs/sdk-ui-dashboard/src/presentation/flexibleLayout/DefaultDashboardLayoutRenderer/DashboardLayoutGridRow.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/flexibleLayout/DefaultDashboardLayoutRenderer/DashboardLayoutGridRow.tsx
@@ -1,4 +1,4 @@
-// (C) 2007-2024 GoodData Corporation
+// (C) 2007-2025 GoodData Corporation
 import React from "react";
 
 import { RenderMode } from "../../../types.js";
@@ -29,6 +29,7 @@ export interface DashboardLayoutGridRowProps<TWidget> {
     getLayoutDimensions: () => DOMRect;
     items: IDashboardLayoutItemFacade<TWidget>[];
     renderMode: RenderMode;
+    rowIndex: number;
 }
 
 const defaultItemKeyGetter: IDashboardLayoutItemKeyGetter<unknown> = ({ item }) =>
@@ -43,6 +44,7 @@ export function DashboardLayoutGridRow<TWidget>(props: DashboardLayoutGridRowPro
         widgetRenderer,
         items,
         renderMode,
+        rowIndex,
     } = props;
     const screen = useScreenSize();
 
@@ -52,6 +54,7 @@ export function DashboardLayoutGridRow<TWidget>(props: DashboardLayoutGridRowPro
             item={item}
             itemRenderer={itemRenderer}
             widgetRenderer={widgetRenderer}
+            rowIndex={rowIndex}
         />
     ));
 

--- a/libs/sdk-ui-dashboard/src/presentation/flexibleLayout/DefaultDashboardLayoutRenderer/DashboardLayoutGridRowEdit.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/flexibleLayout/DefaultDashboardLayoutRenderer/DashboardLayoutGridRowEdit.tsx
@@ -39,14 +39,17 @@ export function DashboardLayoutGridRowEdit<TWidget>(
     const isDraggingWidget = useIsDraggingWidget();
     const rowItems = useMemo(
         () =>
-            items.map((item) => (
-                <DashboardLayoutItem
-                    key={itemKeyGetter({ item, screen })}
-                    item={item}
-                    itemRenderer={itemRenderer}
-                    widgetRenderer={widgetRenderer}
-                />
-            )),
+            itemsInRowsByIndex.flatMap(([, itemsInRow], rowIndex) =>
+                itemsInRow.map((item) => (
+                    <DashboardLayoutItem
+                        key={itemKeyGetter({ item, screen })}
+                        item={item}
+                        itemRenderer={itemRenderer}
+                        widgetRenderer={widgetRenderer}
+                        rowIndex={rowIndex}
+                    />
+                )),
+            ),
         [itemKeyGetter, itemRenderer, items, screen, widgetRenderer],
     );
 

--- a/libs/sdk-ui-dashboard/src/presentation/flexibleLayout/DefaultDashboardLayoutRenderer/DashboardLayoutItem.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/flexibleLayout/DefaultDashboardLayoutRenderer/DashboardLayoutItem.tsx
@@ -1,4 +1,4 @@
-// (C) 2007-2024 GoodData Corporation
+// (C) 2007-2025 GoodData Corporation
 
 import React from "react";
 import {
@@ -17,6 +17,7 @@ export interface IDashboardLayoutItemProps<TWidget> {
     item: IDashboardLayoutItemFacade<TWidget>;
     itemRenderer?: IDashboardLayoutItemRenderer<TWidget>;
     widgetRenderer: IDashboardLayoutWidgetRenderer<TWidget>;
+    rowIndex: number;
 }
 
 const defaultItemRenderer: IDashboardLayoutItemRenderer<unknown> = (props) => (
@@ -24,11 +25,12 @@ const defaultItemRenderer: IDashboardLayoutItemRenderer<unknown> = (props) => (
 );
 
 export function DashboardLayoutItem<TWidget>(props: IDashboardLayoutItemProps<TWidget>): JSX.Element {
-    const { item, itemRenderer = defaultItemRenderer, widgetRenderer } = props;
+    const { item, itemRenderer = defaultItemRenderer, widgetRenderer, rowIndex } = props;
 
     const renderProps = {
         item,
         DefaultWidgetRenderer: DashboardLayoutWidgetRenderer,
+        rowIndex,
     } as IDashboardLayoutWidgetRenderProps<TWidget>;
 
     return itemRenderer({

--- a/libs/sdk-ui-dashboard/src/presentation/flexibleLayout/DefaultDashboardLayoutRenderer/DashboardLayoutSection.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/flexibleLayout/DefaultDashboardLayoutRenderer/DashboardLayoutSection.tsx
@@ -99,6 +99,9 @@ export function DashboardLayoutSection<TWidget>(props: IDashboardLayoutSectionPr
                     widgetRenderer={widgetRenderer}
                     renderMode={renderMode}
                     getLayoutDimensions={getLayoutDimensions}
+                    // The information is required by the interface but edit row counts the indexes of rows
+                    // in the inside of the component, unlike view row component.
+                    rowIndex={-1}
                 />
             );
         }
@@ -115,6 +118,7 @@ export function DashboardLayoutSection<TWidget>(props: IDashboardLayoutSectionPr
                     widgetRenderer={widgetRenderer}
                     renderMode={renderMode}
                     getLayoutDimensions={getLayoutDimensions}
+                    rowIndex={index}
                 />
             );
         });

--- a/libs/sdk-ui-dashboard/src/presentation/flexibleLayout/DefaultDashboardLayoutRenderer/DashboardLayoutSectionHeaderRenderer.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/flexibleLayout/DefaultDashboardLayoutRenderer/DashboardLayoutSectionHeaderRenderer.tsx
@@ -1,4 +1,4 @@
-// (C) 2019-2024 GoodData Corporation
+// (C) 2019-2025 GoodData Corporation
 
 import React, { useMemo } from "react";
 
@@ -28,6 +28,9 @@ export function DashboardLayoutSectionHeaderRenderer(
         <DashboardLayoutItemViewRenderer
             DefaultItemRenderer={DashboardLayoutItemViewRenderer}
             item={emptyItem}
+            // header is always at the top, this information is not usable by it but required by
+            // the shared interface with widget
+            rowIndex={-1}
         >
             <DashboardLayoutViewSectionHeader section={section} />
         </DashboardLayoutItemViewRenderer>

--- a/libs/sdk-ui-dashboard/src/presentation/flexibleLayout/DefaultDashboardLayoutRenderer/interfaces.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/flexibleLayout/DefaultDashboardLayoutRenderer/interfaces.ts
@@ -208,6 +208,11 @@ export interface IDashboardLayoutItemRenderProps<TWidget = IDashboardWidget> {
      * Widget rendered by widgetRenderer.
      */
     children: React.ReactNode;
+
+    /**
+     * Zero-based index of the row in which the item is rendered,
+     */
+    rowIndex: number;
 }
 
 /**
@@ -276,6 +281,11 @@ export interface IDashboardLayoutWidgetRenderProps<TWidget = IDashboardWidget> {
      * Default widget renderer - can be used as a fallback for custom widgetRenderer.
      */
     DefaultWidgetRenderer: IDashboardLayoutWidgetRenderer<TWidget>;
+
+    /**
+     * Zero-based index of the row in which the item is rendered,
+     */
+    rowIndex: number;
 }
 
 /**

--- a/libs/sdk-ui-dashboard/src/presentation/flexibleLayout/dragAndDrop/DragLayerPreview/WidthResizerDragPreview.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/flexibleLayout/dragAndDrop/DragLayerPreview/WidthResizerDragPreview.tsx
@@ -9,21 +9,6 @@ import { WidthResizerDragItem } from "../../../dragAndDrop/types.js";
 import { applySizeLimitation } from "./sizeLimiting.js";
 import { DragResizeProps } from "../../../dragAndDrop/DragLayerPreview/types.js";
 import { useResizeHandlers } from "../../../dragAndDrop/index.js";
-import { isFirstInContainer } from "../../../../_staging/layout/coordinates.js";
-
-interface IWidthResizerDragPreviewOwnProps {
-    item: WidthResizerDragItem;
-    differenceFromInitialOffset: XYCoord;
-    initialSourceClientOffset: XYCoord;
-}
-
-export interface IWidthResizerDragPreviewDispatchProps {
-    toggleMinLimitReached: (value: boolean) => void;
-    positionIndexChanged: (initialIndex: number, currentIndex: number) => void;
-}
-
-export type IWidthResizerDragPreviewProps = IWidthResizerDragPreviewDispatchProps &
-    IWidthResizerDragPreviewOwnProps;
 
 export type WidthResizerDragPreviewProps = DragResizeProps<WidthResizerDragItem>;
 
@@ -32,8 +17,7 @@ export function WidthResizerDragPreview(props: WidthResizerDragPreviewProps) {
 
     const { item, differenceFromInitialOffset, initialOffset, scrollCorrection, getDragLayerPosition } =
         props;
-    const { gridColumnHeightInPx, layoutPath } = item;
-    const firstInContainer = isFirstInContainer(layoutPath);
+    const { gridColumnHeightInPx, rowIndex } = item;
 
     const sizeAndCoords = getSizeAndXCoords(
         item,
@@ -72,7 +56,7 @@ export function WidthResizerDragPreview(props: WidthResizerDragPreviewProps) {
                 "gd-grid-layout-resizer-drag-preview",
                 "gd-grid-layout-width-resizer-drag-preview",
                 {
-                    "gd-first-in-container": firstInContainer,
+                    "gd-first-container-row-widget": rowIndex === 0,
                 },
             )}
             style={style}

--- a/libs/sdk-ui-dashboard/src/presentation/flexibleLayout/dragAndDrop/Resize/WidthResizerHotspot.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/flexibleLayout/dragAndDrop/Resize/WidthResizerHotspot.tsx
@@ -18,13 +18,13 @@ import { useDashboardDrag, useResizeHandlers, useResizeWidthItemStatus } from ".
 import { WidthResizer } from "./WidthResizer.js";
 import { useScreenSize } from "../../../dashboard/components/DashboardScreenSizeContext.js";
 import { useHoveredWidget } from "../../../dragAndDrop/HoveredWidgetContext.js";
-import { isFirstInContainer } from "../../../../_staging/layout/coordinates.js";
 
 export type WidthResizerHotspotProps = {
     item: IDashboardLayoutItemFacade<unknown>;
     getGridColumnHeightInPx: () => number;
     getGridColumnWidth: () => number;
     getLayoutDimensions: () => DOMRect;
+    rowIndex: number;
 };
 
 export function WidthResizerHotspot({
@@ -32,6 +32,7 @@ export function WidthResizerHotspot({
     getGridColumnWidth,
     getGridColumnHeightInPx,
     getLayoutDimensions,
+    rowIndex,
 }: WidthResizerHotspotProps) {
     const dispatch = useDashboardDispatch();
     const insightsMap = useDashboardSelector(selectInsightsMap);
@@ -48,7 +49,6 @@ export function WidthResizerHotspot({
     const onMouseEnter = () => setResizerVisibility(true);
     const onMouseLeave = () => setResizerVisibility(false);
     const layoutPath = item.index();
-    const firstInContainer = isFirstInContainer(layoutPath);
 
     const currentWidth = item.sizeForScreen(screen)!.gridWidth;
     const minLimit = getMinWidth(widget, insightsMap, screen, settings);
@@ -69,6 +69,7 @@ export function WidthResizerHotspot({
                     currentWidth,
                     minLimit,
                     maxLimit,
+                    rowIndex,
                 };
             },
             dragEnd: (dragItem, monitor) => {
@@ -86,7 +87,7 @@ export function WidthResizerHotspot({
             },
         },
 
-        [widget, insightsMap, layoutPath, currentWidth, minLimit, maxLimit],
+        [widget, insightsMap, layoutPath, currentWidth, minLimit, maxLimit, rowIndex],
     );
 
     useEffect(() => {
@@ -110,7 +111,7 @@ export function WidthResizerHotspot({
     return (
         <div
             className={cx("dash-width-resizer-container", {
-                "gd-first-in-container": firstInContainer,
+                "gd-first-container-row-widget": rowIndex === 0,
             })}
         >
             {status === "default" ? (

--- a/libs/sdk-ui-dashboard/src/presentation/widget/widget/types.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/widget/types.ts
@@ -1,4 +1,4 @@
-// (C) 2020-2024 GoodData Corporation
+// (C) 2020-2025 GoodData Corporation
 import { ComponentType } from "react";
 import { IAnalyticalBackend } from "@gooddata/sdk-backend-spi";
 import { IErrorProps, ILoadingProps, OnError } from "@gooddata/sdk-ui";
@@ -139,6 +139,17 @@ export interface IDashboardWidgetProps {
      * @alpha
      */
     showMenu?: boolean;
+
+    /**
+     * Zero-based index of the row in which the item is rendered,
+     *
+     * @alpha
+     *
+     * @remarks
+     * Optional only for the compatibility reasons with old fluid layout.
+     * Once the flexible layout is the only one supported, it can be set as required.
+     */
+    rowIndex?: number;
 }
 
 ///

--- a/libs/sdk-ui-dashboard/styles/scss/dashboard.scss
+++ b/libs/sdk-ui-dashboard/styles/scss/dashboard.scss
@@ -748,10 +748,10 @@ $dashboard-menu-item-icon-color: var(--gd-palette-complementary-5-from-theme, #b
                 border-color: kit-variables.$is-focused-background;
             }
         }
-        &:not(.gd-dashboard-nested-layout-widget):not(.gd-first-in-container):not(.drag-info-placeholder) {
+        &:not(.gd-dashboard-nested-layout-widget):not(.gd-first-container-row-widget):not(.drag-info-placeholder) {
             padding: 10px 0; // no place between widgets, render only containers for resizers
         }
-        &.gd-first-in-container:not(.gd-dashboard-nested-layout-widget) {
+        &.gd-first-container-row-widget:not(.gd-dashboard-nested-layout-widget) {
             padding: 0 0 10px 0;
         }
     }

--- a/libs/sdk-ui-dashboard/styles/scss/resizing.scss
+++ b/libs/sdk-ui-dashboard/styles/scss/resizing.scss
@@ -208,7 +208,7 @@
 
 .gd-grid-layout-width-resizer-drag-preview {
     padding: 0 0 0 30px;
-    &.gd-first-in-container {
+    &.gd-first-container-row-widget {
         .gd-fluidlayout-width-resizer__container {
             padding-top: 0;
         }
@@ -291,7 +291,7 @@
         left: -25px;
         right: 0;
         width: 0;
-        &.gd-first-in-container {
+        &.gd-first-container-row-widget {
             .gd-fluidlayout-width-resizer__container {
                 padding-top: 0;
             }


### PR DESCRIPTION
The first widget of the container is higher than the subsequent widgets. We need to detect the row index of the widgets and gave the widgets on the first row the same class and style them the same way. The current code styled only the first widget of the first row differently, counting with the fact that containers will have just a single widget per row which was later changed.

JIRA: LX-736
risk: low

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests.
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```
