### PR TITLE
fix: remove extra padding in first row dropzones and introduce new text for it in nested container

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/flexibleLayout/DashboardLayoutWidget.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/flexibleLayout/DashboardLayoutWidget.tsx
@@ -187,6 +187,7 @@ export const DashboardLayoutWidget: IDashboardLayoutWidgetRenderer<
 
     const hotspotClassNames = cx({
         "gd-nested-layout-hotspot": isNestedLayout,
+        "gd-first-container-row-dropzone": rowIndex === 0,
     });
 
     const remainingGridWidth = isCustomWidget(widget) ? 0 : getRemainingWidthInRow(item, screen);

--- a/libs/sdk-ui-dashboard/src/presentation/flexibleLayout/DefaultDashboardLayoutRenderer/DashboardLayoutItemRenderer.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/flexibleLayout/DefaultDashboardLayoutRenderer/DashboardLayoutItemRenderer.tsx
@@ -1,4 +1,4 @@
-// (C) 2007-2024 GoodData Corporation
+// (C) 2007-2025 GoodData Corporation
 import cx from "classnames";
 import React from "react";
 
@@ -11,7 +11,7 @@ import { IDashboardLayoutItemRenderer } from "./interfaces.js";
 import { useIsDraggingCurrentItem } from "../dragAndDrop/draggableWidget/useIsDraggingCurrentItem.js";
 
 const DashboardLayoutItemEditRenderer: IDashboardLayoutItemRenderer<unknown> = (props) => {
-    const { item, children } = props;
+    const { item, children, rowIndex } = props;
     const isDraggingCurrentItem = useIsDraggingCurrentItem(item.index());
     const isCustomWidget = isCustomWidgetBase(item.widget());
 
@@ -25,7 +25,7 @@ const DashboardLayoutItemEditRenderer: IDashboardLayoutItemRenderer<unknown> = (
             >
                 {children}
             </DashboardLayoutItemViewRenderer>
-            {isCustomWidget ? null : <RowEndHotspot item={item} />}
+            {isCustomWidget ? null : <RowEndHotspot item={item} rowIndex={rowIndex} />}
         </>
     );
 };

--- a/libs/sdk-ui-dashboard/src/presentation/flexibleLayout/dragAndDrop/draggableWidget/RowEndHotspot.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/flexibleLayout/dragAndDrop/draggableWidget/RowEndHotspot.tsx
@@ -1,4 +1,4 @@
-// (C) 2007-2024 GoodData Corporation
+// (C) 2007-2025 GoodData Corporation
 import { IDashboardWidget } from "@gooddata/sdk-model";
 import cx from "classnames";
 import React from "react";
@@ -15,10 +15,11 @@ import { getRemainingWidthInRow } from "../../rowEndHotspotHelper.js";
 
 export type RowEndHotspotProps<TWidget = IDashboardWidget> = {
     item: IDashboardLayoutItemFacade<TWidget>;
+    rowIndex: number;
 };
 
 export const RowEndHotspot = (props: RowEndHotspotProps<unknown>) => {
-    const { item } = props;
+    const { item, rowIndex } = props;
 
     const isInEditMode = useDashboardSelector(selectIsInEditMode);
     const screen = useScreenSize();
@@ -60,6 +61,7 @@ export const RowEndHotspot = (props: RowEndHotspotProps<unknown>) => {
                     "gd-fluidlayout-column-row-end-hotspot",
                     {
                         "gd-fluidlayout-column-dropzone__text--hidden": remainingGridWidth < 2,
+                        "gd-first-container-row-dropzone": rowIndex === 0,
                     },
                 )}
             >

--- a/libs/sdk-ui-dashboard/src/presentation/flexibleLayout/dragAndDrop/draggableWidget/WidgetDropZone.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/flexibleLayout/dragAndDrop/draggableWidget/WidgetDropZone.tsx
@@ -1,4 +1,4 @@
-// (C) 2022-2024 GoodData Corporation
+// (C) 2022-2025 GoodData Corporation
 import React from "react";
 
 import { ILayoutItemPath } from "../../../../types.js";
@@ -12,11 +12,13 @@ export type WidgetDropZoneProps = {
 };
 
 export const WidgetDropZone = (props: WidgetDropZoneProps) => {
-    const { isLastInSection, dropRef } = props;
+    const { isLastInSection, dropRef, layoutPath } = props;
+
+    const isInContainer = layoutPath.length > 1;
 
     return (
         <div className="widget-dropzone" ref={dropRef}>
-            <WidgetDropZoneBox isLast={isLastInSection} />
+            <WidgetDropZoneBox isLast={isLastInSection} isInContainer={isInContainer} />
         </div>
     );
 };

