### PR TITLE
feat: send also configuration with rendered event

### DIFF
--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -2980,6 +2980,10 @@ export interface DashboardRenderRequested extends IDashboardEvent {
 // @public (undocumented)
 export interface DashboardRenderResolved extends IDashboardEvent {
     // (undocumented)
+    readonly payload?: {
+        config: Omit<RenderingWorkerConfiguration, "correlationIdGenerator">;
+    };
+    // (undocumented)
     readonly type: "GDC.DASH/EVT.RENDER.RESOLVED";
 }
 
@@ -7528,6 +7532,16 @@ export function renameDashboard(newTitle: string, correlationId?: string): Renam
 // @beta
 export interface RenameDashboardPayload {
     readonly newTitle: string;
+}
+
+// @beta (undocumented)
+export interface RenderingWorkerConfiguration {
+    asyncRenderExpectedCount?: number;
+    asyncRenderRequestedTimeout: number;
+    asyncRenderResolvedTimeout: number;
+    correlationIdGenerator: () => string;
+    isExport?: boolean;
+    maxTimeout: number;
 }
 
 // @beta (undocumented)

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/render/types.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/render/types.ts
@@ -1,0 +1,54 @@
+// (C) 2025 GoodData Corporation
+
+/**
+ * @beta
+ */
+export interface RenderingWorkerConfiguration {
+    /**
+     * Maximum time limit for rendering the dashboard.
+     * Somehow in sync with limits of exporter
+     * https://github.com/gooddata/gdc-exporters-microservices/blob/master/microservices/visual-exporter-service/src/main/kotlin/com/gooddata/exporters/visual/config/TabSessionConfig.kt
+     *
+     * Default: 20*60000 (20min).
+     * @privateRemarks
+     * If changing this value update it also in documentation of {@link requestAsyncRender} command creator and {@link useDashboardAsyncRender} hook.
+     */
+    maxTimeout: number;
+
+    /**
+     * Maximum time limit for the first asynchronous rendering request.
+     * If no asynchronous rendering request is fired in this time limit, the dashboard will announce that it is rendered.
+     *
+     * Default: 5000 (5s).
+     */
+    asyncRenderRequestedTimeout: number;
+
+    /**
+     * Maximum time limit to re-request asynchronous rendering of the component once it's resolved.
+     *
+     * Default: 2000 (2s).
+     */
+    asyncRenderResolvedTimeout: number;
+
+    /**
+     * Generator of correlation ids
+     *
+     * Default: uuid4
+     */
+    correlationIdGenerator: () => string;
+
+    /**
+     * Wait for given number of async requests.
+     * If provided, we'll not wait full asyncRenderRequestedTimeout and
+     * terminate the waiting if we reach the given number
+     *
+     */
+    asyncRenderExpectedCount?: number;
+
+    /**
+     * Indicates whether rendering worker is triggered inside export mode
+     *
+     * Default: false
+     */
+    isExport?: boolean;
+}

--- a/libs/sdk-ui-dashboard/src/model/events/render.ts
+++ b/libs/sdk-ui-dashboard/src/model/events/render.ts
@@ -1,4 +1,5 @@
-// (C) 2021-2022 GoodData Corporation
+// (C) 2021-2025 GoodData Corporation
+import { RenderingWorkerConfiguration } from "../commandHandlers/render/types.js";
 import { DashboardContext } from "../types/commonTypes.js";
 import { IDashboardEvent } from "./base.js";
 import { eventGuard } from "./util.js";
@@ -154,6 +155,9 @@ export const isDashboardAsyncRenderResolved = eventGuard<DashboardAsyncRenderRes
  */
 export interface DashboardRenderResolved extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.RENDER.RESOLVED";
+    readonly payload?: {
+        config: Omit<RenderingWorkerConfiguration, "correlationIdGenerator">;
+    };
 }
 
 /**
@@ -165,6 +169,27 @@ export interface DashboardRenderResolved extends IDashboardEvent {
 export function renderResolved(ctx: DashboardContext, correlationId?: string): DashboardRenderResolved {
     return {
         type: "GDC.DASH/EVT.RENDER.RESOLVED",
+        correlationId,
+        ctx,
+    };
+}
+
+/**
+ * This event is emitted as soon as the dashboard component is fully rendered,
+ * and asynchronous rendering of each component is complete.
+ *
+ * @public
+ */
+export function renderResolvedWithDetails(
+    ctx: DashboardContext,
+    config: Omit<RenderingWorkerConfiguration, "correlationIdGenerator">,
+    correlationId?: string,
+): DashboardRenderResolved {
+    return {
+        type: "GDC.DASH/EVT.RENDER.RESOLVED",
+        payload: {
+            config,
+        },
         correlationId,
         ctx,
     };

--- a/libs/sdk-ui-dashboard/src/model/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/index.ts
@@ -116,6 +116,7 @@ export { selectDateDatasetsForInsight } from "./queryServices/queryInsightDateDa
 export { selectInsightAttributesMeta } from "./queryServices/queryInsightAttributesMeta.js";
 export { selectDateDatasetsForMeasure } from "./queryServices/queryMeasureDateDatasets.js";
 
+export type { RenderingWorkerConfiguration } from "./commandHandlers/render/types.js";
 export type {
     DashboardEventHandler,
     DashboardEventHandlerFn,

--- a/libs/sdk-ui-dashboard/src/model/tests/DashboardTester.ts
+++ b/libs/sdk-ui-dashboard/src/model/tests/DashboardTester.ts
@@ -1,4 +1,4 @@
-// (C) 2021-2022 GoodData Corporation
+// (C) 2021-2025 GoodData Corporation
 
 import { PayloadAction } from "@reduxjs/toolkit";
 import { Identifier, idRef, ObjRef, uriRef } from "@gooddata/sdk-model";
@@ -14,10 +14,8 @@ import { DashboardCommandType, InitializeDashboard, initializeDashboard } from "
 import { IDashboardQueryService } from "../store/_infra/queryService.js";
 import { IBackendCapabilities } from "@gooddata/sdk-backend-spi";
 import { HeadlessDashboard, HeadlessDashboardConfig } from "../headlessDashboard/index.js";
-import {
-    newRenderingWorker,
-    RenderingWorkerConfiguration,
-} from "../commandHandlers/render/renderingWorker.js";
+import { newRenderingWorker } from "../commandHandlers/render/renderingWorker.js";
+import { RenderingWorkerConfiguration } from "../commandHandlers/render/types.js";
 import {
     DashboardEvents,
     DashboardEventType,
@@ -47,7 +45,7 @@ export class DashboardTester extends HeadlessDashboard {
     protected constructor(ctx: DashboardContext, config?: DashboardTesterConfig) {
         const headlessDahboardConfig: HeadlessDashboardConfig = {
             queryServices: config?.queryServices,
-            backgroundWorkers: [newRenderingWorker(config?.renderingWorkerConfig)],
+            backgroundWorkers: [newRenderingWorker(config?.renderingWorkerConfig || {})],
             customizationFns: config?.customizationFns,
         };
 


### PR DESCRIPTION
So we can subtract `asyncRenderResolvedTimeout`
from performance metrics.

risk: low
JIRA: STL-1064

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```
