### PR TITLE
feat: use automation filter context in scheduling dialog

### DIFF
--- a/libs/sdk-model/api/sdk-model.api.md
+++ b/libs/sdk-model/api/sdk-model.api.md
@@ -996,6 +996,7 @@ export interface IAutomationMetadataObjectBase {
     metadata?: {
         widget?: string;
         filters?: string[];
+        visibleFilters?: IAutomationVisibleFilter[];
     };
     notificationChannel?: string;
     recipients?: IAutomationRecipient[];
@@ -1052,6 +1053,14 @@ export interface IAutomationUserRecipient extends IAutomationRecipientBase {
     email?: string;
     name?: string;
     type: "user";
+}
+
+// @alpha (undocumented)
+export interface IAutomationVisibleFilter {
+    // (undocumented)
+    localIdentifier?: string;
+    // (undocumented)
+    title?: string;
 }
 
 // @alpha

--- a/libs/sdk-model/src/automations/index.ts
+++ b/libs/sdk-model/src/automations/index.ts
@@ -71,8 +71,23 @@ export interface IAutomationMetadataObjectBase {
      */
     metadata?: {
         widget?: string;
+        /**
+         * Filters that are used in the alerting configuration when creating a condition with some measure.
+         */
         filters?: string[];
+        /**
+         * Filters description used for display in all client-related places (e.g. UI, e-mail, exports, etc.)
+         */
+        visibleFilters?: IAutomationVisibleFilter[];
     };
+}
+
+/**
+ * @alpha
+ */
+export interface IAutomationVisibleFilter {
+    localIdentifier?: string;
+    title?: string;
 }
 
 /**

--- a/libs/sdk-model/src/execution/filter/index.ts
+++ b/libs/sdk-model/src/execution/filter/index.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2024 GoodData Corporation
+// (C) 2019-2025 GoodData Corporation
 import isEmpty from "lodash/isEmpty.js";
 import { invariant } from "ts-invariant";
 import { Identifier, isObjRef, ObjRef, ObjRefInScope } from "../../objRef/index.js";
@@ -695,7 +695,7 @@ export function filterObjRef(filter: IFilter): ObjRef | undefined {
  * Gets local identifier of filter.
  *
  * @remarks
- * So far valid only for attribute filters.
+ * So far valid only for attribute and date filters.
  *
  * @param filter - filter to work with
  * @returns local identifier of filter object if defined, undefined otherwise
@@ -705,7 +705,7 @@ export function filterLocalIdentifier(filter: IFilter): string | undefined;
 export function filterLocalIdentifier(filter: IFilter): string | undefined {
     invariant(filter, "filter must be specified");
 
-    if (!isAttributeFilter(filter)) {
+    if (!isAttributeFilter(filter) && !isDateFilter(filter)) {
         return undefined;
     }
 
@@ -714,6 +714,12 @@ export function filterLocalIdentifier(filter: IFilter): string | undefined {
     }
     if (isNegativeAttributeFilter(filter)) {
         return filter.negativeAttributeFilter.localIdentifier;
+    }
+    if (isAbsoluteDateFilter(filter)) {
+        return filter.absoluteDateFilter.localIdentifier;
+    }
+    if (isRelativeDateFilter(filter)) {
+        return filter.relativeDateFilter.localIdentifier;
     }
     return undefined;
 }

--- a/libs/sdk-model/src/index.ts
+++ b/libs/sdk-model/src/index.ts
@@ -1041,6 +1041,7 @@ export type {
     IAlertRelativeArithmeticOperator,
     IAutomationAlertRelativeCondition,
     IAutomationDetails,
+    IAutomationVisibleFilter,
 } from "./automations/index.js";
 export {
     isAutomationMetadataObject,

--- a/libs/sdk-ui-dashboard/.dependency-cruiser.cjs
+++ b/libs/sdk-ui-dashboard/.dependency-cruiser.cjs
@@ -176,6 +176,7 @@ options = {
             "src/presentation/dashboardContexts",
             "src/presentation/localization",
             "src/presentation/constants/*",
+            "src/presentation/automationFilters/*",
             "src/converters",
             "src/types.ts",
         ]),

--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -195,6 +195,7 @@ import { IDashboardWidget } from '@gooddata/sdk-model';
 import { IDashboardWidgetOverlay as IDashboardWidgetOverlay_2 } from '../../index.js';
 import { IDataView } from '@gooddata/sdk-backend-spi';
 import { IDateFilter } from '@gooddata/sdk-model';
+import { IDateFilterButtonProps } from '@gooddata/sdk-ui-filters';
 import { IDateFilterConfig } from '@gooddata/sdk-model';
 import { IDateFilterOptionsByType } from '@gooddata/sdk-ui-filters';
 import { IDateHierarchyTemplate } from '@gooddata/sdk-model';
@@ -4623,6 +4624,8 @@ export interface IDashboardDateFilterConfig {
 // @public (undocumented)
 export interface IDashboardDateFilterProps {
     autoOpen?: boolean;
+    // @alpha
+    ButtonComponent?: ComponentType<IDateFilterButtonProps>;
     config: IDashboardDateFilterConfig;
     filter: IDashboardDateFilter | undefined;
     isDraggable?: boolean;

--- a/libs/sdk-ui-dashboard/src/_staging/dashboard/dashboardFilterConverter.ts
+++ b/libs/sdk-ui-dashboard/src/_staging/dashboard/dashboardFilterConverter.ts
@@ -85,6 +85,7 @@ export function dateFilterOptionToDashboardDateFilter(
     dateFilterOption: DateFilterOption,
     excludeCurrentPeriod: boolean,
     dataSet?: ObjRef,
+    localIdentifier?: string,
 ): IDashboardDateFilter | undefined {
     const tempDateDatasetId = dataSet ?? idRef("TEMP");
     const afmFilter = DateFilterHelpers.mapOptionToAfm(
@@ -100,6 +101,7 @@ export function dateFilterOptionToDashboardDateFilter(
                 type: "relative",
                 granularity: "GDC.time.date",
                 dataSet,
+                localIdentifier,
             },
         };
     }
@@ -113,6 +115,7 @@ export function dateFilterOptionToDashboardDateFilter(
                 from,
                 to,
                 dataSet,
+                localIdentifier,
             },
         };
     } else {
@@ -124,6 +127,7 @@ export function dateFilterOptionToDashboardDateFilter(
                 from,
                 to,
                 dataSet,
+                localIdentifier,
             },
         };
     }

--- a/libs/sdk-ui-dashboard/src/model/react/useDasboardScheduledEmails/useFiltersForDashboardScheduledExport.ts
+++ b/libs/sdk-ui-dashboard/src/model/react/useDasboardScheduledEmails/useFiltersForDashboardScheduledExport.ts
@@ -1,4 +1,4 @@
-// (C) 2024 GoodData Corporation
+// (C) 2024-2025 GoodData Corporation
 import {
     FilterContextItem,
     IAutomationMetadataObject,
@@ -7,6 +7,7 @@ import {
 import {
     ICrossFilteringItem,
     selectCrossFilteringItems,
+    selectEnableAutomationFilterContext,
     selectFilterContextFilters,
     selectOriginalFilterContextFilters,
 } from "../../store/index.js";
@@ -51,12 +52,12 @@ export const useFiltersForDashboardScheduledExport = ({
         dashboardFilters,
         crossFilteringItems,
     );
+    const enableAutomationFilterContext = useDashboardSelector(selectEnableAutomationFilterContext);
 
     // Only changed filters should be stored in scheduled export
-    const dashboardFiltersForScheduledExport = !isEqual(
-        originalDashboardFilters,
-        dashboardFiltersWithoutCrossFiltering,
-    )
+    const dashboardFiltersForScheduledExport = enableAutomationFilterContext
+        ? dashboardFiltersWithoutCrossFiltering
+        : !isEqual(originalDashboardFilters, dashboardFiltersWithoutCrossFiltering)
         ? dashboardFiltersWithoutCrossFiltering
         : undefined;
 

--- a/libs/sdk-ui-dashboard/src/presentation/automationFilters/AutomationFilters.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/automationFilters/AutomationFilters.tsx
@@ -1,0 +1,204 @@
+// (C) 2025 GoodData Corporation
+
+import React, { useState } from "react";
+import { FormattedMessage } from "react-intl";
+import cx from "classnames";
+import noop from "lodash/noop.js";
+import {
+    areObjRefsEqual,
+    FilterContextItem,
+    IDashboardAttributeFilterConfig,
+    IDashboardDateFilterConfigItem,
+    isDashboardAttributeFilter,
+} from "@gooddata/sdk-model";
+import { Bubble, BubbleHoverTrigger, Button, Icon, Typography, UiButton } from "@gooddata/sdk-ui-kit";
+import { AttributesDropdown } from "../filterBar/index.js";
+import { useAutomationFilters } from "./useAutomationFilters.js";
+import { AutomationAttributeFilter } from "./components/AutomationAttributeFilter.js";
+import { AutomationDateFilter } from "./components/AutomationDateFilter.js";
+import { gdColorStateBlank } from "../constants/colors.js";
+import { useTheme } from "@gooddata/sdk-ui-theme-provider";
+
+const TOOLTIP_ALIGN_POINTS = [{ align: "cr cl" }, { align: "cl cr" }];
+
+export interface IAutomationFiltersProps {
+    availableFilters: FilterContextItem[] | undefined;
+    selectedFilters: FilterContextItem[] | undefined;
+    onFiltersChange: (filters: FilterContextItem[]) => void;
+    useFilters: boolean;
+    onUseFiltersChange: (value: boolean, filters: FilterContextItem[]) => void;
+    isDashboardAutomation?: boolean;
+}
+
+export const AutomationFilters: React.FC<IAutomationFiltersProps> = ({
+    availableFilters = [],
+    selectedFilters = [],
+    onFiltersChange,
+    isDashboardAutomation,
+    useFilters,
+    onUseFiltersChange,
+}) => {
+    const theme = useTheme();
+    const [isExpanded, setIsExpanded] = useState(false);
+
+    const {
+        visibleFilters,
+        attributes,
+        dateDatasets,
+        attributeConfigs,
+        dateConfigs,
+        handleAddFilter,
+        handleDeleteFilter,
+        handleChangeFilter,
+    } = useAutomationFilters({
+        availableFilters,
+        selectedFilters,
+        onFiltersChange,
+    });
+
+    return (
+        <div className="gd-automation-filters">
+            <div
+                className={cx("gd-automation-filters__list", {
+                    "gd-automation-filters__list--expanded": isExpanded,
+                })}
+            >
+                <span className="gd-automation-filters__expansion-button s-automation-filters-show-all-button">
+                    <UiButton
+                        label="Show all"
+                        iconAfter={isExpanded ? "chevronUp" : "chevronDown"}
+                        variant="tertiary"
+                        onClick={() => setIsExpanded(!isExpanded)}
+                    />
+                </span>
+                {visibleFilters.map((filter) => (
+                    <div
+                        key={
+                            isDashboardAttributeFilter(filter)
+                                ? filter.attributeFilter.localIdentifier
+                                : filter.dateFilter.localIdentifier
+                        }
+                        className="gd-automation-filters__list-item"
+                    >
+                        <AutomationFilter
+                            filter={filter}
+                            attributeConfigs={attributeConfigs}
+                            dateConfigs={dateConfigs}
+                            onChange={handleChangeFilter}
+                            onDelete={handleDeleteFilter}
+                        />
+                    </div>
+                ))}
+                <AttributesDropdown
+                    onClose={noop}
+                    onSelect={handleAddFilter}
+                    attributes={attributes}
+                    dateDatasets={dateDatasets}
+                    openOnInit={false}
+                    className="gd-automation-filters__dropdown s-automation-filters-add-filter-dropdown"
+                    DropdownButtonComponent={({ onClick }) => (
+                        <Button
+                            className="gd-button-link gd-button-icon-only gd-icon-plus"
+                            size="small"
+                            onClick={onClick}
+                        />
+                    )}
+                    DropdownTitleComponent={() => (
+                        <div className="gd-automation-filters__dropdown-header">
+                            <Typography tagName="h3">
+                                <FormattedMessage id="dialogs.schedule.email.filters.title" />
+                            </Typography>
+                        </div>
+                    )}
+                />
+            </div>
+            {isDashboardAutomation ? (
+                <label className="input-checkbox-label gd-automation-filters__use-filters-checkbox s-automation-filters-use-filters-checkbox">
+                    <input
+                        type="checkbox"
+                        className="input-checkbox s-checkbox"
+                        checked={useFilters}
+                        onChange={(e) => onUseFiltersChange(e.target.checked, selectedFilters)}
+                    />
+                    <span className="input-label-text">
+                        <FormattedMessage id="dialogs.schedule.email.filters.useFiltersMessage" />
+                    </span>
+                    <BubbleHoverTrigger eventsOnBubble>
+                        <Icon.QuestionMark
+                            className="gd-automation-filters__checkbox-icon"
+                            color={theme?.palette?.complementary?.c6 ?? gdColorStateBlank}
+                            width={14}
+                            height={14}
+                        />
+                        <Bubble alignPoints={TOOLTIP_ALIGN_POINTS}>
+                            <FormattedMessage
+                                id="dialogs.schedule.email.filters.useFiltersMessage.tooltip"
+                                values={{
+                                    a: (chunk) => (
+                                        <a href="TODO" target="_blank" rel="noreferrer">
+                                            {chunk}
+                                        </a>
+                                    ),
+                                }}
+                            />
+                        </Bubble>
+                    </BubbleHoverTrigger>
+                </label>
+            ) : (
+                <div className="gd-automation-filters__message">
+                    <FormattedMessage id="dialogs.schedule.email.filters.activeFilters" />
+                </div>
+            )}
+        </div>
+    );
+};
+
+interface IAutomationFilterProps {
+    filter: FilterContextItem;
+    attributeConfigs: IDashboardAttributeFilterConfig[];
+    dateConfigs: IDashboardDateFilterConfigItem[];
+    onChange: (filter: FilterContextItem | undefined) => void;
+    onDelete: (filter: FilterContextItem) => void;
+}
+
+const AutomationFilter: React.FC<IAutomationFilterProps> = ({
+    filter,
+    attributeConfigs,
+    dateConfigs,
+    onChange,
+    onDelete,
+}) => {
+    if (isDashboardAttributeFilter(filter)) {
+        const config = attributeConfigs.find(
+            (attribute) => attribute.localIdentifier === filter.attributeFilter.localIdentifier,
+        );
+        const displayAsLabel = config?.displayAsLabel;
+        const isLocked = config?.mode === "readonly";
+
+        return (
+            <AutomationAttributeFilter
+                key={filter.attributeFilter.localIdentifier}
+                filter={filter}
+                onChange={onChange}
+                onDelete={onDelete}
+                isLocked={isLocked}
+                displayAsLabel={displayAsLabel}
+            />
+        );
+    } else {
+        const config = dateConfigs.find((date) =>
+            areObjRefsEqual(date.dateDataSet, filter.dateFilter.dataSet),
+        );
+        const isLocked = config?.config.mode === "readonly";
+
+        return (
+            <AutomationDateFilter
+                key={filter.dateFilter.localIdentifier}
+                filter={filter}
+                onChange={onChange}
+                onDelete={onDelete}
+                isLocked={isLocked}
+            />
+        );
+    }
+};

--- a/libs/sdk-ui-dashboard/src/presentation/automationFilters/components/AutomationAttributeFilter.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/automationFilters/components/AutomationAttributeFilter.tsx
@@ -1,0 +1,57 @@
+// (C) 2025 GoodData Corporation
+
+import React from "react";
+import { FilterContextItem, IDashboardAttributeFilter, ObjRef } from "@gooddata/sdk-model";
+import { AttributeFilterButton } from "@gooddata/sdk-ui-filters";
+import { UiChip, UiSkeleton } from "@gooddata/sdk-ui-kit";
+import noop from "lodash/noop.js";
+import { DefaultDashboardAttributeFilter } from "../../../presentation/filterBar/index.js";
+import { attributeFilterToDashboardAttributeFilter } from "../../../_staging/dashboard/dashboardFilterConverter.js";
+
+export const AutomationAttributeFilter: React.FC<{
+    filter: IDashboardAttributeFilter;
+    onChange: (filter: FilterContextItem) => void;
+    onDelete: (filter: FilterContextItem) => void;
+    isLocked?: boolean;
+    displayAsLabel?: ObjRef;
+}> = ({ filter, onChange, onDelete, isLocked, displayAsLabel }) => {
+    return (
+        <DefaultDashboardAttributeFilter
+            filter={filter}
+            onFilterChanged={noop}
+            displayAsLabel={displayAsLabel}
+            AttributeFilterComponent={(props) => (
+                <AttributeFilterButton
+                    {...props}
+                    LoadingComponent={() => (
+                        <UiSkeleton itemWidth={160} itemHeight={27} itemBorderRadius={20} />
+                    )}
+                    onApply={(newFilter) =>
+                        onChange(
+                            attributeFilterToDashboardAttributeFilter(
+                                newFilter,
+                                filter.attributeFilter.localIdentifier,
+                                filter.attributeFilter.title,
+                            ),
+                        )
+                    }
+                    DropdownButtonComponent={(innerProps) => (
+                        <UiChip
+                            label={innerProps.title! + ": " + innerProps.subtitle!}
+                            tag={
+                                innerProps.selectedItemsCount
+                                    ? `(${innerProps.selectedItemsCount})`
+                                    : undefined
+                            }
+                            isLocked={isLocked}
+                            isActive={innerProps.isOpen}
+                            isDeletable={!isLocked}
+                            onClick={innerProps.onClick}
+                            onDelete={() => onDelete(filter)}
+                        />
+                    )}
+                />
+            )}
+        />
+    );
+};

--- a/libs/sdk-ui-dashboard/src/presentation/automationFilters/components/AutomationDateFilter.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/automationFilters/components/AutomationDateFilter.tsx
@@ -1,0 +1,63 @@
+// (C) 2025 GoodData Corporation
+
+import React from "react";
+import { UiChip } from "@gooddata/sdk-ui-kit";
+import {
+    areObjRefsEqual,
+    FilterContextItem,
+    isDashboardCommonDateFilter,
+    IDashboardDateFilter,
+} from "@gooddata/sdk-model";
+import { DefaultDashboardDateFilter, IDashboardDateFilterConfig } from "../../filterBar/index.js";
+import {
+    selectCatalogDateDatasets,
+    selectEffectiveDateFilterAvailableGranularities,
+    selectEffectiveDateFilterOptions,
+    useDashboardSelector,
+} from "../../../model/index.js";
+
+export const AutomationDateFilter: React.FC<{
+    filter: IDashboardDateFilter;
+    onChange: (filter: FilterContextItem | undefined) => void;
+    onDelete: (filter: FilterContextItem) => void;
+    isLocked?: boolean;
+}> = ({ filter, onChange, onDelete, isLocked }) => {
+    const isCommonDateFilter = isDashboardCommonDateFilter(filter);
+
+    const availableGranularities = useDashboardSelector(selectEffectiveDateFilterAvailableGranularities);
+    const dateFilterOptions = useDashboardSelector(selectEffectiveDateFilterOptions);
+    const allDateDatasets = useDashboardSelector(selectCatalogDateDatasets);
+    const commonDateFilterComponentConfig: IDashboardDateFilterConfig = {
+        availableGranularities,
+        dateFilterOptions,
+    };
+
+    const defaultDateFilterName = allDateDatasets.find((ds) =>
+        areObjRefsEqual(ds.dataSet.ref, filter.dateFilter.dataSet),
+    )?.dataSet?.title;
+    const filterConfig = isCommonDateFilter
+        ? commonDateFilterComponentConfig
+        : {
+              ...commonDateFilterComponentConfig,
+              customFilterName: defaultDateFilterName,
+          };
+
+    return (
+        <DefaultDashboardDateFilter
+            filter={filter}
+            workingFilter={filter}
+            onFilterChanged={onChange}
+            config={filterConfig}
+            ButtonComponent={(props) => (
+                <UiChip
+                    label={props.textTitle + ": " + props.textSubtitle || ""}
+                    iconBefore="date"
+                    isActive={props.isOpen}
+                    isLocked={isLocked}
+                    isDeletable={!isLocked && !isCommonDateFilter}
+                    onDelete={() => onDelete(filter)}
+                />
+            )}
+        />
+    );
+};

--- a/libs/sdk-ui-dashboard/src/presentation/automationFilters/useAutomationDashboardFilters.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/automationFilters/useAutomationDashboardFilters.ts
@@ -1,0 +1,57 @@
+// (C) 2025 GoodData Corporation
+
+import { useMemo, useState } from "react";
+import { FilterContextItem, IAutomationMetadataObject, IAutomationVisibleFilter } from "@gooddata/sdk-model";
+import { getVisibleFiltersByFilters } from "./utils.js";
+
+interface IUseAutomationDashboardFiltersResult {
+    useFilters: boolean;
+    setUseFilters: React.Dispatch<React.SetStateAction<boolean>>;
+    effectiveDashboardFilters: FilterContextItem[] | undefined;
+    visibleDashboardFilters: IAutomationVisibleFilter[] | undefined;
+}
+
+/**
+ * Logic to prepare automation filters for dashboard.
+ */
+export const useAutomationDashboardFilters = ({
+    editAutomation,
+    dashboardFilters,
+    allVisibleFiltersMetadata,
+    enableAutomationFilterContext,
+}: {
+    editAutomation: IAutomationMetadataObject | undefined;
+    dashboardFilters: FilterContextItem[] | undefined;
+    allVisibleFiltersMetadata?: IAutomationVisibleFilter[] | undefined;
+    enableAutomationFilterContext?: boolean;
+}): IUseAutomationDashboardFiltersResult => {
+    const areFiltersStored = useMemo(
+        () =>
+            editAutomation?.exportDefinitions?.some((exportDefinition) => {
+                return (exportDefinition.requestPayload.content.filters?.length ?? 0) > 0;
+            }) ?? false,
+        [editAutomation],
+    );
+    const visibleFilters = useMemo(
+        () => getVisibleFiltersByFilters(dashboardFilters, allVisibleFiltersMetadata),
+        [dashboardFilters, allVisibleFiltersMetadata],
+    );
+
+    const [useFilters, setUseFilters] = useState(areFiltersStored);
+
+    if (!enableAutomationFilterContext) {
+        return {
+            useFilters: false,
+            setUseFilters: () => {},
+            effectiveDashboardFilters: dashboardFilters,
+            visibleDashboardFilters: undefined,
+        };
+    }
+
+    return {
+        useFilters,
+        setUseFilters,
+        effectiveDashboardFilters: useFilters ? dashboardFilters : undefined,
+        visibleDashboardFilters: useFilters ? visibleFilters : undefined,
+    };
+};

--- a/libs/sdk-ui-dashboard/src/presentation/automationFilters/useAutomationFilters.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/automationFilters/useAutomationFilters.ts
@@ -1,0 +1,105 @@
+// (C) 2025 GoodData Corporation
+
+import { useCallback, useMemo } from "react";
+import {
+    selectAttributeFilterConfigsOverrides,
+    selectCatalogAttributes,
+    selectCatalogDateDatasets,
+    selectDateFilterConfigsOverrides,
+    useDashboardSelector,
+} from "../../model/index.js";
+import {
+    areFiltersMatchedByIdentifier,
+    getCatalogAttributesByFilters,
+    getCatalogDateDatasetsByFilters,
+    getFilterByCatalogItemRef,
+    getNonHiddenFilters,
+    getNonSelectedFilters,
+} from "./utils.js";
+import { FilterContextItem, ObjRef } from "@gooddata/sdk-model";
+
+/**
+ * Logic for handling inner filters component logic.
+ */
+export const useAutomationFilters = ({
+    availableFilters,
+    selectedFilters,
+    onFiltersChange,
+}: {
+    availableFilters: FilterContextItem[];
+    selectedFilters: FilterContextItem[];
+    onFiltersChange: (filters: FilterContextItem[]) => void;
+}) => {
+    const allAttributes = useDashboardSelector(selectCatalogAttributes);
+    const allDateDatasets = useDashboardSelector(selectCatalogDateDatasets);
+    const attributeConfigs = useDashboardSelector(selectAttributeFilterConfigsOverrides);
+    const dateConfigs = useDashboardSelector(selectDateFilterConfigsOverrides);
+
+    const visibleFilters = useMemo(() => {
+        return getNonHiddenFilters(selectedFilters, attributeConfigs, dateConfigs);
+    }, [attributeConfigs, dateConfigs, selectedFilters]);
+
+    const nonSelectedFilters = useMemo(
+        () => getNonSelectedFilters(availableFilters, selectedFilters),
+        [availableFilters, selectedFilters],
+    );
+
+    const attributes = useMemo(
+        () => getCatalogAttributesByFilters(nonSelectedFilters, allAttributes),
+        [nonSelectedFilters, allAttributes],
+    );
+
+    const dateDatasets = useMemo(
+        () => getCatalogDateDatasetsByFilters(nonSelectedFilters, allDateDatasets),
+        [nonSelectedFilters, allDateDatasets],
+    );
+
+    const handleChangeFilter = useCallback(
+        (filter: FilterContextItem | undefined) => {
+            if (!filter) {
+                return;
+            }
+
+            const updatedFilters = selectedFilters.map((prevFilter) => {
+                if (areFiltersMatchedByIdentifier(prevFilter, filter)) {
+                    return filter;
+                }
+                return prevFilter;
+            });
+            onFiltersChange(updatedFilters);
+        },
+        [onFiltersChange, selectedFilters],
+    );
+
+    const handleDeleteFilter = useCallback(
+        (filter: FilterContextItem) => {
+            const updatedFilters = selectedFilters.filter(
+                (prevFilter) => !areFiltersMatchedByIdentifier(prevFilter, filter),
+            );
+            onFiltersChange(updatedFilters);
+        },
+        [onFiltersChange, selectedFilters],
+    );
+
+    const handleAddFilter = useCallback(
+        (catalogItemRef: ObjRef) => {
+            const filter = getFilterByCatalogItemRef(catalogItemRef, nonSelectedFilters);
+            if (filter) {
+                const updatedFilters = [...selectedFilters, filter];
+                onFiltersChange(updatedFilters);
+            }
+        },
+        [nonSelectedFilters, onFiltersChange, selectedFilters],
+    );
+
+    return {
+        visibleFilters,
+        attributes,
+        dateDatasets,
+        attributeConfigs,
+        dateConfigs,
+        handleChangeFilter,
+        handleDeleteFilter,
+        handleAddFilter,
+    };
+};

--- a/libs/sdk-ui-dashboard/src/presentation/automationFilters/useAutomationFiltersData.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/automationFilters/useAutomationFiltersData.ts
@@ -1,0 +1,102 @@
+// (C) 2025 GoodData Corporation
+
+import {
+    FilterContextItem,
+    IAutomationVisibleFilter,
+    isAllValuesDashboardAttributeFilter,
+    isDashboardAttributeFilter,
+} from "@gooddata/sdk-model";
+import { useMemo, useState } from "react";
+import compact from "lodash/compact.js";
+import { getNonHiddenFilters, validateAllFilterLocalIdentifiers } from "./utils.js";
+import { useFiltersNamings } from "../../_staging/sharedHooks/useFiltersNamings.js";
+import {
+    selectAttributeFilterConfigsOverrides,
+    selectDateFilterConfigsOverrides,
+    useDashboardSelector,
+} from "../../model/index.js";
+
+interface IUseAutomationFiltersData {
+    availableFilters: FilterContextItem[] | undefined;
+    automationFilters: FilterContextItem[] | undefined;
+    setAutomationFilters: (filters: FilterContextItem[]) => void;
+    allVisibleFiltersMetadata: IAutomationVisibleFilter[] | undefined;
+}
+
+/**
+ * Logic for preparation of data needed to be passed to other automation hooks outside of the component.
+ */
+export const useAutomationFiltersData = ({
+    allFilters,
+    storedFilters,
+    enableAutomationFilterContext,
+}: {
+    /**
+     * All possible filters at all times.
+     */
+    allFilters: FilterContextItem[] | undefined;
+    /**
+     * Filters that are already stored or about to be stored.
+     * Difference of allFilters and storedFilters should represent filters that can be added.
+     */
+    storedFilters: FilterContextItem[] | undefined;
+    enableAutomationFilterContext: boolean;
+}): IUseAutomationFiltersData => {
+    const effectiveFilters = useMemo(
+        () =>
+            storedFilters?.filter((filter) => {
+                if (isDashboardAttributeFilter(filter)) {
+                    return !isAllValuesDashboardAttributeFilter(filter);
+                } else {
+                    return true;
+                }
+            }),
+        [storedFilters],
+    );
+
+    const allVisibleFilters = useAutomationVisibleFilters(allFilters);
+    const doAllFiltersHaveLocalIdentifiers = useMemo(
+        () => validateAllFilterLocalIdentifiers(allFilters ?? []),
+        [allFilters],
+    );
+    const [selectedFilters, setSelectedFilters] = useState<FilterContextItem[]>(effectiveFilters ?? []);
+
+    // Just use filters without any changes when FF is off or filters do not have localIdentifiers
+    if (!enableAutomationFilterContext || !doAllFiltersHaveLocalIdentifiers) {
+        return {
+            availableFilters: allFilters,
+            automationFilters: undefined,
+            setAutomationFilters: () => {},
+            allVisibleFiltersMetadata: undefined,
+        };
+    }
+
+    return {
+        availableFilters: allFilters,
+        automationFilters: selectedFilters,
+        setAutomationFilters: setSelectedFilters,
+        allVisibleFiltersMetadata: allVisibleFilters,
+    };
+};
+
+const useAutomationVisibleFilters = (
+    filters: FilterContextItem[] | undefined,
+): IAutomationVisibleFilter[] => {
+    const attributeConfigs = useDashboardSelector(selectAttributeFilterConfigsOverrides);
+    const dateConfigs = useDashboardSelector(selectDateFilterConfigsOverrides);
+
+    const nonHiddenFilters = useMemo(() => {
+        return getNonHiddenFilters(filters, attributeConfigs, dateConfigs);
+    }, [filters, attributeConfigs, dateConfigs]);
+
+    const filterNamings = useFiltersNamings(nonHiddenFilters);
+
+    return useMemo(() => {
+        return compact(filterNamings).map((filter) => {
+            return {
+                title: filter.title,
+                localIdentifier: filter.id,
+            };
+        });
+    }, [filterNamings]);
+};

--- a/libs/sdk-ui-dashboard/src/presentation/automationFilters/useAutomationWidgetFilters.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/automationFilters/useAutomationWidgetFilters.ts
@@ -1,0 +1,76 @@
+// (C) 2025 GoodData Corporation
+
+import { useMemo } from "react";
+import {
+    FilterContextItem,
+    filterLocalIdentifier,
+    IAutomationVisibleFilter,
+    IFilter,
+    IInsightWidget,
+    isInsightWidget,
+} from "@gooddata/sdk-model";
+import compact from "lodash/compact.js";
+import { filterContextItemsToDashboardFiltersByWidget } from "../../converters/index.js";
+import { getFilterLocalIdentifier, getVisibleFiltersByFilters } from "./utils.js";
+import { ExtendedDashboardWidget } from "src/model/index.js";
+
+interface IUseAutomationWidgetFilters {
+    insightExecutionFilters: IFilter[];
+    dashboardExecutionFilters: IFilter[];
+    visibleWidgetFilters?: IAutomationVisibleFilter[] | undefined;
+}
+
+/**
+ * Logic to prepare automation filters for widget.
+ */
+export const useAutomationWidgetFilters = ({
+    widget,
+    allDashboardFilters,
+    widgetFilters,
+    allVisibleFiltersMetadata,
+    enableAutomationFilterContext,
+}: {
+    widget: ExtendedDashboardWidget | undefined;
+    allDashboardFilters?: FilterContextItem[] | undefined;
+    widgetFilters?: IFilter[] | undefined;
+    allVisibleFiltersMetadata?: IAutomationVisibleFilter[] | undefined;
+    enableAutomationFilterContext?: boolean;
+}): IUseAutomationWidgetFilters => {
+    const visibleFilters = useMemo(
+        () => getVisibleFiltersByFilters(allDashboardFilters, allVisibleFiltersMetadata),
+        [allDashboardFilters, allVisibleFiltersMetadata],
+    );
+
+    const dashboardFiltersLocalIdentifiers = useMemo(
+        () => compact((allDashboardFilters ?? []).map(getFilterLocalIdentifier)),
+        [allDashboardFilters],
+    );
+
+    const insightExecutionFilters = useMemo(
+        () =>
+            (widgetFilters ?? []).filter((filter) => {
+                const localIdentifier = filterLocalIdentifier(filter);
+                return localIdentifier ? !dashboardFiltersLocalIdentifiers?.includes(localIdentifier) : false;
+            }),
+        [dashboardFiltersLocalIdentifiers, widgetFilters],
+    );
+
+    const dashboardExecutionFilters = isInsightWidget(widget)
+        ? filterContextItemsToDashboardFiltersByWidget(allDashboardFilters ?? [], widget as IInsightWidget)
+        : [];
+
+    // When FF is off, return widget filters for previous experience
+    if (!enableAutomationFilterContext) {
+        return {
+            insightExecutionFilters: widgetFilters ?? [],
+            dashboardExecutionFilters: [],
+            visibleWidgetFilters: undefined,
+        };
+    }
+
+    return {
+        insightExecutionFilters,
+        dashboardExecutionFilters,
+        visibleWidgetFilters: visibleFilters,
+    };
+};

--- a/libs/sdk-ui-dashboard/src/presentation/automationFilters/utils.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/automationFilters/utils.ts
@@ -1,0 +1,129 @@
+// (C) 2025 GoodData Corporation
+
+import {
+    areObjRefsEqual,
+    FilterContextItem,
+    IAutomationVisibleFilter,
+    ICatalogAttribute,
+    ICatalogDateDataset,
+    IDashboardAttributeFilterConfig,
+    IDashboardDateFilterConfigItem,
+    isDashboardAttributeFilter,
+    isDashboardDateFilter,
+    ObjRef,
+} from "@gooddata/sdk-model";
+import compact from "lodash/compact.js";
+
+export const getFilterLocalIdentifier = (filter: FilterContextItem): string | undefined => {
+    if (isDashboardAttributeFilter(filter)) {
+        return filter.attributeFilter.localIdentifier;
+    } else if (isDashboardDateFilter(filter)) {
+        return filter.dateFilter.localIdentifier;
+    }
+    return undefined;
+};
+
+export const validateAllFilterLocalIdentifiers = (filters: FilterContextItem[]): boolean => {
+    return filters.every((filter) => getFilterLocalIdentifier(filter) !== undefined);
+};
+
+export const areFiltersMatchedByIdentifier = (
+    filter1: FilterContextItem,
+    filter2: FilterContextItem,
+): boolean => {
+    return getFilterLocalIdentifier(filter1) === getFilterLocalIdentifier(filter2);
+};
+
+export const getNonSelectedFilters = (
+    allFilters: FilterContextItem[],
+    selectedFilters: FilterContextItem[],
+) => {
+    return allFilters.filter((allFilter) => {
+        return !selectedFilters.some((selectedFilter) => {
+            return areFiltersMatchedByIdentifier(allFilter, selectedFilter);
+        });
+    });
+};
+
+export const getCatalogAttributesByFilters = (
+    filters: FilterContextItem[],
+    attributes: ICatalogAttribute[],
+): ICatalogAttribute[] => {
+    return attributes.filter((attribute) => {
+        return filters.some((filter) => {
+            if (isDashboardAttributeFilter(filter)) {
+                return attribute.displayForms.some((displayForm) => {
+                    return areObjRefsEqual(displayForm.ref, filter.attributeFilter.displayForm);
+                });
+            }
+
+            return false;
+        });
+    });
+};
+
+export const getCatalogDateDatasetsByFilters = (
+    filters: FilterContextItem[],
+    dateDataset: ICatalogDateDataset[],
+): ICatalogDateDataset[] => {
+    return dateDataset.filter((dateDataset) => {
+        return filters.some((filter) => {
+            if (isDashboardDateFilter(filter)) {
+                return areObjRefsEqual(dateDataset.dataSet.ref, filter.dateFilter.dataSet);
+            }
+
+            return false;
+        });
+    });
+};
+
+export const getFilterByCatalogItemRef = (
+    ref: ObjRef,
+    filters: FilterContextItem[],
+): FilterContextItem | undefined => {
+    return filters.find((filter) => {
+        if (isDashboardAttributeFilter(filter)) {
+            return areObjRefsEqual(filter.attributeFilter.displayForm, ref);
+        } else if (isDashboardDateFilter(filter)) {
+            return areObjRefsEqual(filter.dateFilter.dataSet, ref);
+        }
+        return false;
+    });
+};
+
+export const getVisibleFiltersByFilters = (
+    selectedFilters: FilterContextItem[] | undefined,
+    visibleFiltersMetadata: IAutomationVisibleFilter[] | undefined,
+): IAutomationVisibleFilter[] => {
+    const filters = (selectedFilters ?? []).map((selectedFilter) => {
+        return (visibleFiltersMetadata ?? []).find((visibleFilter) => {
+            if (isDashboardAttributeFilter(selectedFilter)) {
+                return selectedFilter.attributeFilter.localIdentifier === visibleFilter.localIdentifier;
+            } else {
+                return selectedFilter.dateFilter.localIdentifier === visibleFilter.localIdentifier;
+            }
+        });
+    });
+
+    return compact(filters);
+};
+
+export const getNonHiddenFilters = (
+    filters: FilterContextItem[] | undefined,
+    attributeConfigs: IDashboardAttributeFilterConfig[],
+    dateConfigs: IDashboardDateFilterConfigItem[],
+): FilterContextItem[] => {
+    return (filters ?? []).filter((filter) => {
+        if (isDashboardAttributeFilter(filter)) {
+            const config = attributeConfigs.find(
+                (attribute) => attribute.localIdentifier === filter.attributeFilter.localIdentifier,
+            );
+            return config?.mode !== "hidden";
+        } else {
+            const config = dateConfigs.find((date) =>
+                areObjRefsEqual(date.dateDataSet, filter.dateFilter.dataSet),
+            );
+            return config?.config.mode !== "hidden";
+        }
+    });
+};

--- a/libs/sdk-ui-dashboard/src/presentation/filterBar/dateFilter/DefaultDashboardDateFilter.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/filterBar/dateFilter/DefaultDashboardDateFilter.tsx
@@ -49,7 +49,7 @@ export const DefaultDashboardDateFilter = (props: IDashboardDateFilterProps): JS
     const weekStart = useDashboardSelector(selectWeekStart);
     const filtersApplyMode = useDashboardSelector(selectDashboardFiltersApplyMode);
     const enableDashboardFiltersApplyModes = useDashboardSelector(selectEnableDashboardFiltersApplyModes);
-    const { filter, workingFilter, onFilterChanged, config, readonly, autoOpen } = props;
+    const { filter, workingFilter, onFilterChanged, config, readonly, autoOpen, ButtonComponent } = props;
 
     const allDateDatasets = useDashboardSelector(selectCatalogDateDatasets);
     let defaultDateFilterName: string;
@@ -87,22 +87,32 @@ export const DefaultDashboardDateFilter = (props: IDashboardDateFilterProps): JS
         (option, exclude) => {
             setLastSelectedOptionId(option.localIdentifier);
             onFilterChanged(
-                dateFilterOptionToDashboardDateFilter(option, exclude, filter?.dateFilter.dataSet),
+                dateFilterOptionToDashboardDateFilter(
+                    option,
+                    exclude,
+                    filter?.dateFilter.dataSet,
+                    filter?.dateFilter.localIdentifier,
+                ),
                 option.localIdentifier,
             );
         },
-        [onFilterChanged, filter?.dateFilter.dataSet],
+        [onFilterChanged, filter?.dateFilter.dataSet, filter?.dateFilter.localIdentifier],
     );
     const onSelect = useCallback<NonNullable<IDateFilterProps["onSelect"]>>(
         (option, exclude) => {
             setLastSelectedOptionId(option.localIdentifier);
             onFilterChanged(
-                dateFilterOptionToDashboardDateFilter(option, exclude, filter?.dateFilter.dataSet),
+                dateFilterOptionToDashboardDateFilter(
+                    option,
+                    exclude,
+                    filter?.dateFilter.dataSet,
+                    filter?.dateFilter.localIdentifier,
+                ),
                 option.localIdentifier,
                 true,
             );
         },
-        [onFilterChanged, filter?.dateFilter.dataSet],
+        [onFilterChanged, filter?.dateFilter.dataSet, filter?.dateFilter.localIdentifier],
     );
     const dateFormat = settings.formatLocale
         ? getLocalizedIcuDateFormatPattern(settings.formatLocale)
