### PR TITLE
feat: hide flexible layout New container link behind a new ff

### DIFF
--- a/libs/sdk-backend-tiger/src/backend/features/feature.ts
+++ b/libs/sdk-backend-tiger/src/backend/features/feature.ts
@@ -557,6 +557,13 @@ export function mapFeatures(features: FeaturesMap): Partial<ITigerFeatureFlags> 
         ),
         ...loadFeature(
             features,
+            TigerFeaturesNames.EnableDashboardFlexibleLayoutContainer,
+            "enableDashboardFlexibleLayoutContainer",
+            "BOOLEAN",
+            FeatureFlagsValues.enableDashboardFlexibleLayoutContainer,
+        ),
+        ...loadFeature(
+            features,
             TigerFeaturesNames.EnableNumberSeparators,
             "enableNumberSeparators",
             "BOOLEAN",

--- a/libs/sdk-backend-tiger/src/backend/uiFeatures.ts
+++ b/libs/sdk-backend-tiger/src/backend/uiFeatures.ts
@@ -116,6 +116,7 @@ export enum TigerFeaturesNames {
     EnableCrossFilteringAliasTitles = "enableCrossFilteringAliasTitles",
     EnableDefaultSmtp = "enableDefaultSmtp",
     EnableDashboardFlexibleLayout = "enableDashboardFlexibleLayout",
+    EnableDashboardFlexibleLayoutContainer = "enableDashboardFlexibleLayoutContainer",
     EnableNumberSeparators = "enableNumberSeparators",
     EnableNewUserCreationFlow = "enableNewUserCreationFlow",
     EnableDestinationTesting = "enableDestinationTesting",
@@ -215,6 +216,7 @@ export type ITigerFeatureFlags = {
     enableCrossFilteringAliasTitles: typeof FeatureFlagsValues["enableCrossFilteringAliasTitles"][number];
     enableDefaultSmtp: typeof FeatureFlagsValues["enableDefaultSmtp"][number];
     enableDashboardFlexibleLayout: typeof FeatureFlagsValues["enableDashboardFlexibleLayout"][number];
+    enableDashboardFlexibleLayoutContainer: typeof FeatureFlagsValues["enableDashboardFlexibleLayoutContainer"][number];
     enableNumberSeparators: typeof FeatureFlagsValues["enableNumberSeparators"][number];
     enableNewUserCreationFlow: typeof FeatureFlagsValues["enableNewUserCreationFlow"][number];
     enableDestinationTesting: typeof FeatureFlagsValues["enableDestinationTesting"][number];
@@ -314,6 +316,7 @@ export const DefaultFeatureFlags: ITigerFeatureFlags = {
     enableCrossFilteringAliasTitles: true,
     enableDefaultSmtp: false,
     enableDashboardFlexibleLayout: false,
+    enableDashboardFlexibleLayoutContainer: false,
     enableNumberSeparators: true,
     enableNewUserCreationFlow: false,
     enableDestinationTesting: true,
@@ -417,6 +420,7 @@ export const FeatureFlagsValues = {
     enableCrossFilteringAliasTitles: [true, false] as const,
     enableDefaultSmtp: [true, false] as const,
     enableDashboardFlexibleLayout: [true, false] as const,
+    enableDashboardFlexibleLayoutContainer: [true, false] as const,
     enableNumberSeparators: [true, false] as const,
     enableNewUserCreationFlow: [true, false] as const,
     enableDestinationTesting: [true, false] as const,

--- a/libs/sdk-model/api/sdk-model.api.md
+++ b/libs/sdk-model/api/sdk-model.api.md
@@ -3371,6 +3371,7 @@ export interface ISettings {
     enableDashboardFiltersApplyModes?: boolean;
     enableDashboardFilterViews?: boolean;
     enableDashboardFlexibleLayout?: boolean;
+    enableDashboardFlexibleLayoutContainer?: boolean;
     enableDashboardTabularExport?: boolean;
     enableDataSampling?: boolean;
     // (undocumented)

--- a/libs/sdk-model/src/settings/index.ts
+++ b/libs/sdk-model/src/settings/index.ts
@@ -474,8 +474,14 @@ export interface ISettings {
 
     /**
      * Enables new dashboard layout renderer with nesting support.
+     * The nesting itself needs to be enabled by enableDashboardFlexibleLayoutContainer.
      */
     enableDashboardFlexibleLayout?: boolean;
+
+    /**
+     * Enables container support in the new dashboard layout renderer.
+     */
+    enableDashboardFlexibleLayoutContainer?: boolean;
 
     /**
      * Enable GenAI-powered functionality, such as semantic-search.

--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -8377,6 +8377,9 @@ export const selectEnableFilterViews: DashboardSelector<boolean>;
 export const selectEnableFlexibleLayout: DashboardSelector<boolean>;
 
 // @internal
+export const selectEnableFlexibleLayoutContainer: DashboardSelector<boolean>;
+
+// @internal
 export const selectEnableIgnoreCrossFiltering: DashboardSelector<boolean>;
 
 // @internal

--- a/libs/sdk-ui-dashboard/src/model/store/config/configSelectors.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/config/configSelectors.ts
@@ -804,7 +804,7 @@ export const selectEnableCrossFilteringAliasTitles: DashboardSelector<boolean> =
 );
 
 /**
- * Returns whether nested layout is enabled.
+ * Returns whether flexible layout renderer is enabled.
  *
  * @internal
  */
@@ -812,6 +812,18 @@ export const selectEnableFlexibleLayout: DashboardSelector<boolean> = createSele
     selectConfig,
     (state) => {
         return state.settings?.enableDashboardFlexibleLayout ?? false;
+    },
+);
+
+/**
+ * Returns whether nesting is enabled in flexible layout renderer.
+ *
+ * @internal
+ */
+export const selectEnableFlexibleLayoutContainer: DashboardSelector<boolean> = createSelector(
+    selectConfig,
+    (state) => {
+        return state.settings?.enableDashboardFlexibleLayoutContainer ?? false;
     },
 );
 

--- a/libs/sdk-ui-dashboard/src/model/store/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/index.ts
@@ -99,6 +99,7 @@ export {
     selectEnableAutomations,
     selectEnableCrossFilteringAliasTitles,
     selectEnableFlexibleLayout,
+    selectEnableFlexibleLayoutContainer,
     selectEnableInPlatformNotifications,
     selectEnableExternalRecipients,
     selectEnableDrilledTooltip,

--- a/libs/sdk-ui-dashboard/src/presentation/dashboard/DashboardSidebar/CreationPanel.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/dashboard/DashboardSidebar/CreationPanel.tsx
@@ -16,6 +16,7 @@ import {
     selectSupportsRichTextWidgets,
     selectEnableVisualizationSwitcher,
     selectEnableFlexibleLayout,
+    selectEnableFlexibleLayoutContainer,
 } from "../../../model/index.js";
 import cx from "classnames";
 import {
@@ -48,6 +49,7 @@ export const CreationPanel: React.FC<ICreationPanelProps> = (props) => {
     const enableRichText = useDashboardSelector(selectEnableKDRichText);
     const enableVisualizationSwitcher = useDashboardSelector(selectEnableVisualizationSwitcher);
     const enableFlexibleLayout = useDashboardSelector(selectEnableFlexibleLayout);
+    const enableFlexibleLayoutContainer = useDashboardSelector(selectEnableFlexibleLayoutContainer);
     const isAnalyticalDesignerEnabled = useDashboardSelector(selectIsAnalyticalDesignerEnabled);
     const isNewDashboard = useDashboardSelector(selectIsNewDashboard);
     const settings = useDashboardSelector(selectSettings);
@@ -61,7 +63,9 @@ export const CreationPanel: React.FC<ICreationPanelProps> = (props) => {
         const items = compact([
             InsightWidgetComponentSet.creating,
             AttributeFilterComponentSet.creating,
-            enableFlexibleLayout && DashboardLayoutWidgetComponentSet.creating,
+            enableFlexibleLayout &&
+                enableFlexibleLayoutContainer &&
+                DashboardLayoutWidgetComponentSet.creating,
             enableVisualizationSwitcher && VisualizationSwitcherWidgetComponentSet.creating,
             supportsRichText && enableRichText && RichTextWidgetComponentSet.creating,
         ]);


### PR DESCRIPTION
The new feature flag is necessary to roll out the current flexible layout renderer without fixing all the nesting issues. The containers can be created only when the new ff is enabled.

JIRA: LX-770
risk: low

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests.
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```
