### PR TITLE
chore: enable legacy PR command for BEAR

### DIFF
--- a/.github/workflows/pull-request-comment.yaml
+++ b/.github/workflows/pull-request-comment.yaml
@@ -4,6 +4,9 @@ on:
     types:
       - created
 jobs:
+  ##########################################################################
+  # Handling commands for extended-test mainly from PR to master
+  ##########################################################################
   get-pr-info:
     if: github.event.issue.pull_request != null && startsWith(github.event.comment.body, 'extended-test')
     runs-on:
@@ -193,3 +196,77 @@ jobs:
           TEST_RESULT_RECORD: ${{ needs.e2e-record.result }}
           TEST_RESULT_INTEGRATED: ${{ needs.e2e-integrated.result }}
           TEST_RESULT_BACKSTOP: ${{ needs.e2e-backstop.result }}
+
+  ##########################################################################
+  # Handling legacy commands from PR to rel/9.9 Bear platform
+  # Jobs are running on jenkins
+  # All commands are different than extended-test
+  ##########################################################################
+
+  prepare-env:
+    if: ${{ github.event.issue.pull_request && startsWith(github.event.comment.body, 'extended test') }}
+    runs-on:
+      group: infra1-runners-arc
+      labels: runners-small
+    permissions: read-all
+    outputs:
+      branch: ${{ steps.branch.outputs.branch }}
+      ref: refs/pull/${{ github.event.issue.number }}/merge
+      commit: ${{ steps.commit.outputs.commit }}
+      pr_number: ${{ github.event.issue.number }}
+      project: ${{ github.repository }}
+      changed_files: ${{ steps.changed-files.outputs.all_changed_files }}
+    steps:
+      - name: Branch name
+        id: branch
+        run: |-
+          branch=$(echo "${{ github.ref }}" | sed 's/^refs\/heads\///')
+          echo "branch=$branch" >> "$GITHUB_OUTPUT"
+
+      - name: Commit
+        id: commit
+        run: |-
+          pr_head_sha=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            "https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.issue.number }}" | \
+            jq --raw-output .head.sha)
+          echo "commit=$pr_head_sha" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ github.event.issue.number }}/merge
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v40
+
+  gooddata-ui-sdk-pull-request-dispatcher-pipeline:
+    if: ${{ github.event.issue.pull_request && startsWith(github.event.comment.body, 'extended test') }}
+    runs-on:
+      group: infra1-runners-arc
+      labels: runners-small
+    needs:
+      - prepare-env
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Call Jenkins trigger
+        id: call-jenkins
+        uses: gooddata/github-actions-public/jenkins/trigger@master
+        with:
+          server: ${{ vars.JENKINS_ADDRESS }}
+          folder: gooddata-ui-sdk
+          job-name: gooddata-ui-sdk-pull-request-dispatcher-pipeline
+          vault-url: ${{ vars.VAULT_ADDRESS }}
+          params: |-
+            {
+              "GH_BRANCH": "${{ needs.prepare-env.outputs.branch }}",
+              "GH_REF": "${{ needs.prepare-env.outputs.ref }}",
+              "GH_COMMIT": "${{ needs.prepare-env.outputs.commit }}",
+              "GH_URL": "git@github.com:",
+              "GH_CHANGE": "${{ needs.prepare-env.outputs.pr_number }}",
+              "GH_PROJECT": "${{ needs.prepare-env.outputs.project }}",
+              "BUILD_BY_GITHUB": "true",
+              "GH_PIPELINE": "Pull request ~ comment",
+              "GH_COMMENT": "${{ github.event.comment.body }}"
+            }
+          comment-pr: 'true'


### PR DESCRIPTION
risk: nonprod

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```
