### PR TITLE
RELATED: GDAI-108 Allow user to save visualizations that triggered NO_DATA error

### DIFF
--- a/libs/sdk-ui-gen-ai/src/components/messages/contents/VisualizationContents.tsx
+++ b/libs/sdk-ui-gen-ai/src/components/messages/contents/VisualizationContents.tsx
@@ -15,7 +15,13 @@ import { newMessageAction, visualizationErrorAction } from "../../../store/index
 import { useConfig } from "../../ConfigContext.js";
 import { VisualizationSaveDialog } from "./VisualizationSaveDialog.js";
 import { FormattedMessage } from "react-intl";
-import { GoodDataSdkError, OnError, OnLoadingChanged, useWorkspaceStrict } from "@gooddata/sdk-ui";
+import {
+    GoodDataSdkError,
+    isNoDataSdkError,
+    OnError,
+    OnLoadingChanged,
+    useWorkspaceStrict,
+} from "@gooddata/sdk-ui";
 
 const VIS_HEIGHT = 250;
 
@@ -66,7 +72,10 @@ export const VisualizationContentsComponent: React.FC<VisualizationContentsProps
     };
 
     const handleSdkError = (error: GoodDataSdkError) => {
-        setHasVisError(true);
+        // Ignore NO_DATA error, we still want an option to save the visualization
+        if (!isNoDataSdkError(error)) {
+            setHasVisError(true);
+        }
         dispatch(
             visualizationErrorAction({
                 errorType: error.seType,


### PR DESCRIPTION
### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests.
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```
