### PR TITLE
fix: embedded dashboard hideControl=[filterBar] didn't work

### DIFF
--- a/libs/sdk-ui-dashboard/src/plugins/customizationApis/layoutCustomizer.tsx
+++ b/libs/sdk-ui-dashboard/src/plugins/customizationApis/layoutCustomizer.tsx
@@ -98,6 +98,7 @@ export class DefaultLayoutCustomizer implements IDashboardLayoutCustomizer {
     private readonly mutationContext: CustomizerMutationsContext;
     private readonly fluidLayoutTransformations: FluidLayoutCustomizationFn[] = [];
     private readonly exportLayoutTransformations: ExportLayoutCustomizationFn[] = [];
+    private updated = false;
     private sealed = false;
     private state: ILayoutCustomizerState;
 
@@ -150,6 +151,7 @@ export class DefaultLayoutCustomizer implements IDashboardLayoutCustomizer {
 
         this.state.addCustomProvider(provider);
         this.mutationContext.layout = union(this.mutationContext.layout, ["provider"]);
+        this.updated = true;
 
         return this;
     };
@@ -186,16 +188,19 @@ export class DefaultLayoutCustomizer implements IDashboardLayoutCustomizer {
         // this currently registered one
         this.state.switchRootProvider(newRootProvider);
         this.mutationContext.layout = union(this.mutationContext.layout, ["decorator"]);
+        this.updated = true;
 
         return this;
     }
 
     getCustomizerResult = (): ILayoutCustomizerResult => {
         return {
-            LayoutComponent: (props) => {
-                const Comp = this.state.getRootProvider()(props);
-                return <Comp {...props} />;
-            },
+            LayoutComponent: this.updated
+                ? (props) => {
+                      const Comp = this.state.getRootProvider()(props);
+                      return <Comp {...props} />;
+                  }
+                : undefined,
         };
     };
 

--- a/libs/sdk-ui-dashboard/src/plugins/customizationApis/loadingCustomizer.tsx
+++ b/libs/sdk-ui-dashboard/src/plugins/customizationApis/loadingCustomizer.tsx
@@ -132,6 +132,7 @@ export class DefaultLoadingCustomizer implements ILoadingCustomizer {
     private readonly logger: IDashboardCustomizationLogger;
     private readonly mutationContext: CustomizerMutationsContext;
     private state: ILoadingCustomizerState;
+    private updated = false;
 
     constructor(
         logger: IDashboardCustomizationLogger,
@@ -146,6 +147,7 @@ export class DefaultLoadingCustomizer implements ILoadingCustomizer {
     public withCustomProvider = (provider: OptionalLoadingComponentProvider): ILoadingCustomizer => {
         this.state.addCustomProvider(provider);
         this.mutationContext.loading = union(this.mutationContext.loading, ["provider"]);
+        this.updated = true;
 
         return this;
     };
@@ -174,16 +176,19 @@ export class DefaultLoadingCustomizer implements ILoadingCustomizer {
         // this currently registered one
         this.state.switchRootProvider(newRootProvider);
         this.mutationContext.loading = union(this.mutationContext.loading, ["decorator"]);
+        this.updated = true;
 
         return this;
     }
 
     getCustomizerResult = (): ILoadingCustomizerResult => {
         return {
-            LoadingComponent: (props) => {
-                const Comp = this.state.getRootProvider()(props);
-                return <Comp {...props} />;
-            },
+            LoadingComponent: this.updated
+                ? (props) => {
+                      const Comp = this.state.getRootProvider()(props);
+                      return <Comp {...props} />;
+                  }
+                : undefined,
         };
     };
 

--- a/libs/sdk-ui-dashboard/src/plugins/customizationApis/tests/__snapshots__/layoutCustomizer.test.tsx.snap
+++ b/libs/sdk-ui-dashboard/src/plugins/customizationApis/tests/__snapshots__/layoutCustomizer.test.tsx.snap
@@ -2,6 +2,6 @@
 
 exports[`layout customizer > rendering > should render with decorator 1`] = `"<div>Decorator</div>"`;
 
-exports[`layout customizer > rendering > should render with default 1`] = `"<div>Default</div>"`;
+exports[`layout customizer > rendering > should render with default 1`] = `null`;
 
 exports[`layout customizer > rendering > should render with provider 1`] = `"<div>Provider</div>"`;

--- a/libs/sdk-ui-dashboard/src/plugins/customizationApis/tests/__snapshots__/loadingCustomizer.test.tsx.snap
+++ b/libs/sdk-ui-dashboard/src/plugins/customizationApis/tests/__snapshots__/loadingCustomizer.test.tsx.snap
@@ -2,19 +2,6 @@
 
 exports[`loading customizer > loading rendering mode > should render with decorator 1`] = `"<div>Decorator</div>"`;
 
-exports[`loading customizer > loading rendering mode > should render with default 1`] = `
-"<div class="s-loading" style="text-align: center; display: flex; vertical-align: middle; flex-direction: column; align-content: center; justify-content: center; flex: 1 0 auto; height: 100px; width: 100px;"><svg style="max-height: 100%; max-width: 100%; flex: 0 1 auto; width: 100px; height: 100px;" version="1.1" x="0px" y="0px" viewBox="0 0 36 8"><style>
-                        @keyframes GDC-pop {
-                            0%,
-                            80%,
-                            100% {
-                                transform: scale(0);
-                            }
-                            40% {
-                                transform: scale(1);
-                            }
-                        }
-                    </style><g style="transform-origin: 4px 4px; animation: GDC-pop 1.4s infinite; animation-delay: -0.5599999999999999s; fill: var(--gd-palette-complementary-6, #94a1ad);"><circle cx="4" cy="4" r="4"></circle></g><g style="transform-origin: 18px 4px; animation: GDC-pop 1.4s infinite; animation-delay: -0.27999999999999997s; fill: var(--gd-palette-complementary-6, #94a1ad);"><circle cx="18" cy="4" r="4"></circle></g><g style="transform-origin: 32px 4px; animation: GDC-pop 1.4s infinite; animation-delay: 0; fill: var(--gd-palette-complementary-6, #94a1ad);"><circle cx="32" cy="4" r="4"></circle></g></svg></div>"
-`;
+exports[`loading customizer > loading rendering mode > should render with default 1`] = `null`;
 
 exports[`loading customizer > loading rendering mode > should render with provider 1`] = `"<div>Provider</div>"`;

--- a/libs/sdk-ui-dashboard/src/plugins/customizationApis/tests/__snapshots__/titleCustomizer.test.tsx.snap
+++ b/libs/sdk-ui-dashboard/src/plugins/customizationApis/tests/__snapshots__/titleCustomizer.test.tsx.snap
@@ -2,6 +2,6 @@
 
 exports[`title customizer > title rendering mode > should render with decorator 1`] = `"<div>Decorator</div>"`;
 
-exports[`title customizer > title rendering mode > should render with default 1`] = `"<div>Default</div>"`;
+exports[`title customizer > title rendering mode > should render with default 1`] = `null`;
 
 exports[`title customizer > title rendering mode > should render with provider 1`] = `"<div>Provider</div>"`;

--- a/libs/sdk-ui-dashboard/src/plugins/customizationApis/tests/__snapshots__/topBarCustomizer.test.tsx.snap
+++ b/libs/sdk-ui-dashboard/src/plugins/customizationApis/tests/__snapshots__/topBarCustomizer.test.tsx.snap
@@ -2,6 +2,6 @@
 
 exports[`topBar customizer > topBar rendering mode > should render with decorator 1`] = `"<div>Decorator</div>"`;
 
-exports[`topBar customizer > topBar rendering mode > should render with default 1`] = `"<div>DefaultTopBar</div>"`;
+exports[`topBar customizer > topBar rendering mode > should render with default 1`] = `null`;
 
 exports[`topBar customizer > topBar rendering mode > should render with provider 1`] = `"<div>Provider</div>"`;

--- a/libs/sdk-ui-dashboard/src/plugins/customizationApis/tests/filterBarCustomizer.test.tsx
+++ b/libs/sdk-ui-dashboard/src/plugins/customizationApis/tests/filterBarCustomizer.test.tsx
@@ -27,7 +27,6 @@ function renderToHtml(customizer: DefaultFilterBarCustomizer) {
     invariant(Component);
 
     const { container } = render(<Component {...props} />);
-
     return container.innerHTML;
 }
 
@@ -48,13 +47,13 @@ describe("filter bar customizer", () => {
     describe("filter bar rendering mode", () => {
         it("should return undefined if no mode was explicitly set", () => {
             const actual = Customizer.getCustomizerResult();
-            expect(actual.FilterBarComponent).toBeInstanceOf(Function);
+            expect(actual.FilterBarComponent).toBe(undefined);
         });
 
         it("should return undefined if mode: default was explicitly set", () => {
             Customizer.setRenderingMode("default");
             const actual = Customizer.getCustomizerResult();
-            expect(actual.FilterBarComponent).toBeInstanceOf(Function);
+            expect(actual.FilterBarComponent).toBe(undefined);
         });
 
         it("should return HiddenFilterBar if mode: hidden set using the setter", () => {

--- a/libs/sdk-ui-dashboard/src/plugins/customizationApis/tests/layoutCustomizer.test.tsx
+++ b/libs/sdk-ui-dashboard/src/plugins/customizationApis/tests/layoutCustomizer.test.tsx
@@ -9,7 +9,6 @@ import { createCustomizerMutationsContext, CustomizerMutationsContext } from "..
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { TestingDashboardCustomizationLogger } from "./fixtures/TestingDashboardCustomizationLogger";
 import { IDashboardLayoutProps } from "../../../presentation";
-import { invariant } from "ts-invariant";
 import { render } from "@testing-library/react";
 import { EMPTY_MUTATIONS } from "./utils";
 
@@ -36,17 +35,19 @@ const EmptyDashboard: IDashboard<ExtendedDashboardWidget> = {
 function renderToHtml(customizer: DefaultLayoutCustomizer) {
     const provider = customizer.getCustomizerResult();
     const Component = provider.LayoutComponent;
+
+    // Component can be null if no override
+    if (!Component) {
+        return null;
+    }
+
     const props: IDashboardLayoutProps = {
         onDrill: () => {},
         onError: () => {},
         onFiltersChange: () => {},
     };
 
-    // this should not happen; if it does something is seriously hosed in the customizer
-    invariant(Component);
-
     const { container } = render(<Component {...props} />);
-
     return container.innerHTML;
 }
 

--- a/libs/sdk-ui-dashboard/src/plugins/customizationApis/tests/loadingCustomizer.test.tsx
+++ b/libs/sdk-ui-dashboard/src/plugins/customizationApis/tests/loadingCustomizer.test.tsx
@@ -3,7 +3,6 @@ import React from "react";
 import { ILoadingProps } from "@gooddata/sdk-ui";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render } from "@testing-library/react";
-import { invariant } from "ts-invariant";
 
 import { DefaultLoadingCustomizer } from "../loadingCustomizer";
 import { CustomizerMutationsContext, createCustomizerMutationsContext } from "../types";
@@ -18,15 +17,17 @@ import { EMPTY_MUTATIONS } from "./utils";
 function renderToHtml(customizer: DefaultLoadingCustomizer) {
     const provider = customizer.getCustomizerResult();
     const Component = provider.LoadingComponent;
+
+    if (!Component) {
+        return null;
+    }
+
     const props: ILoadingProps = {
         imageWidth: 100,
         imageHeight: 100,
         width: 100,
         height: 100,
     };
-
-    // this should not happen; if it does something is seriously hosed in the customizer
-    invariant(Component);
 
     const { container } = render(<Component {...props} />);
 

--- a/libs/sdk-ui-dashboard/src/plugins/customizationApis/tests/titleCustomizer.test.tsx
+++ b/libs/sdk-ui-dashboard/src/plugins/customizationApis/tests/titleCustomizer.test.tsx
@@ -2,7 +2,6 @@
 import React from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render } from "@testing-library/react";
-import { invariant } from "ts-invariant";
 
 import { ITitleProps } from "../../../presentation/index.js";
 import { DefaultTitleCustomizer } from "../titleCustomizer";
@@ -18,16 +17,18 @@ import { EMPTY_MUTATIONS } from "./utils";
 function renderToHtml(customizer: DefaultTitleCustomizer) {
     const provider = customizer.getCustomizerResult();
     const Component = provider.TitleComponent;
+
+    // Component can be null if no override
+    if (!Component) {
+        return null;
+    }
+
     const props: ITitleProps = {
         title: "Title",
         onTitleChanged: () => {},
     };
 
-    // this should not happen; if it does something is seriously hosed in the customizer
-    invariant(Component);
-
     const { container } = render(<Component {...props} />);
-
     return container.innerHTML;
 }
 

--- a/libs/sdk-ui-dashboard/src/plugins/customizationApis/tests/topBarCustomizer.test.tsx
+++ b/libs/sdk-ui-dashboard/src/plugins/customizationApis/tests/topBarCustomizer.test.tsx
@@ -2,7 +2,6 @@
 import React from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render } from "@testing-library/react";
-import { invariant } from "ts-invariant";
 
 import { ITopBarProps } from "../../../presentation/index.js";
 import { DefaultTopBarCustomizer } from "../topBarCustomizer";
@@ -18,6 +17,12 @@ import { EMPTY_MUTATIONS } from "./utils";
 function renderToHtml(customizer: DefaultTopBarCustomizer) {
     const provider = customizer.getCustomizerResult();
     const Component = provider.TopBarComponent;
+
+    // Component can be null if no override
+    if (!Component) {
+        return null;
+    }
+
     const props: ITopBarProps = {
         titleProps: {
             title: "Title",
@@ -66,11 +71,7 @@ function renderToHtml(customizer: DefaultTopBarCustomizer) {
         },
     };
 
-    // this should not happen; if it does something is seriously hosed in the customizer
-    invariant(Component);
-
     const { container } = render(<Component {...props} />);
-
     return container.innerHTML;
 }
 

--- a/libs/sdk-ui-dashboard/src/plugins/customizationApis/titleCustomizer.tsx
+++ b/libs/sdk-ui-dashboard/src/plugins/customizationApis/titleCustomizer.tsx
@@ -132,6 +132,7 @@ export class DefaultTitleCustomizer implements ITitleCustomizer {
     private readonly logger: IDashboardCustomizationLogger;
     private readonly mutationContext: CustomizerMutationsContext;
     private state: ITitleCustomizerState;
+    private updated = false;
 
     constructor(
         logger: IDashboardCustomizationLogger,
@@ -146,6 +147,7 @@ export class DefaultTitleCustomizer implements ITitleCustomizer {
     public withCustomProvider = (provider: OptionalTitleComponentProvider): ITitleCustomizer => {
         this.state.addCustomProvider(provider);
         this.mutationContext.title = union(this.mutationContext.title, ["provider"]);
+        this.updated = true;
 
         return this;
     };
@@ -174,16 +176,19 @@ export class DefaultTitleCustomizer implements ITitleCustomizer {
         // this currently registered one
         this.state.switchRootProvider(newRootProvider);
         this.mutationContext.title = union(this.mutationContext.title, ["decorator"]);
+        this.updated = true;
 
         return this;
     }
 
     getCustomizerResult = (): ITitleCustomizerResult => {
         return {
-            TitleComponent: (props) => {
-                const Comp = this.state.getRootProvider()(props);
-                return <Comp {...props} />;
-            },
+            TitleComponent: this.updated
+                ? (props) => {
+                      const Comp = this.state.getRootProvider()(props);
+                      return <Comp {...props} />;
+                  }
+                : undefined,
         };
     };
 

--- a/libs/sdk-ui-dashboard/src/plugins/customizationApis/topBarCustomizer.tsx
+++ b/libs/sdk-ui-dashboard/src/plugins/customizationApis/topBarCustomizer.tsx
@@ -136,6 +136,7 @@ export class DefaultTopBarCustomizer implements ITopBarCustomizer {
     private readonly logger: IDashboardCustomizationLogger;
     private readonly mutationContext: CustomizerMutationsContext;
     private state: ITopBarCustomizerState;
+    private updated = false;
 
     constructor(
         logger: IDashboardCustomizationLogger,
@@ -150,6 +151,7 @@ export class DefaultTopBarCustomizer implements ITopBarCustomizer {
     public withCustomProvider = (provider: OptionalTopBarComponentProvider): ITopBarCustomizer => {
         this.state.addCustomProvider(provider);
         this.mutationContext.topBar = union(this.mutationContext.topBar, ["provider"]);
+        this.updated = true;
 
         return this;
     };
@@ -178,16 +180,19 @@ export class DefaultTopBarCustomizer implements ITopBarCustomizer {
         // this currently registered one
         this.state.switchRootProvider(newRootProvider);
         this.mutationContext.topBar = union(this.mutationContext.topBar, ["decorator"]);
+        this.updated = true;
 
         return this;
     }
 
     getCustomizerResult = (): ITopBarCustomizerResult => {
         return {
-            TopBarComponent: (props) => {
-                const Comp = this.state.getRootProvider()(props);
-                return <Comp {...props} />;
-            },
+            TopBarComponent: this.updated
+                ? (props) => {
+                      const Comp = this.state.getRootProvider()(props);
+                      return <Comp {...props} />;
+                  }
+                : undefined,
         };
     };
 


### PR DESCRIPTION
Param embedded dashboard hideControl=[filterBar] didn't work after Tiger 3.27.0

risk: low
JIRA: F1-1076

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests.
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```
