### PR TITLE
feat: dropzones do not reflect widgets default size anymore

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/flexibleLayout/dragAndDrop/draggableWidget/EmptyDashboardDropZone.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/flexibleLayout/dragAndDrop/draggableWidget/EmptyDashboardDropZone.tsx
@@ -1,5 +1,5 @@
-// (C) 2022-2024 GoodData Corporation
-import React, { ReactNode, useMemo } from "react";
+// (C) 2022-2025 GoodData Corporation
+import React, { ReactNode } from "react";
 import { FormattedMessage } from "react-intl";
 import cx from "classnames";
 import { Typography } from "@gooddata/sdk-ui-kit";
@@ -8,7 +8,6 @@ import { BaseDraggableLayoutItem, DraggableItemType } from "../../../dragAndDrop
 import { useDashboardComponentsContext } from "../../../dashboardContexts/index.js";
 import { useEmptyContentHandlers } from "./useEmptyContentHandlers.js";
 import { GridLayoutElement } from "../../DefaultDashboardLayoutRenderer/index.js";
-import { getDashboardLayoutItemHeightForGrid } from "../../../../_staging/layout/sizing.js";
 
 const widgetCategoryMapping: Partial<{ [D in DraggableItemType]: string }> = {
     "insight-placeholder": "insight",
@@ -29,17 +28,7 @@ export const EmptyDashboardDropZone: React.FC = () => {
 
     const { item, itemType, canDrop, isOver, dropRef } = useEmptyContentHandlers(sectionPath);
 
-    const { gridWidth = 12, gridHeight } = (item as BaseDraggableLayoutItem)?.size || {};
-    const layoutItemSize = useMemo(
-        () => ({
-            xl: { gridWidth, gridHeight },
-            lg: { gridWidth, gridHeight },
-            md: { gridWidth, gridHeight },
-            sm: { gridWidth, gridHeight },
-            xs: { gridWidth, gridHeight },
-        }),
-        [gridWidth, gridHeight],
-    );
+    const { gridHeight } = (item as BaseDraggableLayoutItem)?.size || {};
 
     const widgetCategory = widgetCategoryMapping[itemType];
     const message =
@@ -52,29 +41,28 @@ export const EmptyDashboardDropZone: React.FC = () => {
             />
         );
 
+    const emptyDashboardDropZoneSize = {
+        xl: { gridWidth: 12, gridHeight },
+        lg: { gridWidth: 12, gridHeight },
+        md: { gridWidth: 12, gridHeight },
+        sm: { gridWidth: 12, gridHeight },
+        xs: { gridWidth: 12, gridHeight },
+    };
+
     return (
         <GridLayoutElement
             type={"root"}
-            layoutItemSize={{
-                xl: { gridWidth: 12, gridHeight },
-                lg: { gridWidth: 12, gridHeight },
-                md: { gridWidth: 12, gridHeight },
-                sm: { gridWidth: 12, gridHeight },
-                xs: { gridWidth: 12, gridHeight },
-            }}
+            layoutItemSize={emptyDashboardDropZoneSize}
             className="gd-empty-dashboard-dropzone"
         >
             <GridLayoutElement
                 type={"item"}
-                layoutItemSize={layoutItemSize}
+                layoutItemSize={emptyDashboardDropZoneSize}
                 className={cx("drag-info-placeholder", "dash-item", {
                     [`type-${widgetCategory}`]: !!widgetCategory,
                     "type-none": !widgetCategory,
                     "s-last-drop-position": canDrop,
                 })}
-                style={{
-                    minHeight: gridHeight ? getDashboardLayoutItemHeightForGrid(gridHeight) : undefined,
-                }}
             >
                 <div
                     className={cx("drag-info-placeholder-inner", { "can-drop": canDrop, "is-over": isOver })}

--- a/libs/sdk-ui-dashboard/src/presentation/flexibleLayout/dragAndDrop/draggableWidget/EmptyNestedLayoutDropZone.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/flexibleLayout/dragAndDrop/draggableWidget/EmptyNestedLayoutDropZone.tsx
@@ -4,8 +4,7 @@ import { FormattedMessage, defineMessages } from "react-intl";
 import cx from "classnames";
 import { Typography } from "@gooddata/sdk-ui-kit";
 
-import { BaseDraggableLayoutItem, DraggableItemType } from "../../../dragAndDrop/types.js";
-import { getDashboardLayoutItemHeightForGrid } from "../../../../_staging/layout/sizing.js";
+import { DraggableItemType } from "../../../dragAndDrop/types.js";
 import { useEmptyContentHandlers } from "./useEmptyContentHandlers.js";
 import { useDashboardItemPathAndSize } from "../../../dashboard/components/DashboardItemPathAndSizeContext.js";
 
@@ -56,17 +55,12 @@ export const EmptyNestedLayoutDropZone: React.FC = () => {
         sectionIndex: 0,
     };
 
-    const { item, itemType, canDrop, isOver, dropRef } = useEmptyContentHandlers(sectionPath);
-
-    const { gridHeight } = (item as BaseDraggableLayoutItem)?.size || {};
+    const { itemType, canDrop, isOver, dropRef } = useEmptyContentHandlers(sectionPath);
 
     const widgetCategory = widgetCategoryMapping[itemType];
 
     return (
         <div
-            style={{
-                minHeight: gridHeight ? getDashboardLayoutItemHeightForGrid(gridHeight) : undefined,
-            }}
             className={cx("drag-info-placeholder", "dash-item", {
                 [`type-${widgetCategory}`]: !!widgetCategory,
                 "type-none": !widgetCategory,

--- a/libs/sdk-ui-dashboard/src/presentation/flexibleLayout/dragAndDrop/draggableWidget/RowEndHotspot.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/flexibleLayout/dragAndDrop/draggableWidget/RowEndHotspot.tsx
@@ -39,7 +39,7 @@ export const RowEndHotspot = (props: RowEndHotspotProps<unknown>) => {
     ); // increment item index manually as end hotspot is rendered as prev type
 
     const remainingGridWidth = getRemainingWidthInRow(item, screen);
-    const { gridHeight } = item.sizeForScreenWithFallback(screen);
+    //const { gridHeight } = item.sizeForScreenWithFallback(screen);
 
     const isDropZoneVisible = shouldShowRowEndDropZone(remainingGridWidth);
 
@@ -48,11 +48,11 @@ export const RowEndHotspot = (props: RowEndHotspotProps<unknown>) => {
             <GridLayoutElement
                 type="item"
                 layoutItemSize={{
-                    xl: { gridWidth: remainingGridWidth, gridHeight },
-                    lg: { gridWidth: remainingGridWidth, gridHeight },
-                    md: { gridWidth: remainingGridWidth, gridHeight },
-                    sm: { gridWidth: remainingGridWidth, gridHeight },
-                    xs: { gridWidth: remainingGridWidth, gridHeight },
+                    xl: { gridWidth: remainingGridWidth },
+                    lg: { gridWidth: remainingGridWidth },
+                    md: { gridWidth: remainingGridWidth },
+                    sm: { gridWidth: remainingGridWidth },
+                    xs: { gridWidth: remainingGridWidth },
                 }}
                 className={cx(
                     "gd-fluidlayout-column",

--- a/libs/sdk-ui-dashboard/src/presentation/flexibleLayout/dragAndDrop/draggableWidget/WidgetDropZoneColumn.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/flexibleLayout/dragAndDrop/draggableWidget/WidgetDropZoneColumn.tsx
@@ -1,4 +1,4 @@
-// (C) 2007-2024 GoodData Corporation
+// (C) 2007-2025 GoodData Corporation
 import cx from "classnames";
 import React, { useMemo } from "react";
 import {
@@ -12,7 +12,6 @@ import { useInsightListItemDropHandler } from "./useInsightListItemDropHandler.j
 import { useInsightPlaceholderDropHandler } from "./useInsightPlaceholderDropHandler.js";
 import { useKpiPlaceholderDropHandler } from "./useKpiPlaceholderDropHandler.js";
 import { useMoveWidgetDropHandler } from "./useMoveWidgetHandler.js";
-import { getDashboardLayoutItemHeightForGrid } from "../../../../_staging/layout/sizing.js";
 import { BaseDraggableLayoutItem } from "../../../dragAndDrop/types.js";
 import { useRichTextPlaceholderDropHandler } from "./useRichTextPlaceholderDropHandler.js";
 import { useVisualizationSwitcherPlaceholderDropHandler } from "./useVisualizationSwitcherPlaceholderDropHandler.js";
@@ -112,9 +111,6 @@ export const WidgetDropZoneColumn = (props: WidgetDropZoneColumnProps) => {
                 xs: { gridWidth: usedWidth, gridHeight },
             }}
             className={cx("gd-fluidlayout-column", "gd-fluidlayout-column-dropzone", "s-fluid-layout-column")}
-            style={{
-                minHeight: getDashboardLayoutItemHeightForGrid(gridHeight),
-            }}
         >
             <WidgetDropZone isLastInSection={isLastInSection} layoutPath={layoutPath} dropRef={dropRef} />
         </GridLayoutElement>

--- a/libs/sdk-ui-dashboard/styles/scss/dashboardNestedLayoutWidget.scss
+++ b/libs/sdk-ui-dashboard/styles/scss/dashboardNestedLayoutWidget.scss
@@ -94,6 +94,10 @@
 }
 
 .gd-grid-layout {
+    .gd-fluidlayout-column-dropzone {
+        height: 100%;
+    }
+
     .gd-empty-dashboard-dropzone {
         .drag-info-placeholder-inner,
         .drag-info-placeholder-drop-target {
@@ -103,6 +107,10 @@
         .drop-target-inner {
             align-content: center;
             height: 100%;
+        }
+
+        .drag-info-placeholder {
+            min-height: 300px;
         }
     }
 


### PR DESCRIPTION
Dropzone in existing row now fills just row's height, same in nested container. Dropznone on empty dashboard is full width and 300px height now.

JIRA: LX-751
risk: low

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests.
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```
