### PR TITLE
feat: use generic accessibility interface

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/configuration/InsightAlertConfig/AlertTitle.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/configuration/InsightAlertConfig/AlertTitle.tsx
@@ -29,7 +29,9 @@ export function AlertTitle({ id, alert, measures, separators, onChange }: AlertT
             value={alert?.title}
             placeholder={description}
             onChange={onChange}
-            ariaLabel={intl.formatMessage({ id: "insightAlert.config.accessibility.title" })}
+            accessibilityConfig={{
+                ariaLabel: intl.formatMessage({ id: "insightAlert.config.accessibility.title" }),
+            }}
         />
     );
 }

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/configuration/InsightAlertConfig/EditAlert.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/configuration/InsightAlertConfig/EditAlert.tsx
@@ -284,7 +284,11 @@ export const EditAlert: React.FC<IEditAlertProps> = ({
                             onBlur={onBlur}
                             type="number"
                             suffix={getValueSuffix(updatedAlert.alert)}
-                            ariaLabel={intl.formatMessage({ id: "insightAlert.config.accessbility.input" })}
+                            accessibilityConfig={{
+                                ariaLabel: intl.formatMessage({
+                                    id: "insightAlert.config.accessbility.input",
+                                }),
+                            }}
                         />
                         <AlertComparisonPeriodSelect
                             measure={selectedMeasure}

--- a/libs/sdk-ui-kit/api/sdk-ui-kit.api.md
+++ b/libs/sdk-ui-kit/api/sdk-ui-kit.api.md
@@ -3206,8 +3206,6 @@ export interface InputPureProps extends IDomNativeProps {
     // (undocumented)
     accessibilityType?: string;
     // (undocumented)
-    ariaLabel?: string;
-    // (undocumented)
     autocomplete?: string;
     // (undocumented)
     className: string;

--- a/libs/sdk-ui-kit/src/Dropdown/DropdownList.tsx
+++ b/libs/sdk-ui-kit/src/Dropdown/DropdownList.tsx
@@ -177,7 +177,9 @@ export function DropdownList<T>(props: IDropdownListProps<T>): JSX.Element {
                     onEscKeyPress={onEscKeyPress}
                     isSearch={true}
                     autofocus={!disableAutofocus}
-                    ariaLabel={searchLabel}
+                    accessibilityConfig={{
+                        ariaLabel: searchLabel,
+                    }}
                 />
             ) : null}
             {showTabs ? (

--- a/libs/sdk-ui-kit/src/Form/InputPure.tsx
+++ b/libs/sdk-ui-kit/src/Form/InputPure.tsx
@@ -42,7 +42,6 @@ export interface InputPureProps extends IDomNativeProps {
     type?: string;
     required?: boolean;
     accessibilityType?: string;
-    ariaLabel?: string;
     accessibilityConfig?: IAccessibilityConfigBase;
     autocomplete?: string;
 }

--- a/libs/sdk-ui-kit/src/List/InvertableSelect/InvertableSelectSearchBar.tsx
+++ b/libs/sdk-ui-kit/src/List/InvertableSelect/InvertableSelectSearchBar.tsx
@@ -34,7 +34,9 @@ export function InvertableSelectSearchBar(props: IInvertableSelectSearchBarProps
             isSearch
             isSmall={isSmall}
             type="search"
-            ariaLabel={intl.formatMessage({ id: "gs.list.acessibility.search.label" })}
+            accessibilityConfig={{
+                ariaLabel: intl.formatMessage({ id: "gs.list.acessibility.search.label" }),
+            }}
         />
     );
 }

--- a/libs/sdk-ui-semantic-search/src/internal/SearchOverlay.tsx
+++ b/libs/sdk-ui-semantic-search/src/internal/SearchOverlay.tsx
@@ -259,7 +259,9 @@ const SearchOverlayCore: React.FC<
                 className="gd-semantic-search__overlay-input"
                 autofocus
                 placeholder={intl.formatMessage({ id: "semantic-search.placeholder" })}
-                ariaLabel={intl.formatMessage({ id: "semantic-search.label" })}
+                accessibilityConfig={{
+                    ariaLabel: intl.formatMessage({ id: "semantic-search.label" }),
+                }}
                 isSearch
                 clearOnEsc
                 value={value}


### PR DESCRIPTION
Remove `ariaLabel` prop and use generic interface `AccessibilityConfig`.

risk: low
JIRA: LX-1058

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```

#### Commands for Bear platform working on branch rel/9.9

```
extended-test-legacy --backstop
extended-test-legacy --isolated
extended-test-legacy --record
```
