### PR TITLE
fix: normalizing backend execution break definition of filters

### DIFF
--- a/libs/sdk-backend-base/src/normalizingBackend/normalizer.ts
+++ b/libs/sdk-backend-base/src/normalizingBackend/normalizer.ts
@@ -1,4 +1,4 @@
-// (C) 2007-2023 GoodData Corporation
+// (C) 2007-2025 GoodData Corporation
 import {
     attributeAlias,
     attributeLocalId,
@@ -478,6 +478,22 @@ export class Normalizer {
                 [...attributes, measure].filter(isLocalIdRef).forEach((ref) => {
                     ref.localIdentifier = this.normalizedLocalId(ref.localIdentifier);
                 });
+            }
+
+            if (isPositiveAttributeFilter(filter)) {
+                const { displayForm } = filter.positiveAttributeFilter;
+
+                if (isLocalIdRef(displayForm)) {
+                    displayForm.localIdentifier = this.normalizedLocalId(displayForm.localIdentifier);
+                }
+            }
+
+            if (isNegativeAttributeFilter(filter)) {
+                const { displayForm } = filter.negativeAttributeFilter;
+
+                if (isLocalIdRef(displayForm)) {
+                    displayForm.localIdentifier = this.normalizedLocalId(displayForm.localIdentifier);
+                }
             }
         });
     };

--- a/libs/sdk-backend-base/src/normalizingBackend/tests/__snapshots__/withNormalization.test.ts.snap
+++ b/libs/sdk-backend-base/src/normalizingBackend/tests/__snapshots__/withNormalization.test.ts.snap
@@ -1,0 +1,151 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`withNormalization > should normalize also attributes locals ids in filters 1`] = `
+{
+  "attributes": [
+    {
+      "attribute": {
+        "displayForm": {
+          "identifier": "cross_border_ind",
+          "type": "displayForm",
+        },
+        "localIdentifier": "a_cross_border_ind",
+        "showAllValues": false,
+      },
+    },
+  ],
+  "buckets": [],
+  "dimensions": [
+    {
+      "itemIdentifiers": [
+        "measureGroup",
+      ],
+    },
+    {
+      "itemIdentifiers": [
+        "a_cross_border_ind",
+      ],
+    },
+  ],
+  "filters": [
+    {
+      "relativeDateFilter": {
+        "dataSet": {
+          "identifier": "DW_PROCESS_MONTH_END_DATE",
+          "type": "dataSet",
+        },
+        "from": -15,
+        "granularity": "GDC.time.month",
+        "to": -1,
+      },
+    },
+    {
+      "positiveAttributeFilter": {
+        "displayForm": {
+          "localIdentifier": "a_cross_border_ind",
+        },
+        "in": {
+          "values": [
+            "Domestic",
+          ],
+        },
+      },
+    },
+  ],
+  "measures": [
+    {
+      "measure": {
+        "definition": {
+          "measureDefinition": {
+            "computeRatio": false,
+            "filters": [],
+            "item": {
+              "identifier": "gross_fraud_rate",
+              "type": "measure",
+            },
+          },
+        },
+        "localIdentifier": "m_gross_fraud_rate",
+      },
+    },
+  ],
+  "postProcessing": {},
+  "sortBy": [],
+  "workspace": "testWorkspace",
+}
+`;
+
+exports[`withNormalization > should normalize also attributes locals ids in filters 2`] = `
+{
+  "attributes": [
+    {
+      "attribute": {
+        "displayForm": {
+          "identifier": "cross_border_ind",
+          "type": "displayForm",
+        },
+        "localIdentifier": "5050b198945940d989c6ec1dc5d41cb0",
+        "showAllValues": false,
+      },
+    },
+  ],
+  "buckets": [],
+  "dimensions": [
+    {
+      "itemIdentifiers": [
+        "measureGroup",
+      ],
+    },
+    {
+      "itemIdentifiers": [
+        "5050b198945940d989c6ec1dc5d41cb0",
+      ],
+    },
+  ],
+  "filters": [
+    {
+      "relativeDateFilter": {
+        "dataSet": {
+          "identifier": "DW_PROCESS_MONTH_END_DATE",
+          "type": "dataSet",
+        },
+        "from": -15,
+        "granularity": "GDC.time.month",
+        "to": -1,
+      },
+    },
+    {
+      "positiveAttributeFilter": {
+        "displayForm": {
+          "localIdentifier": "5050b198945940d989c6ec1dc5d41cb0",
+        },
+        "in": {
+          "values": [
+            "Domestic",
+          ],
+        },
+      },
+    },
+  ],
+  "measures": [
+    {
+      "measure": {
+        "definition": {
+          "measureDefinition": {
+            "computeRatio": false,
+            "filters": [],
+            "item": {
+              "identifier": "gross_fraud_rate",
+              "type": "measure",
+            },
+          },
+        },
+        "localIdentifier": "dfa7419de85a48cab8a203960a84e766",
+      },
+    },
+  ],
+  "postProcessing": {},
+  "sortBy": [],
+  "workspace": "testWorkspace",
+}
+`;

