### PR TITLE
fix: preloading attributes / datasets

### DIFF
--- a/libs/sdk-ui-dashboard/src/_staging/sharedHooks/useAttributes.ts
+++ b/libs/sdk-ui-dashboard/src/_staging/sharedHooks/useAttributes.ts
@@ -8,6 +8,7 @@ import {
     selectPreloadedAttributesWithReferences,
     selectEnableCriticalContentPerformanceOptimizations,
     useDashboardSelector,
+    selectIsNewDashboard,
 } from "../../model/index.js";
 
 /**
@@ -30,13 +31,14 @@ export function useAttributes(displayForms: ObjRef[]) {
     // First wait for preloaded filter attributes, otherwise we might be spawning lot of unnecessary requests
     const attributesWithReferences = useDashboardSelector(selectPreloadedAttributesWithReferences);
     const enablePerfOptimizations = useDashboardSelector(selectEnableCriticalContentPerformanceOptimizations);
+    const isNewDashboard = useDashboardSelector(selectIsNewDashboard);
 
     useEffect(() => {
-        const shouldLoad = enablePerfOptimizations ? attributesWithReferences : true;
+        const shouldLoad = enablePerfOptimizations ? isNewDashboard || attributesWithReferences : true;
         if (shouldLoad) {
             getAttributes(displayForms);
         }
-    }, [displayForms, getAttributes, enablePerfOptimizations, attributesWithReferences]);
+    }, [displayForms, getAttributes, enablePerfOptimizations, isNewDashboard, attributesWithReferences]);
 
     const attributesLoading = useMemo(() => {
         return attributesLoadingStatus === "pending" || attributesLoadingStatus === "running";

--- a/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/dashboardDropdownBody/configuration/hooks/useAttributeDataSet.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/dashboardDropdownBody/configuration/hooks/useAttributeDataSet.ts
@@ -8,6 +8,7 @@ import {
     selectEnableCriticalContentPerformanceOptimizations,
     useDashboardQueryProcessing,
     useDashboardSelector,
+    selectIsNewDashboard,
 } from "../../../../../../model/index.js";
 
 /**
@@ -30,13 +31,21 @@ export function useAttributeDataSet(displayForm: ObjRef, loadQuery = true) {
     // First wait for preloaded filter attributes, otherwise we might be spawning lot of unnecessary requests
     const attributesWithReferences = useDashboardSelector(selectPreloadedAttributesWithReferences);
     const enablePerfOptimizations = useDashboardSelector(selectEnableCriticalContentPerformanceOptimizations);
+    const isNewDashboard = useDashboardSelector(selectIsNewDashboard);
 
     useEffect(() => {
-        const shouldLoad = enablePerfOptimizations ? attributesWithReferences : true;
+        const shouldLoad = enablePerfOptimizations ? isNewDashboard || attributesWithReferences : true;
         if (loadQuery && shouldLoad) {
             getAttributeDataSet(displayForm);
         }
-    }, [displayForm, loadQuery, getAttributeDataSet, enablePerfOptimizations, attributesWithReferences]);
+    }, [
+        displayForm,
+        isNewDashboard,
+        loadQuery,
+        getAttributeDataSet,
+        enablePerfOptimizations,
+        attributesWithReferences,
+    ]);
 
     const attributesDataSetLoading = useMemo(() => {
         return attributesDataSetLoadingStatus === "pending" || attributesDataSetLoadingStatus === "running";


### PR DESCRIPTION
Do not wait for preloaded attributes/datasets if creating new dashboard, as they are available only for existing dashboards.

risk: low
JIRA: STL-1097

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests.
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```
