### PR TITLE
fix: new dashboard needs dashboardslist loaded

### DIFF
--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/initializeDashboardHandler/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/initializeDashboardHandler/index.ts
@@ -222,7 +222,7 @@ function* loadExistingDashboard(
         PromiseFnReturnType<typeof resolveEntitlements>,
         PromiseFnReturnType<typeof decideAndLoadFullCatalog>,
         PromiseFnReturnType<typeof loadUser>,
-        PromiseFnReturnType<typeof loadDashboardList>,
+        PromiseFnReturnType<typeof decideAndLoadDashboardsList>,
         PromiseFnReturnType<typeof loadDashboardPermissions>,
         PromiseFnReturnType<typeof loadDateHierarchyTemplates>,
         PromiseFnReturnType<typeof loadFilterViews>,
@@ -339,7 +339,7 @@ function* initializeNewDashboard(
         PromiseFnReturnType<typeof resolveEntitlements>,
         PromiseFnReturnType<typeof loadCatalog>,
         PromiseFnReturnType<typeof loadUser>,
-        PromiseFnReturnType<typeof decideAndLoadDashboardsList>,
+        PromiseFnReturnType<typeof loadDashboardList>,
         PromiseFnReturnType<typeof loadDateHierarchyTemplates>,
     ] = yield all([
         call(resolveDashboardConfigAndFeatureFlagDependentCalls, ctx, cmd),
@@ -347,17 +347,10 @@ function* initializeNewDashboard(
         call(resolveEntitlements, ctx, cmd),
         call(loadCatalog, ctx, cmd),
         call(loadUser, ctx),
-        call(decideAndLoadDashboardsList, ctx, cmd),
+        call(loadDashboardList, ctx),
         call(loadDateHierarchyTemplates, ctx),
         call(loadFilterViews, ctx),
     ]);
-
-    const dashboardsListActions = cmd.payload.config?.settings?.enableCriticalContentPerformanceOptimizations
-        ? []
-        : [
-              listedDashboardsActions.setListedDashboards(listedDashboards),
-              accessibleDashboardsActions.setAccessibleDashboards(listedDashboards),
-          ];
 
     const batch: BatchAction = batchActions(
         [
@@ -374,7 +367,8 @@ function* initializeNewDashboard(
                 attributeHierarchies: catalog.attributeHierarchies(),
                 dateHierarchyTemplates: dateHierarchyTemplates,
             }),
-            ...dashboardsListActions,
+            listedDashboardsActions.setListedDashboards(listedDashboards),
+            accessibleDashboardsActions.setAccessibleDashboards(listedDashboards),
             executionResultsActions.clearAllExecutionResults(),
             ...actionsToInitializeNewDashboard(config.dateFilterConfig),
             dateFilterConfigActions.setDateFilterConfig({


### PR DESCRIPTION
new dashboard is defacto edit mode, load dashboards similarly as catalog

risk: low
JIRA: STL-1119


<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests.
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```