### PR TITLE
feat: add additional info to user profile

### DIFF
--- a/libs/api-client-tiger/api/api-client-tiger.api.md
+++ b/libs/api-client-tiger/api/api-client-tiger.api.md
@@ -9087,6 +9087,8 @@ interface ITotalItem {
 // @public (undocumented)
 export interface IUserProfile {
     // (undocumented)
+    deployment?: string;
+    // (undocumented)
     email?: string;
     // (undocumented)
     entitlements: ApiEntitlement[];

--- a/libs/sdk-backend-tiger/src/convertors/fromBackend/UsersConverter.ts
+++ b/libs/sdk-backend-tiger/src/convertors/fromBackend/UsersConverter.ts
@@ -16,7 +16,18 @@ import {
  * as a container for full name and lastname will be an empty string
  */
 export const convertUser = (user: IUserProfile): IUser => {
-    const { name, userId, email, links, organizationName, firstName, lastName, permissions } = user;
+    const {
+        name,
+        userId,
+        email,
+        links,
+        organizationName,
+        firstName,
+        lastName,
+        permissions,
+        entitlements,
+        deployment,
+    } = user;
 
     return {
         ref: uriRef(links!.user!),
@@ -27,6 +38,8 @@ export const convertUser = (user: IUserProfile): IUser => {
         lastName: lastName,
         organizationName: organizationName,
         permissions,
+        entitlements,
+        deployment,
     };
 };
 

--- a/libs/sdk-model/api/sdk-model.api.md
+++ b/libs/sdk-model/api/sdk-model.api.md
@@ -4080,7 +4080,9 @@ export interface ITotalLocatorItemBody {
 // @public
 export interface IUser {
     authenticationId?: string;
+    deployment?: string;
     email?: string;
+    entitlements?: IEntitlementDescriptor[];
     firstName?: string;
     fullName?: string;
     lastName?: string;

--- a/libs/sdk-model/src/user/index.ts
+++ b/libs/sdk-model/src/user/index.ts
@@ -1,9 +1,10 @@
-// (C) 2021-2024 GoodData Corporation
+// (C) 2021-2025 GoodData Corporation
 import { invariant } from "ts-invariant";
 import isEmpty from "lodash/isEmpty.js";
 
 import { ObjRef } from "../objRef/index.js";
 import { IDataSourcePermissionAssignment, IWorkspacePermissionAssignment } from "../organization/index.js";
+import { IEntitlementDescriptor } from "../entitlements/index.js";
 
 /**
  * Represents platform user.
@@ -58,6 +59,16 @@ export interface IUser {
      * Authentication id of the user.
      */
     authenticationId?: string;
+
+    /**
+     * Entitlements for the user.
+     */
+    entitlements?: IEntitlementDescriptor[];
+
+    /**
+     * In which deployment the user was requested
+     */
+    deployment?: string;
 }
 
 /**


### PR DESCRIPTION
add entitlements and info about deployment, for which it's no longer to call specific api
in tiger specific fn (await sdk.entities.getAllEntitiesWorkspaces) later in 
https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-backend-tiger/src/backend/tigerSpecificFunctions.ts#L658

risk: low
JIRA: STL-1058


<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests.
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```