### PR TITLE
fix: caching

### DIFF
--- a/libs/sdk-ui-dashboard/src/model/store/executionResults/executionResultsSelectors.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/executionResults/executionResultsSelectors.ts
@@ -35,7 +35,8 @@ export const selectExecutionResult = adapterSelectors.selectById;
 export const selectHasSomeExecutionResult: DashboardSelector<boolean> = createSelector(
     selectExecutionResultEntities,
     (executionResults): boolean => {
-        return Object.values(executionResults).filter((e) => !!e?.executionResult).length >= 1;
+        // Empty results can be resolved as error, so consider error also as resolved
+        return Object.values(executionResults).filter((e) => !!e?.executionResult || !!e?.error).length >= 1;
     },
 );
 


### PR DESCRIPTION
Get rid of attributesWithReferences cache and map results from more granular caches to it properly.

Also fix selectHasSomeExecutionResult selector, as empty results are resolved as error.

risk: low
JIRA: F1-1052

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests.
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```
