### PR TITLE
fix: adhoc dashboard for export

### DIFF
--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -1582,6 +1582,7 @@ export interface DashboardConfig {
     hideSaveAsNewButton?: boolean;
     // @internal
     hideShareButton?: boolean;
+    initialContent?: DashboardItem[];
     initialRenderMode?: RenderMode;
     isEmbedded?: boolean;
     isExport?: boolean;
@@ -2303,8 +2304,21 @@ export interface DashboardInsightWidgetVisPropertiesChangedPayload {
     readonly ref: ObjRef;
 }
 
+// @public
+export type DashboardItem = DashboardItemVisualization | DashboardItemVisualizationContent;
+
 // @beta
 export type DashboardItemDefinition = ExtendedDashboardItem<ExtendedDashboardWidget | IWidgetDefinition | ICustomWidgetDefinition> | StashedDashboardItemsId;
+
+// @public
+export type DashboardItemVisualization = {
+    visualization: ObjRef;
+};
+
+// @public
+export type DashboardItemVisualizationContent = {
+    visualizationContent: IInsight;
+};
 
 // @beta
 export interface DashboardKpiWidgetChanged extends IDashboardEvent {
@@ -2657,6 +2671,7 @@ export type DashboardLayoutWidgetComponentSet = CustomComponentBase<IDashboardNe
 // @beta (undocumented)
 export interface DashboardMetaState {
     descriptor?: DashboardDescriptor;
+    initialContent?: boolean;
     persistedDashboard?: IDashboard;
 }
 
@@ -5587,6 +5602,12 @@ export const isDashboardInsightWidgetVisConfigurationChanged: (obj: unknown) => 
 // @beta
 export const isDashboardInsightWidgetVisPropertiesChanged: (obj: unknown) => obj is DashboardInsightWidgetVisPropertiesChanged;
 
+// @public
+export function isDashboardItemVisualization(item: unknown): item is DashboardItemVisualization;
+
+// @public
+export function isDashboardItemVisualizationContent(item: unknown): item is DashboardItemVisualizationContent;
+
 // @beta
 export const isDashboardKpiWidgetChanged: (obj: unknown) => obj is DashboardKpiWidgetChanged;
 
@@ -7181,7 +7202,7 @@ export interface ResolveAsyncRenderPayload {
 }
 
 // @public
-export type ResolvedDashboardConfig = Omit<Required<DashboardConfig>, "mapboxToken" | "exportId" | "focusObject" | "slideConfig" | "references" | "entitlements"> & DashboardConfig;
+export type ResolvedDashboardConfig = Omit<Required<DashboardConfig>, "mapboxToken" | "exportId" | "focusObject" | "slideConfig" | "references" | "entitlements" | "initialContent"> & DashboardConfig;
 
 // @alpha (undocumented)
 export type ResolvedDateFilterValues = IResolvedDateFilterValue[];
@@ -8172,6 +8193,9 @@ export const selectIsLayoutEmpty: DashboardSelector<boolean>;
 
 // @internal
 export const selectIsNewDashboard: DashboardSelector<boolean>;
+
+// @internal
+export const selectIsNewDashboardWithContent: DashboardSelector<boolean>;
 
 // @public
 export const selectIsReadOnly: DashboardSelector<boolean>;

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/common/dashboardInitialize.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/common/dashboardInitialize.ts
@@ -1,0 +1,97 @@
+// (C) 2022-2025 GoodData Corporation
+import { IDashboard, IDashboardLayout, IDashboardLayoutItem, IInsight, IWidget } from "@gooddata/sdk-model";
+
+import {
+    DashboardContext,
+    DashboardItem,
+    isDashboardItemVisualization,
+    isDashboardItemVisualizationContent,
+} from "../../../types/commonTypes.js";
+import { loadInsight } from "../../widgets/common/loadInsight.js";
+
+const size = { xl: { gridHeight: 22, gridWidth: 12 } };
+
+export const EmptyDashboardLayout: IDashboardLayout<IWidget> = {
+    type: "IDashboardLayout",
+    sections: [],
+};
+
+export async function dashboardInitialize(
+    ctx: DashboardContext,
+    items: DashboardItem[],
+): Promise<{
+    dashboard: IDashboard;
+    insights: IInsight[];
+}> {
+    const layoutItems: IDashboardLayoutItem[] = [];
+    const insights: IInsight[] = [];
+
+    for (let i = 0; i < items.length; i++) {
+        const item = items[i];
+        if (isDashboardItemVisualization(item)) {
+            const insight = await loadInsight(ctx, item.visualization);
+            insights.push(insight);
+            layoutItems.push(buildInitialItem(insight, i));
+        }
+        if (isDashboardItemVisualizationContent(item)) {
+            const insight = item.visualizationContent;
+            insights.push(insight);
+            layoutItems.push(buildInitialItem(insight, i));
+        }
+    }
+
+    const dashboard = buildInitialDashboard(layoutItems);
+
+    return {
+        dashboard,
+        insights,
+    };
+}
+
+function buildInitialDashboard(items: IDashboardLayoutItem[]) {
+    const ref = {
+        type: "analyticalDashboard",
+        identifier: "",
+    };
+
+    return {
+        type: "IDashboard",
+        layout: {
+            type: "IDashboardLayout",
+            sections: [
+                {
+                    header: {},
+                    type: "IDashboardLayoutSection",
+                    items,
+                },
+            ],
+        },
+        shareStatus: "private",
+        created: "",
+        updated: "",
+        title: "",
+        description: "",
+        ref,
+        uri: ref.identifier,
+        identifier: ref.identifier,
+    } as IDashboard;
+}
+
+function buildInitialItem(insight: IInsight, i: number): IDashboardLayoutItem {
+    return {
+        type: "IDashboardLayoutItem",
+        size,
+        widget: {
+            type: "insight",
+            title: insight.insight.title,
+            description: "",
+            localIdentifier: `${insight.insight.identifier}_${i}`,
+            insight: insight.insight.ref,
+            identifier: insight.insight.identifier,
+            uri: insight.insight.uri,
+            ref: insight.insight.ref,
+            ignoreDashboardFilters: [],
+            drills: [],
+        },
+    };
+}

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/common/tests/__snapshots__/adhocDashboard.test.ts.snap
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/common/tests/__snapshots__/adhocDashboard.test.ts.snap
@@ -1,0 +1,175 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`adhocDashboard > should build adhoc dashboard as empty 1`] = `
+{
+  "dashboard": {
+    "created": "",
+    "description": "",
+    "identifier": "",
+    "layout": {
+      "sections": [
+        {
+          "header": {},
+          "items": [],
+          "type": "IDashboardLayoutSection",
+        },
+      ],
+      "type": "IDashboardLayout",
+    },
+    "ref": {
+      "identifier": "",
+      "type": "analyticalDashboard",
+    },
+    "shareStatus": "private",
+    "title": "",
+    "type": "IDashboard",
+    "updated": "",
+    "uri": "",
+  },
+  "insights": [],
+}
+`;
+
+exports[`adhocDashboard > should build adhoc dashboard with one insight 1`] = `
+{
+  "dashboard": {
+    "created": "",
+    "description": "",
+    "identifier": "",
+    "layout": {
+      "sections": [
+        {
+          "header": {},
+          "items": [
+            {
+              "size": {
+                "xl": {
+                  "gridHeight": 22,
+                  "gridWidth": 12,
+                },
+              },
+              "type": "IDashboardLayoutItem",
+              "widget": {
+                "description": "",
+                "drills": [],
+                "identifier": undefined,
+                "ignoreDashboardFilters": [],
+                "insight": {
+                  "identifier": "test",
+                  "type": "insight",
+                },
+                "localIdentifier": "undefined_0",
+                "ref": {
+                  "identifier": "test",
+                  "type": "insight",
+                },
+                "title": "Test",
+                "type": "insight",
+                "uri": undefined,
+              },
+            },
+          ],
+          "type": "IDashboardLayoutSection",
+        },
+      ],
+      "type": "IDashboardLayout",
+    },
+    "ref": {
+      "identifier": "",
+      "type": "analyticalDashboard",
+    },
+    "shareStatus": "private",
+    "title": "",
+    "type": "IDashboard",
+    "updated": "",
+    "uri": "",
+  },
+  "insights": [
+    {
+      "insight": {
+        "buckets": [],
+        "ref": {
+          "identifier": "test",
+          "type": "insight",
+        },
+        "title": "Test",
+      },
+    },
+  ],
+}
+`;
+
+exports[`adhocDashboard > should build adhoc dashboard with one insight content 1`] = `
+{
+  "dashboard": {
+    "created": "",
+    "description": "",
+    "identifier": "",
+    "layout": {
+      "sections": [
+        {
+          "header": {},
+          "items": [
+            {
+              "size": {
+                "xl": {
+                  "gridHeight": 22,
+                  "gridWidth": 12,
+                },
+              },
+              "type": "IDashboardLayoutItem",
+              "widget": {
+                "description": "",
+                "drills": [],
+                "identifier": "test",
+                "ignoreDashboardFilters": [],
+                "insight": {
+                  "identifier": "test",
+                  "type": "insight",
+                },
+                "localIdentifier": "test_0",
+                "ref": {
+                  "identifier": "test",
+                  "type": "insight",
+                },
+                "title": "Test",
+                "type": "insight",
+                "uri": "/uri",
+              },
+            },
+          ],
+          "type": "IDashboardLayoutSection",
+        },
+      ],
+      "type": "IDashboardLayout",
+    },
+    "ref": {
+      "identifier": "",
+      "type": "analyticalDashboard",
+    },
+    "shareStatus": "private",
+    "title": "",
+    "type": "IDashboard",
+    "updated": "",
+    "uri": "",
+  },
+  "insights": [
+    {
+      "insight": {
+        "buckets": [],
+        "filters": [],
+        "identifier": "test",
+        "properties": {},
+        "ref": {
+          "identifier": "test",
+          "type": "insight",
+        },
+        "sorts": [],
+        "title": "Test",
+        "uri": "/uri",
+        "visualizationUrl": "/url",
+      },
+    },
+  ],
+}
+`;

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/common/tests/__snapshots__/dashboardInitialize.test.ts.snap
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/common/tests/__snapshots__/dashboardInitialize.test.ts.snap
@@ -1,0 +1,175 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`adhocDashboard > should build adhoc dashboard as empty 1`] = `
+{
+  "dashboard": {
+    "created": "",
+    "description": "",
+    "identifier": "",
+    "layout": {
+      "sections": [
+        {
+          "header": {},
+          "items": [],
+          "type": "IDashboardLayoutSection",
+        },
+      ],
+      "type": "IDashboardLayout",
+    },
+    "ref": {
+      "identifier": "",
+      "type": "analyticalDashboard",
+    },
+    "shareStatus": "private",
+    "title": "",
+    "type": "IDashboard",
+    "updated": "",
+    "uri": "",
+  },
+  "insights": [],
+}
+`;
+
+exports[`adhocDashboard > should build adhoc dashboard with one insight 1`] = `
+{
+  "dashboard": {
+    "created": "",
+    "description": "",
+    "identifier": "",
+    "layout": {
+      "sections": [
+        {
+          "header": {},
+          "items": [
+            {
+              "size": {
+                "xl": {
+                  "gridHeight": 22,
+                  "gridWidth": 12,
+                },
+              },
+              "type": "IDashboardLayoutItem",
+              "widget": {
+                "description": "",
+                "drills": [],
+                "identifier": undefined,
+                "ignoreDashboardFilters": [],
+                "insight": {
+                  "identifier": "test",
+                  "type": "insight",
+                },
+                "localIdentifier": "undefined_0",
+                "ref": {
+                  "identifier": "test",
+                  "type": "insight",
+                },
+                "title": "Test",
+                "type": "insight",
+                "uri": undefined,
+              },
+            },
+          ],
+          "type": "IDashboardLayoutSection",
+        },
+      ],
+      "type": "IDashboardLayout",
+    },
+    "ref": {
+      "identifier": "",
+      "type": "analyticalDashboard",
+    },
+    "shareStatus": "private",
+    "title": "",
+    "type": "IDashboard",
+    "updated": "",
+    "uri": "",
+  },
+  "insights": [
+    {
+      "insight": {
+        "buckets": [],
+        "ref": {
+          "identifier": "test",
+          "type": "insight",
+        },
+        "title": "Test",
+      },
+    },
+  ],
+}
+`;
+
+exports[`adhocDashboard > should build adhoc dashboard with one insight content 1`] = `
+{
+  "dashboard": {
+    "created": "",
+    "description": "",
+    "identifier": "",
+    "layout": {
+      "sections": [
+        {
+          "header": {},
+          "items": [
+            {
+              "size": {
+                "xl": {
+                  "gridHeight": 22,
+                  "gridWidth": 12,
+                },
+              },
+              "type": "IDashboardLayoutItem",
+              "widget": {
+                "description": "",
+                "drills": [],
+                "identifier": "test",
+                "ignoreDashboardFilters": [],
+                "insight": {
+                  "identifier": "test",
+                  "type": "insight",
+                },
+                "localIdentifier": "test_0",
+                "ref": {
+                  "identifier": "test",
+                  "type": "insight",
+                },
+                "title": "Test",
+                "type": "insight",
+                "uri": "/uri",
+              },
+            },
+          ],
+          "type": "IDashboardLayoutSection",
+        },
+      ],
+      "type": "IDashboardLayout",
+    },
+    "ref": {
+      "identifier": "",
+      "type": "analyticalDashboard",
+    },
+    "shareStatus": "private",
+    "title": "",
+    "type": "IDashboard",
+    "updated": "",
+    "uri": "",
+  },
+  "insights": [
+    {
+      "insight": {
+        "buckets": [],
+        "filters": [],
+        "identifier": "test",
+        "properties": {},
+        "ref": {
+          "identifier": "test",
+          "type": "insight",
+        },
+        "sorts": [],
+        "title": "Test",
+        "uri": "/uri",
+        "visualizationUrl": "/url",
+      },
+    },
+  ],
+}
+`;

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/common/tests/dashboardInitialize.test.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/common/tests/dashboardInitialize.test.ts
@@ -1,0 +1,73 @@
+// (C) 2024-2025 GoodData Corporation
+
+import { describe, it, expect, vi } from "vitest";
+import { dummyBackend } from "@gooddata/sdk-backend-base";
+
+import { dashboardInitialize } from "../dashboardInitialize";
+import { DashboardContext } from "../../../../types/commonTypes";
+
+vi.mock("../../../widgets/common/loadInsight.js", () => ({
+    loadInsight: async (ctx: DashboardContext, ref: any) => {
+        return {
+            insight: {
+                ref,
+                title: "Test",
+                buckets: [],
+            },
+        };
+    },
+}));
+
+describe("adhocDashboard", () => {
+    const ctx: DashboardContext = {
+        backend: dummyBackend(),
+        dashboardRef: null,
+        clientId: "client",
+        workspace: "workspace",
+        filterContextRef: null,
+        config: {
+            initialContent: [],
+        },
+    };
+
+    it("should build adhoc dashboard as empty", async () => {
+        const data = await dashboardInitialize(ctx, []);
+        expect(data).toMatchSnapshot();
+    });
+
+    it("should build adhoc dashboard with one insight", async () => {
+        const data = await dashboardInitialize(ctx, [
+            {
+                visualization: {
+                    identifier: "test",
+                    type: "insight",
+                },
+            },
+        ]);
+        expect(data).toMatchSnapshot();
+    });
+
+    it("should build adhoc dashboard with one insight content", async () => {
+        const data = await dashboardInitialize(ctx, [
+            {
+                visualizationContent: {
+                    insight: {
+                        identifier: "test",
+                        title: "Test",
+                        buckets: [],
+                        ref: {
+                            identifier: "test",
+                            type: "insight",
+                        },
+                        uri: "/uri",
+                        filters: [],
+                        sorts: [],
+                        properties: {},
+                        visualizationUrl: "/url",
+                    },
+                },
+            },
+        ]);
+        expect(data).toMatchSnapshot();
+    });
+});

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/deleteDashboardHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/deleteDashboardHandler.ts
@@ -1,16 +1,20 @@
-// (C) 2021-2023 GoodData Corporation
+// (C) 2021-2025 GoodData Corporation
 
 import { DashboardContext } from "../../types/commonTypes.js";
 import { DeleteDashboard } from "../../commands/index.js";
 import { SagaIterator } from "redux-saga";
 import { DashboardDeleted } from "../../events/index.js";
