### PR TITLE
fix: support exportid also on new dashboard

### DIFF
--- a/libs/sdk-ui-dashboard/src/_staging/dashboard/dashboardFilterContext.ts
+++ b/libs/sdk-ui-dashboard/src/_staging/dashboard/dashboardFilterContext.ts
@@ -1,4 +1,4 @@
-// (C) 2021-2024 GoodData Corporation
+// (C) 2021-2025 GoodData Corporation
 import {
     IDateFilterConfig,
     IDashboardObjectIdentity,
@@ -6,6 +6,7 @@ import {
     isDashboardAttributeFilter,
     isTempFilterContext,
     IDashboard,
+    FilterContextItem,
 } from "@gooddata/sdk-model";
 import { createDefaultFilterContext } from "./defaultFilterContext.js";
 
@@ -27,15 +28,21 @@ import { createDefaultFilterContext } from "./defaultFilterContext.js";
  *
  * @param dashboard - dashboard to get filter context from
  * @param dateFilterConfig - date filter config to use in case default filter context has to be created
+ * @param filters - predefined filters
  */
 export function dashboardFilterContextDefinition<TWidget>(
-    dashboard: IDashboard<TWidget>,
+    dashboard: IDashboard<TWidget> | null | undefined,
     dateFilterConfig: IDateFilterConfig,
+    filters?: FilterContextItem[],
 ): IFilterContextDefinition {
+    if (!dashboard) {
+        return createDefaultFilterContext(dateFilterConfig, true, filters);
+    }
+
     const { filterContext } = dashboard;
 
     if (!filterContext) {
-        return createDefaultFilterContext(dateFilterConfig, !dashboard.ref);
+        return createDefaultFilterContext(dateFilterConfig, !dashboard.ref, filters);
     }
 
     if (isTempFilterContext(filterContext)) {

--- a/libs/sdk-ui-dashboard/src/_staging/dashboard/defaultFilterContext.ts
+++ b/libs/sdk-ui-dashboard/src/_staging/dashboard/defaultFilterContext.ts
@@ -1,4 +1,4 @@
-// (C) 2021-2022 GoodData Corporation
+// (C) 2021-2025 GoodData Corporation
 import {
     IDateFilterConfig,
     isAllTimeDateFilterOption,
@@ -6,6 +6,7 @@ import {
     isRelativeDateFilterPreset,
     IDashboardDateFilter,
     IFilterContextDefinition,
+    FilterContextItem,
 } from "@gooddata/sdk-model";
 import { convertDateFilterConfigToDateFilterOptions } from "../dateFilterConfig/dateFilterConfigConverters.js";
 import { flattenDateFilterOptions } from "../dateFilterConfig/dateFilterOptionMapping.js";
@@ -73,13 +74,14 @@ export function createDefaultFilterContext(
      * is always respected (for both new and existing dashboards without filterContext).
      * Done like this for now because it is the way gdc-dashboards behave.
      */
-    respectSelectedOption: boolean = true,
+    respectSelectedOption: boolean,
+    filters?: FilterContextItem[],
 ): IFilterContextDefinition {
     const defaultDateFilter = getDefaultDateFilter(dateFilterConfig, respectSelectedOption);
 
     return {
         title: "filterContext",
         description: "",
-        filters: defaultDateFilter ? [defaultDateFilter] : [],
+        filters: filters ? filters : defaultDateFilter ? [defaultDateFilter] : [],
     };
 }

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/common/dashboardInitialize.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/common/dashboardInitialize.ts
@@ -8,6 +8,7 @@ import {
     isDashboardItemVisualizationContent,
 } from "../../../types/commonTypes.js";
 import { loadInsight } from "../../widgets/common/loadInsight.js";
+import { ExtendedDashboardWidget } from "../../../types/layoutTypes.js";
 
 const size = { xl: { gridHeight: 22, gridWidth: 12 } };
 
@@ -18,11 +19,18 @@ export const EmptyDashboardLayout: IDashboardLayout<IWidget> = {
 
 export async function dashboardInitialize(
     ctx: DashboardContext,
-    items: DashboardItem[],
+    items?: DashboardItem[],
 ): Promise<{
-    dashboard: IDashboard;
+    dashboard: IDashboard<ExtendedDashboardWidget> | undefined;
     insights: IInsight[];
 }> {
+    if (!items) {
+        return {
+            dashboard: undefined,
+            insights: [],
+        };
+    }
+
     const layoutItems: IDashboardLayoutItem[] = [];
     const insights: IInsight[] = [];
 
@@ -40,7 +48,7 @@ export async function dashboardInitialize(
         }
     }
 
-    const dashboard = buildInitialDashboard(layoutItems);
+    const dashboard = buildInitialDashboard(layoutItems) as IDashboard<ExtendedDashboardWidget>;
 
     return {
         dashboard,

--- a/libs/sdk-ui-loaders/src/dashboard/useDashboardLoader.ts
+++ b/libs/sdk-ui-loaders/src/dashboard/useDashboardLoader.ts
@@ -1,4 +1,4 @@
-// (C) 2021-2023 GoodData Corporation
+// (C) 2021-2025 GoodData Corporation
 import { useEffect, useMemo, useState } from "react";
 import stringify from "json-stable-stringify";
 import { IDashboardBasePropsForLoader, IDashboardLoadOptions, IEmbeddedPlugin } from "./types.js";
@@ -123,6 +123,7 @@ export function useDashboardLoader(options: IDashboardLoadOptions): DashboardLoa
         );
 
         return loader;
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [
         backend,
         workspace,


### PR DESCRIPTION
This is implementation of support using exportid also in case that we are empty dashboard. This is combined with initial content where some visualisation are loaded to dashboard on start, and also we need to load filters on start.

risk: low
JIRA: GDP-2903

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests.
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```
