### PR TITLE
fix: new text for active state and styles unification for drop zone

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/flexibleLayout/dragAndDrop/draggableWidget/EmptyNestedLayoutDropZone.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/flexibleLayout/dragAndDrop/draggableWidget/EmptyNestedLayoutDropZone.tsx
@@ -1,6 +1,6 @@
-// (C) 2022-2024 GoodData Corporation
+// (C) 2022-2025 GoodData Corporation
 import React, { ReactNode } from "react";
-import { FormattedMessage } from "react-intl";
+import { FormattedMessage, defineMessages } from "react-intl";
 import cx from "classnames";
 import { Typography } from "@gooddata/sdk-ui-kit";
 
@@ -17,11 +17,21 @@ const widgetCategoryMapping: Partial<{ [D in DraggableItemType]: string }> = {
     visualizationSwitcherListItem: "visualizationSwitcher",
     dashboardLayoutListItem: "dashboardLayout",
 };
-export const DropZoneMessage: React.FC = () => {
+
+const messages = defineMessages({
+    dropZoneMessage: {
+        id: "nestedLayout.emptyDropZone.message",
+    },
+    dropZoneMessageActive: {
+        id: "nestedLayout.emptyDropZone.active.message",
+    },
+});
+
+export const DropZoneMessage: React.FC<{ canDrop?: boolean }> = ({ canDrop = false }) => {
     return (
         <Typography tagName="p" className="drop-target-message">
             <FormattedMessage
-                id="nestedLayout.emptyDropZone.message"
+                id={canDrop ? messages.dropZoneMessageActive.id : messages.dropZoneMessage.id}
                 values={{
                     b: (chunks: ReactNode) => <b>{chunks}</b>,
                     br: <br />,
@@ -71,7 +81,7 @@ export const EmptyNestedLayoutDropZone: React.FC = () => {
                 <DefaultEmptyNestedLayoutDropZoneBody />
                 <div className="drag-info-placeholder-drop-target s-drag-info-placeholder-drop-target">
                     <div className="drop-target-inner">
-                        <DropZoneMessage />
+                        <DropZoneMessage canDrop={canDrop} />
                     </div>
                 </div>
             </div>

--- a/libs/sdk-ui-dashboard/src/presentation/localization/bundles/en-US.json
+++ b/libs/sdk-ui-dashboard/src/presentation/localization/bundles/en-US.json
@@ -2639,6 +2639,11 @@
         "comment": "<b>, </b> and {br} are HTML tags. Do not translate them.",
         "limit": 0
     },
+    "nestedLayout.emptyDropZone.active.message": {
+        "value": "<b>Drop here</b>{br}to add to the container",
+        "comment": "<b>, </b> and {br} are HTML tags. Do not translate them.",
+        "limit": 0
+    },
     "attributesDropdown.valuesLimiting.title": {
         "value": "Filter values by",
         "comment": "The title of section that configures filters for listed values in the filter. There is a list of applied filters below the title.",

--- a/libs/sdk-ui-dashboard/styles/scss/dragAndDrop.scss
+++ b/libs/sdk-ui-dashboard/styles/scss/dragAndDrop.scss
@@ -448,6 +448,16 @@
     }
 }
 
+.gd-dashboard-nested-layout-widget-visualization-content {
+    .drag-info-placeholder-box p {
+        margin-top: 0;
+    }
+
+    .drop-target-message {
+        line-height: 28px;
+    }
+}
+
 .drag-info-placeholder-drop-target,
 .drop-target-inner {
     position: absolute;


### PR DESCRIPTION
Initial drop zone now has new text for active state.

JIRA: LX-749
risk: low

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests.
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```
