### PR TITLE
fix: save ad-hoc migrated attribute filters via Save as dashboard

### DIFF
--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/common/migratedAttributeFilters.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/common/migratedAttributeFilters.ts
@@ -1,0 +1,55 @@
+// (C) 2025 GoodData Corporation
+
+import {
+    IDashboardAttributeFilter,
+    areObjRefsEqual,
+    IFilterContextDefinition,
+    isDashboardAttributeFilter,
+} from "@gooddata/sdk-model";
+
+/**
+ * Returns attribute filters that were ad-hoc migrated (non-primary label information was moved from
+ * filter's displayForm to dashboard's attribute filter config).
+ *
+ * @param persistedAttributeFilters - attribute filters that are persisted in metadata
+ * @param currentAttributeFilters - attribute filters that are in the current state
+ */
+export function getMigratedAttributeFilters(
+    persistedAttributeFilters: IDashboardAttributeFilter[] = [],
+    currentAttributeFilters: IDashboardAttributeFilter[] = [],
+): IDashboardAttributeFilter[] {
+    return currentAttributeFilters.filter((currentFilter) => {
+        const persistedFilter = persistedAttributeFilters.find(
+            (persistedFilter) =>
+                persistedFilter.attributeFilter.localIdentifier ===
+                currentFilter.attributeFilter.localIdentifier,
+        );
+        return !areObjRefsEqual(
+            persistedFilter?.attributeFilter.displayForm,
+            currentFilter.attributeFilter.displayForm,
+        );
+    });
+}
+
+/**
+ * Returns provided filter context with provided filters merged into (the filters are matched by
+ * local identifier).
+ * @param filterContext - the filter context that will get the provided filters merged into
+ * @param migratedAttributeFilters - filters that should be merged into the provided filter context
+ */
+export const mergedMigratedAttributeFilters = (
+    filterContext: IFilterContextDefinition,
+    migratedAttributeFilters: IDashboardAttributeFilter[],
+): IFilterContextDefinition => ({
+    ...filterContext,
+    filters: filterContext.filters.map((filter) => {
+        if (isDashboardAttributeFilter(filter)) {
+            const migratedFilter = migratedAttributeFilters.find(
+                (migratedFilter) =>
+                    migratedFilter.attributeFilter.localIdentifier === filter.attributeFilter.localIdentifier,
+            );
+            return migratedFilter ?? filter;
+        }
+        return filter;
+    }),
+});

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/common/stateInitializers.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/common/stateInitializers.ts
@@ -54,6 +54,7 @@ import { dateFilterConfigsActions } from "../../../store/dateFilterConfigs/index
 import { drillActions } from "../../../store/drill/index.js";
 
 import { dashboardInitialize, EmptyDashboardLayout } from "./dashboardInitialize.js";