-import { call, put, select } from "redux-saga/effects";
+import { call, put, SagaReturnType, select } from "redux-saga/effects";
 import { invalidArgumentsProvided } from "../../events/general.js";
 import { areObjRefsEqual, idRef, ObjRef, uriRef } from "@gooddata/sdk-model";
 import { batchActions } from "redux-batched-actions";
 import { executionResultsActions } from "../../store/executionResults/index.js";
-import { selectDateFilterConfig } from "../../store/config/configSelectors.js";
+import { selectDateFilterConfig, selectSettings } from "../../store/config/configSelectors.js";
 import { selectPersistedDashboard } from "../../store/meta/metaSelectors.js";
+import {
+    selectAllCatalogDisplayFormsMap,
+    selectCatalogDateDatasets,
+} from "../../store/catalog/catalogSelectors.js";
 import { dashboardDeleted } from "../../events/dashboard.js";
 import { invariant } from "ts-invariant";
 import { actionsToInitializeNewDashboard } from "./common/stateInitializers.js";
@@ -28,14 +32,27 @@ function deleteDashboard(ctx: DashboardContext, dashboardRef: ObjRef): Promise<v
  * Note: This will not clear any of the dashboard-agnostic global state such as config and settings.
  */
 function* resetToNewDashboard(ctx: DashboardContext): SagaIterator<void> {
+    const settings: ReturnType<typeof selectSettings> = yield select(selectSettings);
     const dateFilterConfig: ReturnType<typeof selectDateFilterConfig> = yield select(selectDateFilterConfig);
+    const dateDataSets: ReturnType<typeof selectCatalogDateDatasets> = yield select(
+        selectCatalogDateDatasets,
+    );
+    const displayForms: ReturnType<typeof selectAllCatalogDisplayFormsMap> = yield select(
+        selectAllCatalogDisplayFormsMap,
+    );
+
+    const { initActions }: SagaReturnType<typeof actionsToInitializeNewDashboard> = yield call(
+        actionsToInitializeNewDashboard,
+        ctx,
+        settings,
+        dateFilterConfig,
+        dateDataSets,
+        displayForms,
+    );
 
     yield put(
         batchActions(
-            [
-                ...actionsToInitializeNewDashboard(dateFilterConfig),
-                executionResultsActions.clearAllExecutionResults(),
-            ],
+            [...initActions, executionResultsActions.clearAllExecutionResults()],
             "@@GDC.DASH/BATCH.CLEAR",
         ),
     );

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/initializeDashboardHandler/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/initializeDashboardHandler/index.ts
@@ -352,6 +352,16 @@ function* initializeNewDashboard(
         call(loadFilterViews, ctx),
     ]);
 
