### PR TITLE
fix: make resize overlay match the size of widget

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/flexibleLayout/DashboardLayoutWidget.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/flexibleLayout/DashboardLayoutWidget.tsx
@@ -254,6 +254,7 @@ export const DashboardLayoutWidget: IDashboardLayoutWidgetRenderer<
                         reachedWidthLimit={widthLimitReached}
                         reachedHeightLimit={heightLimitReached}
                         isOverNestedLayout={isNestedLayout}
+                        isInFirstRow={rowIndex === 0}
                     />
                 ) : null}
                 {canShowHotspot && !isAnyPlaceholderWidget(widget) ? (

--- a/libs/sdk-ui-dashboard/src/presentation/flexibleLayout/dragAndDrop/Resize/ResizeOverlay.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/flexibleLayout/dragAndDrop/Resize/ResizeOverlay.tsx
@@ -1,4 +1,4 @@
-// (C) 2019-2024 GoodData Corporation
+// (C) 2019-2025 GoodData Corporation
 import React from "react";
 import cx from "classnames";
 import { FormattedMessage, defineMessages } from "react-intl";
@@ -24,6 +24,7 @@ export interface ResizeOverlayProps {
     reachedWidthLimit: ReachedResizingLimit;
     reachedHeightLimit: ReachedResizingLimit;
     isOverNestedLayout?: boolean;
+    isInFirstRow?: boolean;
 }
 
 function getMessage({
@@ -69,7 +70,7 @@ function getStatus({
 
 export function ResizeOverlay(props: ResizeOverlayProps) {
     const status = getStatus(props);
-    const { isOverNestedLayout = false } = props;
+    const { isOverNestedLayout = false, isInFirstRow = false } = props;
 
     if (status === ResizeOverlayStatus.None) {
         return null;
@@ -82,6 +83,7 @@ export function ResizeOverlay(props: ResizeOverlayProps) {
         active: isActive,
         error: isInError,
         squared: isOverNestedLayout,
+        "gd-first-container-row-widget": isInFirstRow && !isOverNestedLayout,
     });
 
     const message = getMessage({

--- a/libs/sdk-ui-dashboard/styles/scss/resizing.scss
+++ b/libs/sdk-ui-dashboard/styles/scss/resizing.scss
@@ -150,6 +150,8 @@
             background: variables.$gd-palette-primary-base-mix15-white;
         }
         &.squared {
+            top: 0;
+            bottom: 0;
             left: 0;
             right: 0;
             margin: 0;
@@ -315,8 +317,15 @@
         height: 100%;
     }
     .gd-resize-overlay {
-        left: -10px;
-        right: -10px;
+        top: 5px;
+        bottom: 5px;
+        left: -5px;
+        right: -5px;
+        border-radius: calc(#{variables.$gd-dashboards-content-widget-borderRadius});
+    }
+
+    .gd-resize-overlay.gd-first-container-row-widget {
+        top: -5px;
     }
 }
 


### PR DESCRIPTION
Size of overlay changed so it matches exactly the size of widget with selected border. For both regular widgets and nested containers

JIRA: LX-754
risk: low

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests.
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```
