### PR TITLE
feat: execution cancelling in public API

### DIFF
--- a/common/changes/@gooddata/sdk-ui-all/mkn-f1-1112_2025-02-25-09-21.json
+++ b/common/changes/@gooddata/sdk-ui-all/mkn-f1-1112_2025-02-25-09-21.json
@@ -1,0 +1,10 @@
+{
+    "changes": [
+        {
+            "packageName": "@gooddata/sdk-ui-all",
+            "comment": "Add support for execution cancelling via AbortController.",
+            "type": "none"
+        }
+    ],
+    "packageName": "@gooddata/sdk-ui-all"
+}

--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -5955,12 +5955,14 @@ export interface IUseAttributeElements {
 
 // @public
 export interface IUseCustomWidgetExecutionDataViewConfig {
+    enableExecutionCancelling?: boolean;
     execution?: Exclude<IExecutionConfiguration, "filters">;
     widget: ICustomWidget;
 }
 
 // @public
 export interface IUseCustomWidgetInsightDataViewConfig {
+    enableExecutionCancelling?: boolean;
     insight?: IInsightDefinition | ObjRef;
     widget: ICustomWidget;
 }
@@ -9175,13 +9177,13 @@ export const useCancelEditDialog: () => {
 };
 
 // @public
-export function useCustomWidgetExecutionDataView({ widget, execution, onCancel, onError, onLoading, onPending, onSuccess, }: IUseCustomWidgetExecutionDataViewConfig & UseCustomWidgetExecutionDataViewCallbacks): UseCancelablePromiseState<DataViewFacade, GoodDataSdkError>;
+export function useCustomWidgetExecutionDataView({ enableExecutionCancelling, widget, execution, onCancel, onError, onLoading, onPending, onSuccess, }: IUseCustomWidgetExecutionDataViewConfig & UseCustomWidgetExecutionDataViewCallbacks): UseCancelablePromiseState<DataViewFacade, GoodDataSdkError>;
 
 // @public
 export type UseCustomWidgetExecutionDataViewCallbacks = UseCancelablePromiseCallbacks<DataViewFacade, GoodDataSdkError>;
 
 // @public
-export function useCustomWidgetInsightDataView({ widget, insight, onCancel, onError, onLoading, onPending, onSuccess, }: IUseCustomWidgetInsightDataViewConfig & UseCustomWidgetInsightDataViewCallbacks): UseCancelablePromiseState<DataViewFacade, GoodDataSdkError>;
+export function useCustomWidgetInsightDataView({ widget, insight, enableExecutionCancelling, onCancel, onError, onLoading, onPending, onSuccess, }: IUseCustomWidgetInsightDataViewConfig & UseCustomWidgetInsightDataViewCallbacks): UseCancelablePromiseState<DataViewFacade, GoodDataSdkError>;
 
 // @public
 export type UseCustomWidgetInsightDataViewCallbacks = UseCancelablePromiseCallbacks<DataViewFacade, GoodDataSdkError>;

--- a/libs/sdk-ui-dashboard/src/presentation/widget/common/useCustomWidgetInsightDataView.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/common/useCustomWidgetInsightDataView.ts
@@ -1,4 +1,4 @@
-// (C) 2022-2024 GoodData Corporation
+// (C) 2022-2025 GoodData Corporation
 import { useEffect, useMemo } from "react";
 import { IInsightDefinition, insightSetFilters, isInsight, ObjRef } from "@gooddata/sdk-model";
 import {
@@ -13,7 +13,8 @@ import {
 } from "@gooddata/sdk-ui";
 import stringify from "json-stable-stringify";
 
-import { ICustomWidget, useWidgetFilters } from "../../../model/index.js";
+import { ICustomWidget, selectEnableExecutionCancelling, useWidgetFilters } from "../../../model/index.js";
+import { useSelector } from "react-redux";
 
 /**
  * Configuration options for the {@link useCustomWidgetInsightDataView} hook.
@@ -33,6 +34,14 @@ export interface IUseCustomWidgetInsightDataViewConfig {
      * Note: When the insight is not provided, hook is locked in a "pending" state.
      */
     insight?: IInsightDefinition | ObjRef;
+
+    /**
+     * Enable or disable real execution cancellation.
+     *
+     * This means that if the execution request is not yet finished and the execution changes,
+     * the request will be cancelled and the new execution will be started.
+     */
+    enableExecutionCancelling?: boolean;
 }
 
 /**
@@ -54,6 +63,7 @@ export type UseCustomWidgetInsightDataViewCallbacks = UseCancelablePromiseCallba
 export function useCustomWidgetInsightDataView({
     widget,
     insight,
+    enableExecutionCancelling,
     onCancel,
     onError,
     onLoading,
@@ -63,6 +73,8 @@ export function useCustomWidgetInsightDataView({
     UseCustomWidgetInsightDataViewCallbacks): UseCancelablePromiseState<DataViewFacade, GoodDataSdkError> {
     const backend = useBackendStrict();
     const workspace = useWorkspaceStrict();
+    const enableExecutionCancellingFF = useSelector(selectEnableExecutionCancelling);
+    const effectiveExecutionCancelling = enableExecutionCancelling ?? enableExecutionCancellingFF;
 
     const effectiveInsightTask = useCancelablePromise(
         {
@@ -114,6 +126,7 @@ export function useCustomWidgetInsightDataView({
 
     const dataViewTask = useExecutionDataView({
         execution: insightExecution,
+        enableExecutionCancelling: effectiveExecutionCancelling,
         onCancel,
         onError,
         onSuccess,

--- a/libs/sdk-ui/api/sdk-ui.api.md
+++ b/libs/sdk-ui/api/sdk-ui.api.md
@@ -316,6 +316,7 @@ export class DataViewLoader {
     seriesFrom: (...measuresAndScopingAttributes: IAttributeOrMeasure[]) => DataViewLoader;
     slicesFrom: (...attributes: IAttribute[]) => DataViewLoader;
     sortBy: (...sorts: ISortItem[]) => DataViewLoader;
+    withSignal: (signal: AbortSignal) => DataViewLoader;
     withTotals: (...totals: ITotal[]) => DataViewLoader;
 }
 
@@ -883,6 +884,7 @@ export interface IExecuteInsightProps extends IWithLoadingEvents<IExecuteInsight
     componentName?: string;
     dateFormat?: string | ((def: IExecutionDefinition, props: IExecuteInsightProps) => string);
     dimensions?: IDimension[] | ((def: IExecutionDefinition, props: IExecuteInsightProps) => IDimension[]);
+    enableExecutionCancelling?: boolean;
     ErrorComponent?: IExecuteErrorComponent;
     executeByReference?: boolean;
     exportTitle?: string;
@@ -903,6 +905,7 @@ export interface IExecuteProps extends IWithLoadingEvents<IExecuteProps> {
     backend?: IAnalyticalBackend;
     children: (executionResult: WithLoadingResult) => React_2.ReactElement | null;
     componentName?: string;
+    enableExecutionCancelling?: boolean;
     ErrorComponent?: IExecuteErrorComponent;
     exportTitle?: string;
     filters?: NullableFiltersOrPlaceholders;
@@ -1128,6 +1131,7 @@ export interface IPushData {
 // @public
 export interface IRawExecuteProps extends IWithLoadingEvents<IRawExecuteProps> {
     children: (executionResult: WithLoadingResult) => React_2.ReactElement | null;
+    enableExecutionCancelling?: boolean;
     ErrorComponent?: IExecuteErrorComponent;
     execution: IPreparedExecution;
     exportTitle?: string;
@@ -1322,6 +1326,7 @@ export type IUseComposedPlaceholderHook<T extends IComposedPlaceholder<any, any,
 // @public
 export interface IUseExecutionDataViewConfig {
     backend?: IAnalyticalBackend;
+    enableExecutionCancelling?: boolean;
     execution?: IPreparedExecution | IExecutionConfiguration;
     window?: DataViewWindow;
     workspace?: string;
@@ -1332,6 +1337,7 @@ export interface IUseInsightDataViewConfig {
     backend?: IAnalyticalBackend;
     dateFormat?: string | ((def: IExecutionDefinition) => string);
     dimensions?: IDimension[] | ((def: IExecutionDefinition) => IDimension[]);
+    enableExecutionCancelling?: boolean;
     executeByReference?: boolean;
     filters?: INullableFilter[];
     insight?: ObjRef;
@@ -1383,6 +1389,7 @@ export interface IVisualizationProps {
 
 // @internal
 export interface IWithExecution<T> {
+    enableExecutionCancelling?: boolean | ((props: T) => boolean);
     events?: IWithLoadingEvents<T> | ((props: T) => IWithLoadingEvents<T>);
     execution: IPreparedExecution | ((props: T) => IPreparedExecution) | ((props: T) => Promise<IPreparedExecution>);
     exportTitle: string | ((props: T) => string);
@@ -1393,10 +1400,11 @@ export interface IWithExecution<T> {
 
 // @internal
 export interface IWithExecutionLoading<TProps> {
+    enableExecutionCancelling?: boolean | ((props: TProps) => boolean);
     events?: IWithLoadingEvents<TProps> | ((props: TProps) => IWithLoadingEvents<TProps>);
     exportTitle: string | ((props: TProps) => string);
     loadOnMount?: boolean | ((props: TProps) => boolean);
-    promiseFactory: (props: TProps, window?: DataViewWindow) => Promise<DataViewFacade>;
+    promiseFactory: (props: TProps, window?: DataViewWindow, signal?: AbortSignal) => Promise<DataViewFacade>;
     shouldRefetch?: (prevProps: TProps, nextProps: TProps) => boolean;
     window?: DataViewWindow | ((props: TProps) => DataViewWindow | undefined);
 }

--- a/libs/sdk-ui/src/execution/Execute.tsx
+++ b/libs/sdk-ui/src/execution/Execute.tsx
@@ -1,4 +1,4 @@
-// (C) 2019-2022 GoodData Corporation
+// (C) 2019-2025 GoodData Corporation
 import React from "react";
 import { withExecution } from "./withExecution.js";
 import { DataViewWindow, IWithLoadingEvents, WithLoadingResult } from "./withExecutionLoading.js";
@@ -117,6 +117,16 @@ export interface IExecuteProps extends IWithLoadingEvents<IExecuteProps> {
     window?: DataViewWindow;
 
     /**
+     * Optionally enable real execution cancellation.
+     *
+     * This means that if the execution request is not yet finished and the execution changes,
+     * the request will be cancelled and the new execution will be started.
+     *
+     * Default: false
+     */
+    enableExecutionCancelling?: boolean;
+
+    /**
      * Child component to which rendering is delegated.
      *
      * @remarks
@@ -180,6 +190,7 @@ function exportTitle(props: IExecuteProps): string {
 
 const WrappedExecute = withContexts(
     withExecution<IExecuteProps>({
+        enableExecutionCancelling: (props: IExecuteProps) => props.enableExecutionCancelling ?? false,
         exportTitle,
         execution: (props) => {
             const { seriesBy, slicesBy, totals, filters, sortBy } = props;

--- a/libs/sdk-ui/src/execution/ExecuteInsight.tsx
+++ b/libs/sdk-ui/src/execution/ExecuteInsight.tsx
@@ -1,4 +1,4 @@
-// (C) 2019-2022 GoodData Corporation
+// (C) 2019-2025 GoodData Corporation
 import React from "react";
 import { withExecution } from "./withExecution.js";
 import { DataViewWindow, IWithLoadingEvents, WithLoadingResult } from "./withExecutionLoading.js";
@@ -120,6 +120,16 @@ export interface IExecuteInsightProps extends IWithLoadingEvents<IExecuteInsight
     executeByReference?: boolean;
 
     /**
+     * Optionally enable real execution cancellation.
+     *
+     * This means that if the execution request is not yet finished and the execution changes,
+     * the request will be cancelled and the new execution will be started.
+     *
+     * Default: false
+     */
+    enableExecutionCancelling?: boolean;
+
+    /**
      * Child component to which rendering is delegated.
      *
      * @remarks
@@ -188,6 +198,7 @@ function exportTitle(props: IExecuteInsightProps): string {
  */
 export const ExecuteInsight = withContexts(
     withExecution<IExecuteInsightProps>({
+        enableExecutionCancelling: (props: IExecuteInsightProps) => props.enableExecutionCancelling ?? false,
         exportTitle,
         execution: async (props) => {
             const {
@@ -217,7 +228,7 @@ export const ExecuteInsight = withContexts(
                 executeByReference ? executionFactory.forInsightByRef : executionFactory.forInsight
             ).bind(executionFactory);
 
-            let insightExecution = executeFn(insight, filters);
+            let insightExecution = executeFn(insight, filters); //
 
             if (sorts) {
                 const resolvedSorts =

--- a/libs/sdk-ui/src/execution/RawExecute.tsx
+++ b/libs/sdk-ui/src/execution/RawExecute.tsx
@@ -1,4 +1,4 @@
-// (C) 2019-2022 GoodData Corporation
+// (C) 2019-2025 GoodData Corporation
 import React from "react";
 import { IPreparedExecution } from "@gooddata/sdk-backend-spi";
 import { withExecution } from "./withExecution.js";
@@ -48,6 +48,16 @@ export interface IRawExecuteProps extends IWithLoadingEvents<IRawExecuteProps> {
      * to trigger the execution and loading.
      */
     loadOnMount?: boolean;
+
+    /**
+     * Optionally enable real execution cancellation.
+     *
+     * This means that if the execution request is not yet finished and the execution changes,
+     * the request will be cancelled and the new execution will be started.
+     *
+     * Default: false
+     */
+    enableExecutionCancelling?: boolean;
 
     /**
      * Child component to which rendering is delegated.
@@ -123,6 +133,7 @@ function exportTitle(props: IRawExecuteProps): string {
  * @public
  */
 export const RawExecute = withExecution<IRawExecuteProps>({
+    enableExecutionCancelling: (props: IRawExecuteProps) => props.enableExecutionCancelling ?? false,
     exportTitle,
     execution: (props: IRawExecuteProps) => props.execution,
     events: (props: IRawExecuteProps) => {

--- a/libs/sdk-ui/src/execution/useInsightDataView.ts
+++ b/libs/sdk-ui/src/execution/useInsightDataView.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2022 GoodData Corporation
+// (C) 2019-2025 GoodData Corporation
 import { IAnalyticalBackend } from "@gooddata/sdk-backend-spi";
 import { IDimension, IExecutionDefinition, INullableFilter, ISortItem, ObjRef } from "@gooddata/sdk-model";
 import {
@@ -92,6 +92,16 @@ export interface IUseInsightDataViewConfig {
      * workspace here, then the executor MUST be rendered within an existing WorkspaceContext.
      */
     workspace?: string;
+
+    /**
+     * Optionally enable real execution cancellation.
+     *
+     * This means that if the execution request is not yet finished and the execution changes,
+     * the request will be cancelled and the new execution will be started.
+     *
+     * Default: false
+     */
+    enableExecutionCancelling?: boolean;
 }
 
 /**
@@ -118,6 +128,7 @@ export function useInsightDataView(
         filters,
         window,
         executeByReference,
+        enableExecutionCancelling = false,
         onCancel,
         onError,
         onLoading,
@@ -161,6 +172,7 @@ export function useInsightDataView(
             window,
             backend,
             workspace,
+            enableExecutionCancelling,
             onCancel,
             onError,
             onLoading,

--- a/libs/sdk-ui/src/execution/withExecutionLoading.tsx
+++ b/libs/sdk-ui/src/execution/withExecutionLoading.tsx
@@ -131,8 +131,9 @@ export interface IWithExecutionLoading<TProps> {
      *
      * @param props - wrapped component props
      * @param window - data view window to retrieve, not specified in case all data should be retrieved
+     * @param signal - abort signal, will be used to cancel the execution
      */
-    promiseFactory: (props: TProps, window?: DataViewWindow) => Promise<DataViewFacade>;
+    promiseFactory: (props: TProps, window?: DataViewWindow, signal?: AbortSignal) => Promise<DataViewFacade>;
 
     /**
      * Specify data view window to retrieve from backend.
@@ -163,6 +164,16 @@ export interface IWithExecutionLoading<TProps> {
      * @param nextProps - next props
      */
     shouldRefetch?: (prevProps: TProps, nextProps: TProps) => boolean;
+
+    /**
+     * Optionally enable real execution cancellation.
+     *
+     * This means that if the execution request is not yet finished and the execution changes,
+     * the request will be cancelled and the new execution will be started.
+     *
+     * Default: false
+     */
+    enableExecutionCancelling?: boolean | ((props: TProps) => boolean);
 }
 
 type WithLoadingState = {
@@ -189,6 +200,7 @@ export function withExecutionLoading<TProps>(
         shouldRefetch = () => false,
         window,
         exportTitle,
+        enableExecutionCancelling = false,
     } = params;
 
     return (
@@ -292,8 +304,15 @@ export function withExecutionLoading<TProps>(
                 this.startLoading();
 
                 const readWindow = typeof window === "function" ? window(this.props) : window;
-                const promise = promiseFactory(this.props, readWindow);
-                this.cancelablePromise = makeCancelable(() => promise);
+                const enableRealCancellation =
+                    typeof enableExecutionCancelling === "function"
+                        ? enableExecutionCancelling(this.props)
+                        : enableExecutionCancelling;
+                const promise = (signal?: AbortSignal) => promiseFactory(this.props, readWindow, signal);
+                this.cancelablePromise = makeCancelable(
+                    (signal) => promise(enableRealCancellation ? signal : undefined),
+                    enableRealCancellation,
+                );
 
                 try {
                     const result = await this.cancelablePromise.promise;


### PR DESCRIPTION
Add support for execution cancelling to all execution public APIs:
    - React hooks
    - React higher order components
    - React execute components
    - DataViewLoader

risk: low
JIRA: F1-1112

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests.
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```
