### PR TITLE
feat: add enableRichTooManyDatapointsErrors feature flag

### DIFF
--- a/libs/sdk-backend-tiger/src/backend/features/feature.ts
+++ b/libs/sdk-backend-tiger/src/backend/features/feature.ts
@@ -730,6 +730,13 @@ export function mapFeatures(features: FeaturesMap): Partial<ITigerFeatureFlags> 
             "BOOLEAN",
             FeatureFlagsValues.enableAlertsEvaluationFrequencySetup,
         ),
+        ...loadFeature(
+            features,
+            TigerFeaturesNames.EnableRichTooManyDatapointsErrors,
+            "enableRichTooManyDatapointsErrors",
+            "BOOLEAN",
+            FeatureFlagsValues.enableRichTooManyDatapointsErrors,
+        ),
     };
 }
 

--- a/libs/sdk-backend-tiger/src/backend/uiFeatures.ts
+++ b/libs/sdk-backend-tiger/src/backend/uiFeatures.ts
@@ -143,6 +143,7 @@ export enum TigerFeaturesNames {
     EnableAutomationFilterContext = "enableAutomationFilterContext",
     EnableDateFilterIdentifiersRollout = "enableDateFilterIdentifiersRollout",
     EnableAlertsEvaluationFrequencySetup = "enableAlertsEvaluationFrequencySetup",
+    EnableRichTooManyDatapointsErrors = "enableRichTooManyDatapointsErrors",
 }
 
 export type ITigerFeatureFlags = {
@@ -248,6 +249,7 @@ export type ITigerFeatureFlags = {
     enableAutomationFilterContext: typeof FeatureFlagsValues["enableAutomationFilterContext"][number];
     enableDateFilterIdentifiersRollout: typeof FeatureFlagsValues["enableDateFilterIdentifiersRollout"][number];
     enableAlertsEvaluationFrequencySetup: typeof FeatureFlagsValues["enableAlertsEvaluationFrequencySetup"][number];
+    enableRichTooManyDatapointsErrors: typeof FeatureFlagsValues["enableRichTooManyDatapointsErrors"][number];
 };
 
 export const DefaultFeatureFlags: ITigerFeatureFlags = {
@@ -353,6 +355,7 @@ export const DefaultFeatureFlags: ITigerFeatureFlags = {
     enableAutomationFilterContext: false,
     enableDateFilterIdentifiersRollout: false,
     enableAlertsEvaluationFrequencySetup: false,
+    enableRichTooManyDatapointsErrors: false,
 };
 
 export const FeatureFlagsValues = {
@@ -462,4 +465,5 @@ export const FeatureFlagsValues = {
     enableAutomationFilterContext: [true, false] as const,
     enableDateFilterIdentifiersRollout: [true, false] as const,
     enableAlertsEvaluationFrequencySetup: [true, false] as const,
+    enableRichTooManyDatapointsErrors: [true, false] as const,
 };


### PR DESCRIPTION
This is to make the rollout of rich too many datapoints errors safer.

JIRA: CQ-1151
risk: low

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```

#### Commands for Bear platform working on branch rel/9.9

```
extended-test-legacy --backstop
extended-test-legacy --isolated
extended-test-legacy --record
```
