### PR TITLE
chore: add script to local publish

### DIFF
--- a/common/config/rush/command-line.json
+++ b/common/config/rush/command-line.json
@@ -187,6 +187,13 @@
       "summary": "Uninstalls rootCA on your system removes ~/.gooddata/certs folder",
       "shellCommand": "node common/scripts/uninstall-certs.js",
       "safeForSimultaneousRushProcesses": true
+    },
+    {
+      "commandKind": "global",
+      "name": "publish-local",
+      "summary": "Publish SDK to local files",
+      "shellCommand": "node common/scripts/publish-local.js",
+      "safeForSimultaneousRushProcesses": true
     }
     // {
     //   /**

--- a/common/scripts/publish-local.js
+++ b/common/scripts/publish-local.js
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+
+// (C) 2025 GoodData Corporation
+
+const fs = require('fs');
+const { execSync } = require('child_process');
+
+// Define the path to the package.json file
+const pkgPath = "./libs/sdk-ui-all/package.json";
+
+// Define the path for local packages
+const localPackagesPath = './localPackages';
+
+let pkg;
+try {
+  pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+} catch (error) {
+  console.error(`Error reading package.json at ${pkgPath}:`, error);
+  process.exit(1);
+}
+
+// Extract the version attribute
+const version = pkg.version;
+if (!version) {
+  console.error('Version attribute not found in package.json.');
+  process.exit(1);
+}
+
+// Get the current commit's shortened hash
+let hash;
+try {
+  hash = execSync('git log -n 1 --pretty=format:%h').toString().trim();
+} catch (error) {
+  console.error('Error retrieving git commit hash:', error);
+  process.exit(1);
+}
+
+// Combine version and hash into the new version string
+const newVersion = `${version}${hash}`;
+console.log(`New version: ${newVersion}`);
+
+// Build and run the Rush version command
+const rushVersionCommand = `rush version --ensure-version-policy --override-version ${newVersion} --version-policy sdk`;
+console.log(`Running command: ${rushVersionCommand}`);
+
+try {
+  execSync(rushVersionCommand, { stdio: 'inherit' });
+} catch (error) {
+  console.error('Error executing rush version command:', error);
+  process.exit(1);
+}
+
+// Check if localPackagesPath exists, and if so, delete its content
+if (fs.existsSync(localPackagesPath)) {
+  console.log(`Directory ${localPackagesPath} exists. Removing its content...`);
+  // Remove the directory recursively
+  fs.rmSync(localPackagesPath, { recursive: true, force: true });
+}
+
+// Recreate the localPackagesPath directory
+fs.mkdirSync(localPackagesPath);
+console.log(`Directory ${localPackagesPath} is now clean.`);
+
+// Build and run the Rush publish command
+const rushPublishCommand = `rush publish --publish --include-all --version-policy sdk --pack --release-folder ${localPackagesPath}`;
+console.log(`Running command: ${rushPublishCommand}`);
+
+try {
+  execSync(rushPublishCommand, { stdio: 'inherit' });
+} catch (error) {
+  console.error('Error executing rush publish command:', error);
+  process.exit(1);
+}


### PR DESCRIPTION
risk: nonprod

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests.
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```