@@ -169,6 +179,7 @@ export const DefaultDashboardDateFilter = (props: IDashboardDateFilterProps): JS
             FilterConfigurationComponent={isConfigurationEnabled ? FilterConfigurationComponent : undefined}
             withoutApply={filtersApplyMode.mode === "ALL_AT_ONCE" && enableDashboardFiltersApplyModes}
             enableDashboardFiltersApplyModes={enableDashboardFiltersApplyModes}
+            ButtonComponent={ButtonComponent}
         />
     );
 };

--- a/libs/sdk-ui-dashboard/src/presentation/filterBar/dateFilter/types.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/filterBar/dateFilter/types.ts
@@ -1,7 +1,7 @@
 // (C) 2021-2025 GoodData Corporation
 import { ComponentType } from "react";
 import { DateFilterGranularity, IDashboardDateFilter } from "@gooddata/sdk-model";
-import { IDateFilterOptionsByType } from "@gooddata/sdk-ui-filters";
+import { IDateFilterOptionsByType, IDateFilterButtonProps } from "@gooddata/sdk-ui-filters";
 
 /**
  * Defines the configuration of the DateFilter component.
@@ -74,6 +74,13 @@ export interface IDashboardDateFilterProps {
      * Specify whether should render filter with open dropdown
      */
     autoOpen?: boolean;
