### PR TITLE
feat: revert "feat: reorder palette calls"

### DIFF
--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/initializeDashboardHandler/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/initializeDashboardHandler/index.ts
@@ -4,16 +4,9 @@ import { spawn, all, call, put, SagaReturnType } from "redux-saga/effects";
 import { InitializeDashboard } from "../../../commands/dashboard.js";
 import { DashboardInitialized, dashboardInitialized } from "../../../events/dashboard.js";
 import { loadingActions } from "../../../store/loading/index.js";
-import {
-    DashboardContext,
-    ResolvedDashboardConfig,
-    PrivateDashboardContext,
-} from "../../../types/commonTypes.js";
+import { DashboardContext, PrivateDashboardContext } from "../../../types/commonTypes.js";
 import { IDashboardWithReferences, walkLayout, IWorkspaceCatalog } from "@gooddata/sdk-backend-spi";
-import {
-    resolveColorPalette,
-    resolveDashboardConfigAndFeatureFlagDependentCalls,
-} from "./resolveDashboardConfig.js";
+import { resolveDashboardConfigAndFeatureFlagDependentCalls } from "./resolveDashboardConfig.js";
 import { configActions } from "../../../store/config/index.js";
 import { entitlementsActions } from "../../../store/entitlements/index.js";
 import { PromiseFnReturnType } from "../../../types/sagas.js";
