### PR TITLE
test: stabilize dependent filter tests

### DIFF
--- a/libs/sdk-ui-tests-e2e/cypress/tools/dashboards.ts
+++ b/libs/sdk-ui-tests-e2e/cypress/tools/dashboards.ts
@@ -42,6 +42,12 @@ export class Dashboard {
         return this;
     }
 
+    waitForDashboardLoaded() {
+        cy.get(".catalog-is-loaded").should("exist");
+        cy.get(".accessible-dashboards-loaded").should("exist");
+        return this;
+    }
+
     moveWidget(fromIndex: number, toIndex: number, dropzone: WidgetDropZone) {
         const dataTransfer = new DataTransfer();
         cy.get(".dash-item-content").eq(fromIndex).trigger("dragstart", { dataTransfer });

--- a/libs/sdk-ui-tests-e2e/cypress/tools/filterBar.ts
+++ b/libs/sdk-ui-tests-e2e/cypress/tools/filterBar.ts
@@ -148,7 +148,7 @@ export class AttributeFilter {
     showAllElementValues() {
         cy.get(".overlay.dropdown-body .s-attribute-filter-status-show-all .s-action-show-all")
             .should("be.visible")
-            .click();
+            .realClick();
 
         this.elementsAreLoaded();
         return this;


### PR DESCRIPTION
when try searching or checking somethings on attribute filter, the filter often works unstable because dashboard hasn't done loading yet or widget is still loading
=Solution: wait for the dashboard and widget loading done before doing actions of attribute filter

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests.
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```
