### PR TITLE
fix: move recording-unstable depfilters tests to checklist

### DIFF
--- a/libs/sdk-ui-tests-e2e/cypress/integration/01-sdk-ui-dashboard/dependentFilters.spec.ts
+++ b/libs/sdk-ui-tests-e2e/cypress/integration/01-sdk-ui-dashboard/dependentFilters.spec.ts
@@ -18,7 +18,7 @@ describe("Dependent filter", () => {
         Navigation.visit("dashboard/dashboard-dependent-filters");
     });
 
-    it("should test parent - child interaction in view mode", { tags: "pre-merge_isolated_tiger" }, () => {
+    it("should test parent - child interaction in view mode", { tags: "checklist_integrated_tiger" }, () => {
         table
             .waitLoaded()
             .getColumnValues(2)
@@ -109,7 +109,7 @@ describe("Dependent filter", () => {
         cityFilter.open().hasSubtitle("Hartford").hasFilterListSize(10).hasSelectedValueList(["Hartford"]);
     });
 
-    it("should test parent - child interaction in edit mode", { tags: "pre-merge_isolated_tiger" }, () => {
+    it("should test parent - child interaction in edit mode", { tags: "checklist_integrated_tiger" }, () => {
         topBar.enterEditMode().editButtonIsVisible(false);
 
         table


### PR DESCRIPTION
risk: low


<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests.
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```