@@ -191,7 +184,6 @@ function* loadExistingDashboard(
     const { backend } = ctx;
     const privateCtx: PrivateDashboardContext = yield call(getPrivateContext);
     const { usesStrictAccessControl } = backend.capabilities;
-    const cmdConfig = cmd.payload?.config ?? {};
 
     const calls = [
         call(loadDashboardFromBackend, ctx, privateCtx, dashboardRef, !!cmd.payload.persistedDashboard),
@@ -206,7 +198,6 @@ function* loadExistingDashboard(
         call(loadDashboardPermissions, ctx),
         call(loadDateHierarchyTemplates, ctx),
         call(loadFilterViews, ctx),
-        call(resolveColorPalette, ctx, cmdConfig),
     ];
 
     if (!usesStrictAccessControl) {
@@ -229,7 +220,6 @@ function* loadExistingDashboard(
         dashboardPermissions,
         dateHierarchyTemplates,
         filterViews,
-        colorPalette,
         accessibleDashboards,
     ]: [
         PromiseFnReturnType<typeof loadDashboardFromBackend>,
@@ -244,27 +234,21 @@ function* loadExistingDashboard(
         PromiseFnReturnType<typeof loadDashboardPermissions>,
         PromiseFnReturnType<typeof loadDateHierarchyTemplates>,
         PromiseFnReturnType<typeof loadFilterViews>,
-        PromiseFnReturnType<typeof resolveColorPalette>,
         PromiseFnReturnType<typeof loadAccessibleDashboardList>,
     ] = yield all(calls);
-
-    const resolvedConfig: ResolvedDashboardConfig = {
-        ...config,
-        colorPalette,
-    };
 
     const {
         dashboard: loadedDashboard,
         references: { insights },
     } = dashboardWithReferences;
 
-    const dashboard = applyDefaultFilterView(loadedDashboard, filterViews, resolvedConfig.settings);
+    const dashboard = applyDefaultFilterView(loadedDashboard, filterViews, config.settings);
 
     const effectiveDateFilterConfig: DateFilterMergeResult = yield call(
         mergeDateFilterConfigWithOverrides,
         ctx,
         cmd,
-        resolvedConfig.dateFilterConfig!,
+        config.dateFilterConfig!,
         dashboard.dateFilterConfig,
     );
 
@@ -273,7 +257,7 @@ function* loadExistingDashboard(
         ctx,
         dashboard,
         insights,
-        resolvedConfig.settings,
+        config.settings,
         effectiveDateFilterConfig.config,
         catalog ? catalog.dateDatasets() : [],
         catalog ? createDisplayFormMapFromCatalog(catalog) : createDisplayFormMap([], []),
@@ -342,7 +326,6 @@ function* initializeNewDashboard(
     cmd: InitializeDashboard,
 ): SagaIterator<DashboardLoadResult> {
     const { backend } = ctx;
-    const cmdConfig = cmd.payload?.config ?? {};
 
     const [
         {
@@ -357,7 +340,6 @@ function* initializeNewDashboard(
         accessibleDashboards,
         legacyDashboards,
         dateHierarchyTemplates,
-        colorPalette,
     ]: [
         SagaReturnType<typeof resolveDashboardConfigAndFeatureFlagDependentCalls>,
         SagaReturnType<typeof resolvePermissions>,
@@ -368,7 +350,6 @@ function* initializeNewDashboard(
         PromiseFnReturnType<typeof loadAccessibleDashboardList>,
         PromiseFnReturnType<typeof loadLegacyDashboards>,
         PromiseFnReturnType<typeof loadDateHierarchyTemplates>,
-        PromiseFnReturnType<typeof resolveColorPalette>,
     ] = yield all([
         call(resolveDashboardConfigAndFeatureFlagDependentCalls, ctx, cmd),
         call(resolvePermissions, ctx, cmd),
@@ -379,19 +360,13 @@ function* initializeNewDashboard(
         call(loadAccessibleDashboardList, ctx),
         call(loadLegacyDashboards, ctx),
         call(loadDateHierarchyTemplates, ctx),
-        call(resolveColorPalette, ctx, cmdConfig),
         call(loadFilterViews, ctx),
     ]);
-
-    const resolvedConfig: ResolvedDashboardConfig = {
-        ...config,
-        colorPalette,
-    };
 
     const batch: BatchAction = batchActions(
         [
             backendCapabilitiesActions.setBackendCapabilities(backend.capabilities),
-            configActions.setConfig(resolvedConfig),
+            configActions.setConfig(config),
             entitlementsActions.setEntitlements(entitlements),
             userActions.setUser(user),
             permissionsActions.setPermissions(permissions),

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/initializeDashboardHandler/resolveDashboardConfig.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/initializeDashboardHandler/resolveDashboardConfig.ts
@@ -15,7 +15,12 @@ import {
 import { stripUserAndWorkspaceProps } from "../../../../_staging/settings/conversion.js";
 import { InitializeDashboard } from "../../../commands/index.js";
 import { dateFilterConfigActions } from "../../../store/dateFilterConfig/index.js";
-import { DashboardConfig, DashboardContext, ResolvedDashboardConfig } from "../../../types/commonTypes.js";
+import {
+    DashboardConfig,
+    DashboardContext,
+    isResolvedConfig,
+    ResolvedDashboardConfig,
+} from "../../../types/commonTypes.js";
 import { PromiseFnReturnType } from "../../../types/sagas.js";
 import { sanitizeUnfinishedFeatureSettings } from "./sanitizeUnfinishedFeatureSettings.js";
 import { onDateFilterConfigValidationError } from "./onDateFilterConfigValidationError.js";
@@ -129,7 +134,7 @@ function resolveUserSettings(ctx: DashboardContext, config: DashboardConfig): Pr
     }));
 }
 
-export function resolveColorPalette(ctx: DashboardContext, config: DashboardConfig): Promise<IColorPalette> {
+function resolveColorPalette(ctx: DashboardContext, config: DashboardConfig): Promise<IColorPalette> {
     if (config.colorPalette) {
         return Promise.resolve(config.colorPalette);
     }
@@ -145,12 +150,25 @@ export function resolveColorPalette(ctx: DashboardContext, config: DashboardConf
 export function* resolveDashboardConfig(
     ctx: DashboardContext,
     cmd: InitializeDashboard,
-): SagaIterator<Partial<ResolvedDashboardConfig>> {
+): SagaIterator<ResolvedDashboardConfig> {
     const {
         payload: { config = {} },
     } = cmd;
 
     yield put(dateFilterConfigActions.clearDateFilterConfigValidationWarning());
+
+    if (isResolvedConfig(config)) {
+        /*
+         * Config coming in props is fully specified. There is nothing to do. Bail out immediately.
+         */
+        if (config.allowUnfinishedFeatures || !config.settings) {
+            return applyConfigDefaults(config);
+        }
+        return {
+            ...applyConfigDefaults(config),
+            settings: sanitizeUnfinishedFeatureSettings(config.settings),
+        };
+    }
 
     /*
      * Resolve the config values. The resolve* functions will take value from config if it is defined,
@@ -160,37 +178,28 @@ export function* resolveDashboardConfig(
      * for the current user in the context of the workspace.
      */
 
-    const [dateFilterConfig, settings]: [
+    const [dateFilterConfig, settings, colorPalette]: [
         PromiseFnReturnType<typeof resolveDateFilterConfig>,
         PromiseFnReturnType<typeof resolveUserSettings>,
-    ] = yield all([call(resolveDateFilterConfig, ctx, config, cmd), call(resolveUserSettings, ctx, config)]);
+        PromiseFnReturnType<typeof resolveColorPalette>,
+    ] = yield all([
+        call(resolveDateFilterConfig, ctx, config, cmd),
+        call(resolveUserSettings, ctx, config),
+        call(resolveColorPalette, ctx, config),
+    ]);
 
-    const { config: composedConfig, configValidation } = composeDateFilterConfig(
-        config,
+    const [validDateFilterConfig, configValidation] = getValidDateFilterConfig(
         dateFilterConfig,
-        settings,
+        settings.settings,
     );
 
     if (configValidation !== "Valid") {
         yield call(onDateFilterConfigValidationError, ctx, configValidation, cmd.correlationId);
     }
 
-    return composedConfig;
-}
-
-function composeDateFilterConfig(
-    config: DashboardConfig,
-    dateFilterConfig: PromiseFnReturnType<typeof resolveDateFilterConfig>,
-    settings: PromiseFnReturnType<typeof resolveUserSettings>,
-) {
-    const [validDateFilterConfig, configValidation] = getValidDateFilterConfig(
-        dateFilterConfig,
-        settings.settings,
-    );
-
     const configWithDefaults = applyConfigDefaults(config);
 
-    const resultingConfig = {
+    return {
         ...configWithDefaults,
         locale: settings.locale,
         separators: settings.separators,
@@ -198,12 +207,8 @@ function composeDateFilterConfig(
         settings: configWithDefaults.allowUnfinishedFeatures
             ? settings.settings
             : sanitizeUnfinishedFeatureSettings(settings.settings),
+        colorPalette,
         mapboxToken: config.mapboxToken,
-    };
-
-    return {
-        config: resultingConfig,
-        configValidation,
     };
 }
 
@@ -243,8 +248,6 @@ export function* resolveDashboardConfigAndFeatureFlagDependentCalls(
     };
 }> {
     const resolvedConfig = yield call(resolveDashboardConfig, ctx, cmd);
-
-    // these really need resolved config before initiating requests
     const additionalData = yield call(loadAutomationsData, ctx, resolvedConfig.settings);
 
     return {

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/initializeDashboardHandler/tests/__snapshots__/handler.test.ts.snap
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/initializeDashboardHandler/tests/__snapshots__/handler.test.ts.snap
@@ -43,6 +43,7 @@ exports[`initialize dashboard handler > for any dashboard > should resolve confi
 {
   "allowCreateInsightRequest": false,
   "allowUnfinishedFeatures": false,
+  "colorPalette": [],
   "dateFilterConfig": {
     "absoluteForm": {
       "from": Any<String>,


### PR DESCRIPTION
This reverts commit 84a4a72eaa0a4b6aac1ea3a5e425970abdd7f908.
Breaks dashboard plugins as some of them cannot deal with empty palette and palette refresh.

risk: low
JIRA: STL-1110


<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests.
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```