### PR TITLE
fix: omit date filter local identifiers when undefined

### DIFF
--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/filterContext/changeFilterContextSelectionHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/filterContext/changeFilterContextSelectionHandler.ts
@@ -359,11 +359,14 @@ function* getDateFilterUpdateActions(
             return [];
         }
 
+        const localIdentifierObj = dateFilter.dateFilter.localIdentifier
+            ? { localIdentifier: dateFilter.dateFilter.localIdentifier }
+            : {};
         const upsertPayload: IUpsertDateFilterPayload = isAllTimeDashboardDateFilter(dateFilter)
             ? {
                   type: "allTime",
                   dataSet: dateFilter.dateFilter.dataSet,
-                  localIdentifier: dateFilter.dateFilter.localIdentifier,
+                  ...localIdentifierObj,
               }
             : {
                   type: dateFilter.dateFilter.type,
@@ -371,7 +374,7 @@ function* getDateFilterUpdateActions(
                   from: dateFilter.dateFilter.from,
                   to: dateFilter.dateFilter.to,
                   dataSet: dateFilter.dateFilter.dataSet,
-                  localIdentifier: dateFilter.dateFilter.localIdentifier,
+                  ...localIdentifierObj,
               };
 
         return [filterContextActions.upsertDateFilter(upsertPayload)];
@@ -395,12 +398,15 @@ function* getDateFiltersUpdateActions(
             yield select(selectFilterContextDateFilterByDataSet(filterRef));
 
         if (dashboardFilter) {
+            const localIdentifierObj = dateFilter.dateFilter.localIdentifier
+                ? { localIdentifier: dateFilter.dateFilter.localIdentifier }
+                : {};
             handledDataSets.add(serializeObjRef(dashboardFilter.dateFilter.dataSet!));
             const upsertPayload: IUpsertDateFilterPayload = isAllTimeDashboardDateFilter(dateFilter)
                 ? {
                       type: "allTime",
                       dataSet: dateFilter.dateFilter.dataSet,
-                      localIdentifier: dateFilter.dateFilter.localIdentifier,
+                      ...localIdentifierObj,
                   }
                 : {
                       type: dateFilter.dateFilter.type,
@@ -408,7 +414,7 @@ function* getDateFiltersUpdateActions(
                       from: dateFilter.dateFilter.from,
                       to: dateFilter.dateFilter.to,
                       dataSet: dateFilter.dateFilter.dataSet,
-                      localIdentifier: dateFilter.dateFilter.localIdentifier,
+                      ...localIdentifierObj,
                   };
 
             updateActions.push(filterContextActions.upsertDateFilter(upsertPayload));
@@ -425,11 +431,14 @@ function* getDateFiltersUpdateActions(
         );
         if (unhandledFilters.length > 0) {
             for (const dateFilter of dateFilters) {
+                const localIdentifierObj = dateFilter.dateFilter.localIdentifier
+                    ? { localIdentifier: dateFilter.dateFilter.localIdentifier }
+                    : {};
                 updateActions.push(
                     filterContextActions.upsertDateFilter({
                         type: "allTime",
                         dataSet: dateFilter.dateFilter.dataSet,
-                        localIdentifier: dateFilter.dateFilter.localIdentifier,
+                        ...localIdentifierObj,
                     }),
                 );
             }

--- a/libs/sdk-ui-dashboard/src/model/store/filterContext/filterContextReducers.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/filterContext/filterContextReducers.ts
@@ -221,7 +221,10 @@ const upsertDateFilter: FilterContextReducer<PayloadAction<IUpsertDateFilterPayl
             dateFilter.dateFilter.granularity = granularity;
             dateFilter.dateFilter.from = from;
             dateFilter.dateFilter.to = to;
-            dateFilter.dateFilter.localIdentifier = localIdentifier;
+
+            if (localIdentifier) {
+                dateFilter.dateFilter.localIdentifier = localIdentifier;
+            }
         }
     } else {
         const { type, granularity, from, to, dataSet, localIdentifier } = action.payload;
@@ -232,7 +235,7 @@ const upsertDateFilter: FilterContextReducer<PayloadAction<IUpsertDateFilterPayl
                 from,
                 to,
                 ...(dataSet ? { dataSet } : {}),
-                localIdentifier,
+                ...(localIdentifier ? { localIdentifier } : {}),
             },
         });
     }


### PR DESCRIPTION
JIRA: F1-1291
risk: low

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```

#### Commands for Bear platform working on branch rel/9.9

```
extended-test-legacy --backstop
extended-test-legacy --isolated
extended-test-legacy --record
```
