### PR TITLE
fix: bug with invalid state of recipients

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/components/RecipientsSelect/RecipientsSelect.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/components/RecipientsSelect/RecipientsSelect.tsx
@@ -94,7 +94,7 @@ export const RecipientsSelect: React.FC<IRecipientsSelectProps> = (props) => {
 
     const options = useMemo(() => {
         const validUsers = [
-            ...(allowOnlyLoggedUserRecipients ? users : []),
+            ...(allowOnlyLoggedUserRecipients ? [] : users),
             ...(allowOnlyLoggedUserRecipients && loggedUser ? [loggedUser] : []),
         ];
         const filteredUsers = search ? validUsers.filter((user) => matchUser(user, search)) : validUsers;


### PR DESCRIPTION
[External recipient] Button "Save" editing schedule/alert is disabled after switching destination from EXTERNAL to CREATOR

risk: low
JIRA: F1-1043

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests.
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```
