### PR TITLE
fix: dashboard overrideDefaultFilters

### DIFF
--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -4043,6 +4043,8 @@ export interface FilterContextState {
     // @beta
     attributesWithReferences?: IAttributeWithReferences[];
     // @beta
+    defaultFilterOverrides?: FilterContextItem[];
+    // @beta
     filterContextDefinition?: IFilterContextDefinition;
     // @beta
     filterContextIdentity?: IDashboardObjectIdentity;
@@ -8460,6 +8462,9 @@ export const selectDateFormat: DashboardSelector<string | undefined>;
 
 // @alpha (undocumented)
 export const selectDateHierarchyTemplates: DashboardSelector<IDateHierarchyTemplate[]>;
+
+// @beta
+export const selectDefaultFilterOverrides: DashboardSelector<FilterContextItem[] | undefined>;
 
 // @internal
 export const selectDeleteVisible: DashboardSelector<boolean>;

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/common/stateInitializers.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/common/stateInitializers.ts
@@ -497,6 +497,9 @@ export function* actionsToInitializeExistingDashboard(
             filterContextIdentity,
             attributeFilterDisplayForms,
         }),
+        overrideDefaultFilters
+            ? filterContextActions.setDefaultFilterOverrides(overrideDefaultFilters)
+            : null,
         layoutActions.setLayout(dashboardLayout),
         metaActions.setMeta({
             dashboard: persistedDashboard ?? dashboard,

--- a/libs/sdk-ui-dashboard/src/model/react/useDasboardScheduledEmails/useFiltersForDashboardScheduledExport.ts
+++ b/libs/sdk-ui-dashboard/src/model/react/useDasboardScheduledEmails/useFiltersForDashboardScheduledExport.ts
@@ -12,6 +12,7 @@ import {
     selectEnableAutomationFilterContext,
     selectFilterContextFilters,
     selectOriginalFilterContextFilters,
+    selectDefaultFilterOverrides,
 } from "../../store/index.js";
 import { getAutomationDashboardFilters } from "../../../_staging/automation/index.js";
 import isEqual from "lodash/isEqual.js";
@@ -50,6 +51,7 @@ export const useFiltersForDashboardScheduledExport = ({
         ? getAutomationDashboardFilters(scheduledExportToEdit)
         : undefined;
     const dashboardFilters = useDashboardSelector(selectFilterContextFilters);
+    const defaultFilterOverrides = useDashboardSelector(selectDefaultFilterOverrides);
     const crossFilteringItems = useDashboardSelector(selectCrossFilteringItems);
     const dashboardFiltersWithoutCrossFiltering = removeCrossFilteringFilters(
         dashboardFilters,
@@ -60,7 +62,9 @@ export const useFiltersForDashboardScheduledExport = ({
     // Only changed filters should be stored in scheduled export
     const dashboardFiltersForScheduledExport = enableAutomationFilterContext
         ? dashboardFiltersWithoutCrossFiltering
-        : !isEqual(originalDashboardFilters, dashboardFiltersWithoutCrossFiltering)
+        : // If there are any default filter overrides (e. g. coming from shared dashboard filter context in url),
+        // always store them in scheduled export. In this case we won't ever save the default dashboard filter context.
+        defaultFilterOverrides || !isEqual(originalDashboardFilters, dashboardFiltersWithoutCrossFiltering)
         ? dashboardFiltersWithoutCrossFiltering
         : undefined;
 

--- a/libs/sdk-ui-dashboard/src/model/store/filterContext/filterContextReducers.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/filterContext/filterContextReducers.ts
@@ -800,6 +800,17 @@ const resetWorkingSelection: FilterContextReducer<PayloadAction> = (state) => {
 //
 //
 
+const setDefaultFilterOverrides: FilterContextReducer<PayloadAction<FilterContextItem[]>> = (
+    state,
+    action,
+) => {
+    state.defaultFilterOverrides = action.payload;
+};
+
+//
+//
+//
+
 export const filterContextReducers = {
     setFilterContext,
     updateFilterContextIdentity,
@@ -823,4 +834,5 @@ export const filterContextReducers = {
     setPreloadedAttributesWithReferences,
     applyWorkingSelection,
     resetWorkingSelection,
+    setDefaultFilterOverrides,
 };

--- a/libs/sdk-ui-dashboard/src/model/store/filterContext/filterContextSelectors.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/filterContext/filterContextSelectors.ts
@@ -666,3 +666,11 @@ export const selectPreloadedAttributesWithReferences: DashboardSelector<
 > = createSelector(selectSelf, (state) => {
     return state.attributesWithReferences;
 });
+
+/**
+ * Selects default filter overrides for the dashboard.
+ *
+ * @beta
+ */
+export const selectDefaultFilterOverrides: DashboardSelector<FilterContextItem[] | undefined> =
+    createSelector(selectSelf, (state) => state.defaultFilterOverrides);

--- a/libs/sdk-ui-dashboard/src/model/store/filterContext/filterContextState.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/filterContext/filterContextState.ts
@@ -7,6 +7,7 @@ import {
     IAttributeDisplayFormMetadataObject,
     IDashboardAttributeFilter,
     IDashboardDateFilter,
+    FilterContextItem,
 } from "@gooddata/sdk-model";
 
 /**
@@ -100,6 +101,13 @@ export interface FilterContextState {
      * @beta
      */
     attributesWithReferences?: IAttributeWithReferences[];
+
+    /**
+     * Default filter overrides for the dashboard, provided via `overrideDefaultFilters` dashboard config,
+     * after sanitization and merging with the original filter context definition.
+     * @beta
+     */
+    defaultFilterOverrides?: FilterContextItem[];
 }
 
 export const filterContextInitialState: FilterContextState = {
@@ -108,4 +116,5 @@ export const filterContextInitialState: FilterContextState = {
     filterContextIdentity: undefined,
     attributeFilterDisplayForms: undefined,
     attributesWithReferences: undefined,
+    defaultFilterOverrides: undefined,
 };

--- a/libs/sdk-ui-dashboard/src/model/store/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/index.ts
@@ -193,6 +193,7 @@ export {
     selectIsAttributeFilterDependentByLocalIdentifier,
     selectFilterContextDateFilterByDataSet,
     selectPreloadedAttributesWithReferences,
+    selectDefaultFilterOverrides,
 } from "./filterContext/filterContextSelectors.js";
 export { getFilterIdentifier } from "./filterContext/filterContextUtils.js";
 export type { IImplicitDrillWithPredicates } from "./widgetDrills/widgetDrillSelectors.js";


### PR DESCRIPTION
When using overrideDefaultFilters,
always store them in scheduled export.

E. g. when using shared dashboard filter context via url, expected is that user wants to save them in the scheduled export, and not the default dashboard filter context.

User is still able to opt out and use
the default dashboard filter context by configuration in the scheduled export dialog.

risk: low
JIRA: F1-1208

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```

#### Commands for Bear platform working on branch rel/9.9

```
extended-test-legacy --backstop
extended-test-legacy --isolated
extended-test-legacy --record
```
