### PR TITLE
fix(sdk-ui-filters): crash when reset and apply at same time

### DIFF
--- a/common/changes/@gooddata/sdk-ui-all/ovel-fix-search-w-apply-crash_2025-03-31-10-21.json
+++ b/common/changes/@gooddata/sdk-ui-all/ovel-fix-search-w-apply-crash_2025-03-31-10-21.json
@@ -1,0 +1,10 @@
+{
+    "changes": [
+        {
+            "packageName": "@gooddata/sdk-ui-filters",
+            "comment": "Bugfix of attribute filter. When together apply all filters and close values dropdown with filled search the app crashes.",
+            "type": "fix"
+        }
+    ],
+    "packageName": "@gooddata/sdk-ui-filters"
+}

--- a/libs/sdk-ui-filters/src/AttributeFilter/hooks/useAttributeFilterController.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilter/hooks/useAttributeFilterController.ts
@@ -423,6 +423,7 @@ function useInitOrReload(
                   props,
                   supportsKeepingDependentFiltersSelection,
                   enableDuplicatedLabelValuesInAttributeFilter,
+                  enableDashboardFiltersApplyModes,
               );
         refreshByType(handler, change, supportsKeepingDependentFiltersSelection);
 
@@ -536,6 +537,7 @@ function updateNonResettingFilter(
     }: UpdateFilterProps,
     supportsKeepingDependentFiltersSelection: boolean,
     enableDuplicatedLabelValuesInAttributeFilter: boolean,
+    enableDashboardFiltersApplyModes: boolean,
 ): UpdateFilterType {
     if (
         limitingAttributesChanged ||
@@ -571,6 +573,9 @@ function updateNonResettingFilter(
                 const displayFormRef = filterObjRef(filter);
                 handler.setDisplayForm(displayFormRef);
                 handler.setDisplayAsLabel(displayAsLabel);
+            }
+            if (enableDashboardFiltersApplyModes) {
+                handler.setSearch("");
             }
             handler.changeSelection({ keys, isInverted, ...irrelevantKeysObj });
             handler.commitSelection();
@@ -847,7 +852,10 @@ function useCallbacks(
 
         if (handler.getSearch().length > 0) {
             handler.setSearch("");
-            handler.loadInitialElementsPage(RESET_CORRELATION);
+            if (handler.getInitStatus() === "loading" || !enableDashboardFiltersApplyModes) {
+                // if status is loading, updateNonResettingFilter takes care of clearing search and reloading elements.
+                handler.loadInitialElementsPage(RESET_CORRELATION);
+            }
         }
 
         /**


### PR DESCRIPTION
- why it crashes:
- after apply filter changes in dashboard state
- and therefore in filter props
- filter starts reloading
- if, before finishes, try to reset search
- it crashes
- because cannot reload when already realoding

JIRA: MC-3576
risk: low

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```
