### PR TITLE
fix(sdk-ui-filters): not reset date filter on cancel click

### DIFF
--- a/common/changes/@gooddata/sdk-ui-all/ovel-fix-date-filter-reset-on-cancel_2025-04-03-08-12.json
+++ b/common/changes/@gooddata/sdk-ui-all/ovel-fix-date-filter-reset-on-cancel_2025-04-03-08-12.json
@@ -1,0 +1,10 @@
+{
+    "changes": [
+        {
+            "packageName": "@gooddata/sdk-ui-all",
+            "comment": "Fix: Do not reset date filter on cancel click in apply all filters at once mode",
+            "type": "none"
+        }
+    ],
+    "packageName": "@gooddata/sdk-ui-all"
+}

--- a/libs/sdk-ui-filters/src/DateFilter/DateFilter.tsx
+++ b/libs/sdk-ui-filters/src/DateFilter/DateFilter.tsx
@@ -293,7 +293,14 @@ export class DateFilter extends React.PureComponent<IDateFilterProps, IDateFilte
     };
 
     private onChangesDiscarded = () => {
-        this.setState(() => DateFilter.getStateFromProps(this.props), this.handleSelectChange);
+        if (!this.props.withoutApply || !this.props.enableDashboardFiltersApplyModes) {
+            this.setState(() => DateFilter.getStateFromProps(this.props), this.handleSelectChange);
+        } else if (
+            this.props.enableDashboardFiltersApplyModes &&
+            !isEmpty(validateFilterOption(this.state.selectedFilterOption))
+        ) {
+            this.setState(() => DateFilter.getStateFromWorkingProps(this.props));
+        }
     };
 
     private onCancelClicked = () => {
@@ -306,14 +313,7 @@ export class DateFilter extends React.PureComponent<IDateFilterProps, IDateFilte
             this.props.onOpen();
         } else {
             this.props.onClose();
-            if (!this.props.withoutApply || !this.props.enableDashboardFiltersApplyModes) {
-                this.onChangesDiscarded();
-            } else if (
-                this.props.enableDashboardFiltersApplyModes &&
-                !isEmpty(validateFilterOption(this.state.selectedFilterOption))
-            ) {
-                this.setState(() => DateFilter.getStateFromWorkingProps(this.props));
-            }
+            this.onChangesDiscarded();
         }
     };
 


### PR DESCRIPTION
- in apply all at once mode

JIRA: MC-3537
risk: low

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```
