### PR TITLE
fix: do not cut widgets at the end of nested layout during export

### DIFF
--- a/libs/sdk-ui-dashboard/styles/scss/export.scss
+++ b/libs/sdk-ui-dashboard/styles/scss/export.scss
@@ -1,27 +1,5 @@
 // (C) 2020-2025 GoodData Corporation
 
-// The following fixes export of flexible layouts to work in the most cases.
-// The below are some magic numbers that ensure that widgets at the end of dashboard are
-// usually not cut of and widgets at the end of the nested container do not bleed into the
-// next container/section. For some reason grid items overflow its container. It can be fixed
-// by changing display: grid to display: block/flex on the containers but then the grid nesting
-// is broken. Something is wrong with how the layout is constructed and interpreted by print
-// preview in Chromium. Maybe our grid structure is not clean enough and some flex containers
-// inside the grid tree messes up with it. For now, this is good enough but this needs to be fixed properly.
-// For future debugging purposes:
-// The export service sets the browser to width: 1265, height: 960, deviceScaleFactor: 0, mobile: false
-// The PDF is created with the following parameters: scale: 0.58, paperWidth: 8.5, paperHeight: 11.0,
-// marginTop: 0, marginBottom: 0, marginLeft: 0, marginRight: 0, printBackground: true
-@media print {
-    .gd-grid-layout__container--root {
-        padding-bottom: 500px;
-    }
-
-    .gd-grid-layout__container--nested {
-        padding-bottom: 300px;
-    }
-}
-
 .export-mode {
     * {
         transition: none !important; /* stylelint-disable-line declaration-no-important */
@@ -47,9 +25,8 @@
     }
 
     .gd-grid-layout__item--leaf {
-        // overwrite 'flex'
-        display: block !important; /* stylelint-disable-line declaration-no-important */
         page-break-inside: avoid;
+        border: 1px solid red !important; /* stylelint-disable-line declaration-no-important */
 
         .dash-item {
             min-height: inherit;
@@ -73,5 +50,25 @@
         left: 0;
         right: 0;
         bottom: 0;
+    }
+
+    // The following fixes export of flexible layouts to work in the most cases.
+    // The below are some magic numbers that ensure that widgets at the end of dashboard are
+    // usually not cut of and widgets at the end of the nested container do not bleed into the
+    // next container/section. For some reason grid items overflow its container. It can be fixed
+    // by changing display: grid to display: block/flex on the containers but then the grid nesting
+    // is broken. Something is wrong with how the layout is constructed and interpreted by print
+    // preview in Chromium. Maybe our grid structure is not clean enough and some flex containers
+    // inside the grid tree messes up with it. For now, this is good enough but this needs to be fixed properly.
+    // For future debugging purposes:
+    // The export service sets the browser to width: 1265, height: 960, deviceScaleFactor: 0, mobile: false
+    // The PDF is created with the following parameters: scale: 0.58, paperWidth: 8.5, paperHeight: 11.0,
+    // marginTop: 0, marginBottom: 0, marginLeft: 0, marginRight: 0, printBackground: true
+    .gd-grid-layout__container--root {
+        padding-bottom: 500px;
+    }
+
+    .gd-grid-layout__container--nested {
+        padding-bottom: 300px;
     }
 }


### PR DESCRIPTION
Includes temporary debugging style.

JIRA: LX-696
risk: low

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests.
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```
