### PR TITLE
fix: performance

### DIFF
--- a/libs/sdk-backend-tiger/src/backend/features/feature.ts
+++ b/libs/sdk-backend-tiger/src/backend/features/feature.ts
@@ -625,6 +625,13 @@ export function mapFeatures(features: FeaturesMap): Partial<ITigerFeatureFlags> 
             "BOOLEAN",
             FeatureFlagsValues.enableAmplitudeTracker,
         ),
+        ...loadFeature(
+            features,
+            TigerFeaturesNames.EnableCriticalContentPerformanceOptimizations,
+            "enableCriticalContentPerformanceOptimizations",
+            "BOOLEAN",
+            FeatureFlagsValues.enableCriticalContentPerformanceOptimizations,
+        ),
     };
 }
 

--- a/libs/sdk-backend-tiger/src/backend/uiFeatures.ts
+++ b/libs/sdk-backend-tiger/src/backend/uiFeatures.ts
@@ -127,6 +127,7 @@ export enum TigerFeaturesNames {
     EnableVisualizationFineTuning = "enableVisualizationFineTuning",
     EnableDashboardDescriptionDynamicHeight = "enableDashboardDescriptionDynamicHeight",
     EnableAmplitudeTracker = "enableAmplitudeTracker",
+    EnableCriticalContentPerformanceOptimizations = "enableCriticalContentPerformanceOptimizations",
 }
 
 export type ITigerFeatureFlags = {
@@ -217,6 +218,7 @@ export type ITigerFeatureFlags = {
     enableDrilledTooltip: typeof FeatureFlagsValues["enableDrilledTooltip"][number];
     enableDashboardDescriptionDynamicHeight: typeof FeatureFlagsValues["enableDashboardDescriptionDynamicHeight"][number];
     enableAmplitudeTracker: typeof FeatureFlagsValues["enableAmplitudeTracker"][number];
+    enableCriticalContentPerformanceOptimizations: typeof FeatureFlagsValues["enableCriticalContentPerformanceOptimizations"][number];
 };
 
 export const DefaultFeatureFlags: ITigerFeatureFlags = {
@@ -307,6 +309,7 @@ export const DefaultFeatureFlags: ITigerFeatureFlags = {
     enableDrilledTooltip: true,
     enableDashboardDescriptionDynamicHeight: false,
     enableAmplitudeTracker: false,
+    enableCriticalContentPerformanceOptimizations: false,
 };
 
 export const FeatureFlagsValues = {
@@ -401,4 +404,5 @@ export const FeatureFlagsValues = {
     enableDrilledTooltip: [true, false] as const,
     enableDashboardDescriptionDynamicHeight: [true, false] as const,
     enableAmplitudeTracker: [true, false] as const,
+    enableCriticalContentPerformanceOptimizations: [true, false] as const,
 };

--- a/libs/sdk-model/api/sdk-model.api.md
+++ b/libs/sdk-model/api/sdk-model.api.md
@@ -3338,6 +3338,8 @@ export interface ISettings {
     enableComparisonInAlerting?: boolean;
     enableCompositeGrain?: boolean;
     enableCreateUser?: boolean;
+    // @alpha
+    enableCriticalContentPerformanceOptimizations?: boolean;
     // @internal
     enableCrossFilteringAliasTitles?: boolean;
     // (undocumented)

--- a/libs/sdk-model/src/settings/index.ts
+++ b/libs/sdk-model/src/settings/index.ts
@@ -581,6 +581,12 @@ export interface ISettings {
      */
     enableAmplitudeTracker?: boolean;
 
+    /**
+     * Enables critical content performance optimizations.
+     * @alpha
+     */
+    enableCriticalContentPerformanceOptimizations?: boolean;
+
     [key: string]: number | boolean | string | object | undefined;
 }
 

--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -3131,7 +3131,7 @@ export function DefaultCancelButton({ isVisible, onCancelClick }: ICancelButtonP
 export const DefaultCancelEditDialog: React_2.FC<ICancelEditDialogProps>;
 
 // @alpha
-export const DefaultDashboardAttributeFilter: (props: IDashboardAttributeFilterProps) => JSX.Element | null;
+export const DefaultDashboardAttributeFilter: (props: IDashboardAttributeFilterProps) => JSX.Element;
 
 // @internal (undocumented)
 export function DefaultDashboardAttributeFilterComponentSetFactory(attributeFilterProvider: AttributeFilterComponentProvider): AttributeFilterComponentSet;
@@ -7692,6 +7692,9 @@ export const selectEnableCompanyLogoInEmbeddedUI: DashboardSelector<boolean>;
 
 // @alpha (undocumented)
 export const selectEnableComparisonInAlerting: DashboardSelector<boolean>;
+
+// @internal (undocumented)
+export const selectEnableCriticalContentPerformanceOptimizations: DashboardSelector<boolean>;
 
 // @internal
 export const selectEnableCrossFilteringAliasTitles: DashboardSelector<boolean>;

--- a/libs/sdk-ui-dashboard/src/model/store/config/configSelectors.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/config/configSelectors.ts
@@ -863,3 +863,13 @@ export const selectEnableDashboardDescriptionDynamicHeight: DashboardSelector<bo
         return state.settings?.enableDashboardDescriptionDynamicHeight ?? false;
     },
 );
+
+/**
+ * @internal
+ */
+export const selectEnableCriticalContentPerformanceOptimizations: DashboardSelector<boolean> = createSelector(
+    selectConfig,
+    (state) => {
+        return state.settings?.enableCriticalContentPerformanceOptimizations ?? false;
+    },
+);

--- a/libs/sdk-ui-dashboard/src/model/store/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/index.ts
@@ -103,6 +103,7 @@ export {
     selectEnableDrilledTooltip,
     selectFocusObject,
     selectEnableDashboardDescriptionDynamicHeight,
+    selectEnableCriticalContentPerformanceOptimizations,
 } from "./config/configSelectors.js";
 export type { EntitlementsState } from "./entitlements/entitlementsState.js";
 export {

--- a/libs/sdk-ui-filters/src/AttributeFilter/hooks/useAttributeFilterControllerData.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilter/hooks/useAttributeFilterControllerData.ts
@@ -1,4 +1,4 @@
-// (C) 2022-2024 GoodData Corporation
+// (C) 2022-2025 GoodData Corporation
 import { useState, useEffect } from "react";
 import isEmpty from "lodash/isEmpty.js";
 import {
@@ -23,7 +23,7 @@ export function useAttributeFilterControllerData(
 
     const initStatus = handlerState.initialization.status;
     const initError = handlerState.initialization.error;
-    const isInitializing = initStatus === "loading";
+    const isInitializing = initStatus === "loading" || initStatus === "pending";
 
     const attribute = handlerState.attribute.data;
 


### PR DESCRIPTION
Add `enableCriticalContentPerformanceOptimizations` feature flag to enable possible performance optimizations for the critical content rendering of the dashboard.

Postpone initialization of the dashboard attribute filter(s), which significantly reduces the time to show the visualizations, especially in the case of a large number of attribute filters (in case `enableCriticalContentPerformanceOptimizations` is enabled).

risk: low
JIRA: F1-1052

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests.
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```