--- a/libs/sdk-backend-base/src/normalizingBackend/tests/withNormalization.test.ts
+++ b/libs/sdk-backend-base/src/normalizingBackend/tests/withNormalization.test.ts
@@ -1,9 +1,10 @@
-// (C) 2007-2024 GoodData Corporation
+// (C) 2007-2025 GoodData Corporation
 import { describe, it, expect } from "vitest";
 import { withNormalization } from "../index.js";
 import { dummyBackend, dummyBackendEmptyData } from "../../dummyBackend/index.js";
 import { ReferenceMd, ReferenceMdExt } from "@gooddata/reference-workspace";
 import { NoDataError } from "@gooddata/sdk-backend-spi";
+import { IAutomationAlertExecutionDefinition } from "@gooddata/sdk-model";
 
 describe("withNormalization", () => {
     const measures = [
@@ -52,5 +53,86 @@ describe("withNormalization", () => {
             expect(typedError.dataView?.definition.attributes).toEqual(attributes);
             expect(typedError.dataView?.definition.measures).toEqual(measures);
         }
+    });
+
+    it("should normalize also attributes locals ids in filters", async () => {
+        const AlertExecution: IAutomationAlertExecutionDefinition = {
+            attributes: [
+                {
+                    attribute: {
+                        localIdentifier: "5050b198945940d989c6ec1dc5d41cb0",
+                        displayForm: {
+                            identifier: "cross_border_ind",
+                            type: "displayForm",
+                        },
+                        showAllValues: false,
+                    },
+                },
+            ],
+            measures: [
+                {
+                    measure: {
+                        localIdentifier: "dfa7419de85a48cab8a203960a84e766",
+                        definition: {
+                            measureDefinition: {
+                                item: {
+                                    identifier: "gross_fraud_rate",
+                                    type: "measure",
+                                },
+                                filters: [],
+                                computeRatio: false,
+                            },
+                        },
+                    },
+                },
+            ],
+            auxMeasures: [],
+            filters: [
+                {
+                    relativeDateFilter: {
+                        dataSet: {
+                            identifier: "DW_PROCESS_MONTH_END_DATE",
+                            type: "dataSet",
+                        },
+                        from: -15,
+                        to: -1,
+                        granularity: "GDC.time.month",
+                    },
+                },
+                {
+                    positiveAttributeFilter: {
+                        displayForm: {
+                            localIdentifier: "5050b198945940d989c6ec1dc5d41cb0",
+                        },
+                        in: {
+                            values: ["Domestic"],
+                        },
+                    },
+                },
+            ],
+        };
+
+        let normalized;
+        const backend = withNormalization(
+            dummyBackend({
+                // make sure the dataView is passed to the NoDataError
+                raiseNoDataExceptions: "with-data-view",
+            }),
+            {
+                normalizationStatus: (s) => {
+                    normalized = s.normalized;
+                },
+            },
+        );
+
+        const query = backend
+            .workspace("testWorkspace")
+            .execution()
+            .forItems([...AlertExecution.attributes, ...AlertExecution.measures], AlertExecution.filters);
+
+        const r = await query.execute();
+        expect(r).toBeDefined();
+        expect(normalized).toMatchSnapshot();
+        expect(r.definition).toMatchSnapshot();
     });
 });


### PR DESCRIPTION
risk: low
JIRA: F1-1131

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests.
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```