--- a/libs/sdk-ui-dashboard/src/presentation/flexibleLayout/dragAndDrop/draggableWidget/WidgetDropZoneBox.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/flexibleLayout/dragAndDrop/draggableWidget/WidgetDropZoneBox.tsx
@@ -1,15 +1,30 @@
-// (C) 2022-2024 GoodData Corporation
+// (C) 2022-2025 GoodData Corporation
 import React, { ReactNode } from "react";
 import cx from "classnames";
-import { FormattedMessage } from "react-intl";
+import { FormattedMessage, defineMessages } from "react-intl";
 import { Typography } from "@gooddata/sdk-ui-kit";
 
 interface IWidgetDropZoneBoxProps {
     isLast: boolean;
+    isInContainer: boolean;
 }
 
+const messages = defineMessages({
+    last: {
+        id: "dropzone.widget.last.in.row.desc",
+    },
+    lastInContainer: {
+        id: "dropzone.widget.last.in.container.row.desc",
+    },
+    default: {
+        id: "dropzone.widget.desc",
+    },
+});
+
 export const WidgetDropZoneBox: React.FC<IWidgetDropZoneBoxProps> = (props) => {
-    const { isLast } = props;
+    const { isLast, isInContainer } = props;
+
+    const message = isLast ? (isInContainer ? messages.lastInContainer : messages.last) : messages.default;
     return (
         <div
             className={cx("drag-info-placeholder", "widget-dropzone-box", "s-last-drop-position", "type-kpi")}
@@ -18,17 +33,10 @@ export const WidgetDropZoneBox: React.FC<IWidgetDropZoneBoxProps> = (props) => {
                 <div className="drag-info-placeholder-drop-target">
                     <div className="drop-target-inner">
                         <Typography tagName="p" className="drop-target-message kpi-drop-target">
-                            {isLast ? (
-                                <FormattedMessage
-                                    id="dropzone.widget.last.in.row.desc"
-                                    values={{ b: (chunks: ReactNode) => <b>{chunks}</b> }}
-                                />
-                            ) : (
-                                <FormattedMessage
-                                    id="dropzone.widget.desc"
-                                    values={{ b: (chunks: ReactNode) => <b>{chunks}</b> }}
-                                />
-                            )}
+                            <FormattedMessage
+                                id={message.id}
+                                values={{ b: (chunks: ReactNode) => <b>{chunks}</b> }}
+                            />
                         </Typography>
                     </div>
                 </div>

--- a/libs/sdk-ui-dashboard/src/presentation/localization/bundles/en-US.json
+++ b/libs/sdk-ui-dashboard/src/presentation/localization/bundles/en-US.json
@@ -2372,6 +2372,11 @@
         "comment": "Used as placeholder when user drags some widget and tries to drop it on dashboard. Dropping the widget over such placeholder will cause adding the widget to an existing section of a dashboard. Do not translate HTML markup enclosed in <>. Translate words 'existing section'.",
         "limit": 0
     },
+    "dropzone.widget.last.in.container.row.desc": {
+        "value": "Drop to the <b>existing container</b>",
+        "comment": "Used as placeholder when user drags some widget and tries to drop it on dashboard. Dropping the widget over such placeholder will cause adding the widget to an existing container of a dashboard. Do not translate HTML markup enclosed in <>. Translate words 'existing container'.",
+        "limit": 0
+    },
     "deleteKpiConfirmationDialog.headline": {
         "value": "Delete KPI",
         "comment": "",

--- a/libs/sdk-ui-dashboard/styles/scss/dashboardNestedLayoutWidget.scss
+++ b/libs/sdk-ui-dashboard/styles/scss/dashboardNestedLayoutWidget.scss
@@ -114,6 +114,10 @@
         height: 100%;
     }
 
+    .gd-first-container-row-dropzone .gd-hotspot-border__container {
+        padding-top: 0;
+    }
+
     .gd-hotspot-border__drop-target {
         width: 100%;
         height: 100%;

--- a/libs/sdk-ui-dashboard/styles/scss/dragAndDrop.scss
+++ b/libs/sdk-ui-dashboard/styles/scss/dragAndDrop.scss
@@ -839,12 +839,16 @@
         .drag-info-placeholder-inner {
             padding: 0;
         }
+        &.gd-first-container-row-dropzone .widget-dropzone-box {
+            padding-top: 0;
+        }
         .drag-info-placeholder-drop-target,
         .drop-target-inner {
             position: unset;
             height: 100%;
         }
     }
+
     .gd-fluidlayout-column-row-end-hotspot.gd-fluidlayout-column-dropzone__text--hidden {
         .drop-target-message.kpi-drop-target {
             display: none;


### PR DESCRIPTION
<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests.
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```
