### PR TITLE
fix: activate drilling after dashboardslist is loaded

### DIFF
--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -299,6 +299,12 @@ import { VisualizationProperties } from '@gooddata/sdk-model';
 import { WeekStart } from '@gooddata/sdk-model';
 import { WritableDraft } from 'immer/dist/internal.js';
 
+// @alpha (undocumented)
+export interface AccessibleDashboardsState extends EntityState<IListedDashboard> {
+    // (undocumented)
+    isLoaded: boolean;
+}
+
 // @beta (undocumented)
 export type ActionFailedErrorReason = "USER_ERROR" | "INTERNAL_ERROR";
 
@@ -2871,7 +2877,7 @@ export interface DashboardSharingChangedPayload {
 // @public
 export interface DashboardState {
     // @beta (undocumented)
-    accessibleDashboards: EntityState<IListedDashboard>;
+    accessibleDashboards: AccessibleDashboardsState;
     // @alpha (undocumented)
     attributeFilterConfigs: AttributeFilterConfigsState;
     // @alpha (undocumented)

--- a/libs/sdk-ui-dashboard/src/model/store/accessibleDashboards/accessibleDashboardsSelectors.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/accessibleDashboards/accessibleDashboardsSelectors.ts
@@ -1,4 +1,4 @@
-// (C) 2021-2023 GoodData Corporation
+// (C) 2021-2025 GoodData Corporation
 import { createSelector } from "@reduxjs/toolkit";
 import { IListedDashboard } from "@gooddata/sdk-model";
 
@@ -20,6 +20,16 @@ const adapterSelectors = accessibleDashboardsEntityAdapter.getSelectors(selectSe
  * @alpha
  */
 export const selectAccessibleDashboards = adapterSelectors.selectAll;
+
+/**
+ * Select if accessible dashboards were loaded
+ *
+ * @alpha
+ */
+export const selectAccessibleDashboardsLoaded: DashboardSelector<boolean> = createSelector(
+    selectSelf,
+    (dashboards) => dashboards.isLoaded,
+);
 
 /**
  * Select all accessible dashboard in project and returns them in a mapping of obj ref to the insight object.

--- a/libs/sdk-ui-dashboard/src/model/store/accessibleDashboards/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/accessibleDashboards/index.ts
@@ -1,14 +1,35 @@
-// (C) 2021-2022 GoodData Corporation
-
-import { createSlice } from "@reduxjs/toolkit";
+// (C) 2021-2025 GoodData Corporation
+import { IListedDashboard } from "@gooddata/sdk-model";
+import { createSlice, PayloadAction, EntityState } from "@reduxjs/toolkit";
 import { accessibleDashboardsEntityAdapter } from "./accessibleDashboardsEntityAdapter.js";
+
+/**
+ * @alpha
+ */
+export interface AccessibleDashboardsState extends EntityState<IListedDashboard> {
+    isLoaded: boolean;
+}
 
 const accessibleDashboardsSlice = createSlice({
     name: "accessibleDashboards",
-    initialState: accessibleDashboardsEntityAdapter.getInitialState(),
+    initialState: accessibleDashboardsEntityAdapter.getInitialState({
+        isLoaded: false,
+    }),
     reducers: {
-        setAccessibleDashboards: accessibleDashboardsEntityAdapter.setAll,
-        addAccessibleDashboard: accessibleDashboardsEntityAdapter.upsertOne,
+        setAccessibleDashboards: (
+            state: AccessibleDashboardsState,
+            action: PayloadAction<IListedDashboard[]>,
+        ) => {
+            accessibleDashboardsEntityAdapter.setAll(state, action.payload);
+            state.isLoaded = true;
+        },
+        addAccessibleDashboard: (
+            state: AccessibleDashboardsState,
+            action: PayloadAction<IListedDashboard>,
+        ) => {
+            accessibleDashboardsEntityAdapter.upsertOne(state, action.payload);
+            state.isLoaded = true;
+        },
     },
 });
 

--- a/libs/sdk-ui-dashboard/src/model/store/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/index.ts
@@ -436,3 +436,5 @@ export { selectFilterViews, selectFilterViewsAreLoading } from "./filterViews/in
 
 export type { ExecutedState } from "./executed/executedState.js";
 export { selectIsDashboardExecuted } from "./executed/executedSelectors.js";
+
+export type { AccessibleDashboardsState } from "./accessibleDashboards/index.js";

--- a/libs/sdk-ui-dashboard/src/model/store/types.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/types.ts
@@ -27,6 +27,7 @@ import { AutomationsState } from "./automations/automationsState.js";
 import { UsersState } from "./users/usersState.js";
 import { FilterViewsState } from "./filterViews/filterViewsState.js";
 import { ExecutedState } from "./executed/executedState.js";
+import { AccessibleDashboardsState } from "./accessibleDashboards/index.js";
 
 /*
  * This explicit typing is unfortunate but cannot find better way. Normally the typings get inferred from store,
@@ -79,7 +80,7 @@ export interface DashboardState {
     /** @beta */
     listedDashboards: EntityState<IListedDashboard>;
     /** @beta */
-    accessibleDashboards: EntityState<IListedDashboard>;
+    accessibleDashboards: AccessibleDashboardsState;
     /** @alpha */
     inaccessibleDashboards: EntityState<IInaccessibleDashboard>;
     dashboardPermissions: DashboardPermissionsState;

--- a/libs/sdk-ui-dashboard/src/model/store/widgetDrills/widgetDrillSelectors.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/widgetDrills/widgetDrillSelectors.ts
@@ -62,7 +62,10 @@ import {
     selectIsDisabledCrossFiltering,
 } from "../config/configSelectors.js";
 import flatMap from "lodash/flatMap.js";
-import { selectAccessibleDashboardsMap } from "../accessibleDashboards/accessibleDashboardsSelectors.js";
+import {
+    selectAccessibleDashboardsMap,
+    selectAccessibleDashboardsLoaded,
+} from "../accessibleDashboards/accessibleDashboardsSelectors.js";
 import { selectInsightByWidgetRef, selectInsightsMap } from "../insights/insightsSelectors.js";
 import { DashboardSelector } from "../types.js";
 import { ObjRefMap } from "../../../_staging/metadata/objRefMap.js";
@@ -630,19 +633,22 @@ export const selectConfiguredAndImplicitDrillsByWidgetRef: (
 ) => DashboardSelector<IImplicitDrillWithPredicates[]> = createMemoizedSelector((ref: ObjRef) =>
     createSelector(
         selectCatalogIsLoaded,
+        selectAccessibleDashboardsLoaded,
         selectValidConfiguredDrillsByWidgetRef(ref),
         selectImplicitDrillsDownByWidgetRef(ref),
         selectImplicitDrillsToUrlByWidgetRef(ref),
         selectCrossFilteringByWidgetRef(ref),
         (
             catalogIsLoaded,
+            accessibleDashboardsLoaded,
             configuredDrills,
             implicitDrillDownDrills,
             implicitDrillToUrlDrills,
             crossFiltering,
         ) => {
-            // disable drilling until catalog is fully loaded
-            return catalogIsLoaded
+            // disable drilling until all necessary items are loaded (catalog, dash list, ...)
+            const drillActive = catalogIsLoaded && accessibleDashboardsLoaded;
+            return drillActive
                 ? compact([
                       ...configuredDrills,
                       ...implicitDrillDownDrills,


### PR DESCRIPTION
This will prevent showing incomplete drill options
when clicked before dashboardslist finished loading.

risk: low
JIRA: STL-1122


<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests.
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```