### PR TITLE
fix: register for async render as early as possible

### DIFF
--- a/libs/sdk-ui-dashboard/src/model/react/useInitializeDashboardStore.ts
+++ b/libs/sdk-ui-dashboard/src/model/react/useInitializeDashboardStore.ts
@@ -1,4 +1,4 @@
-// (C) 2021-2024 GoodData Corporation
+// (C) 2021-2025 GoodData Corporation
 import { useEffect, useRef, useState } from "react";
 import { useBackendStrict, useClientWorkspaceIdentifiers, usePrevious, useWorkspace } from "@gooddata/sdk-ui";
 import { useMapboxToken, enrichMapboxToken } from "@gooddata/sdk-ui-geo";
@@ -71,7 +71,7 @@ function useNotifyDeinitializedOnUnmount(
 export const useInitializeDashboardStore = (
     props: IDashboardStoreProviderProps,
 ): ReduxedDashboardStore | null => {
-    const { dashboard, persistedDashboard } = props;
+    const { dashboard, persistedDashboard, config } = props;
     const backend = useBackendStrict(props.backend);
     const workspace = useWorkspace(props.workspace);
     const mapboxToken = useMapboxToken(props.config?.mapboxToken);
@@ -110,11 +110,16 @@ export const useInitializeDashboardStore = (
 
             let asyncRenderExpectedCount = undefined;
             if (isDashboard(dashboard) && dashboard.layout !== undefined && !dashboard.plugins) {
-                asyncRenderExpectedCount = getWidgetsOfType(dashboard.layout, ["kpi", "insight"]).length;
+                asyncRenderExpectedCount = getWidgetsOfType(dashboard.layout, [
+                    "kpi",
+                    "insight",
+                    "visualizationSwitcher",
+                ]).length;
             }
             const backgroundWorkers = [
                 newRenderingWorker({
                     asyncRenderExpectedCount,
+                    isExport: config?.isExport,
                 }),
             ];
 
@@ -127,6 +132,7 @@ export const useInitializeDashboardStore = (
                     filterContextRef: currentInitProps.filterContextRef,
                     clientId: currentInitProps.clientId,
                     dataProductId: currentInitProps.dataProductId,
+                    config,
                 },
                 eventing: {
                     initialEventHandlers: props.eventHandlers,


### PR DESCRIPTION
- move registration to earlier stage (useEffect)
- fix async expected count for vis switcher widget

risk: low
JIRA: GRIF-168

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```

#### Commands for Bear platform working on branch rel/9.9

```
extended-test-legacy --backstop
extended-test-legacy --isolated
extended-test-legacy --record
```
