### PR TITLE
RELATED: GDAI-61 save vis filters

### DIFF
--- a/libs/sdk-ui-gen-ai/src/components/messages/contents/useExecution.tsx
+++ b/libs/sdk-ui-gen-ai/src/components/messages/contents/useExecution.tsx
@@ -72,20 +72,25 @@ export const prepareExecution = (vis: IGenAIVisualization) => {
 
 const convertFilter = (data: GenAIFilter): IFilter | false => {
     if (isPositiveAttributeFilter(data)) {
-        return newPositiveAttributeFilter(data.using, { values: data.include });
+        return newPositiveAttributeFilter(idRef(data.using, "attribute"), { values: data.include });
     }
 
     if (isNegativeAttributeFilter(data)) {
-        return newNegativeAttributeFilter(data.using, { values: data.exclude });
+        return newNegativeAttributeFilter(idRef(data.using, "attribute"), { values: data.exclude });
     }
 
     if (isRelativeDateFilter(data)) {
-        return newRelativeDateFilter(data.using, granularityMap[data.granularity], data.from, data.to);
+        return newRelativeDateFilter(
+            idRef(data.using, "dataSet"),
+            granularityMap[data.granularity],
+            data.from,
+            data.to,
+        );
     }
 
     if (isAbsoluteDateFilter(data)) {
         return newAbsoluteDateFilter(
-            data.using,
+            idRef(data.using, "dataSet"),
             data.from ??
                 (() => {
                     const date = new Date();


### PR DESCRIPTION
Fixed a bug where visualization could not be saved if has filters

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests.
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```