+
+    /**
+     * Specify custom button component
+     *
+     * @alpha
+     */
+    ButtonComponent?: ComponentType<IDateFilterButtonProps>;
 }
 
 /**

--- a/libs/sdk-ui-dashboard/src/presentation/localization/bundles/en-US.json
+++ b/libs/sdk-ui-dashboard/src/presentation/localization/bundles/en-US.json
@@ -618,6 +618,11 @@
         "comment": "Emails of the schedule email.",
         "limit": 0
     },
+    "dialogs.schedule.email.filters": {
+        "value": "Filters ({count})",
+        "comment": "Pick filters for automated schedule. Do not translate variable enclosed in {}.",
+        "limit": 0
+    },
     "dialogs.schedule.email.destination": {
         "value": "Destination",
         "comment": "Way how to send automated schedule",
@@ -681,6 +686,26 @@
     "dialogs.schedule.email.destinationWarning": {
         "value": "The selected destination only supports sending the export to yourself.",
         "comment": "Schedule warning message",
+        "limit": 0
+    },
+    "dialogs.schedule.email.filters.title": {
+        "value": "Add filters",
+        "comment": "Schedule filters dialog title",
+        "limit": 0
+    },
+    "dialogs.schedule.email.filters.useFiltersMessage": {
+        "value": "Always use these filters for future exports",
+        "comment": "",
+        "limit": 0
+    },
+    "dialogs.schedule.email.filters.useFiltersMessage.tooltip": {
+        "value": "Check to keep these filters for every export. If unchecked, the export will use the latest default filters from the dashboard. <a>Learn more</a>",
+        "comment": "Do not translate html tags <a>, </a>",
+        "limit": 0
+    },
+    "dialogs.schedule.email.filters.activeFilters": {
+        "value": "Note: These filters will always be used for future exports.",
+        "comment": "",
         "limit": 0
     },
     "dialogs.schedule.management.title": {

--- a/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/DefaultLoadingScheduledEmailDialog.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/DefaultLoadingScheduledEmailDialog.tsx
@@ -1,10 +1,9 @@
-// (C) 2019-2024 GoodData Corporation
+// (C) 2019-2025 GoodData Corporation
 import React from "react";
 import { useIntl } from "react-intl";
 import {
     ConfirmDialogBase,
     Overlay,
-    ContentDivider,
     OverlayControllerProvider,
     OverlayController,
     UiSkeleton,
@@ -53,7 +52,7 @@ export function DefaultLoadingScheduledEmailDialog({
                         )}
                     >
                         <div className="gd-notifications-channel-dialog-content-wrapper">
-                            <ContentDivider className="gd-divider-with-margin gd-divider-full-row" />
+                            <div className="gd-divider-with-margin" />
                             <UiSkeleton itemHeight={50} itemsCount={3} />
                         </div>
                     </ConfirmDialogBase>

--- a/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/components/Attachments/DashboardAttachments.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/components/Attachments/DashboardAttachments.tsx
@@ -20,6 +20,7 @@ export interface IDashboardAttachmentsProps {
         dashboardSelected: boolean,
         filters?: FilterContextItem[],
     ) => void;
+    enableAutomationFilterContext?: boolean;
 }
 
 export const DashboardAttachments = (props: IDashboardAttachmentsProps) => {
@@ -31,6 +32,7 @@ export const DashboardAttachments = (props: IDashboardAttachmentsProps) => {
         isCrossFiltering,
         filtersToDisplayInfo,
         onDashboardAttachmentsSelectionChange,
+        enableAutomationFilterContext,
     } = props;
 
     /**
@@ -50,7 +52,9 @@ export const DashboardAttachments = (props: IDashboardAttachmentsProps) => {
         !isEditing || savedFilters ? "edited" : "default",
     );
 
-    const showAttachmentFilters = isEditing
+    const showAttachmentFilters = enableAutomationFilterContext
+        ? false
+        : isEditing
         ? attachmentFilterType !== "default"
         : areDashboardFiltersChanged && dashboardSelected;
 

--- a/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/components/Attachments/WidgetAttachments.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/components/Attachments/WidgetAttachments.tsx
@@ -25,6 +25,7 @@ export interface IWidgetAttachmentsProps {
         filters?: IFilter[],
     ) => void;
     onWidgetAttachmentsSettingsChange: (obj: IExportDefinitionVisualizationObjectSettings) => void;
+    enableAutomationFilterContext?: boolean;
 }
 
 export const WidgetAttachments = (props: IWidgetAttachmentsProps) => {
@@ -38,8 +39,10 @@ export const WidgetAttachments = (props: IWidgetAttachmentsProps) => {
         scheduledExportToEdit,
         onWidgetAttachmentsSelectionChange,
         onWidgetAttachmentsSettingsChange,
+        enableAutomationFilterContext,
     } = props;
 
+    const renderFiltersMessage = !enableAutomationFilterContext;
     const isEditing = !!scheduledExportToEdit;
 
     const handleWidgetAttachmentSelectionChange = (format: WidgetAttachmentType) => {
@@ -60,7 +63,9 @@ export const WidgetAttachments = (props: IWidgetAttachmentsProps) => {
                     onSelectionChange={handleWidgetAttachmentSelectionChange}
                     onSettingsChange={onWidgetAttachmentsSettingsChange}
                 />
-                {(isEditing || areDashboardFiltersChanged) && (csvSelected || xlsxSelected) ? (
+                {renderFiltersMessage &&
+                (isEditing || areDashboardFiltersChanged) &&
+                (csvSelected || xlsxSelected) ? (
                     <div>
                         <FormattedMessage id="dialogs.schedule.management.attachments.filters.using" />{" "}
                         <FormattedMessage id="dialogs.schedule.management.attachments.filters.edited" />

--- a/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/components/AutomationFiltersSelect/AutomationFiltersSelect.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/components/AutomationFiltersSelect/AutomationFiltersSelect.tsx
@@ -1,0 +1,46 @@
+// (C) 2025 GoodData Corporation
+
+import React from "react";
+import { AutomationFilters } from "../../../../automationFilters/AutomationFilters.js";
+import { FormattedMessage } from "react-intl";
+import { FilterContextItem } from "@gooddata/sdk-model";
+
+export interface IAutomationFiltersSelectProps {
+    availableFilters: FilterContextItem[] | undefined;
+    selectedFilters: FilterContextItem[] | undefined;
+    onFiltersChange: (filters: FilterContextItem[]) => void;
+    useFilters: boolean;
+    onUseFiltersChange: (value: boolean, filters: FilterContextItem[]) => void;
+    isDashboardAutomation?: boolean;
+}
+
+export const AutomationFiltersSelect: React.FC<IAutomationFiltersSelectProps> = ({
+    availableFilters = [],
+    selectedFilters = [],
+    onFiltersChange,
+    isDashboardAutomation,
+    useFilters,
+    onUseFiltersChange,
+}) => {
+    const numberOfSelectedFilters = selectedFilters.length;
+    const accessibilityValue = "schedule.filters";
+
+    return (
+        <div className="gd-input-component gd-notification-channels-automation-filters s-gd-notifications-channels-dialog-automation-filters">
+            <label htmlFor={accessibilityValue} className="gd-label">
+                <FormattedMessage
+                    id="dialogs.schedule.email.filters"
+                    values={{ count: numberOfSelectedFilters }}
+                />
+            </label>
+            <AutomationFilters
+                availableFilters={availableFilters}
+                selectedFilters={selectedFilters}
+                onFiltersChange={onFiltersChange}
+                useFilters={useFilters}
+                onUseFiltersChange={onUseFiltersChange}
+                isDashboardAutomation={isDashboardAutomation}
+            />
+        </div>
+    );
+};

--- a/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/hooks/useEditScheduledEmail.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/hooks/useEditScheduledEmail.ts
@@ -16,6 +16,8 @@ import {
     isWidget,
     isAutomationExternalUserRecipient,
     isAutomationUnknownUserRecipient,
+    IAutomationVisibleFilter,
+    isInsightWidget,
 } from "@gooddata/sdk-model";
 import {
     useDashboardSelector,
@@ -49,6 +51,10 @@ import {
 } from "../../utils/date.js";
 import { isEmail } from "../../utils/validate.js";
 import { getUserTimezone } from "../../utils/timezone.js";
+import { getVisibleFiltersByFilters } from "../../../automationFilters/utils.js";
+import { filterContextItemsToDashboardFiltersByWidget } from "../../../../converters/index.js";
+import { useAutomationWidgetFilters } from "../../../automationFilters/useAutomationWidgetFilters.js";
+import { useAutomationDashboardFilters } from "../../../automationFilters/useAutomationDashboardFilters.js";
 
 export interface IUseEditScheduledEmailProps {
     scheduledExportToEdit?: IAutomationMetadataObject;
@@ -60,8 +66,20 @@ export interface IUseEditScheduledEmailProps {
     insight?: IInsight;
     widgetFilters?: IFilter[];
 
+    // Dashboard filters at all times
+    allDashboardFilters?: FilterContextItem[];
+
     // In case we are editing dashboard scheduled export
     dashboardFilters?: FilterContextItem[];
+
+    setAutomationFilters: (filters: FilterContextItem[]) => void;
+
+    // Metadata for identifying visible filters shown on dashboards
+    allVisibleFiltersMetadata?: IAutomationVisibleFilter[] | undefined;
+
+    // Option to opt out of storing filters
+    useFilters?: boolean;
+    enableAutomationFilterContext?: boolean;
 }
 
 export function useEditScheduledEmail(props: IUseEditScheduledEmailProps) {
@@ -70,10 +88,15 @@ export function useEditScheduledEmail(props: IUseEditScheduledEmailProps) {
         notificationChannels,
         insight,
         widget,
+        allDashboardFilters,
         dashboardFilters,
         widgetFilters,
         maxAutomationsRecipients,
+        setAutomationFilters,
+        allVisibleFiltersMetadata,
+        enableAutomationFilterContext,
     } = props;
+
     const intl = useIntl();
     const [isCronValid, setIsCronValid] = useState(true);
     const [warningMessage, setWarningMessage] = useState<string | undefined>(undefined);
@@ -95,6 +118,22 @@ export function useEditScheduledEmail(props: IUseEditScheduledEmailProps) {
 
     const firstChannel = notificationChannels[0]?.id;
 
+    const { insightExecutionFilters, dashboardExecutionFilters, visibleWidgetFilters } =
+        useAutomationWidgetFilters({
+            widget,
+            allDashboardFilters,
+            widgetFilters,
+            allVisibleFiltersMetadata,
+            enableAutomationFilterContext,
+        });
+    const { useFilters, setUseFilters, effectiveDashboardFilters, visibleDashboardFilters } =
+        useAutomationDashboardFilters({
+            editAutomation: scheduledExportToEdit,
+            dashboardFilters,
+            allVisibleFiltersMetadata,
+            enableAutomationFilterContext,
+        });
+
     const [editedAutomation, setEditedAutomation] = useState<IAutomationMetadataObjectDefinition>(
         scheduledExportToEdit ??
             newAutomationMetadataObjectDefinition(
@@ -106,7 +145,10 @@ export function useEditScheduledEmail(props: IUseEditScheduledEmailProps) {
                           insight,
                           widget,
                           recipient: defaultRecipient,
-                          widgetFilters,
+                          widgetFilters: enableAutomationFilterContext
+                              ? [...dashboardExecutionFilters, ...insightExecutionFilters]
+                              : widgetFilters,
+                          visibleFiltersMetadata: visibleWidgetFilters,
                       }
                     : {
                           timezone,
@@ -114,7 +156,8 @@ export function useEditScheduledEmail(props: IUseEditScheduledEmailProps) {
                           notificationChannel: firstChannel,
                           title: dashboardTitle,
                           recipient: defaultRecipient,
-                          dashboardFilters,
+                          dashboardFilters: effectiveDashboardFilters,
+                          visibleFiltersMetadata: visibleDashboardFilters,
                       },
             ),
     );
@@ -301,6 +344,107 @@ export function useEditScheduledEmail(props: IUseEditScheduledEmailProps) {
         }));
     };
 
+    const onFiltersChange = (filters: FilterContextItem[], useFilters = true) => {
+        setAutomationFilters(filters);
+
+        // If filters are not used, we don't want to set them in the automation
+        if (!isWidget && !useFilters) {
+            return;
+        }
+
+        const visibleFilters = getVisibleFiltersByFilters(filters, allVisibleFiltersMetadata);
+
+        if (!isWidget) {
+            setEditedAutomation((s) => ({
+                ...s,
+                exportDefinitions: s.exportDefinitions?.map((exportDefinition) => {
+                    if (isExportDefinitionDashboardRequestPayload(exportDefinition.requestPayload)) {
+                        return {
+                            ...exportDefinition,
+                            requestPayload: {
+                                ...exportDefinition.requestPayload,
+                                content: {
+                                    ...exportDefinition.requestPayload.content,
+                                    filters,
+                                },
+                            },
+                        };
+                    } else {
+                        return exportDefinition;
+                    }
+                }),
+                metadata: {
+                    ...s.metadata,
+                    visibleFilters,
+                },
+            }));
+        } else {
+            if (!isInsightWidget(widget)) {
+                return;
+            }
+
+            const convertedFilters = filterContextItemsToDashboardFiltersByWidget(filters, widget);
+
+            setEditedAutomation((s) => ({
+                ...s,
+                exportDefinitions: s.exportDefinitions?.map((exportDefinition) => {
+                    if (
+                        isExportDefinitionVisualizationObjectRequestPayload(exportDefinition.requestPayload)
+                    ) {
+                        return {
+                            ...exportDefinition,
+                            requestPayload: {
+                                ...exportDefinition.requestPayload,
+                                content: {
+                                    ...exportDefinition.requestPayload.content,
+                                    filters: [...convertedFilters, ...insightExecutionFilters],
+                                },
+                            },
+                        };
+                    } else {
+                        return exportDefinition;
+                    }
+                }),
+                metadata: {
+                    ...s.metadata,
+                    visibleFilters,
+                },
+            }));
+        }
+    };
+
+    const onUseFiltersChange = (value: boolean, filters: FilterContextItem[]) => {
+        setUseFilters(value);
+        if (value) {
+            onFiltersChange(filters, value);
+        } else {
+            setEditedAutomation((s) => ({
+                ...s,
+                exportDefinitions: s.exportDefinitions?.map((exportDefinition) => {
+                    // Use filters flag is only relevant for dashboard automation
+                    if (isExportDefinitionDashboardRequestPayload(exportDefinition.requestPayload)) {
+                        return {
+                            ...exportDefinition,
+                            requestPayload: {
+                                ...exportDefinition.requestPayload,
+                                content: {
+                                    ...exportDefinition.requestPayload.content,
+                                    filters: undefined,
+                                },
+                            },
+                        };
+                    } else {
+                        return exportDefinition;
+                    }
+                }),
+                metadata: {
+                    ...s.metadata,
+                    visibleFilters: undefined,
+                },
+            }));
+        }
+    };
+
     const isDashboardExportSelected =
         editedAutomation.exportDefinitions?.some((exportDefinition) =>
             isExportDefinitionDashboardRequestPayload(exportDefinition.requestPayload),
@@ -402,6 +546,7 @@ export function useEditScheduledEmail(props: IUseEditScheduledEmailProps) {
         allowExternalRecipients,
         validationErrorMessage,
         isSubmitDisabled,
+        useFilters,
         onTitleChange,
         onRecurrenceChange,
         onDestinationChange,
@@ -411,6 +556,8 @@ export function useEditScheduledEmail(props: IUseEditScheduledEmailProps) {
         onDashboardAttachmentsChange,
         onWidgetAttachmentsChange,
         onWidgetAttachmentsSettingsChange,
+        onFiltersChange,
+        onUseFiltersChange,
     };
 }
 
@@ -492,6 +639,7 @@ function newAutomationMetadataObjectDefinition({
     recipient,
     dashboardFilters,
     widgetFilters,
+    visibleFiltersMetadata,
 }: {
     timezone?: string;
     dashboardId: string;
@@ -502,6 +650,7 @@ function newAutomationMetadataObjectDefinition({
     recipient: IAutomationRecipient;
     dashboardFilters?: FilterContextItem[];
     widgetFilters?: IFilter[];
+    visibleFiltersMetadata?: IAutomationVisibleFilter[];
 }): IAutomationMetadataObjectDefinition {
     const { firstRun, cron } = toNormalizedFirstRunAndCron(timezone);
     const exportDefinition =
@@ -518,6 +667,14 @@ function newAutomationMetadataObjectDefinition({
                   dashboardTitle: title ?? "",
                   dashboardFilters,
               });
+
+    const metadataObj = visibleFiltersMetadata
+        ? {
+              metadata: {
+                  visibleFilters: visibleFiltersMetadata,
+              },
+          }
+        : {};
 
     const automation: IAutomationMetadataObjectDefinition = {
         type: "automation",
@@ -537,6 +694,7 @@ function newAutomationMetadataObjectDefinition({
         recipients: [recipient],
         notificationChannel,
         dashboard: dashboardId,
+        ...metadataObj,
     };
 
     return automation;

--- a/libs/sdk-ui-dashboard/styles/scss/automationFilters.scss
+++ b/libs/sdk-ui-dashboard/styles/scss/automationFilters.scss
@@ -1,0 +1,80 @@
+// (C) 2025 GoodData Corporation
+
+@use "@gooddata/sdk-ui-kit/styles/scss/variables" as kit-variables;
+
+$item-height: 27px;
+
+.gd-automation-filters {
+    width: 100%;
+
+    &__list {
+        max-height: $item-height;
+        display: inline-block;
+        overflow: hidden;
+        width: 100%;
+
+        &--expanded {
+            max-height: 100%;
+        }
+    }
+
+    &__list-item {
+        display: inline-block;
+        vertical-align: top;
+        height: $item-height;
+        margin-right: 5px;
+        margin-bottom: 5px;
+
+        > div {
+            vertical-align: top;
+        }
+    }
+
+    &__expansion-button {
+        float: right;
+        height: $item-height;
+        margin-top: -3px;
+    }
+
+    &__message {
+        color: var(--gd-palette-complementary-7, #6d7680);
+        font-size: 12px;
+        font-style: normal;
+        font-weight: 400;
+        line-height: 21px;
+        margin-top: 5px;
+    }
+
+    &__dropdown {
+        display: inline-block;
+        vertical-align: top;
+    }
+
+    &__dropdown-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        padding: 10px;
+        background: kit-variables.$is-focused-background;
+
+        h3 {
+            color: kit-variables.$gd-color-state-blank;
+            font-size: 11px;
+            font-weight: bold;
+            text-transform: uppercase;
+            line-height: normal;
+        }
+    }
+
+    &__use-filters-checkbox {
+        .input-label-text {
+            color: kit-variables.$gd-color-link;
+        }
+    }
+
+    &__checkbox-icon {
+        position: relative;
+        margin-left: 5px;
+        top: 3px;
+    }
+}

--- a/libs/sdk-ui-dashboard/styles/scss/main.scss
+++ b/libs/sdk-ui-dashboard/styles/scss/main.scss
@@ -41,3 +41,4 @@
 @use "dashboardNestedLayoutWidget";
 @use "dashboardSettingsDialog";
 @use "descriptionPanel";
+@use "automationFilters";

--- a/libs/sdk-ui-dashboard/styles/scss/notifications_channels_dialog.scss
+++ b/libs/sdk-ui-dashboard/styles/scss/notifications_channels_dialog.scss
@@ -93,6 +93,10 @@ $min-content-height: 110px;
     }
 }
 
+.gd-notification-channels-automation-filters {
+    align-items: normal;
+}
+
 .gd-notifications-channels-attachments {
     @media #{kit-variables.$medium-up} {
         align-items: flex-start;
@@ -635,6 +639,20 @@ $min-content-height: 110px;
     background: variables.$dialog-background;
     margin: 0 (-$dialog-padding);
     padding: 0 $dialog-padding;
+
+    display: flex;
+    flex-direction: column;
+    box-sizing: content-box;
+    height: 544px;
+    width: 100%;
+    overflow-y: auto;
+    overflow-x: hidden;
+    border-top: 1px solid kit-variables.$gd-border-color;
+    border-bottom: 1px solid kit-variables.$gd-border-color;
+
+    @media #{kit-variables.$small-only} {
+        height: inherit;
+    }
 }
 
 .gd-divider-with-margin {


### PR DESCRIPTION
- feature is behind enableAutomationFilterContext FF
- all dashboard filters are cloned in scheduling dialog
- filters can be changed or removed
- visible filters are stored in automation metadata
- visible filters describe localId and title used on server

JIRA: F1-1249
risk: low

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```

#### Commands for Bear platform working on branch rel/9.9

```
extended-test-legacy --backstop
extended-test-legacy --isolated
extended-test-legacy --record
```
