### PR TITLE
feat: allow running full backstop

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,7 +19,7 @@ extended-test --backstop | --integrated | --isolated | --record [--filter <file1
 
 #### Explanation
 
--   `--backstop` The command to run screen tests.
+-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
 -   `--integrated` The command to run integrated tests against the live backend.
 -   `--isolated` The command to run isolated tests against recordings.
 -   `--record` The command to create new recordings for isolated tests.
@@ -29,6 +29,7 @@ extended-test --backstop | --integrated | --isolated | --record [--filter <file1
 
 ```
 extended-test --backstop
+extended-test --backstop --keep-passing-screenshots
 extended-test --integrated
 extended-test --integrated --filter test1.spec.ts,test2.spec.ts
 extended-test --isolated

--- a/.github/workflows/pull-request-comment.yaml
+++ b/.github/workflows/pull-request-comment.yaml
@@ -145,6 +145,7 @@ jobs:
     uses: ./.github/workflows/rw-rush-build-e2e-tests-backstop.yml
     with:
       source-ref: ${{ needs.get-pr-info.outputs.sha }}
+      keep-passing-screenshots: ${{ contains(github.event.comment.body, '--keep-passing-screenshots') && true : false }}
     secrets: inherit
 
   comment-pr:

--- a/.github/workflows/rw-rush-build-e2e-tests-backstop.yml
+++ b/.github/workflows/rw-rush-build-e2e-tests-backstop.yml
@@ -6,6 +6,11 @@ on:
           required: false
           description: "source ref of the current code"
           type: string
+      keep-passing-screenshots:
+          required: false
+          description: "whether to keep all backstop output as artifacts, even for passing tests (large)"
+          type: boolean
+          default: false
 
 jobs:
   warm-up-cache:
@@ -79,12 +84,14 @@ jobs:
         env:
           GH_RUN_ID: ${{ github.run_id }}
       - name: Cleanup backstop artifacts
-        if: ${{ !cancelled() && failure() }}
+        if: ${{ !cancelled() && (failure() || inputs.keep-passing-screenshots == true) }}
         run: |
           node libs/sdk-ui-tests/backstop/backstop-cleanup-artifacts.cjs
+        env:
+          KEEP_ALL_ARTIFACTS: ${{ inputs.keep-passing-screenshots }}
       - name: Archive the cypress test artifacts
         uses: actions/upload-artifact@v4
-        if: ${{ !cancelled() && failure() }}
+        if: ${{ !cancelled() && (failure() || inputs.keep-passing-screenshots == true) }}
         with:
           name: backstop-test-artifacts-failed
           path: |

--- a/.github/workflows/test-backstop.yml
+++ b/.github/workflows/test-backstop.yml
@@ -3,6 +3,12 @@
 name: Test ~ Backstop screen tests
 on:
   workflow_dispatch:
+    inputs:
+      keep-passing-screenshots:
+        description: Keep screenshots for passing tests
+        type: boolean
+        required: false
+        default: false
   schedule:
     - cron: '0 6 * * 1-5'
 
@@ -13,6 +19,8 @@ jobs:
       contents: read
       pull-requests: read
     uses: ./.github/workflows/rw-rush-build-e2e-tests-backstop.yml
+    with:
+      keep-passing-screenshots: ${{ inputs.keep-passing-screenshots }}
     secrets: inherit
 
   slack-notification:


### PR DESCRIPTION
JIRA: STL-1259
risk: low


<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```