### PR TITLE
fix: reset filter button do not reset before ad-hoc migration state

### DIFF
--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -727,6 +727,7 @@ export function changeAttributeFilterSelection(filterLocalId: string, elements: 
 export interface ChangeAttributeFilterSelectionPayload {
     readonly elements: IAttributeElements;
     readonly filterLocalId: string;
+    readonly isResultOfMigration?: boolean;
     readonly isWorkingSelectionChange?: boolean;
     readonly selectionType: AttributeFilterSelectionType;
 }
@@ -1025,6 +1026,9 @@ export interface ChangeLayoutSectionHeaderPayload {
     readonly index: number | ILayoutSectionPath;
     readonly merge?: boolean;
 }
+
+// @internal
+export function changeMigratedAttributeFilterSelection(filterLocalId: string, elements: IAttributeElements, selectionType: AttributeFilterSelectionType, correlationId?: string): ChangeAttributeFilterSelection;
 
 // @alpha
 export function changeNestedLayoutSectionHeader(index: ILayoutSectionPath, header: IDashboardLayoutSectionHeader, merge?: boolean, correlationId?: string): ChangeLayoutSectionHeader;
@@ -4360,7 +4364,7 @@ export interface IDashboardAttributeFilterProps {
     filter: IDashboardAttributeFilter;
     isDraggable?: boolean;
     onClose?: () => void;
-    onFilterChanged: (filter: IDashboardAttributeFilter, displayAsLabel?: ObjRef, isWorkingSelectionChange?: boolean) => void;
+    onFilterChanged: (filter: IDashboardAttributeFilter, displayAsLabel?: ObjRef, isWorkingSelectionChange?: boolean, isResultOfMigration?: boolean) => void;
     // @alpha
     readonly?: boolean;
     workingFilter?: IDashboardAttributeFilter;
@@ -8888,7 +8892,7 @@ export interface SetAttributeFilterDisplayForm extends IDashboardCommand {
 }
 
 // @beta
-export function setAttributeFilterDisplayForm(filterLocalId: string, displayForm: ObjRef, isWorkingSelectionChange?: boolean): SetAttributeFilterDisplayForm;
+export function setAttributeFilterDisplayForm(filterLocalId: string, displayForm: ObjRef, isWorkingSelectionChange?: boolean, isResultOfMigration?: boolean): SetAttributeFilterDisplayForm;
 
 // @beta (undocumented)
 export interface SetAttributeFilterDisplayFormPayload {
@@ -8896,6 +8900,8 @@ export interface SetAttributeFilterDisplayFormPayload {
     displayForm: ObjRef;
     // (undocumented)
     filterLocalId: string;
+    // (undocumented)
+    isResultOfMigration?: boolean;
     // (undocumented)
     isWorkingSelectionChange?: boolean;
 }

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/common/stateInitializers.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/common/stateInitializers.ts
@@ -367,6 +367,10 @@ function getDisplayAsLabels(attributeFilterConfigs: IDashboardAttributeFilterCon
  *  the settings in the state; it uses the settings during layout sanitization
  * @param isImmediateAttributeFilterMigrationEnabled - enables transfer of changes made to the dashboard and
  *  its filter context in view mode to the edit mode.
+ * @param originalFilterContextDefinition - original filter definition that should be used instead of the
+ *  one taken from the persisted dashboard ("dashboard" parameter of this function). It contains ad-hoc
+ *  migrated attribute filters in state right after the migration, before potential user change to selection.
+ *  If not provided, the filter context from persisted dashboard will be used.
  * @param migratedAttributeFilters - ad-hoc migrated attribute filters in view mode that must be applied to
  *  the dashboard so user can save these changes (persisted dashboard state remains as is).
  * @param migratedAttributeFilterConfigs - ad-hoc migrated attribute filter configs in view mode that must be
@@ -386,6 +390,7 @@ export function* actionsToInitializeExistingDashboard(
     insights: IInsight[],
     settings: ISettings,
     isImmediateAttributeFilterMigrationEnabled: boolean,
+    originalFilterContextDefinition: IFilterContextDefinition | undefined,
     migratedAttributeFilters: IDashboardAttributeFilter[],
     migratedAttributeFilterConfigs: IDashboardAttributeFilterConfig[] = [],
     dateFilterConfig: IDateFilterConfig,
@@ -421,6 +426,11 @@ export function* actionsToInitializeExistingDashboard(
         ? mergedMigratedAttributeFilters(filterContextDefinition, migratedAttributeFilters)
         : filterContextDefinition;
 
+    const migratedOriginalFilterContext: IFilterContextDefinition =
+        isImmediateAttributeFilterMigrationEnabled && originalFilterContextDefinition !== undefined
+            ? originalFilterContextDefinition
+            : filterContextDefinition;
+
     const effectiveAttributeFilterConfigs = isImmediateAttributeFilterMigrationEnabled
         ? migratedAttributeFilterConfigs
         : dashboard.attributeFilterConfigs;
@@ -448,10 +458,9 @@ export function* actionsToInitializeExistingDashboard(
         insights,
         settings,
     );
-
     return [
         filterContextActions.setFilterContext({
-            originalFilterContextDefinition: filterContextDefinition,
+            originalFilterContextDefinition: migratedOriginalFilterContext,
             filterContextDefinition: migratedFilterContext,
             filterContextIdentity,
             attributeFilterDisplayForms,

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/initializeDashboardHandler/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/initializeDashboardHandler/index.ts
@@ -250,6 +250,7 @@ function* loadExistingDashboard(
         insights,
         config.settings,
         config.settings.enableImmediateAttributeFilterDisplayAsLabelMigration ?? false,
+        undefined,
         [],
         dashboard.attributeFilterConfigs,
         effectiveDateFilterConfig.config,

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/resetDashboardHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/resetDashboardHandler.ts
@@ -33,7 +33,10 @@ import {
 } from "../../store/catalog/catalogSelectors.js";
 import { applyDefaultFilterView } from "./common/filterViews.js";
 import { selectFilterViews } from "../../store/filterViews/filterViewsReducersSelectors.js";
-import { selectFilterContextAttributeFilters } from "../../store/filterContext/filterContextSelectors.js";
+import {
+    selectFilterContextAttributeFilters,
+    selectOriginalFilterContextDefinition,
+} from "../../store/filterContext/filterContextSelectors.js";
 import { selectAttributeFilterConfigsOverrides } from "../../store/attributeFilterConfigs/attributeFilterConfigsSelectors.js";
 import { getMigratedAttributeFilters } from "./common/migratedAttributeFilters.js";
 import { selectCrossFilteringFiltersLocalIdentifiers } from "../../store/drill/drillSelectors.js";
@@ -115,6 +118,12 @@ function* resetDashboardFromPersisted(ctx: DashboardContext) {
               )
             : persistedDashboard.attributeFilterConfigs;
 
+        const originalFilterContext: ReturnType<typeof selectOriginalFilterContextDefinition> = yield select(
+            selectOriginalFilterContextDefinition,
+        );
+        const effectiveOriginalFilterContext = isImmediateAttributeFilterMigrationEnabled
+            ? originalFilterContext
+            : undefined;
         // end of ad-hoc migration content
 
         const settings: ReturnType<typeof selectSettings> = yield select(selectSettings);
@@ -152,6 +161,7 @@ function* resetDashboardFromPersisted(ctx: DashboardContext) {
             resolvedInsightsValues,
             settings,
             isImmediateAttributeFilterMigrationEnabled,
+            effectiveOriginalFilterContext,
             migratedAttributeFilters,
             effectiveAttributeFilterConfigs,
             effectiveDateFilterConfig,

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/filterContext/attributeFilter/changeAttributeDisplayFormHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/filterContext/attributeFilter/changeAttributeDisplayFormHandler.ts
@@ -29,7 +29,7 @@ export function* changeAttributeDisplayFormHandler(
     ctx: DashboardContext,
     cmd: SetAttributeFilterDisplayForm,
 ): SagaIterator<void> {
-    const { filterLocalId, displayForm, isWorkingSelectionChange } = cmd.payload;
+    const { filterLocalId, displayForm, isWorkingSelectionChange, isResultOfMigration } = cmd.payload;
     const {
         backend: {
             capabilities: { supportsElementUris },
@@ -94,6 +94,8 @@ export function* changeAttributeDisplayFormHandler(
                     isWorkingSelectionChange &&
                     !enableImmediateAttributeFilterDisplayAsLabelMigration &&
                     enableDashboardFiltersApplyModes,
+                enableImmediateAttributeFilterDisplayAsLabelMigration,
+                isResultOfMigration,
             }),
         ]),
     );

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/filterContext/attributeFilter/changeAttributeFilterSelectionHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/filterContext/attributeFilter/changeAttributeFilterSelectionHandler.ts
@@ -18,13 +18,17 @@ import {
     selectIsCrossFiltering,
     selectIsFilterFromCrossFilteringByLocalIdentifier,
 } from "../../../store/drill/drillSelectors.js";
-import { selectEnableDashboardFiltersApplyModes } from "../../../store/config/configSelectors.js";
+import {
+    selectEnableDashboardFiltersApplyModes,
+    selectEnableImmediateAttributeFilterDisplayAsLabelMigration,
+} from "../../../store/config/configSelectors.js";
 
 export function* changeAttributeFilterSelectionHandler(
     ctx: DashboardContext,
     cmd: ChangeAttributeFilterSelection,
 ): SagaIterator<void> {
-    const { elements, filterLocalId, selectionType, isWorkingSelectionChange } = cmd.payload;
+    const { elements, filterLocalId, selectionType, isWorkingSelectionChange, isResultOfMigration } =
+        cmd.payload;
 
     // validate filterLocalId
     const affectedFilter: ReturnType<ReturnType<typeof selectFilterContextAttributeFilterByLocalId>> =
@@ -37,12 +41,18 @@ export function* changeAttributeFilterSelectionHandler(
     const enableDashboardFiltersApplyModes: ReturnType<typeof selectEnableDashboardFiltersApplyModes> =
         yield select(selectEnableDashboardFiltersApplyModes);
 
+    const enableImmediateAttributeFilterDisplayAsLabelMigration: ReturnType<
+        typeof selectEnableImmediateAttributeFilterDisplayAsLabelMigration
+    > = yield select(selectEnableImmediateAttributeFilterDisplayAsLabelMigration);
+
     yield put(
         filterContextActions.updateAttributeFilterSelection({
             elements,
             filterLocalId,
             negativeSelection: selectionType === "NOT_IN",
             isWorkingSelectionChange: isWorkingSelectionChange && enableDashboardFiltersApplyModes,
+            enableImmediateAttributeFilterDisplayAsLabelMigration,
+            isResultOfMigration,
         }),
     );
 

--- a/libs/sdk-ui-dashboard/src/model/commands/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/commands/index.ts
@@ -230,6 +230,7 @@ export {
     moveDateFilter,
     resetAttributeFilterSelection,
     changeAttributeFilterSelection,
+    changeMigratedAttributeFilterSelection,
     changeWorkingAttributeFilterSelection,
     setAttributeFilterParents,
     changeFilterContextSelection,

--- a/libs/sdk-ui-dashboard/src/model/store/filterContext/filterContextState.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/filterContext/filterContextState.ts
@@ -59,7 +59,7 @@ export interface FilterContextState {
      * This way we do not need to synchronize other fields, which makes it easier to maintain.
      *
      * This state is used when DashboardFiltersApplyMode is ALL_AT_ONCE.
-     * But can be used programatically when embedding the dashboard too.
+     * But can be used programmatically when embedding the dashboard too.
      *
      * @alpha
      */

--- a/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/DefaultDashboardAttributeFilter.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/DefaultDashboardAttributeFilter.tsx
@@ -456,7 +456,14 @@ const DefaultDashboardAttributeFilterInner = (props: IDashboardAttributeFilterPr
                 filter={attributeFilter}
                 workingFilter={enableDashboardFiltersApplyModes ? workingAttributeFilter : undefined}
                 displayAsLabel={displayAsLabel}
-                onApply={(newFilter, _isInverted, _selectionMode, _selectionTitles, displayAsLabel) => {
+                onApply={(
+                    newFilter,
+                    _isInverted,
+                    _selectionMode,
+                    _selectionTitles,
+                    displayAsLabel,
+                    isResultOfMigration,
+                ) => {
                     onFilterChanged(
                         attributeFilterToDashboardAttributeFilter(
                             newFilter,
@@ -464,6 +471,8 @@ const DefaultDashboardAttributeFilterInner = (props: IDashboardAttributeFilterPr
                             filter.attributeFilter.title,
                         ),
                         displayAsLabel,
+                        false,
+                        isResultOfMigration,
                     );
                 }}
                 onSelect={(newFilter, isInverted, selectionMode, selectionTitles, displayAsLabel) => {

--- a/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/types.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/types.ts
@@ -25,12 +25,16 @@ export interface IDashboardAttributeFilterProps {
      *
      * @param filter - new attribute filter value.
      * @param displayAsLabel - label used for presentation of attribute filter elements in UI
-     * @param isWorkingSelectionChange - if the change is to applied (application of filters) or unapplied filters (filters staged before application).
+     * @param isWorkingSelectionChange - if the change is to applied (application of filters) or un-applied filters (filters staged before application).
+     * @param isResultOfMigration - internal value, specifies that filter change was caused by displayAsLabel
+     *  ad-hoc migration, the param will be removed once the usage of displayAsLabel is migrated on database
+     *  metadata level.
      */
     onFilterChanged: (
         filter: IDashboardAttributeFilter,
         displayAsLabel?: ObjRef,
         isWorkingSelectionChange?: boolean,
+        isResultOfMigration?: boolean,
     ) => void;
 
     /**

--- a/libs/sdk-ui-dashboard/src/presentation/filterBar/filterBar/DefaultFilterBar.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/filterBar/filterBar/DefaultFilterBar.tsx
@@ -17,6 +17,7 @@ import {
 } from "@gooddata/sdk-model";
 import {
     changeAttributeFilterSelection,
+    changeMigratedAttributeFilterSelection,
     changeDateFilterSelection,
     clearDateFilterSelection,
     selectEffectiveDateFilterAvailableGranularities,
@@ -81,7 +82,12 @@ export const useFilterBarProps = (): IFilterBarProps => {
 
     const dispatch = useDashboardDispatch();
     const onAttributeFilterChanged = useCallback(
-        (filter: IDashboardAttributeFilter, displayAsLabel?: ObjRef, isWorkingSelectionChange?: boolean) => {
+        (
+            filter: IDashboardAttributeFilter,
+            displayAsLabel?: ObjRef,
+            isWorkingSelectionChange?: boolean,
+            isResultOfMigration?: boolean,
+        ) => {
             const convertedFilter = supportElementUris
                 ? filter
                 : convertDashboardAttributeFilterElementsValuesToUris(filter);
@@ -110,6 +116,7 @@ export const useFilterBarProps = (): IFilterBarProps => {
                             localIdentifier!,
                             filter.attributeFilter.displayForm,
                             isWorkingSelectionChange && enableDashboardFiltersApplyModes,
+                            isResultOfMigration,
                         ),
                     );
                 }
@@ -120,19 +127,31 @@ export const useFilterBarProps = (): IFilterBarProps => {
                 }
             }
 
-            dispatch(
-                isWorkingSelectionChange && enableDashboardFiltersApplyModes
-                    ? changeWorkingAttributeFilterSelection(
-                          localIdentifier!,
-                          attributeElements,
-                          negativeSelection ? "NOT_IN" : "IN",
-                      )
-                    : changeAttributeFilterSelection(
-                          localIdentifier!,
-                          attributeElements,
-                          negativeSelection ? "NOT_IN" : "IN",
-                      ),
-            );
+            if (isWorkingSelectionChange && enableDashboardFiltersApplyModes) {
+                dispatch(
+                    changeWorkingAttributeFilterSelection(
+                        localIdentifier!,
+                        attributeElements,
+                        negativeSelection ? "NOT_IN" : "IN",
+                    ),
+                );
+            } else if (isResultOfMigration) {
+                dispatch(
+                    changeMigratedAttributeFilterSelection(
+                        localIdentifier!,
+                        attributeElements,
+                        negativeSelection ? "NOT_IN" : "IN",
+                    ),
+                );
+            } else {
+                dispatch(
+                    changeAttributeFilterSelection(
+                        localIdentifier!,
+                        attributeElements,
+                        negativeSelection ? "NOT_IN" : "IN",
+                    ),
+                );
+            }
         },
         [
             dispatch,

--- a/libs/sdk-ui-filters/api/sdk-ui-filters.api.md
+++ b/libs/sdk-ui-filters/api/sdk-ui-filters.api.md
@@ -1141,7 +1141,7 @@ export function newAttributeFilterHandler(backend: IAnalyticalBackend, workspace
 export function newAttributeFilterHandler(backend: IAnalyticalBackend, workspace: string, attributeFilter: IAttributeFilter, options: IMultiSelectAttributeFilterHandlerOptions): IMultiSelectAttributeFilterHandler;
 
 // @public (undocumented)
-export type OnApplyCallbackType = (filter: IAttributeFilter, isInverted: boolean, selectionMode?: DashboardAttributeFilterSelectionMode, selectionTitles?: IAttributeElement[], displayAsLabel?: ObjRef) => void;
+export type OnApplyCallbackType = (filter: IAttributeFilter, isInverted: boolean, selectionMode?: DashboardAttributeFilterSelectionMode, selectionTitles?: IAttributeElement[], displayAsLabel?: ObjRef, isResultOfMigration?: boolean) => void;
 
 // @public
 export type OnInitCancelCallbackPayload = CallbackPayloadWithCorrelation;

--- a/libs/sdk-ui-filters/src/AttributeFilter/types.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilter/types.ts
@@ -36,6 +36,7 @@ export type OnApplyCallbackType = (
     selectionMode?: DashboardAttributeFilterSelectionMode,
     selectionTitles?: IAttributeElement[],
     displayAsLabel?: ObjRef,
+    isResultOfMigration?: boolean,
 ) => void;
 
 /**


### PR DESCRIPTION
Additionally, reset filter context button is not enabled when ad-hoc migration happen.

To achieve this behavior, the apply payload from attribute filter, that is used to propagate the migrated filter data, is marked as emitted via migration process. Not only the current state is changed in reducer but also something called originalFilterContext. This state is used to compare filters by reset button, by automation dialog code, and by last filter state in KD. For some reason, when dashboard is being saved, filter context from persisted dashboard state is used, therefore migrated filters are still detected as "changed" and Save button is enabled. Effectively, persisted state of filter context was at two places for some reason, and each place has never been updated, until know. It's weird but it allows this fix to work.

JIRA: LX-871
risk: low

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests.
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```
