### PR TITLE
fix: show wrong startOn and repeats for specific timezone

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/utils/date.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/utils/date.ts
@@ -72,10 +72,16 @@ export function toNormalizedFirstRunAndCron(timezone?: string) {
         normalizedFirstRun,
         timezone ?? getUserTimezone().identifier,
     );
-    const cron = getDefaultCronExpression(normalizedFirstRun);
+
+    // We need to calculate the relative time zones difference to get the correct cron expression
+    const isoUrl = parseISO(firstRun);
+    const offsetFrom = getTimezoneOffset(isoUrl, timezone ?? getUserTimezone().identifier);
+    const offsetTo = getTimezoneOffset(isoUrl, getUserTimezone().identifier);
+    const firstRunDate = new Date(isoUrl.getTime() + offsetFrom - offsetTo);
+    const cron = getDefaultCronExpression(firstRunDate);
 
     return {
-        firstRunDate: normalizedFirstRun,
+        normalizedFirstRun,
         firstRun,
         cron,
     };

--- a/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/utils/tests/utils.test.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/utils/tests/utils.test.ts
@@ -8,8 +8,10 @@ import {
     toModifiedISOString,
     toNormalizedFirstRunAndCron,
     toNormalizedStartDate,
+    toModifiedISOStringToTimezone,
     getTimezoneOffset,
 } from "../date";
+import { getUserTimezone } from "../timezone";
 
 const toHours = -3600000;
 
@@ -33,9 +35,15 @@ describe("toNormalizedFirstRunAndCron", () => {
     it("no zone", () => {
         const res = toNormalizedFirstRunAndCron();
 
-        const iso = isoDate(now.getFullYear(), now.getMonth(), now.getDate(), now.getHours() - offset, 0);
-        const cron = cronDaily(res.firstRunDate.getHours());
-
+        const iso = isoDate(
+            now.getFullYear(),
+            now.getMonth(),
+            now.getDate(),
+            offset ? now.getHours() + 1 : now.getHours(),
+            0,
+        );
+        const dt = toModifiedISOStringToTimezone(res.normalizedFirstRun, getUserTimezone().identifier);
+        const cron = cronDaily(dt.date.getHours());
         expect(res.firstRun).toEqual(iso);
         expect(res.cron).toEqual(cron);
     });
@@ -45,13 +53,14 @@ describe("toNormalizedFirstRunAndCron", () => {
         const res = toNormalizedFirstRunAndCron("Africa/Abidjan");
 
         const iso = isoDate(
-            res.firstRunDate.getFullYear(),
-            res.firstRunDate.getMonth(),
-            res.firstRunDate.getDate(),
-            res.firstRunDate.getHours() + timezoneOffset,
+            res.normalizedFirstRun.getFullYear(),
+            res.normalizedFirstRun.getMonth(),
+            res.normalizedFirstRun.getDate(),
+            res.normalizedFirstRun.getHours() + timezoneOffset,
             0,
         );
-        const cron = cronDaily(res.firstRunDate.getHours());
+        const dt = toModifiedISOStringToTimezone(res.normalizedFirstRun, getUserTimezone().identifier);
+        const cron = cronDaily(dt.date.getHours());
         expect(res.firstRun).toEqual(iso);
         expect(res.cron).toEqual(cron);
     });
@@ -61,13 +70,14 @@ describe("toNormalizedFirstRunAndCron", () => {
         const res = toNormalizedFirstRunAndCron("Indian/Mauritius");
 
         const iso = isoDate(
-            res.firstRunDate.getFullYear(),
-            res.firstRunDate.getMonth(),
-            res.firstRunDate.getDate(),
-            res.firstRunDate.getHours() + timezoneOffset,
+            res.normalizedFirstRun.getFullYear(),
+            res.normalizedFirstRun.getMonth(),
+            res.normalizedFirstRun.getDate(),
+            res.normalizedFirstRun.getHours() + timezoneOffset,
             0,
         );
-        const cron = cronDaily(res.firstRunDate.getHours());
+        const dt = toModifiedISOStringToTimezone(res.normalizedFirstRun, getUserTimezone().identifier);
+        const cron = cronDaily(dt.date.getHours());
 
         expect(res.firstRun).toEqual(iso);
         expect(res.cron).toEqual(cron);
@@ -78,13 +88,14 @@ describe("toNormalizedFirstRunAndCron", () => {
         const res = toNormalizedFirstRunAndCron("America/Nassau");
 
         const iso = isoDate(
-            res.firstRunDate.getFullYear(),
-            res.firstRunDate.getMonth(),
-            res.firstRunDate.getDate(),
-            res.firstRunDate.getHours() + timezoneOffset,
+            res.normalizedFirstRun.getFullYear(),
+            res.normalizedFirstRun.getMonth(),
+            res.normalizedFirstRun.getDate(),
+            res.normalizedFirstRun.getHours() + timezoneOffset,
             0,
         );
-        const cron = cronDaily(res.firstRunDate.getHours());
+        const dt = toModifiedISOStringToTimezone(res.normalizedFirstRun, getUserTimezone().identifier);
+        const cron = cronDaily(dt.date.getHours());
 
         expect(res.firstRun).toEqual(iso);
         expect(res.cron).toEqual(cron);


### PR DESCRIPTION
Show wrong startOn and Repeats when using timezone Africa/Abidjan

risk: low
JIRA: F1-1092

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests.
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```
