### PR TITLE
fix: do not enable Save button in edit mode for cross filters

### DIFF
--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/common/migratedAttributeFilters.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/common/migratedAttributeFilters.ts
@@ -13,22 +13,31 @@ import {
  *
  * @param persistedAttributeFilters - attribute filters that are persisted in metadata
  * @param currentAttributeFilters - attribute filters that are in the current state
+ * @param crossFilteringFiltersLocalIdentifiers - current filters that have cross filtering applied
  */
 export function getMigratedAttributeFilters(
     persistedAttributeFilters: IDashboardAttributeFilter[] = [],
     currentAttributeFilters: IDashboardAttributeFilter[] = [],
+    crossFilteringFiltersLocalIdentifiers: string[] = [],
 ): IDashboardAttributeFilter[] {
-    return currentAttributeFilters.filter((currentFilter) => {
-        const persistedFilter = persistedAttributeFilters.find(
-            (persistedFilter) =>
-                persistedFilter.attributeFilter.localIdentifier ===
-                currentFilter.attributeFilter.localIdentifier,
-        );
-        return !areObjRefsEqual(
-            persistedFilter?.attributeFilter.displayForm,
-            currentFilter.attributeFilter.displayForm,
-        );
-    });
+    return currentAttributeFilters
+        .filter(
+            (currentFilter) =>
+                !crossFilteringFiltersLocalIdentifiers.includes(
+                    currentFilter.attributeFilter.localIdentifier!,
+                ),
+        )
+        .filter((currentFilter) => {
+            const persistedFilter = persistedAttributeFilters.find(
+                (persistedFilter) =>
+                    persistedFilter.attributeFilter.localIdentifier ===
+                    currentFilter.attributeFilter.localIdentifier,
+            );
+            return !areObjRefsEqual(
+                persistedFilter?.attributeFilter.displayForm,
+                currentFilter.attributeFilter.displayForm,
+            );
+        });
 }
 
 /**

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/saveAsDashboardHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/saveAsDashboardHandler.ts
@@ -51,6 +51,7 @@ import {
     getMigratedAttributeFilters,
     mergedMigratedAttributeFilters,
 } from "./common/migratedAttributeFilters.js";
+import { selectCrossFilteringFiltersLocalIdentifiers } from "../../store/drill/drillSelectors.js";
 
 type DashboardSaveAsContext = {
     cmd: SaveDashboardAs;
@@ -108,10 +109,14 @@ function* createDashboardSaveAsContext(cmd: SaveDashboardAs): SagaIterator<Dashb
     const currentFilters: ReturnType<typeof selectFilterContextAttributeFilters> = yield select(
         selectFilterContextAttributeFilters,
     );
+    const crossFilteringFiltersLocalIdentifiers: ReturnType<
+        typeof selectCrossFilteringFiltersLocalIdentifiers
+    > = yield select(selectCrossFilteringFiltersLocalIdentifiers);
     const migratedAttributeFilters = isImmediateAttributeFilterMigrationEnabled
         ? getMigratedAttributeFilters(
               originalPersistedDashboard?.filterContext?.filters.filter(isDashboardAttributeFilter),
               currentFilters,
+              crossFilteringFiltersLocalIdentifiers,
           )
         : [];
     const filterContextDefinition: ReturnType<typeof selectFilterContextDefinition> = yield select(


### PR DESCRIPTION
The fix that allows saving of ad-hoc migrated filters in view mode when user enters the edit mode enables Save button also when user applied cross filter for an attribute with non-primary label. The fix skips such filters to be considered as migrated.

This means that if filter is migrated in view mode and then cross filter is applied on it, the filter will not be part of saved set that can be saved in edit mode. However, this is not a problem as user can migrate this filter the next time he will enter the edit mode when the cross filter was not used.

JIRA: LX-846
risk: low

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests.
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```
