### PR TITLE
fix: automation attribute filters reloading

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/automationFilters/components/AutomationAttributeFilterContext.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/automationFilters/components/AutomationAttributeFilterContext.tsx
@@ -1,0 +1,47 @@
+// (C) 2025 GoodData Corporation
+
+import React from "react";
+import { FilterContextItem, IDashboardAttributeFilter } from "@gooddata/sdk-model";
+
+const AutomationAttributeFilterContext = React.createContext<IAutomationAttributeFilterContext | null>(null);
+
+/**
+ * @internal
+ */
+export interface IAutomationAttributeFilterContext {
+    onChange: (filter: FilterContextItem) => void;
+    onDelete: (filter: FilterContextItem) => void;
+    filter: IDashboardAttributeFilter;
+    isLocked?: boolean;
+}
+
+/**
+ * @internal
+ */
+export const useAutomationAttributeFilterContext = () => {
+    const context = React.useContext(AutomationAttributeFilterContext);
+    if (!context) {
+        throw new Error("AutomationAttributeFilterContext not found");
+    }
+    return context;
+};
+
+export interface IAutomationAttributeFilterProviderProps extends IAutomationAttributeFilterContext {
+    children: React.ReactNode;
+}
+/**
+ * @internal
+ */
+export const AutomationAttributeFilterProvider = ({
+    children,
+    onChange,
+    onDelete,
+    isLocked,
+    filter,
+}: IAutomationAttributeFilterProviderProps) => {
+    return (
+        <AutomationAttributeFilterContext.Provider value={{ onChange, onDelete, isLocked, filter }}>
+            {children}
+        </AutomationAttributeFilterContext.Provider>
+    );
+};

--- a/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/hooks/useEditScheduledEmail.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/hooks/useEditScheduledEmail.ts
@@ -410,9 +410,9 @@ export function useEditScheduledEmail(props: IUseEditScheduledEmailProps) {
     const onUseFiltersChange = useCallback(
         (value: boolean, filters: FilterContextItem[]) => {
             setUseFilters(value);
-            if (value) {
-                onFiltersChange(filters, value);
-            } else {
+            onFiltersChange(filters, value);
+
+            if (!value) {
                 setEditedAutomation((s) => ({
                     ...s,
                     exportDefinitions: s.exportDefinitions?.map((exportDefinition) => {


### PR DESCRIPTION
Avoid full re-init of the attribute filter on each change.

Propagate additional data to attribute filter sub-components via context, rather than via useMemo.

risk: low
JIRA: F1-1249

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```

#### Commands for Bear platform working on branch rel/9.9

```
extended-test-legacy --backstop
extended-test-legacy --isolated
extended-test-legacy --record
```
