### PR TITLE
fix: multiple bug fixes

### DIFF
--- a/libs/sdk-ui-kit/src/RichText/hooks/useEvaluatedMetricsAndAttributes.ts
+++ b/libs/sdk-ui-kit/src/RichText/hooks/useEvaluatedMetricsAndAttributes.ts
@@ -37,17 +37,16 @@ export function useEvaluatedMetricsAndAttributes(
     const metrics = getMeasures(references);
     const { metrics: labels, countMap } = getLabels(references);
 
+    const items = [...metrics, ...labels];
+
     const {
         status: executionStatus,
         result: executionResult,
         error: executionError,
     } = useExecutionDataView({
         execution:
-            enabled && metrics.length > 0
-                ? backend
-                      .workspace(workspace)
-                      .execution()
-                      .forItems([...metrics, ...labels], filters)
+            enabled && items.length > 0
+                ? backend.workspace(workspace).execution().forItems(items, filters)
                 : null,
     });
 

--- a/libs/sdk-ui-kit/src/RichText/plugins/rehype-references.ts
+++ b/libs/sdk-ui-kit/src/RichText/plugins/rehype-references.ts
@@ -128,10 +128,10 @@ function iterateReferenceMatch<T>(value: string, onMatch: (ref: IdentifierRef, i
 function createMetricValue(intl: IntlShape, text: TextNode | null, metric: EvaluatedMetric) {
     const value = metric ? metric.data.rawValue : null;
 
-    const isEmpty = value === null || value === undefined || metric?.count === 0;
     const isMultiple = metric?.count && metric.count > 1;
 
-    const formattedValue = !metric
+    let isEmpty = value === null || value === undefined || metric?.count === 0;
+    let formattedValue = !metric
         ? `(${intl.formatMessage({ id: "richText.no_fetch" })})`
         : isEmpty
         ? `(${intl.formatMessage({ id: "richText.no_data" })})`
@@ -140,6 +140,12 @@ function createMetricValue(intl: IntlShape, text: TextNode | null, metric: Evalu
         : typeof value === "string"
         ? value
         : metric.data.formattedValue();
+
+    // NOTE: If the results value is empty, we should display the empty value message
+    if (formattedValue == "") {
+        formattedValue = `(${intl.formatMessage({ id: "empty_value" })})`;
+        isEmpty = true;
+    }
 
     const metricDef = {
         type: "element",


### PR DESCRIPTION
Didn't execute attribute reference if not have metric reference Show empty when attribute value is empty string

risk: low
JIRA: F1-1201, F1-1203

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests.
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```
