### PR TITLE
RELATED: GDAI-108 Handle side effects in visualization wrapper

### DIFF
--- a/libs/sdk-ui-charts/src/highcharts/ChartTransformation.tsx
+++ b/libs/sdk-ui-charts/src/highcharts/ChartTransformation.tsx
@@ -115,25 +115,25 @@ const ChartTransformationImpl = (props: IChartTransformationProps) => {
         theme,
     );
 
-    let isFilteringRecommended = false;
-    if (validationResult.dataTooLarge) {
-        // always force onDataTooLarge error handling
-        invariant(onDataTooLarge, "Visualization's onDataTooLarge callback is missing.");
-        onDataTooLarge(chartOptions, getDataTooLargeErrorMessage(config.limits, chartOptions));
-    } else if (validationResult.hasNegativeValue) {
-        // ignore hasNegativeValue if validation already fails on dataTooLarge
-        // force onNegativeValues error handling only for pie chart.
-        // hasNegativeValue can be true only for pie chart.
-        invariant(
-            onNegativeValues,
-            '"onNegativeValues" callback required for pie chart transformation is missing.',
-        );
-        onNegativeValues(chartOptions);
-    } else {
-        isFilteringRecommended = getIsFilteringRecommended(chartOptions);
-    }
-
     useEffect(() => {
+        let isFilteringRecommended = false;
+        if (validationResult.dataTooLarge) {
+            // always force onDataTooLarge error handling
+            invariant(onDataTooLarge, "Visualization's onDataTooLarge callback is missing.");
+            onDataTooLarge(chartOptions, getDataTooLargeErrorMessage(config.limits, chartOptions));
+        } else if (validationResult.hasNegativeValue) {
+            // ignore hasNegativeValue if validation already fails on dataTooLarge
+            // force onNegativeValues error handling only for pie chart.
+            // hasNegativeValue can be true only for pie chart.
+            invariant(
+                onNegativeValues,
+                '"onNegativeValues" callback required for pie chart transformation is missing.',
+            );
+            onNegativeValues(chartOptions);
+        } else {
+            isFilteringRecommended = getIsFilteringRecommended(chartOptions);
+        }
+
         pushData({
             propertiesMeta: {
                 legend_enabled: legendOptions.toggleEnabled,

--- a/libs/sdk-ui-gen-ai/src/components/messages/contents/VisualizationContents.tsx
+++ b/libs/sdk-ui-gen-ai/src/components/messages/contents/VisualizationContents.tsx
@@ -63,25 +63,17 @@ export const VisualizationContentsComponent: React.FC<VisualizationContentsProps
     };
 
     const handleSdkError = (error: GoodDataSdkError) => {
-        // Error callback may be triggered from render method in SDK,
-        // have to move the state update to the next tick to keep render pure
-        setTimeout(() => {
-            setHasVisError(true);
-            dispatch(
-                visualizationErrorAction({
-                    errorType: error.seType,
-                    errorMessage: error.getMessage(),
-                }),
-            );
-        });
+        setHasVisError(true);
+        dispatch(
+            visualizationErrorAction({
+                errorType: error.seType,
+                errorMessage: error.getMessage(),
+            }),
+        );
     };
 
     const handleLoadingChanged: OnLoadingChanged = ({ isLoading }) => {
-        // Loading callback is triggered from render method, have to move
-        // the state update to the next tick to keep render pure
-        setTimeout(() => {
-            setVisLoading(isLoading);
-        });
+        setVisLoading(isLoading);
     };
 
     return (


### PR DESCRIPTION
* Wrapped the side effects into useEffect in sdk-ui-charts
* Reverted the hackish fix in sdk-ui-gen-ai

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests.
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```
