### PR TITLE
fix: optimize date filter config requests

### DIFF
--- a/libs/sdk-backend-tiger/src/backend/settings/mapping.ts
+++ b/libs/sdk-backend-tiger/src/backend/settings/mapping.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2024 GoodData Corporation
+// (C) 2019-2025 GoodData Corporation
 import { ISettings } from "@gooddata/sdk-model";
 
 import { TigerSettingsType, TigerOrgSettingsType } from "../../types/index.js";
@@ -34,13 +34,14 @@ export function mapTypeToKey(
             return "separators";
         case "organizationSetting":
             return "organizationSetting";
+        case "DATE_FILTER_CONFIG":
+            return "dateFilterConfig";
         // These cases are intentionally not mapped to maintain an exhaustive check.
         // This ensures we're notified when new properties are added, allowing us to decide if they need mapping.
         case "METADATA_LOCALE":
         case "OPERATOR_OVERRIDES":
         case "TIMEZONE_VALIDATION_ENABLED":
         case "ENABLE_FILE_ANALYTICS":
-        case "DATE_FILTER_CONFIG":
         case undefined:
             return fallback;
         default:

--- a/libs/sdk-backend-tiger/src/backend/workspace/settings/index.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/settings/index.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2024 GoodData Corporation
+// (C) 2019-2025 GoodData Corporation
 import {
     IWorkspaceSettings,
     IWorkspaceSettingsService,
@@ -14,6 +14,10 @@ import { TigerSettingsService, mapTypeToKey } from "../../settings/index.js";
 import { GET_OPTIMIZED_WORKSPACE_PARAMS } from "../constants.js";
 import { FeatureContext, isLiveFeatures, isStaticFeatures } from "@gooddata/api-client-tiger";
 import { LIB_VERSION } from "../../../__version.js";
+import {
+    convertDateFilterConfig,
+    IWrappedDateFilterConfig,
+} from "../../../convertors/fromBackend/DateFilterConfigurationConverter.js";
 
 export class TigerWorkspaceSettings
     extends TigerSettingsService<IWorkspaceSettings>
@@ -171,9 +175,18 @@ async function resolveSettings(authCall: TigerAuthenticatedCallGuard, workspace:
     );
 
     return data.reduce((result: ISettings, setting) => {
+        const key = mapTypeToKey(setting.type, setting.id);
+        if (key === "dateFilterConfig") {
+            return {
+                ...result,
+                [key]: convertDateFilterConfig(
+                    (setting.content as { config: IWrappedDateFilterConfig })?.config,
+                ),
+            };
+        }
         return {
             ...result,
-            [mapTypeToKey(setting.type, setting.id)]: unwrapSettingContent(setting.content),
+            [key]: unwrapSettingContent(setting.content),
         };
     }, {});
 }

--- a/libs/sdk-backend-tiger/src/convertors/fromBackend/DateFilterConfigurationConverter.ts
+++ b/libs/sdk-backend-tiger/src/convertors/fromBackend/DateFilterConfigurationConverter.ts
@@ -1,4 +1,4 @@
-// (C) 2024 GoodData Corporation
+// (C) 2024-2025 GoodData Corporation
 
 import {
     IAbsoluteDateFilterPreset,
@@ -340,7 +340,9 @@ const convertRelativePreset = (relativePreset: IDateFilterRelativePreset): IRela
     };
 };
 
-export const convertDateFilterConfig = (dateFilterConfig: IWrappedDateFilterConfig): IDateFilterConfig => {
+export const convertDateFilterConfig = (
+    dateFilterConfig: IWrappedDateFilterConfig | undefined,
+): IDateFilterConfig => {
     if (!dateFilterConfig) {
         return DefaultDateFilterConfig;
     }

--- a/libs/sdk-model/api/sdk-model.api.md
+++ b/libs/sdk-model/api/sdk-model.api.md
@@ -3312,6 +3312,8 @@ export interface ISettings {
     ADCatalogGroupsExpanded?: boolean;
     ADMeasureValueFilterNullAsZeroOption?: string;
     alertDefault?: IAlertDefault;
+    // @alpha
+    dateFilterConfig?: IDateFilterConfig;
     disableKpiDashboardHeadlineUnderline?: boolean;
     // @beta
     earlyAccessFeatures?: IEarlyAccessFeaturesConfig;

--- a/libs/sdk-model/src/settings/index.ts
+++ b/libs/sdk-model/src/settings/index.ts
@@ -1,4 +1,5 @@
 // (C) 2020-2025 GoodData Corporation
+import { IDateFilterConfig } from "../dateFilterConfig/index.js";
 
 /**
  * Settings are obtained from backend and are effectively a collection of feature flags or settings with
@@ -591,6 +592,12 @@ export interface ISettings {
      * Enable slideshow exports using the new export render mode in KD.
      */
     enableSlideshowExports?: boolean;
+
+    /**
+     * Date filter configuration.
+     * @alpha
+     */
+    dateFilterConfig?: IDateFilterConfig;
 
     [key: string]: number | boolean | string | object | undefined;
 }

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/initializeDashboardHandler/resolveDashboardConfig.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/initializeDashboardHandler/resolveDashboardConfig.ts
@@ -51,6 +51,7 @@ function loadSettingsForCurrentUser(ctx: DashboardContext): Promise<IUserWorkspa
     return backend.workspace(workspace).settings().getSettingsForCurrentUser();
 }
 
+///
 async function loadCustomDateFilterConfig(ctx: DashboardContext): Promise<IDateFilterConfig | undefined> {
     const { backend, workspace } = ctx;
 
@@ -78,8 +79,10 @@ function loadColorPalette(ctx: DashboardContext): Promise<IColorPalette> {
 }
 
 function* resolveDateFilterConfig(ctx: DashboardContext, config: DashboardConfig, cmd: InitializeDashboard) {
-    if (config.dateFilterConfig !== undefined) {
+    if (config.dateFilterConfig) {
         return config.dateFilterConfig;
+    } else if (config?.settings?.dateFilterConfig) {
+        return config.settings.dateFilterConfig;
     }
 
     const customDateFilterConfig: PromiseFnReturnType<typeof loadCustomDateFilterConfig> = yield call(


### PR DESCRIPTION
Avoid duplicate `/resolveSettings` call for date filter configuration.

risk: low
JIRA: F1-1051

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests.
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```
