### PR TITLE
fix: correctly enable drilling when dashboards list is loaded

### DIFF
--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -7388,6 +7388,9 @@ export interface SectionSlidesTransformerFunction<TWidget> {
 export const selectAccessibleDashboards: (state: DashboardState) => IListedDashboard[];
 
 // @alpha
+export const selectAccessibleDashboardsLoaded: DashboardSelector<boolean>;
+
+// @alpha
 export const selectAccessibleDashboardsMap: DashboardSelector<ObjRefMap<IListedDashboard>>;
 
 // @internal

--- a/libs/sdk-ui-dashboard/src/model/store/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/index.ts
@@ -319,6 +319,7 @@ export {
 } from "./listedDashboards/listedDashboardsSelectors.js";
 export {
     selectAccessibleDashboards,
+    selectAccessibleDashboardsLoaded,
     selectAccessibleDashboardsMap,
 } from "./accessibleDashboards/accessibleDashboardsSelectors.js";
 export {

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/ViewModeDashboardInsight/Insight/useDashboardInsightDrills.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/ViewModeDashboardInsight/Insight/useDashboardInsightDrills.ts
@@ -1,6 +1,6 @@
-// (C) 2020-2024 GoodData Corporation
-import { useCallback, useMemo } from "react";
+// (C) 2020-2025 GoodData Corporation
 import isEqual from "lodash/isEqual.js";
+import { useCallback, useMemo } from "react";
 import {
     useDashboardSelector,
     useDashboardDispatch,
@@ -11,6 +11,7 @@ import {
     selectIsInEditMode,
     selectEnableKPIDashboardDrillFromAttribute,
     selectCatalogIsLoaded,
+    selectAccessibleDashboardsLoaded,
 } from "../../../../../model/index.js";
 import { OnWidgetDrill } from "../../../../drill/types.js";
 import {
@@ -43,7 +44,8 @@ export const useDashboardInsightDrills = ({
     const drillTargets = useDashboardSelector(selectDrillTargetsByWidgetRef(widget.ref));
     const isDrillFromAttributeEnabled = useDashboardSelector(selectEnableKPIDashboardDrillFromAttribute);
     const disableDrillDownOnWidget = insight.insight.properties.controls?.disableDrillDown;
-    const isCatalogLoaded = useDashboardSelector(selectCatalogIsLoaded);
+    const catalogIsLoaded = useDashboardSelector(selectCatalogIsLoaded);
+    const accessibleDashboardsLoaded = useDashboardSelector(selectAccessibleDashboardsLoaded);
 
     const onPushData = useCallback(
         (data: IPushData): void => {
@@ -99,9 +101,10 @@ export const useDashboardInsightDrills = ({
           }
         : undefined;
 
-    // disable all drills until catalog is loaded
+    // disable all drills until necessary items are loaded
+    const drillActive = catalogIsLoaded && accessibleDashboardsLoaded;
     return {
-        drillableItems: isCatalogLoaded ? drillableItems : [],
+        drillableItems: drillActive ? drillableItems : [],
         onPushData,
         onDrill,
     };


### PR DESCRIPTION
This condition was forgotten in #5944.

risk: low
JIRA: STL-1122


<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests.
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```