+    const { initActions, dashboard, insights }: SagaReturnType<typeof actionsToInitializeNewDashboard> =
+        yield call(
+            actionsToInitializeNewDashboard,
+            ctx,
+            config.settings,
+            config.dateFilterConfig,
+            catalog ? catalog.dateDatasets() : [],
+            catalog ? createDisplayFormMapFromCatalog(catalog) : createDisplayFormMap([], []),
+        );
+
     const batch: BatchAction = batchActions(
         [
             backendCapabilitiesActions.setBackendCapabilities(backend.capabilities),
@@ -370,7 +380,7 @@ function* initializeNewDashboard(
             listedDashboardsActions.setListedDashboards(listedDashboards),
             accessibleDashboardsActions.setAccessibleDashboards(listedDashboards),
             executionResultsActions.clearAllExecutionResults(),
-            ...actionsToInitializeNewDashboard(config.dateFilterConfig),
+            ...initActions,
             dateFilterConfigActions.setDateFilterConfig({
                 dateFilterConfig: undefined,
                 effectiveDateFilterConfig: config.dateFilterConfig,
@@ -390,7 +400,7 @@ function* initializeNewDashboard(
         ],
         "@@GDC.DASH/BATCH.INIT.NEW",
     );
-    const event = dashboardInitialized(ctx, undefined, [], config, permissions, cmd.correlationId);
+    const event = dashboardInitialized(ctx, dashboard, insights, config, permissions, cmd.correlationId);
 
     return {
         batch,

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/resetDashboardHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/resetDashboardHandler.ts
@@ -1,4 +1,4 @@
-// (C) 2021-2024 GoodData Corporation
+// (C) 2021-2025 GoodData Corporation
 import { DashboardContext } from "../../types/commonTypes.js";
 import { ResetDashboard } from "../../commands/index.js";
 import { SagaIterator } from "redux-saga";
@@ -109,6 +109,8 @@ function* resetDashboardFromPersisted(ctx: DashboardContext) {
             displayForms,
         );
     } else {
+        const settings: ReturnType<typeof selectSettings> = yield select(selectSettings);
+
         /*
          * For dashboard that is not persisted, the dashboard component is reset to an 'empty' state.
          */
@@ -116,7 +118,23 @@ function* resetDashboardFromPersisted(ctx: DashboardContext) {
             selectDateFilterConfig,
         );
 
-        batch = actionsToInitializeNewDashboard(dateFilterConfig);
+        const dateDataSets: ReturnType<typeof selectCatalogDateDatasets> = yield select(
+            selectCatalogDateDatasets,
+        );
+
+        const displayForms: ReturnType<typeof selectAllCatalogDisplayFormsMap> = yield select(
+            selectAllCatalogDisplayFormsMap,
+        );
+
+        const { initActions }: SagaReturnType<typeof actionsToInitializeNewDashboard> = yield call(
+            actionsToInitializeNewDashboard,
+            ctx,
+            settings,
+            dateFilterConfig,
+            dateDataSets,
+            displayForms,
+        );
+        batch = initActions;
     }
 
     return {

--- a/libs/sdk-ui-dashboard/src/model/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/index.ts
@@ -14,6 +14,9 @@
 
 export type {
     DashboardContext,
+    DashboardItem,
+    DashboardItemVisualization,
+    DashboardItemVisualizationContent,
     ObjectAvailabilityConfig,
     DashboardConfig,
     DashboardExportSlideConfig,
@@ -32,6 +35,8 @@ export type {
     IDashboardWidgetOverlay,
     PrivateDashboardContext,
     DashboardLayoutExportTransformFn,
+    isDashboardItemVisualization,
+    isDashboardItemVisualizationContent,
 } from "./types/commonTypes.js";
 export type {
     ICustomWidget,

--- a/libs/sdk-ui-dashboard/src/model/react/types.ts
+++ b/libs/sdk-ui-dashboard/src/model/react/types.ts
@@ -1,11 +1,12 @@
-// (C) 2021-2022 GoodData Corporation
+// (C) 2021-2025 GoodData Corporation
+import React from "react";
+import { ReactReduxContextValue } from "react-redux";
 import { IAnalyticalBackend } from "@gooddata/sdk-backend-spi";
 import { ObjRef, IDashboard, IWorkspacePermissions } from "@gooddata/sdk-model";
+
 import { DashboardEventHandler } from "../eventHandlers/eventHandler.js";
 import { DashboardDispatch, DashboardState } from "../store/index.js";
 import { DashboardConfig, DashboardModelCustomizationFns, WidgetsOverlayFn } from "../types/commonTypes.js";
-import React from "react";
-import { ReactReduxContextValue } from "react-redux";
 import { RenderMode } from "../../types.js";
 
 /**

--- a/libs/sdk-ui-dashboard/src/model/store/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/index.ts
@@ -306,6 +306,7 @@ export {
     selectPersistedDashboard,
     selectDashboardLockStatus,
     selectIsNewDashboard,
+    selectIsNewDashboardWithContent,
     selectIsDashboardDirty,
     selectIsDashboardPrivate,
     selectDashboardWorkingDefinition,

--- a/libs/sdk-ui-dashboard/src/model/store/meta/metaReducers.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/meta/metaReducers.ts
@@ -1,17 +1,19 @@
-// (C) 2021-2024 GoodData Corporation
+// (C) 2021-2025 GoodData Corporation
 
 import { Action, CaseReducer, PayloadAction } from "@reduxjs/toolkit";
-import { DashboardMetaState, EmptyDashboardDescriptor } from "./metaState.js";
-import { IDashboard } from "@gooddata/sdk-model";
 import { invariant } from "ts-invariant";
+import { IDashboard } from "@gooddata/sdk-model";
+
+import { DashboardMetaState, EmptyDashboardDescriptor } from "./metaState.js";
 
 type MetaReducer<A extends Action> = CaseReducer<DashboardMetaState, A>;
 
 type SetMetaPayload = {
     dashboard?: IDashboard;
+    initialContent?: boolean;
 };
 const setMeta: MetaReducer<PayloadAction<SetMetaPayload>> = (state, action) => {
-    const { dashboard } = action.payload;
+    const { dashboard, initialContent } = action.payload;
 
     state.persistedDashboard = dashboard;
     state.descriptor = dashboard
@@ -28,6 +30,7 @@ const setMeta: MetaReducer<PayloadAction<SetMetaPayload>> = (state, action) => {
               disableFilterViews: dashboard.disableFilterViews,
           }
         : { ...EmptyDashboardDescriptor };
+    state.initialContent = initialContent;
 };
 
 const setDashboardTitle: MetaReducer<PayloadAction<string>> = (state, action) => {

--- a/libs/sdk-ui-dashboard/src/model/store/meta/metaSelectors.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/meta/metaSelectors.ts
@@ -1,4 +1,4 @@
-// (C) 2021-2024 GoodData Corporation
+// (C) 2021-2025 GoodData Corporation
 import { createSelector } from "@reduxjs/toolkit";
 import {
     idRef,
@@ -214,6 +214,19 @@ export const selectDashboardUriRef: DashboardSelector<UriRef | undefined> = crea
 export const selectIsNewDashboard: DashboardSelector<boolean> = createSelector(
     selectDashboardRef,
     isUndefined,
+);
+
+/**
+ * Selects a boolean indication if dashboard is dynamically filled, that mean that the dashboard is filled
+ * with widgets and layout dynamically from initial content
+ *
+ * @internal
+ */
+export const selectIsNewDashboardWithContent: DashboardSelector<boolean> = createSelector(
+    selectSelf,
+    (state) => {
+        return !state.persistedDashboard && (state.initialContent ?? false);
+    },
 );
 
 //

--- a/libs/sdk-ui-dashboard/src/model/store/meta/metaState.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/meta/metaState.ts
@@ -1,4 +1,4 @@
-// (C) 2021-2024 GoodData Corporation
+// (C) 2021-2025 GoodData Corporation
 
 import { IDashboard, IAccessControlAware } from "@gooddata/sdk-model";
 
@@ -41,9 +41,17 @@ export interface DashboardMetaState {
      * SaveAsDashboard command processing (which essentially flush the current dashboard state to backend)
      */
     persistedDashboard?: IDashboard;
+
+    /**
+     * This property indicates whether the dashboard is dynamically filled. This means that the dashboard
+     * is not loaded from existing persisted dashboard but is instead built from scratch based on the
+     * provided items.
+     */
+    initialContent?: boolean;
 }
 
 export const metaInitialState: DashboardMetaState = {
     descriptor: EmptyDashboardDescriptor,
     persistedDashboard: undefined,
+    initialContent: undefined,
 };

--- a/libs/sdk-ui-dashboard/src/model/types/commonTypes.ts
+++ b/libs/sdk-ui-dashboard/src/model/types/commonTypes.ts
@@ -10,6 +10,7 @@ import {
     IEntitlementDescriptor,
     Identifier,
     IDashboardLayout,
+    IInsight,
 } from "@gooddata/sdk-model";
 import { ILocale } from "@gooddata/sdk-ui";
 import keys from "lodash/keys.js";
@@ -47,6 +48,53 @@ export interface ObjectAvailabilityConfig {
      * range of objects may be excluded at first and then a subset will be cherry-picked using this prop.
      */
     includeObjectsWithTags?: string[];
+}
+
+/**
+ * Dashboard item
+ *
+ * @public
+ */
+export type DashboardItem = DashboardItemVisualization | DashboardItemVisualizationContent;
+
+/**
+ * Dashboard item with visualization
+ *
+ * @public
+ */
+export type DashboardItemVisualization = {
+    visualization: ObjRef;
+};
+
+/**
+ * Tests whether the provided item is a dashboard item with visualization.
+ * @param item - item to test
+ *
+ * @public
+ */
+export function isDashboardItemVisualization(item: unknown): item is DashboardItemVisualization {
+    return (item as DashboardItemVisualization).visualization !== undefined;
+}
+
+/**
+ * Dashboard item with visualization content
+ *
+ * @public
+ */
+export type DashboardItemVisualizationContent = {
+    visualizationContent: IInsight;
+};
+
+/**
+ * Tests whether the provided item is a dashboard item with visualization content.
+ * @param item - item to test
+ *
+ * @public
+ */
+export function isDashboardItemVisualizationContent(
+    item: unknown,
+): item is DashboardItemVisualizationContent {
+    return (item as DashboardItemVisualizationContent).visualizationContent !== undefined;
 }
 
 /**
@@ -265,6 +313,12 @@ export interface DashboardConfig {
      * Entitlements for the user who is rendering the dashboard
      */
     entitlements?: IEntitlementDescriptor[];
+
+    /**
+     * Initial content of the dashboard. In case of empty dashboard, this content will be filled
+     * into created section. If the dashboard is loaded from backend, this content will be ignored.
+     */
+    initialContent?: DashboardItem[];
 }
 
 /**
@@ -329,7 +383,13 @@ export interface DashboardFocusObject {
  */
 export type ResolvedDashboardConfig = Omit<
     Required<DashboardConfig>,
-    "mapboxToken" | "exportId" | "focusObject" | "slideConfig" | "references" | "entitlements"
+    | "mapboxToken"
+    | "exportId"
+    | "focusObject"
+    | "slideConfig"
+    | "references"
+    | "entitlements"
+    | "initialContent"
 > &
     DashboardConfig;
 

--- a/libs/sdk-ui-loaders/api/sdk-ui-loaders.api.md
+++ b/libs/sdk-ui-loaders/api/sdk-ui-loaders.api.md
@@ -5,6 +5,7 @@
 ```ts
 
 import { DashboardContext } from '@gooddata/sdk-ui-dashboard';
+import { DashboardItem } from '@gooddata/sdk-ui-dashboard';
 import { IAnalyticalBackend } from '@gooddata/sdk-backend-spi';
 import { IClientWorkspaceIdentifiers } from '@gooddata/sdk-ui';
 import { IDashboard } from '@gooddata/sdk-model';
@@ -83,6 +84,7 @@ export interface IDashboardLoader {
 // @public
 export interface IDashboardLoadOptions extends IDashboardBasePropsForLoader {
     adaptiveLoadOptions?: AdaptiveLoadOptions;
+    adhocItems?: DashboardItem[];
     allowUnfinishedFeatures?: "staticOnly" | "alwaysAllow" | "alwaysPrevent";
     clientWorkspace?: IClientWorkspaceIdentifiers;
     extraPlugins?: IEmbeddedPlugin | IEmbeddedPlugin[];

--- a/libs/sdk-ui-loaders/src/dashboard/types.ts
+++ b/libs/sdk-ui-loaders/src/dashboard/types.ts
@@ -1,5 +1,5 @@
-// (C) 2021-2022 GoodData Corporation
-import { IDashboardBaseProps, IDashboardPluginContract_V1 } from "@gooddata/sdk-ui-dashboard";
+// (C) 2021-2025 GoodData Corporation
+import { DashboardItem, IDashboardBaseProps, IDashboardPluginContract_V1 } from "@gooddata/sdk-ui-dashboard";
 import { IClientWorkspaceIdentifiers } from "@gooddata/sdk-ui";
 import { IDashboard, ObjRef } from "@gooddata/sdk-model";
 
@@ -129,6 +129,12 @@ export interface IDashboardLoadOptions extends IDashboardBasePropsForLoader {
      * Default allowUnfinishedFeatures is `alwaysPrevent`.
      */
     allowUnfinishedFeatures?: "staticOnly" | "alwaysAllow" | "alwaysPrevent";
+
+    /**
+     * List of ad-hoc items to render in the dashboard. These items are not part of the dashboard
+     * definition and are not persisted, it will be rendered into empty layout.
+     */
+    adhocItems?: DashboardItem[];
 }
 
 /**


### PR DESCRIPTION
Implementation for support adhoc items on dashboard in SDK now

risk: low
JIRA: F1-1107

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests.
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```
