### PR TITLE
feat: add core support for execution cancelling

### DIFF
--- a/libs/sdk-backend-base/api/sdk-backend-base.api.md
+++ b/libs/sdk-backend-base/api/sdk-backend-base.api.md
@@ -454,6 +454,8 @@ export abstract class DecoratedPreparedExecution implements IPreparedExecution {
     // (undocumented)
     fingerprint(): string;
     // (undocumented)
+    readonly signal?: AbortSignal;
+    // (undocumented)
     withBuckets(...buckets: IBucket[]): IPreparedExecution;
     // (undocumented)
     withDateFormat(dateFormat: string): IPreparedExecution;
@@ -461,6 +463,8 @@ export abstract class DecoratedPreparedExecution implements IPreparedExecution {
     withDimensions(...dim: Array<IDimension | DimensionGenerator>): IPreparedExecution;
     // (undocumented)
     withExecConfig(config: IExecutionConfig): IPreparedExecution;
+    // (undocumented)
+    withSignal(signal: AbortSignal): IPreparedExecution;
     // (undocumented)
     withSorting(...items: ISortItem[]): IPreparedExecution;
 }

--- a/libs/sdk-backend-base/src/customBackend/execution.ts
+++ b/libs/sdk-backend-base/src/customBackend/execution.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2024 GoodData Corporation
+// (C) 2019-2025 GoodData Corporation
 
 import { AbstractExecutionFactory } from "../toolkit/execution.js";
 import {
@@ -111,6 +111,10 @@ class CustomPreparedExecution implements IPreparedExecution {
 
     public withExecConfig = (config: IExecutionConfig): IPreparedExecution => {
         return this.executionFactory.forDefinition(defWithExecConfig(this.definition, config));
+    };
+
+    public withSignal = (_signal: AbortSignal): IPreparedExecution => {
+        throw new NotSupported("Cancelling is not supported by the custom backend.");
     };
 
     public equals = (other: IPreparedExecution): boolean => {

--- a/libs/sdk-backend-base/src/decoratedBackend/execution.ts
+++ b/libs/sdk-backend-base/src/decoratedBackend/execution.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2024 GoodData Corporation
+// (C) 2019-2025 GoodData Corporation
 import {
     IDataView,
     IForecastView,
@@ -96,9 +96,11 @@ export class DecoratedExecutionFactory implements IExecutionFactory {
  */
 export abstract class DecoratedPreparedExecution implements IPreparedExecution {
     public readonly definition: IExecutionDefinition;
+    public readonly signal?: AbortSignal;
 
     protected constructor(protected readonly decorated: IPreparedExecution) {
         this.definition = decorated.definition;
+        this.signal = decorated.signal;
     }
 
     public equals(other: IPreparedExecution): boolean {
@@ -107,6 +109,10 @@ export abstract class DecoratedPreparedExecution implements IPreparedExecution {
 
     public execute(): Promise<IExecutionResult> {
         return this.decorated.execute();
+    }
+
+    public withSignal(signal: AbortSignal): IPreparedExecution {
+        return this.createNew(this.decorated.withSignal(signal));
     }
 
     public explain<T extends ExplainType | undefined>(

--- a/libs/sdk-backend-base/src/dummyBackend/index.ts
+++ b/libs/sdk-backend-base/src/dummyBackend/index.ts
@@ -494,6 +494,9 @@ function dummyPreparedExecution(
         withBuckets(...buckets: IBucket[]) {
             return executionFactory.forDefinition(defWithBuckets(definition, ...buckets));
         },
+        withSignal(_signal: AbortSignal): IPreparedExecution {
+            return dummyPreparedExecution(definition, executionFactory, config);
+        },
         execute(): Promise<IExecutionResult> {
             return Promise.resolve(dummyExecutionResult(definition, executionFactory, config));
         },

--- a/libs/sdk-backend-base/src/normalizingBackend/index.ts
+++ b/libs/sdk-backend-base/src/normalizingBackend/index.ts
@@ -1,4 +1,4 @@
-// (C) 2007-2024 GoodData Corporation
+// (C) 2007-2025 GoodData Corporation
 
 import {
     IAnalyticalBackend,
@@ -76,9 +76,11 @@ class NormalizingPreparedExecution extends DecoratedPreparedExecution {
 
     public execute = (): Promise<IExecutionResult> => {
         const normalizationState = Normalizer.normalize(this.definition);
-        const normalizedExecution = this.originalExecutionFactory.forDefinition(
-            normalizationState.normalized,
-        );
+        let normalizedExecution = this.originalExecutionFactory.forDefinition(normalizationState.normalized);
+
+        if (this.decorated.signal) {
+            normalizedExecution = normalizedExecution.withSignal(this.decorated.signal);
+        }
 
         this.config.normalizationStatus?.(normalizationState);
 

--- a/libs/sdk-backend-mockingbird/src/legacyRecordedBackend/index.ts
+++ b/libs/sdk-backend-mockingbird/src/legacyRecordedBackend/index.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2024 GoodData Corporation
+// (C) 2019-2025 GoodData Corporation
 
 import {
     IExecutionResult as ILegacyExecutionResult,
@@ -445,6 +445,9 @@ function recordedPreparedExecution(
                 console.warn("Backend does not support data sampling, result will be not affected");
             }
             return executionFactory.forDefinition(definition);
+        },
+        withSignal(_signal: AbortSignal): IPreparedExecution {
+            return recordedPreparedExecution(definition, executionFactory, recordings);
         },
         execute(): Promise<IExecutionResult> {
             return new Promise((resolve, reject) => {

--- a/libs/sdk-backend-mockingbird/src/recordedBackend/execution.ts
+++ b/libs/sdk-backend-mockingbird/src/recordedBackend/execution.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2024 GoodData Corporation
+// (C) 2019-2025 GoodData Corporation
 
 import {
     IDataView,
@@ -140,6 +140,9 @@ function recordedPreparedExecution(
                 console.warn("Backend does not support data sampling, result will be not affected");
             }
             return executionFactory.forDefinition(definition);
+        },
+        withSignal(_signal: AbortSignal): IPreparedExecution {
+            return recordedPreparedExecution(definition, executionFactory, resultRefType, recordings);
         },
         execute(): Promise<IExecutionResult> {
             return new Promise((resolve, reject) => {

--- a/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
+++ b/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
@@ -1105,13 +1105,14 @@ export interface IPermissionsAssignment {
 }
 
 // @public
-export interface IPreparedExecution {
+export interface IPreparedExecution extends ICancelable<IPreparedExecution> {
     readonly definition: IExecutionDefinition;
     equals(other: IPreparedExecution): boolean;
     execute(): Promise<IExecutionResult>;
     // @internal
     explain<T extends ExplainType | undefined>(config: ExplainConfig<T>): IExplainProvider<typeof config["explainType"]>;
     fingerprint(): string;
+    readonly signal?: AbortSignal;
     // @internal
     withBuckets(...buckets: IBucket[]): IPreparedExecution;
     withDateFormat(dateFormat: string): IPreparedExecution;

--- a/libs/sdk-backend-spi/src/workspace/execution/index.ts
+++ b/libs/sdk-backend-spi/src/workspace/execution/index.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2024 GoodData Corporation
+// (C) 2019-2025 GoodData Corporation
 import {
     IAttributeOrMeasure,
     IBucket,
@@ -16,6 +16,7 @@ import {
     IResultWarning,
 } from "@gooddata/sdk-model";
 import { IExportConfig, IExportResult } from "./export.js";
+import { ICancelable } from "../../cancelation/index.js";
 
 /**
  * @beta
@@ -240,11 +241,16 @@ export interface IExplainProvider<T extends ExplainType | undefined> {
  *
  * @public
  */
-export interface IPreparedExecution {
+export interface IPreparedExecution extends ICancelable<IPreparedExecution> {
     /**
      * Definition of the execution accumulated to so far.
      */
     readonly definition: IExecutionDefinition;
+
+    /**
+     * Signal to abort the execution.
+     */
+    readonly signal?: AbortSignal;
 
     /**
      * Changes sorting of the resulting data. Any sorting settings accumulated so far WILL be wiped out.

--- a/libs/sdk-ui-charts/src/charts/headline/internal/providers/tests/__snapshots__/AbstractProvider.test.ts.snap
+++ b/libs/sdk-ui-charts/src/charts/headline/internal/providers/tests/__snapshots__/AbstractProvider.test.ts.snap
@@ -104,6 +104,7 @@ exports[`AbstractProvider > createExecution > execution should be created 1`] = 
   "withDateFormat": [Function],
   "withDimensions": [Function],
   "withExecConfig": [Function],
+  "withSignal": [Function],
   "withSorting": [Function],
 }
 `;
@@ -212,6 +213,7 @@ exports[`AbstractProvider > createExecution > execution should be created withou
   "withDateFormat": [Function],
   "withDimensions": [Function],
   "withExecConfig": [Function],
+  "withSignal": [Function],
   "withSorting": [Function],
 }
 `;

--- a/libs/sdk-ui-charts/src/charts/headline/internal/providers/tests/__snapshots__/ComparisonProvider.test.ts.snap
+++ b/libs/sdk-ui-charts/src/charts/headline/internal/providers/tests/__snapshots__/ComparisonProvider.test.ts.snap
@@ -169,6 +169,7 @@ exports[`ComparisonProvider > createExecution > Should build execution with chan
   "withDateFormat": [Function],
   "withDimensions": [Function],
   "withExecConfig": [Function],
+  "withSignal": [Function],
   "withSorting": [Function],
 }
 `;
@@ -312,6 +313,7 @@ exports[`ComparisonProvider > createExecution > Should build execution with chan
   "withDateFormat": [Function],
   "withDimensions": [Function],
   "withExecConfig": [Function],
+  "withSignal": [Function],
   "withSorting": [Function],
 }
 `;
@@ -455,6 +457,7 @@ exports[`ComparisonProvider > createExecution > Should build execution with chan
   "withDateFormat": [Function],
   "withDimensions": [Function],
   "withExecConfig": [Function],
+  "withSignal": [Function],
   "withSorting": [Function],
 }
 `;
@@ -598,6 +601,7 @@ exports[`ComparisonProvider > createExecution > Should build execution with diff
   "withDateFormat": [Function],
   "withDimensions": [Function],
   "withExecConfig": [Function],
+  "withSignal": [Function],
   "withSorting": [Function],
 }
 `;
@@ -741,6 +745,7 @@ exports[`ComparisonProvider > createExecution > Should build execution with rati
   "withDateFormat": [Function],
   "withDimensions": [Function],
   "withExecConfig": [Function],
+  "withSignal": [Function],
   "withSorting": [Function],
 }
 `;


### PR DESCRIPTION
Add support for execution cancelling in `sdk-backend-spi` and relevant backend implementations.

risk: low
JIRA: F1-1096

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests.
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```
