### PR TITLE
fix: keep filters added in edit mode when getting back to view mode

### DIFF
--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/resetDashboardHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/resetDashboardHandler.ts
@@ -121,9 +121,12 @@ function* resetDashboardFromPersisted(ctx: DashboardContext) {
         const originalFilterContext: ReturnType<typeof selectOriginalFilterContextDefinition> = yield select(
             selectOriginalFilterContextDefinition,
         );
-        const effectiveOriginalFilterContext = isImmediateAttributeFilterMigrationEnabled
-            ? originalFilterContext
-            : undefined;
+
+        const hasUnsavedFilterChanges = migratedAttributeFilters.length > 0;
+        const effectiveOriginalFilterContext =
+            isImmediateAttributeFilterMigrationEnabled && hasUnsavedFilterChanges
+                ? originalFilterContext
+                : undefined;
         // end of ad-hoc migration content
 
         const settings: ReturnType<typeof selectSettings> = yield select(selectSettings);


### PR DESCRIPTION
The reset function used when existing dashboard changed a render mode used original filter context that contained migrated filters in every switch of said render mode. This caused loss of freshly persisted edit state when dashboard returned to view mode. The state was not lost per se but wrong state was shown (the one having migrated filters but not the changes from edit mode). When user saves changes, the new state is correct and there is no reason to pass these between modes any longer. Original reset handler functionality may be used now. The new condition ensures that filter context snapshot is used only when there are some filters that were migrated.

JIRA: LX-947
risk: low

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests.
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```
