### PR TITLE
RELATED: GDAI-13 chat links

### DIFF
--- a/libs/sdk-ui-gen-ai/src/components/messages/contents/SearchContents.tsx
+++ b/libs/sdk-ui-gen-ai/src/components/messages/contents/SearchContents.tsx
@@ -1,10 +1,11 @@
-// (C) 2024 GoodData Corporation
+// (C) 2024-2025 GoodData Corporation
 
 import React from "react";
 import { SearchContents } from "../../../model.js";
 import cx from "classnames";
 import { replaceLinks } from "./replaceLinks.js";
 import { MarkdownComponent } from "./Markdown.js";
+import { useWorkspaceStrict } from "@gooddata/sdk-ui";
 
 export type SearchContentsProps = {
     content: SearchContents;
@@ -13,9 +14,10 @@ export type SearchContentsProps = {
 
 export const SearchContentsComponent: React.FC<SearchContentsProps> = ({ content, useMarkdown }) => {
     const className = cx("gd-gen-ai-chat__messages__content", "gd-gen-ai-chat__messages__content--search");
+    const workspace = useWorkspaceStrict();
     const text = React.useMemo(() => {
-        return replaceLinks(content.text, content.searchResults);
-    }, [content.text, content.searchResults]);
+        return replaceLinks(content.text, content.searchResults, workspace);
+    }, [content.text, content.searchResults, workspace]);
 
     return (
         <div className={className}>

--- a/libs/sdk-ui-gen-ai/src/components/messages/contents/replaceLinks.ts
+++ b/libs/sdk-ui-gen-ai/src/components/messages/contents/replaceLinks.ts
@@ -1,22 +1,26 @@
-// (C) 2024 GoodData Corporation
+// (C) 2024-2025 GoodData Corporation
 
 import { ISemanticSearchResultItem } from "@gooddata/sdk-model";
 
-const getFoundObjectLink = (obj: ISemanticSearchResultItem) => {
+const getFoundObjectLink = (obj: ISemanticSearchResultItem, workspaceId: string) => {
     switch (obj.type) {
         case "visualization":
-            return `/analyze/#/${obj.workspaceId}/${obj.id}/edit`;
+            return `/analyze/#/${workspaceId}/${obj.id}/edit`;
         case "dashboard":
-            return `/dashboards/#/workspace/${obj.workspaceId}/dashboard/${obj.id}`;
+            return `/dashboards/#/workspace/${workspaceId}/dashboard/${obj.id}`;
         case "metric":
-            return `/metrics/#/${obj.workspaceId}/metric/${obj.id}`;
+            return `/metrics/#/${workspaceId}/metric/${obj.id}`;
         default:
             return null;
     }
 };
 
 const rx = /\{[^}][^.}]*\.[^}]+\}/g;
-export const replaceLinks = (text: string, foundObjects: ISemanticSearchResultItem[]): string => {
+export const replaceLinks = (
+    text: string,
+    foundObjects: ISemanticSearchResultItem[],
+    workspaceId: string,
+): string => {
     return text.replace(rx, (chunk) => {
         const [objectType, ...objectIdChunks] = chunk.replace("{", "").replace("}", "").split(".");
         const objectId = objectIdChunks.join(".");
@@ -27,7 +31,7 @@ export const replaceLinks = (text: string, foundObjects: ISemanticSearchResultIt
             return chunk;
         }
 
-        const href = getFoundObjectLink(obj);
+        const href = getFoundObjectLink(obj, workspaceId);
 
         if (!href) {
             return chunk;

--- a/libs/sdk-ui-gen-ai/src/components/messages/contents/test/parseText.test.ts
+++ b/libs/sdk-ui-gen-ai/src/components/messages/contents/test/parseText.test.ts
@@ -1,4 +1,4 @@
-// (C) 2024 GoodData Corporation
+// (C) 2024-2025 GoodData Corporation
 
 import { describe, it, expect } from "vitest";
 import { replaceLinks } from "../replaceLinks";
@@ -13,14 +13,14 @@ describe("parseText", () => {
     it.each([
         [
             "Hello, {visualization.foo} and {dashboard.bar}!",
-            "Hello, [Foo](/analyze/#/baz/foo/edit) and [Bar](/dashboards/#/workspace/qux/dashboard/bar)!",
+            "Hello, [Foo](/analyze/#/wsid/foo/edit) and [Bar](/dashboards/#/workspace/wsid/dashboard/bar)!",
         ],
-        ["{visualization.foo}", "[Foo](/analyze/#/baz/foo/edit)"],
-        ["{dashboard.bar} test", "[Bar](/dashboards/#/workspace/qux/dashboard/bar) test"],
-        ["test {dashboard.bar}", "test [Bar](/dashboards/#/workspace/qux/dashboard/bar)"],
+        ["{visualization.foo}", "[Foo](/analyze/#/wsid/foo/edit)"],
+        ["{dashboard.bar} test", "[Bar](/dashboards/#/workspace/wsid/dashboard/bar) test"],
+        ["test {dashboard.bar}", "test [Bar](/dashboards/#/workspace/wsid/dashboard/bar)"],
         ["Test test", "Test test"],
         ["{foo.bar}", "{foo.bar}"],
     ] as [string, string][])("should parse %s", (text: string, expected: string) => {
-        expect(replaceLinks(text, foundObjects)).toEqual(expected);
+        expect(replaceLinks(text, foundObjects, "wsid")).toEqual(expected);
     });
 });


### PR DESCRIPTION
Fixed a bug when links within chat always lead to native ws of the object

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests.
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```
