### PR TITLE
fix: fix date filter resolution and ignore

### DIFF
--- a/libs/sdk-ui-dashboard/src/model/queryServices/queryWidgetFilters.ts
+++ b/libs/sdk-ui-dashboard/src/model/queryServices/queryWidgetFilters.ts
@@ -229,24 +229,21 @@ function resolveWidgetDateFilterIgnore(
         ({ dateDataset, dateDatasetLink }) => {
             return (
                 !!widget.dateDataSet &&
-                dateDataset &&
                 (avoidCatalogForFilterLookup
-                    ? areObjRefsEqual(widget.dateDataSet, dateDatasetLink)
-                    : refMatchesMdObject(widget.dateDataSet, dateDataset.dataSet, "dataSet"))
+                    ? dateDatasetLink && areObjRefsEqual(widget.dateDataSet, dateDatasetLink)
+                    : dateDataset && refMatchesMdObject(widget.dateDataSet, dateDataset.dataSet, "dataSet"))
             );
         },
     );
     const nonIgnoredWidgetDateFilterDateDatasetPairs = widgetDateFilterDateDatasetPairs.filter(
         ({ dateDataset, dateDatasetLink }) => {
-            const matches =
-                dateDataset &&
-                widget.ignoreDashboardFilters
-                    ?.filter(isDashboardDateFilterReference)
-                    .some((ignored) =>
-                        avoidCatalogForFilterLookup
-                            ? areObjRefsEqual(ignored.dataSet, dateDatasetLink)
-                            : refMatchesMdObject(ignored.dataSet, dateDataset.dataSet, "dataSet"),
-                    );
+            const matches = widget.ignoreDashboardFilters
+                ?.filter(isDashboardDateFilterReference)
+                .some((ignored) =>
+                    avoidCatalogForFilterLookup
+                        ? dateDatasetLink && areObjRefsEqual(ignored.dataSet, dateDatasetLink)
+                        : dateDataset && refMatchesMdObject(ignored.dataSet, dateDataset.dataSet, "dataSet"),
+                );
 
             return !matches;
         },
@@ -286,10 +283,10 @@ function resolveDateFilters(
     // prioritize dashboard filters over insight ones
     // and strip useless all time filters at the end
     const init = dashboardDateFilterDateDatasetPairs
-        .filter((item) => !!item.dateDataset)
+        .filter((item) => (avoidCatalogForFilterLookup ? !!item.dateDatasetLink : !!item.dateDataset))
         .map((item) => item.filter);
     return insightDateFilterDateDatasetPairs
-        .filter((item) => !!item.dateDataset)
+        .filter((item) => (avoidCatalogForFilterLookup ? !!item.dateDatasetLink : !!item.dateDataset))
         .reduceRight((acc: IDateFilter[], curr) => {
             const alreadyPresent = avoidCatalogForFilterLookup
                 ? acc.some((item) => areObjRefsEqual(filterObjRef(item), curr.dateDatasetLink))


### PR DESCRIPTION
use correct part of the pair structure (dateDataset, dateDatasetLink) feature flag is true/false

risk: low
JIRA: STL-1073

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests.
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```
