### PR TITLE
fix: propagate ad hoc displayAsLabel migrated attr filter immediately

### DIFF
--- a/libs/sdk-backend-tiger/src/backend/features/feature.ts
+++ b/libs/sdk-backend-tiger/src/backend/features/feature.ts
@@ -667,6 +667,13 @@ export function mapFeatures(features: FeaturesMap): Partial<ITigerFeatureFlags> 
             "BOOLEAN",
             FeatureFlagsValues.enableDashboardAfterRenderDetection,
         ),
+        ...loadFeature(
+            features,
+            TigerFeaturesNames.EnableImmediateAttributeFilterDisplayAsLabelMigration,
+            "enableImmediateAttributeFilterDisplayAsLabelMigration",
+            "BOOLEAN",
+            FeatureFlagsValues.enableImmediateAttributeFilterDisplayAsLabelMigration,
+        ),
     };
 }
 

--- a/libs/sdk-backend-tiger/src/backend/uiFeatures.ts
+++ b/libs/sdk-backend-tiger/src/backend/uiFeatures.ts
@@ -133,6 +133,7 @@ export enum TigerFeaturesNames {
     EnableDashboardAfterRenderDetection = "enableDashboardAfterRenderDetection",
     EnableDashboardTabularExport = "enableDashboardTabularExport",
     EnableOrchestratedTabularExports = "enableOrchestratedTabularExports",
+    EnableImmediateAttributeFilterDisplayAsLabelMigration = "enableImmediateAttributeFilterDisplayAsLabelMigration",
 }
 
 export type ITigerFeatureFlags = {
@@ -229,6 +230,7 @@ export type ITigerFeatureFlags = {
     enableDashboardFiltersApplyModes: typeof FeatureFlagsValues["enableDashboardFiltersApplyModes"][number];
     enableExecutionCancelling: typeof FeatureFlagsValues["enableExecutionCancelling"][number];
     enableDashboardAfterRenderDetection: typeof FeatureFlagsValues["enableDashboardAfterRenderDetection"][number];
+    enableImmediateAttributeFilterDisplayAsLabelMigration: typeof FeatureFlagsValues["enableImmediateAttributeFilterDisplayAsLabelMigration"][number];
 };
 
 export const DefaultFeatureFlags: ITigerFeatureFlags = {
@@ -325,6 +327,7 @@ export const DefaultFeatureFlags: ITigerFeatureFlags = {
     enableDashboardFiltersApplyModes: false,
     enableExecutionCancelling: false,
     enableDashboardAfterRenderDetection: false,
+    enableImmediateAttributeFilterDisplayAsLabelMigration: false,
 };
 
 export const FeatureFlagsValues = {
@@ -425,4 +428,5 @@ export const FeatureFlagsValues = {
     enableDashboardFiltersApplyModes: [true, false] as const,
     enableExecutionCancelling: [true, false] as const,
     enableDashboardAfterRenderDetection: [true, false] as const,
+    enableImmediateAttributeFilterDisplayAsLabelMigration: [true, false] as const,
 };

--- a/libs/sdk-model/api/sdk-model.api.md
+++ b/libs/sdk-model/api/sdk-model.api.md
@@ -3385,6 +3385,7 @@ export interface ISettings {
     enableHidingOfDataPoints?: boolean;
     enableHidingOfWidgetTitle?: boolean;
     enableIgnoreCrossFiltering?: boolean;
+    enableImmediateAttributeFilterDisplayAsLabelMigration?: boolean;
     enableInPlatformNotifications?: boolean;
     enableInsightExportScheduling?: boolean;
     enableInsightToReport?: boolean;

--- a/libs/sdk-model/src/settings/index.ts
+++ b/libs/sdk-model/src/settings/index.ts
@@ -621,6 +621,11 @@ export interface ISettings {
      */
     enableExecutionCancelling?: boolean;
 
+    /**
+     * Enable immediate attribute filter displayAsLabel migration information propagation right upon the load of the component.
+     */
+    enableImmediateAttributeFilterDisplayAsLabelMigration?: boolean;
+
     [key: string]: number | boolean | string | object | undefined;
 }
 

--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -8056,6 +8056,9 @@ export const selectEnableFlexibleLayout: DashboardSelector<boolean>;
 export const selectEnableIgnoreCrossFiltering: DashboardSelector<boolean>;
 
 // @internal
+export const selectEnableImmediateAttributeFilterDisplayAsLabelMigration: DashboardSelector<boolean>;
+
+// @internal
 export const selectEnableInPlatformNotifications: DashboardSelector<boolean>;
 
 // @public

--- a/libs/sdk-ui-dashboard/src/model/store/config/configSelectors.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/config/configSelectors.ts
@@ -737,6 +737,16 @@ export const selectEnableDuplicatedLabelValuesInAttributeFilter: DashboardSelect
 );
 
 /**
+ * Returns whether attribute filter displays duplicated values when filter uses secondary label value.
+ *
+ * @internal
+ */
+export const selectEnableImmediateAttributeFilterDisplayAsLabelMigration: DashboardSelector<boolean> =
+    createSelector(selectConfig, (state) => {
+        return state.settings?.enableImmediateAttributeFilterDisplayAsLabelMigration ?? false;
+    });
+
+/**
  * Returns whether rich text in descriptions is enabled.
  *
  * @internal

--- a/libs/sdk-ui-dashboard/src/model/store/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/index.ts
@@ -85,6 +85,7 @@ export {
     selectEnableAttributeFilterValuesValidation,
     selectEnableKDAttributeFilterDatesValidation,
     selectEnableDuplicatedLabelValuesInAttributeFilter,
+    selectEnableImmediateAttributeFilterDisplayAsLabelMigration,
     selectEnableRichTextDescriptions,
     selectIsDisabledCrossFiltering,
     selectIsDisableUserFilterReset,

--- a/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/DefaultDashboardAttributeFilter.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/DefaultDashboardAttributeFilter.tsx
@@ -37,6 +37,7 @@ import {
     selectIsAttributeFilterDependentByLocalIdentifier,
     selectIsFilterFromCrossFilteringByLocalIdentifier,
     selectEnableDuplicatedLabelValuesInAttributeFilter,
+    selectEnableImmediateAttributeFilterDisplayAsLabelMigration,
     selectHasSomeExecutionResult,
     selectEnableCriticalContentPerformanceOptimizations,
     selectPreloadedAttributesWithReferences,
@@ -107,6 +108,9 @@ const DefaultDashboardAttributeFilterInner = (props: IDashboardAttributeFilterPr
     );
     const enableDuplicatedLabelValuesInAttributeFilter = useDashboardSelector(
         selectEnableDuplicatedLabelValuesInAttributeFilter,
+    );
+    const enableImmediateAttributeFilterDisplayAsLabelMigration = useDashboardSelector(
+        selectEnableImmediateAttributeFilterDisplayAsLabelMigration,
     );
 
     const filterRef = useMemo(() => {
@@ -454,6 +458,9 @@ const DefaultDashboardAttributeFilterInner = (props: IDashboardAttributeFilterPr
                 customIcon={visibilityIcon}
                 StatusBarComponent={CustomStatusBarComponent}
                 enableDuplicatedLabelValuesInAttributeFilter={enableDuplicatedLabelValuesInAttributeFilter}
+                enableImmediateAttributeFilterDisplayAsLabelMigration={
+                    enableImmediateAttributeFilterDisplayAsLabelMigration
+                }
             />
         </AttributeFilterParentFilteringProvider>
     );

--- a/libs/sdk-ui-filters/api/sdk-ui-filters.api.md
+++ b/libs/sdk-ui-filters/api/sdk-ui-filters.api.md
@@ -402,6 +402,7 @@ export interface IAttributeFilterCoreProps {
     // @alpha
     displayAsLabel?: ObjRef;
     enableDuplicatedLabelValuesInAttributeFilter?: boolean;
+    enableImmediateAttributeFilterDisplayAsLabelMigration?: boolean;
     filter?: IAttributeFilter;
     fullscreenOnMobile?: boolean;
     hiddenElements?: string[];

--- a/libs/sdk-ui-filters/src/AttributeFilter/AttributeFilterProviders.tsx
+++ b/libs/sdk-ui-filters/src/AttributeFilter/AttributeFilterProviders.tsx
@@ -1,4 +1,4 @@
-// (C) 2021-2024 GoodData Corporation
+// (C) 2021-2025 GoodData Corporation
 import React from "react";
 import { IntlWrapper } from "@gooddata/sdk-ui";
 import { AttributeFilterComponentsProvider } from "./Context/AttributeFilterComponentsContext.js";
@@ -49,6 +49,7 @@ export const AttributeFilterProviders: React.FC<IAttributeFilterBaseProps & { ch
         EmptyResultComponent,
         StatusBarComponent,
         enableDuplicatedLabelValuesInAttributeFilter = true,
+        enableImmediateAttributeFilterDisplayAsLabelMigration = false,
     } = props;
 
     const DefaultComponents = getAttributeFilterDefaultComponents(props);
@@ -105,6 +106,9 @@ export const AttributeFilterProviders: React.FC<IAttributeFilterBaseProps & { ch
                     customIcon={customIcon}
                     enableDuplicatedLabelValuesInAttributeFilter={
                         enableDuplicatedLabelValuesInAttributeFilter
+                    }
+                    enableImmediateAttributeFilterDisplayAsLabelMigration={
+                        enableImmediateAttributeFilterDisplayAsLabelMigration
                     }
                 >
                     {children}

--- a/libs/sdk-ui-filters/src/AttributeFilter/types.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilter/types.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2024 GoodData Corporation
+// (C) 2019-2025 GoodData Corporation
 
 import {
     DashboardAttributeFilterSelectionMode,
@@ -246,6 +246,11 @@ export interface IAttributeFilterCoreProps {
      * Enables duplicated values in secondary labels.
      */
     enableDuplicatedLabelValuesInAttributeFilter?: boolean;
+
+    /**
+     * Enables the migration of displayAsLabel to be immediately reported to the parent app.
+     */
+    enableImmediateAttributeFilterDisplayAsLabelMigration?: boolean;
 }
 
 /**


### PR DESCRIPTION
If a filter was created before the introduction of the ‘support duplicated label values’ feature, it is migrated to the new configuration ad hoc during initialization. Previously, the new configuration was only propagated to the filter’s parent application when the user opened the filter, made changes, and applied them.

After the change, the migration is now detected during filter initialization and reported immediately.

There are some consequences:
- If dashboard component starts in edit mode, Save button is enabled if filter was migrated. This does not happen in view mode.
- Filters can be stored in filter view in the old format when user save view quicker than all filters load values and mark themselves as "initialized: success"

JIRA: LX-824
risk: low

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests.
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```
