### PR TITLE
RELATED: GDAI-131 uncaught error

### DIFF
--- a/libs/sdk-ui-gen-ai/src/components/messages/contents/VisualizationContents.tsx
+++ b/libs/sdk-ui-gen-ai/src/components/messages/contents/VisualizationContents.tsx
@@ -19,6 +19,10 @@ import { GoodDataSdkError, OnError, OnLoadingChanged, useWorkspaceStrict } from 
 
 const VIS_HEIGHT = 250;
 
+const getVisualizationHref = (wsId: string, visId: string) => {
+    return `/analyze/#/${wsId}/${visId}/edit`;
+};
+
 export type VisualizationContentsProps = {
     content: VisualizationContents;
     messageId: string;
@@ -44,7 +48,6 @@ export const VisualizationContentsComponent: React.FC<VisualizationContentsProps
     const [hasVisError, setHasVisError] = React.useState(false);
     const [visLoading, setVisLoading] = React.useState(true);
     const workspaceId = useWorkspaceStrict();
-    const href = `/analyze/#/${workspaceId}/${visualization.savedVisualizationId}/edit`;
 
     const handleButtonClick = (e: React.MouseEvent<HTMLAnchorElement | HTMLDivElement>) => {
         if (visualization?.savedVisualizationId) {
@@ -54,7 +57,7 @@ export const VisualizationContentsComponent: React.FC<VisualizationContentsProps
                 workspaceId,
                 newTab: e.metaKey,
                 preventDefault: e.preventDefault.bind(e),
-                itemUrl: href,
+                itemUrl: getVisualizationHref(workspaceId, visualization.savedVisualizationId),
             });
             e.stopPropagation();
         } else {
@@ -173,7 +176,10 @@ export const VisualizationContentsComponent: React.FC<VisualizationContentsProps
 
                               return visualization.savedVisualizationId && config.allowNativeLinks ? (
                                   <a
-                                      href={href}
+                                      href={getVisualizationHref(
+                                          workspaceId,
+                                          visualization.savedVisualizationId,
+                                      )}
                                       onClick={handleButtonClick}
                                       className="gd-gen-ai-chat__visualization__save"
                                   >


### PR DESCRIPTION
Fixed a bug when UI throws an error when visualization definition does not exist

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests.
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```
