### PR TITLE
fix: rich text component doesn't hide "Formatting options" link

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/widget/richText/EditModeDashboardRichText.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/richText/EditModeDashboardRichText.tsx
@@ -1,10 +1,12 @@
-// (C) 2020-2024 GoodData Corporation
+// (C) 2020-2025 GoodData Corporation
 import React, { useEffect, useMemo, useState } from "react";
 import {
     changeRichTextWidgetContent,
     eagerRemoveSectionItemByWidgetRef,
+    selectIsWhiteLabeled,
     uiActions,
     useDashboardDispatch,
+    useDashboardSelector,
     useWidgetSelection,
 } from "../../../model/index.js";
 import { IDashboardRichTextProps } from "./types.js";
@@ -31,6 +33,7 @@ const overlayController = OverlayController.getInstance(DASHBOARD_OVERLAYS_FILTE
 export const EditModeDashboardRichText: React.FC<IDashboardRichTextProps> = ({ widget, clientWidth }) => {
     const { isSelected } = useWidgetSelection(widgetRef(widget));
     const previousIsSelected = usePrevious(isSelected);
+    const isWhiteLabeled = useDashboardSelector(selectIsWhiteLabeled);
     const intl = useIntl();
 
     const dispatch = useDashboardDispatch();
@@ -74,7 +77,7 @@ export const EditModeDashboardRichText: React.FC<IDashboardRichTextProps> = ({ w
             {isRichTextEditing ? (
                 <div className="gd-rich-text-widget-footer">
                     <div className="gd-rich-text-footer-options">
-                        {typeof clientWidth !== "undefined" && clientWidth > 250 ? (
+                        {!isWhiteLabeled && typeof clientWidth !== "undefined" && clientWidth > 250 ? (
                             <a
                                 className="gd-button-link-dimmed gd-icon-circle-question"
                                 href="https://www.gooddata.com/docs/cloud/create-dashboards/rich-text/"


### PR DESCRIPTION
Rich text component doesn't hide "Formatting options" link when white labeling enabled

risk: low
JIRA: F1-1105

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests.
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```
