### PR TITLE
fix: hide Title cfg for empty container and handle slow css-grid sizing in LinesEllipsis

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/presentationComponents/DashboardItems/DashboardItemHeadline.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/presentationComponents/DashboardItems/DashboardItemHeadline.tsx
@@ -1,5 +1,5 @@
-// (C) 2020-2022 GoodData Corporation
-import React, { useMemo } from "react";
+// (C) 2020-2025 GoodData Corporation
+import React, { useMemo, useRef } from "react";
 import LinesEllipsis from "react-lines-ellipsis";
 import responsiveHOC from "react-lines-ellipsis/lib/responsiveHOC.js";
 
@@ -13,17 +13,36 @@ interface IDashboardItemHeadlineProps {
 }
 
 export const DashboardItemHeadline: React.FC<IDashboardItemHeadlineProps> = ({ title, clientHeight }) => {
+    // actually reference to instance of LinesEllipsis component, but lib has wrong typings
+    const elementRef = useRef<HTMLDivElement>(null);
+
+    /**
+     * Component LinesEllipsis is not working properly with css-grid. It uses internally getComputedStyle on measured element,
+     * but it does it only once on init and it is before the element is placed and sized by the grid.
+     * Manual measurement of the element is needed to get the correct width
+     * and to force LinesEllipsis to re-init with the correct width.
+     */
+
+    //...target is internal reference to the div created by LinesEllipsis
+    // it is not exposed in the typings, so we need to use the type any
+    const target: HTMLDivElement = (elementRef.current as any)?.target;
+    let elementWidth: number | undefined = undefined;
+    if (target) {
+        elementWidth = target.getBoundingClientRect?.().width;
+    }
     // memoize the Truncate render as it is quite expensive
     const truncatedTitlePart = useMemo(() => {
         return (
             <ResponsiveEllipsis
+                key={elementWidth}
                 maxLine={2}
                 ellipsis="..."
                 className="item-headline-inner s-headline"
                 text={title}
+                innerRef={elementRef}
             />
         );
-    }, [title]);
+    }, [title, elementWidth]);
 
     return (
         <DashboardItemHeadlineContainer clientHeight={clientHeight}>

--- a/libs/sdk-ui-dashboard/src/presentation/widget/widget/DashboardNestedLayoutWidget/Toolbar.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/widget/DashboardNestedLayoutWidget/Toolbar.tsx
@@ -1,4 +1,4 @@
-// (C) 2024 GoodData Corporation
+// (C) 2024-2025 GoodData Corporation
 
 import React from "react";
 import { FormattedMessage } from "react-intl";
@@ -28,6 +28,7 @@ interface ToolbarProps {
 export const Toolbar: React.FC<ToolbarProps> = ({ layout, onWidgetDelete, onToggleHeaders, onClose }) => {
     const userInteraction = useDashboardUserInteraction();
     const { areSectionHeadersEnabled } = useLayoutSectionsConfiguration(layout);
+    const hasSections = layout.sections.length > 0;
     return (
         <Bubble
             className="bubble-light"
@@ -40,39 +41,44 @@ export const Toolbar: React.FC<ToolbarProps> = ({ layout, onWidgetDelete, onTogg
             arrowStyle={ARROW_STYLES}
             onClose={onClose}
         >
-            <div>
-                <BubbleHoverTrigger eventsOnBubble={true}>
-                    <div
-                        className="gd-nested-layout__toolbar__button s-nested-layout__button--headers"
-                        onClick={() => {
-                            onToggleHeaders(!areSectionHeadersEnabled);
-                            userInteraction.nestedLayoutInteraction(
-                                areSectionHeadersEnabled
-                                    ? "nestedLayoutHeaderDisabled"
-                                    : "nestedLayoutHeaderEnabled",
-                            );
-                        }}
-                    >
-                        <Icon.Header
-                            className={cx({
-                                "gd-nested-layout__toolbar__icon--headers-active": areSectionHeadersEnabled,
-                                "gd-nested-layout__toolbar__icon--headers-disabled":
-                                    !areSectionHeadersEnabled,
-                            })}
-                            width={28}
-                            height={28}
-                        />
+            {hasSections ? (
+                <>
+                    <div>
+                        <BubbleHoverTrigger eventsOnBubble={true}>
+                            <div
+                                className="gd-nested-layout__toolbar__button s-nested-layout__button--headers"
+                                onClick={() => {
+                                    onToggleHeaders(!areSectionHeadersEnabled);
+                                    userInteraction.nestedLayoutInteraction(
+                                        areSectionHeadersEnabled
+                                            ? "nestedLayoutHeaderDisabled"
+                                            : "nestedLayoutHeaderEnabled",
+                                    );
+                                }}
+                            >
+                                <Icon.Header
+                                    className={cx({
+                                        "gd-nested-layout__toolbar__icon--headers-active":
+                                            areSectionHeadersEnabled,
+                                        "gd-nested-layout__toolbar__icon--headers-disabled":
+                                            !areSectionHeadersEnabled,
+                                    })}
+                                    width={28}
+                                    height={28}
+                                />
+                            </div>
+                            <Bubble alignPoints={TOOLTIP_ALIGN_POINTS}>
+                                {areSectionHeadersEnabled ? (
+                                    <FormattedMessage id="nestedLayoutToolbar.hideHeader" />
+                                ) : (
+                                    <FormattedMessage id="nestedLayoutToolbar.showHeader" />
+                                )}
+                            </Bubble>
+                        </BubbleHoverTrigger>
                     </div>
-                    <Bubble alignPoints={TOOLTIP_ALIGN_POINTS}>
-                        {areSectionHeadersEnabled ? (
-                            <FormattedMessage id="nestedLayoutToolbar.hideHeader" />
-                        ) : (
-                            <FormattedMessage id="nestedLayoutToolbar.showHeader" />
-                        )}
-                    </Bubble>
-                </BubbleHoverTrigger>
-            </div>
-            <div className="gd-nested-layout__toolbar__delimiter" />
+                    <div className="gd-nested-layout__toolbar__delimiter" />
+                </>
+            ) : null}
             <div>
                 <BubbleHoverTrigger eventsOnBubble={true}>
                     <div

--- a/libs/sdk-ui-dashboard/styles/scss/dashboard.scss
+++ b/libs/sdk-ui-dashboard/styles/scss/dashboard.scss
@@ -312,22 +312,24 @@ $dashboard-menu-item-icon-color: var(--gd-palette-complementary-5-from-theme, #b
     }
 }
 
-.item-headline {
-    position: relative;
+.item-headline,
+.item-headline-inner {
     display: inline-block;
-    width: 100%;
-    max-height: (variables.$item-headline-lineHeight + variables.$item-headline-padding-vertical) * 2;
+    vertical-align: middle;
     font-size: 17px;
     line-height: variables.$item-headline-lineHeight;
-    vertical-align: middle;
+}
+
+.item-headline {
+    position: relative;
+    width: 100%;
+    max-height: (variables.$item-headline-lineHeight + variables.$item-headline-padding-vertical) * 2;
     text-align: variables.$gd-dashboards-content-widget-title-textAlign;
     color: variables.$gd-dashboards-content-widget-title-color;
 }
 
 .item-headline-inner {
-    display: inline-block;
     overflow: hidden;
-    vertical-align: middle;
 }
 
 .viz-zoom-out {


### PR DESCRIPTION
<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests.
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```
