### PR TITLE
fix: lost data references in section descriptions

### DIFF
--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -3540,7 +3540,7 @@ export interface DeleteFilterViewPayload {
 
 // @alpha
 export type DescriptionExportData = {
-    description?: CommonExportDataAttributes;
+    description?: SectionDescriptionExportDataAttributes;
     richText?: RichTextExportData;
 };
 
@@ -8054,6 +8054,11 @@ export interface ScreenSizeChangedPayload {
 }
 
 // @alpha
+export type SectionDescriptionExportDataAttributes = CommonExportDataAttributes & {
+    "data-export-description-status"?: "loading" | "loaded" | "error";
+};
+
+// @alpha
 export type SectionExportData = HeaderExportData & {
     section?: CommonExportDataAttributes;
 };
@@ -10717,6 +10722,9 @@ export function useSaveAsNewButtonProps(): ISaveAsNewButtonProps;
 
 // @internal (undocumented)
 export function useSaveButtonProps(): ISaveButtonProps;
+
+// @alpha (undocumented)
+export const useSectionDescriptionExportData: (exportData: SectionExportData | undefined, loading: boolean, error: boolean) => SectionExportData | undefined;
 
 // @alpha (undocumented)
 export const useSectionExportData: (depth: number) => SectionExportData | undefined;

--- a/libs/sdk-ui-dashboard/src/presentation/export/types.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/export/types.ts
@@ -115,7 +115,7 @@ export type HeaderExportData = {
  * @alpha
  */
 export type DescriptionExportData = {
-    description?: CommonExportDataAttributes;
+    description?: SectionDescriptionExportDataAttributes;
     richText?: RichTextExportData;
 };
 
@@ -128,6 +128,15 @@ export type WidgetExportDataAttributes = CommonExportDataAttributes & {
     "data-export-widget-type"?: string;
     "data-export-visualization-type"?: string;
     "data-export-visualization-status"?: "loading" | "loaded" | "error";
+};
+
+/**
+ * Data attributes with export specification for section description component.
+ *
+ * @alpha
+ */
+export type SectionDescriptionExportDataAttributes = CommonExportDataAttributes & {
+    "data-export-description-status"?: "loading" | "loaded" | "error";
 };
 
 /**

--- a/libs/sdk-ui-dashboard/src/presentation/export/useExportData.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/export/useExportData.ts
@@ -17,6 +17,7 @@ import {
     WidgetExportDataAttributes,
     MetaExportDataAttributes,
     CommonExportDataAttributes,
+    SectionDescriptionExportDataAttributes,
 } from "./types.js";
 
 /**
@@ -70,6 +71,40 @@ export const useSectionExportData = (depth: number): SectionExportData | undefin
                 markdown: { "data-export-content-type": "markdown" },
             },
         },
+    };
+};
+
+/**
+ * @alpha
+ */
+export const useSectionDescriptionExportData = (
+    exportData: SectionExportData | undefined,
+    loading: boolean,
+    error: boolean,
+): SectionExportData | undefined => {
+    const isExportMode = useDashboardSelector(selectIsInExportMode);
+
+    if (!isExportMode) {
+        return undefined;
+    }
+
+    if (!exportData) {
+        return exportData;
+    }
+
+    return {
+        ...exportData,
+        ...(exportData.description
+            ? {
+                  description: {
+                      ...exportData.description,
+                      description: {
+                          ...exportData.description?.description,
+                          "data-export-description-status": loading ? "loading" : error ? "error" : "loaded",
+                      } as SectionDescriptionExportDataAttributes,
+                  },
+              }
+            : {}),
     };
 };
 

--- a/libs/sdk-ui-dashboard/src/presentation/flexibleLayout/DefaultDashboardLayoutRenderer/DashboardLayoutExportSectionHeaderRenderer.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/flexibleLayout/DefaultDashboardLayoutRenderer/DashboardLayoutExportSectionHeaderRenderer.tsx
@@ -1,8 +1,9 @@
 // (C) 2019-2025 GoodData Corporation
 
-import React, { useMemo } from "react";
+import React, { useMemo, useState } from "react";
 
 import { determineWidthForScreen } from "../../../_staging/layout/sizing.js";
+import { useSectionDescriptionExportData } from "../../export/index.js";
 import { useScreenSize } from "../../dashboard/components/DashboardScreenSizeContext.js";
 
 import { DashboardLayoutItemViewRenderer } from "./DashboardLayoutItemViewRenderer.js";
@@ -13,13 +14,18 @@ import { DashboardLayoutViewSectionHeader } from "./DashboardLayoutViewSectionHe
 export function DashboardLayoutExportSectionHeaderRenderer(
     props: IDashboardLayoutSectionHeaderRenderProps<unknown>,
 ): JSX.Element | null {
-    const { section, parentLayoutItemSize, exportData } = props;
+    const { section, parentLayoutItemSize } = props;
     const sectionHeader = section.header();
     const screen = useScreenSize();
     const gridWidth = determineWidthForScreen(screen, parentLayoutItemSize);
     const emptyItem = useMemo(() => {
         return buildEmptyItemFacadeWithSetSize(gridWidth, section.index());
     }, [gridWidth, section]);
+
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState(false);
+
+    const exportData = useSectionDescriptionExportData(props.exportData, loading, error);
 
     if (!sectionHeader) {
         return null;
@@ -32,7 +38,12 @@ export function DashboardLayoutExportSectionHeaderRenderer(
             // the shared interface with widget
             rowIndex={-1}
         >
-            <DashboardLayoutViewSectionHeader section={section} exportData={exportData} />
+            <DashboardLayoutViewSectionHeader
+                section={section}
+                exportData={exportData}
+                onLoadingChanged={(loading) => setLoading(loading.isLoading)}
+                onError={(error) => setError(!!error)}
+            />
         </DashboardLayoutItemViewRenderer>
     );
 }

--- a/libs/sdk-ui-dashboard/src/presentation/flexibleLayout/DefaultDashboardLayoutRenderer/DashboardLayoutSectionHeaderDescription.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/flexibleLayout/DefaultDashboardLayoutRenderer/DashboardLayoutSectionHeaderDescription.tsx
@@ -2,6 +2,7 @@
 import * as React from "react";
 import cx from "classnames";
 import { RichText } from "@gooddata/sdk-ui-kit";
+import { OnError, OnLoadingChanged } from "@gooddata/sdk-ui";
 
 import { useRichTextFilters } from "../../../_staging/sharedHooks/useRichTextFilters.js";
 import {
@@ -20,12 +21,14 @@ export interface IDashboardLayoutSectionHeaderDescriptionProps {
     description: string;
     exportData?: DescriptionExportData;
     LoadingComponent?: React.ComponentType;
+    onLoadingChanged?: OnLoadingChanged;
+    onError?: OnError;
 }
 
 export const DashboardLayoutSectionHeaderDescription: React.FC<
     IDashboardLayoutSectionHeaderDescriptionProps
 > = (props) => {
-    const { description, exportData, LoadingComponent } = props;
+    const { description, exportData, LoadingComponent, onLoadingChanged, onError } = props;
     const useRichText = useDashboardSelector(selectEnableRichTextDescriptions);
     const isRichTextReferencesEnabled = useDashboardSelector(selectEnableRichTextDynamicReferences);
     const { loading, filters } = useRichTextFilters(false);
@@ -52,6 +55,8 @@ export const DashboardLayoutSectionHeaderDescription: React.FC<
                     isFiltersLoading={loading}
                     separators={separators}
                     LoadingComponent={LoadingComponent}
+                    onLoadingChanged={onLoadingChanged}
+                    onError={onError}
                 />
             ) : (
                 description

--- a/libs/sdk-ui-dashboard/src/presentation/flexibleLayout/DefaultDashboardLayoutRenderer/DashboardLayoutViewSectionHeaderRenderer.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/flexibleLayout/DefaultDashboardLayoutRenderer/DashboardLayoutViewSectionHeaderRenderer.tsx
@@ -1,7 +1,8 @@
 // (C) 2019-2025 GoodData Corporation
 import React from "react";
-import { Typography } from "@gooddata/sdk-ui-kit";
 import isEmpty from "lodash/isEmpty.js";
+import { Typography } from "@gooddata/sdk-ui-kit";
+import { OnError, OnLoadingChanged } from "@gooddata/sdk-ui";
 
 import { IDashboardLayoutSectionFacade } from "../../../_staging/dashboard/flexibleLayout/index.js";
 import { useLayoutSectionsConfiguration } from "../../widget/common/useLayoutSectionsConfiguration.js";
@@ -13,11 +14,15 @@ import { HeaderExportData } from "../../export/index.js";
 export interface IDashboardLayoutSectionHeaderProps {
     section: IDashboardLayoutSectionFacade<unknown>;
     exportData?: HeaderExportData;
+    onLoadingChanged?: OnLoadingChanged;
+    onError?: OnError;
 }
 
 export const DashboardLayoutViewSectionHeader: React.FC<IDashboardLayoutSectionHeaderProps> = ({
     section,
     exportData,
+    onLoadingChanged,
+    onError,
 }) => {
     const { areSectionHeadersEnabled } = useLayoutSectionsConfiguration(section.layout().raw());
     const { LoadingComponent } = useDashboardComponentsContext();
@@ -49,6 +54,8 @@ export const DashboardLayoutViewSectionHeader: React.FC<IDashboardLayoutSectionH
                             description={description}
                             exportData={exportData?.description}
                             LoadingComponent={LoadingComponent}
+                            onLoadingChanged={onLoadingChanged}
+                            onError={onError}
                         />
                     ) : null}
                 </div>

--- a/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayoutRenderer/DashboardLayoutExportSectionHeaderRenderer.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayoutRenderer/DashboardLayoutExportSectionHeaderRenderer.tsx
@@ -1,15 +1,22 @@
 // (C) 2019-2025 GoodData Corporation
 import * as React from "react";
+import { useState } from "react";
 import { DashboardLayoutItemViewRenderer } from "./DashboardLayoutItemViewRenderer.js";
 import { DashboardLayoutSectionHeader } from "./DashboardLayoutSectionHeader.js";
 import { IDashboardLayoutSectionHeaderRenderProps } from "./interfaces.js";
 import { emptyItemFacadeWithFullSize } from "./utils/emptyFacade.js";
+import { useSectionDescriptionExportData } from "../../export/index.js";
 
 export function DashboardLayoutExportSectionHeaderRenderer(
     props: IDashboardLayoutSectionHeaderRenderProps<any>,
 ): JSX.Element | null {
-    const { section, screen, exportData } = props;
+    const { section, screen } = props;
     const sectionHeader = section.header();
+
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState(false);
+
+    const exportData = useSectionDescriptionExportData(props.exportData, loading, error);
 
     return sectionHeader ? (
         <DashboardLayoutItemViewRenderer
@@ -21,6 +28,8 @@ export function DashboardLayoutExportSectionHeaderRenderer(
                 title={sectionHeader.title}
                 description={sectionHeader.description}
                 exportData={exportData}
+                onLoadingChanged={(loading) => setLoading(loading.isLoading)}
+                onError={(error) => setError(!!error)}
             />
         </DashboardLayoutItemViewRenderer>
     ) : null;

--- a/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayoutRenderer/DashboardLayoutSectionHeader.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayoutRenderer/DashboardLayoutSectionHeader.tsx
@@ -1,9 +1,12 @@
 // (C) 2019-2025 GoodData Corporation
 import React from "react";
 import { Typography } from "@gooddata/sdk-ui-kit";
-import { DashboardLayoutSectionHeaderDescription } from "./DashboardLayoutSectionHeaderDescription.js";
+import { OnError, OnLoadingChanged } from "@gooddata/sdk-ui";
+
 import { HeaderExportData } from "../../export/index.js";
 import { useDashboardComponentsContext } from "../../dashboardContexts/index.js";
+
+import { DashboardLayoutSectionHeaderDescription } from "./DashboardLayoutSectionHeaderDescription.js";
 
 /**
  * @alpha
@@ -28,10 +31,13 @@ export interface IDashboardLayoutSectionHeaderProps {
      * to keep the look of Dashboard component in sync with gdc-dashboards.
      */
     renderHeader?: React.ReactNode;
+    onLoadingChanged?: OnLoadingChanged;
+    onError?: OnError;
 }
 
 export const DashboardLayoutSectionHeader: React.FC<IDashboardLayoutSectionHeaderProps> = (props) => {
-    const { title, description, renderBeforeHeader, renderHeader, exportData } = props;
+    const { title, description, renderBeforeHeader, renderHeader, exportData, onLoadingChanged, onError } =
+        props;
     const { LoadingComponent } = useDashboardComponentsContext();
 
     return (
@@ -54,6 +60,8 @@ export const DashboardLayoutSectionHeader: React.FC<IDashboardLayoutSectionHeade
                                 description={description}
                                 exportData={exportData?.description}
                                 LoadingComponent={LoadingComponent}
+                                onLoadingChanged={onLoadingChanged}
+                                onError={onError}
                             />
                         ) : null}
                     </div>

--- a/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayoutRenderer/DashboardLayoutSectionHeaderDescription.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayoutRenderer/DashboardLayoutSectionHeaderDescription.tsx
@@ -2,6 +2,7 @@
 import * as React from "react";
 import cx from "classnames";
 import { RichText } from "@gooddata/sdk-ui-kit";
+import { OnError, OnLoadingChanged } from "@gooddata/sdk-ui";
 
 import { useRichTextFilters } from "../../../_staging/sharedHooks/useRichTextFilters.js";
 import {
@@ -20,12 +21,14 @@ export interface IDashboardLayoutSectionHeaderDescriptionProps {
     description: string;
     exportData?: DescriptionExportData;
     LoadingComponent?: React.ComponentType;
+    onLoadingChanged?: OnLoadingChanged;
+    onError?: OnError;
 }
 
 export const DashboardLayoutSectionHeaderDescription: React.FC<
     IDashboardLayoutSectionHeaderDescriptionProps
 > = (props) => {
-    const { description, exportData, LoadingComponent } = props;
+    const { description, exportData, LoadingComponent, onLoadingChanged, onError } = props;
     const useRichText = useDashboardSelector(selectEnableRichTextDescriptions);
     const isRichTextReferencesEnabled = useDashboardSelector(selectEnableRichTextDynamicReferences);
     const { filters, loading } = useRichTextFilters(false);
@@ -52,6 +55,8 @@ export const DashboardLayoutSectionHeaderDescription: React.FC<
                     isFiltersLoading={loading}
                     separators={separators}
                     LoadingComponent={LoadingComponent}
+                    onLoadingChanged={onLoadingChanged}
+                    onError={onError}
                 />
             ) : (
                 description


### PR DESCRIPTION
lost data references in section descriptions when exporting slides dashboard to PPTX/PDF

risk: low
JIRA: F1-1253

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```

#### Commands for Bear platform working on branch rel/9.9

```
extended-test-legacy --backstop
extended-test-legacy --isolated
extended-test-legacy --record
```