+import { mergedMigratedAttributeFilters } from "./migratedAttributeFilters.js";
 
 /**
  * Returns a list of actions which when processed will initialize the essential parts of the dashboard
@@ -417,20 +418,7 @@ export function* actionsToInitializeExistingDashboard(
     const filterContextIdentity = dashboardFilterContextIdentity(customizedDashboard);
 
     const migratedFilterContext: IFilterContextDefinition = isImmediateAttributeFilterMigrationEnabled
-        ? {
-              ...filterContextDefinition,
-              filters: filterContextDefinition.filters.map((filter) => {
-                  if (isDashboardAttributeFilter(filter)) {
-                      const migratedFilter = migratedAttributeFilters.find(
-                          (migratedFilter) =>
-                              migratedFilter.attributeFilter.localIdentifier ===
-                              filter.attributeFilter.localIdentifier,
-                      );
-                      return migratedFilter ?? filter;
-                  }
-                  return filter;
-              }),
-          }
+        ? mergedMigratedAttributeFilters(filterContextDefinition, migratedAttributeFilters)
         : filterContextDefinition;
 
     const effectiveAttributeFilterConfigs = isImmediateAttributeFilterMigrationEnabled

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/resetDashboardHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/resetDashboardHandler.ts
@@ -22,7 +22,6 @@ import uniqWith from "lodash/uniqWith.js";
 import {
     areObjRefsEqual,
     IDashboardAttributeFilterConfig,
-    IDashboardAttributeFilter,
     isDashboardAttributeFilter,
 } from "@gooddata/sdk-model";
 import { resolveInsights } from "../../utils/insightResolver.js";
@@ -35,6 +34,7 @@ import { applyDefaultFilterView } from "./common/filterViews.js";
 import { selectFilterViews } from "../../store/filterViews/filterViewsReducersSelectors.js";
 import { selectFilterContextAttributeFilters } from "../../store/filterContext/filterContextSelectors.js";
 import { selectAttributeFilterConfigsOverrides } from "../../store/attributeFilterConfigs/attributeFilterConfigsSelectors.js";
+import { getMigratedAttributeFilters } from "./common/migratedAttributeFilters.js";
 
 export function* resetDashboardHandler(
     ctx: DashboardContext,
@@ -183,23 +183,6 @@ function* resetDashboardFromPersisted(ctx: DashboardContext) {
         batch,
         persistedDashboard,
     };
-}
-
-function getMigratedAttributeFilters(
-    persistedAttributeFilters: IDashboardAttributeFilter[] = [],
-    currentAttributeFilters: IDashboardAttributeFilter[] = [],
-): IDashboardAttributeFilter[] {
-    return currentAttributeFilters.filter((currentFilter) => {
-        const persistedFilter = persistedAttributeFilters.find(
-            (persistedFilter) =>
-                persistedFilter.attributeFilter.localIdentifier ===
-                currentFilter.attributeFilter.localIdentifier,
-        );
-        return !areObjRefsEqual(
-            persistedFilter?.attributeFilter.displayForm,
-            currentFilter.attributeFilter.displayForm,
-        );
-    });
 }
 
 const mergeDashboardAttributeFilterConfigs = (

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/saveAsDashboardHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/saveAsDashboardHandler.ts
@@ -1,6 +1,11 @@
 // (C) 2021-2025 GoodData Corporation
 
-import { IDashboard, IDashboardDefinition, IAccessControlAware } from "@gooddata/sdk-model";
+import {
+    IDashboard,
+    IDashboardDefinition,
+    IAccessControlAware,
+    isDashboardAttributeFilter,
+} from "@gooddata/sdk-model";
 import { BatchAction, batchActions } from "redux-batched-actions";
 import { SagaIterator } from "redux-saga";
 import { call, put, SagaReturnType, select } from "redux-saga/effects";
@@ -12,7 +17,10 @@ import {
 import { SaveDashboardAs } from "../../commands/dashboard.js";
 import { DashboardCopySaved, dashboardCopySaved } from "../../events/dashboard.js";
 import { filterContextActions } from "../../store/filterContext/index.js";
-import { selectFilterContextDefinition } from "../../store/filterContext/filterContextSelectors.js";
+import {
+    selectFilterContextDefinition,
+    selectFilterContextAttributeFilters,
+} from "../../store/filterContext/filterContextSelectors.js";
 import { layoutActions } from "../../store/layout/index.js";
 import { selectBasicLayout } from "../../store/layout/layoutSelectors.js";
 import { metaActions } from "../../store/meta/index.js";
@@ -25,7 +33,10 @@ import { DashboardContext } from "../../types/commonTypes.js";
 import { PromiseFnReturnType } from "../../types/sagas.js";
 import { selectDateFilterConfigOverrides } from "../../store/dateFilterConfig/dateFilterConfigSelectors.js";
 import { savingActions } from "../../store/saving/index.js";
-import { selectSettings } from "../../store/config/configSelectors.js";
+import {
+    selectSettings,
+    selectEnableImmediateAttributeFilterDisplayAsLabelMigration,
+} from "../../store/config/configSelectors.js";
 import { selectBackendCapabilities } from "../../store/backendCapabilities/backendCapabilitiesSelectors.js";
 import { listedDashboardsActions } from "../../store/listedDashboards/index.js";
 import { createListedDashboard } from "../../../_staging/listedDashboard/listedDashboardUtils.js";
@@ -36,6 +47,10 @@ import { changeRenderMode } from "../../commands/index.js";
 import { selectIsInViewMode } from "../../store/renderMode/renderModeSelectors.js";
 import { selectAttributeFilterConfigsOverrides } from "../../store/attributeFilterConfigs/attributeFilterConfigsSelectors.js";
 import { selectDateFilterConfigsOverrides } from "../../store/dateFilterConfigs/dateFilterConfigsSelectors.js";
+import {
+    getMigratedAttributeFilters,
+    mergedMigratedAttributeFilters,
+} from "./common/migratedAttributeFilters.js";
 
 type DashboardSaveAsContext = {
     cmd: SaveDashboardAs;
@@ -83,15 +98,33 @@ function* createDashboardSaveAsContext(cmd: SaveDashboardAs): SagaIterator<Dashb
         selectDashboardDescriptor,
     );
 
-    const originalDashboardDescription: ReturnType<typeof selectPersistedDashboard> = yield select(
+    const originalPersistedDashboard: ReturnType<typeof selectPersistedDashboard> = yield select(
         selectPersistedDashboard,
     );
 
+    const isImmediateAttributeFilterMigrationEnabled: ReturnType<
+        typeof selectEnableImmediateAttributeFilterDisplayAsLabelMigration
+    > = yield select(selectEnableImmediateAttributeFilterDisplayAsLabelMigration);
+    const currentFilters: ReturnType<typeof selectFilterContextAttributeFilters> = yield select(
+        selectFilterContextAttributeFilters,
+    );
+    const migratedAttributeFilters = isImmediateAttributeFilterMigrationEnabled
+        ? getMigratedAttributeFilters(
+              originalPersistedDashboard?.filterContext?.filters.filter(isDashboardAttributeFilter),
+              currentFilters,
+          )
+        : [];
     const filterContextDefinition: ReturnType<typeof selectFilterContextDefinition> = yield select(
-        !useOriginalFilterContext || !originalDashboardDescription
+        !useOriginalFilterContext || !originalPersistedDashboard
             ? selectFilterContextDefinition
             : selectPersistedDashboardFilterContextAsFilterContextDefinition,
     );
+    // merge migrated filters only in view mode (useOriginalFilterContext), edit mode filter context is
+    // selected from state where it is already migrated
+    const migratedFilterContext =
+        isImmediateAttributeFilterMigrationEnabled && useOriginalFilterContext
+            ? mergedMigratedAttributeFilters(filterContextDefinition, migratedAttributeFilters)
+            : filterContextDefinition;
 
     const layout: ReturnType<typeof selectBasicLayout> = yield select(selectBasicLayout);
     const dateFilterConfig: ReturnType<typeof selectDateFilterConfigOverrides> = yield select(
@@ -115,7 +148,7 @@ function* createDashboardSaveAsContext(cmd: SaveDashboardAs): SagaIterator<Dashb
         type: "IDashboard",
         ...dashboardDescriptorRest,
         filterContext: {
-            ...filterContextDefinition,
+            ...migratedFilterContext,
         },
         layout,
         dateFilterConfig,


### PR DESCRIPTION
Ad-hoc updated attribute filters were saved only when dashboard changes were saved from edit mode. When dashboard copy was created via Save as function, the changes to filter context were lost. Attribute filter configs were kept. The fix allows the migrated filters to be saved even from view mode.

JIRA: LX-845
risk: low

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests.
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```
