### PR TITLE
feat: allow passing raw data to DataTooLargeError

### DIFF
--- a/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
+++ b/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
@@ -178,7 +178,9 @@ export class ContractExpired extends AnalyticalBackendError {
 
 // @public
 export class DataTooLargeError extends AnalyticalBackendError {
-    constructor(message: string, cause?: Error);
+    constructor(message: string, cause?: Error, responseBody?: unknown | undefined);
+    // (undocumented)
+    readonly responseBody: unknown | undefined;
 }
 
 // @public

--- a/libs/sdk-backend-spi/src/errors/index.ts
+++ b/libs/sdk-backend-spi/src/errors/index.ts
@@ -61,7 +61,11 @@ export class NoDataError extends AnalyticalBackendError {
  * @public
  */
 export class DataTooLargeError extends AnalyticalBackendError {
-    constructor(message: string, cause?: Error) {
+    constructor(
+        message: string,
+        cause?: Error,
+        public readonly responseBody: unknown | undefined = undefined,
+    ) {
         super(message, AnalyticalBackendErrorTypes.DATA_TOO_LARGE, cause);
     }
 }


### PR DESCRIPTION
* Handle the DataTooLargeError in errorHandling.ts so that it is created when an appropriate error flies from the backend.
* Boy-scout rule: improve getTraceId function. Simplify it and declare its return type properly. The old way would fail once we move to TypeScript >= 5.8.
* Boy-scout rule: unify convertApiError. This is always used in a throw statement, so the `return` is the correct statement here.

JIRA: CQ-1151
risk: low

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```

#### Commands for Bear platform working on branch rel/9.9

```
extended-test-legacy --backstop
extended-test-legacy --isolated
extended-test-legacy --record
```
