### PR TITLE
fix: rework automation filters logic

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/automationFilters/AutomationFilters.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/automationFilters/AutomationFilters.tsx
@@ -34,7 +34,7 @@ export interface IAutomationFiltersProps {
     handleDeleteFilter: (filter: FilterContextItem) => void;
     handleAddFilter: (displayForm: ObjRef) => void;
     storeFilters: boolean;
-    onStoreFiltersChange: (value: boolean, filters: FilterContextItem[]) => void;
+    handleStoreFiltersChange: (value: boolean) => void;
     isDashboardAutomation?: boolean;
     areFiltersMissing?: boolean;
 }
@@ -51,7 +51,7 @@ export const AutomationFilters: React.FC<IAutomationFiltersProps> = ({
     handleAddFilter,
     isDashboardAutomation,
     storeFilters,
-    onStoreFiltersChange,
+    handleStoreFiltersChange,
     areFiltersMissing,
 }) => {
     const theme = useTheme();
@@ -153,7 +153,7 @@ export const AutomationFilters: React.FC<IAutomationFiltersProps> = ({
                         type="checkbox"
                         className="input-checkbox s-checkbox"
                         checked={storeFilters}
-                        onChange={(e) => onStoreFiltersChange(e.target.checked, filters)}
+                        onChange={(e) => handleStoreFiltersChange(e.target.checked)}
                         aria-label={intl.formatMessage({
                             id: "dialogs.automation.filters.attachment",
                         })}

--- a/libs/sdk-ui-dashboard/src/presentation/automationFilters/useAutomationDashboardFilters.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/automationFilters/useAutomationDashboardFilters.ts
@@ -7,7 +7,7 @@ import { getVisibleFiltersByFilters } from "./utils.js";
 interface IUseAutomationDashboardFiltersResult {
     storeFilters: boolean;
     setStoreFilters: React.Dispatch<React.SetStateAction<boolean>>;
-    effectiveDashboardFilters: FilterContextItem[] | undefined;
+    automationDashboardFilters: FilterContextItem[] | undefined;
     visibleDashboardFilters: IAutomationVisibleFilter[] | undefined;
 }
 
@@ -16,14 +16,12 @@ interface IUseAutomationDashboardFiltersResult {
  */
 export const useAutomationDashboardFilters = ({
     editAutomation,
-    dashboardFilters,
+    automationFilters,
     allVisibleFiltersMetadata,
-    enableAutomationFilterContext,
 }: {
     editAutomation: IAutomationMetadataObject | undefined;
-    dashboardFilters: FilterContextItem[] | undefined;
+    automationFilters: FilterContextItem[] | undefined;
     allVisibleFiltersMetadata?: IAutomationVisibleFilter[] | undefined;
-    enableAutomationFilterContext?: boolean;
 }): IUseAutomationDashboardFiltersResult => {
     const areFiltersStored = useMemo(
         () =>
@@ -33,25 +31,16 @@ export const useAutomationDashboardFilters = ({
         [editAutomation],
     );
     const visibleFilters = useMemo(
-        () => getVisibleFiltersByFilters(dashboardFilters, allVisibleFiltersMetadata),
-        [dashboardFilters, allVisibleFiltersMetadata],
+        () => getVisibleFiltersByFilters(automationFilters, allVisibleFiltersMetadata),
+        [automationFilters, allVisibleFiltersMetadata],
     );
 
     const [storeFilters, setStoreFilters] = useState(areFiltersStored);
 
-    if (!enableAutomationFilterContext) {
-        return {
-            storeFilters: false,
-            setStoreFilters: () => {},
-            effectiveDashboardFilters: dashboardFilters,
-            visibleDashboardFilters: undefined,
-        };
-    }
-
     return {
         storeFilters,
         setStoreFilters,
-        effectiveDashboardFilters: storeFilters ? dashboardFilters : undefined,
+        automationDashboardFilters: storeFilters ? automationFilters : undefined,
         visibleDashboardFilters: storeFilters ? visibleFilters : undefined,
     };
 };

--- a/libs/sdk-ui-dashboard/src/presentation/automationFilters/useAutomationFilters.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/automationFilters/useAutomationFilters.ts
@@ -25,10 +25,12 @@ export const useAutomationFilters = ({
     availableFilters,
     selectedFilters,
     onFiltersChange,
+    onStoreFiltersChange,
 }: {
     availableFilters: FilterContextItem[];
     selectedFilters: FilterContextItem[];
     onFiltersChange: (filters: FilterContextItem[]) => void;
+    onStoreFiltersChange: (shouldStore: boolean, filters: FilterContextItem[]) => void;
 }) => {
     const allAttributes = useDashboardSelector(selectCatalogAttributes);
     const allDateDatasets = useDashboardSelector(selectCatalogDateDatasets);
@@ -92,6 +94,13 @@ export const useAutomationFilters = ({
         [nonSelectedFilters, onFiltersChange, selectedFilters],
     );
 
+    const handleStoreFiltersChange = useCallback(
+        (value: boolean) => {
+            onStoreFiltersChange(value, selectedFilters);
+        },
+        [onStoreFiltersChange, selectedFilters],
+    );
+
     return {
         visibleFilters,
         attributes,
@@ -101,5 +110,6 @@ export const useAutomationFilters = ({
         handleChangeFilter,
         handleDeleteFilter,
         handleAddFilter,
+        handleStoreFiltersChange,
     };
 };

--- a/libs/sdk-ui-dashboard/src/presentation/automationFilters/useAutomationWidgetFilters.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/automationFilters/useAutomationWidgetFilters.ts
@@ -6,7 +6,6 @@ import {
     filterLocalIdentifier,
     IAutomationVisibleFilter,
     IFilter,
-    IInsightWidget,
     isInsightWidget,
 } from "@gooddata/sdk-model";
 import compact from "lodash/compact.js";
@@ -25,24 +24,24 @@ interface IUseAutomationWidgetFilters {
  */
 export const useAutomationWidgetFilters = ({
     widget,
-    allDashboardFilters,
+    allDashboardFilters = [],
+    automationFilters = [],
     widgetFilters,
     allVisibleFiltersMetadata,
-    enableAutomationFilterContext,
 }: {
     widget: ExtendedDashboardWidget | undefined;
-    allDashboardFilters?: FilterContextItem[] | undefined;
+    allDashboardFilters?: FilterContextItem[];
+    automationFilters?: FilterContextItem[];
     widgetFilters?: IFilter[] | undefined;
     allVisibleFiltersMetadata?: IAutomationVisibleFilter[] | undefined;
-    enableAutomationFilterContext?: boolean;
 }): IUseAutomationWidgetFilters => {
     const visibleFilters = useMemo(
-        () => getVisibleFiltersByFilters(allDashboardFilters, allVisibleFiltersMetadata),
-        [allDashboardFilters, allVisibleFiltersMetadata],
+        () => getVisibleFiltersByFilters(automationFilters, allVisibleFiltersMetadata),
+        [automationFilters, allVisibleFiltersMetadata],
     );
 
     const dashboardFiltersLocalIdentifiers = useMemo(
-        () => compact((allDashboardFilters ?? []).map(getFilterLocalIdentifier)),
+        () => compact(allDashboardFilters.map(getFilterLocalIdentifier)),
         [allDashboardFilters],
     );
 
@@ -56,17 +55,8 @@ export const useAutomationWidgetFilters = ({
     );
 
     const dashboardExecutionFilters = isInsightWidget(widget)
-        ? filterContextItemsToDashboardFiltersByWidget(allDashboardFilters ?? [], widget as IInsightWidget)
+        ? filterContextItemsToDashboardFiltersByWidget(automationFilters, widget)
         : [];
-
-    // When FF is off, return widget filters for previous experience
-    if (!enableAutomationFilterContext) {
-        return {
-            insightExecutionFilters: widgetFilters ?? [],
-            dashboardExecutionFilters: [],
-            visibleWidgetFilters: undefined,
-        };
-    }
 
     return {
         insightExecutionFilters,

--- a/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/DefaultScheduledEmailDialog.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/DefaultScheduledEmailDialog.tsx
@@ -158,7 +158,6 @@ export function ScheduledMailDialogRenderer({
         storedDashboardFilters: dashboardFilters,
         storedWidgetFilters: widgetFilters,
         metadataVisibleFilters: scheduledExportToEdit?.metadata?.visibleFilters,
-        enableAutomationFilterContext,
         isEditing: !!scheduledExportToEdit,
     });
 
@@ -194,7 +193,8 @@ export function ScheduledMailDialogRenderer({
         widget,
         scheduledExportToEdit,
         allDashboardFilters,
-        dashboardFilters: automationFilters,
+        automationFilters,
+        dashboardFilters,
         widgetFilters,
         maxAutomationsRecipients,
         setAutomationFilters,

--- a/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/components/AutomationFiltersSelect/AutomationFiltersSelect.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/components/AutomationFiltersSelect/AutomationFiltersSelect.tsx
@@ -34,10 +34,12 @@ export const AutomationFiltersSelect: React.FC<IAutomationFiltersSelectProps> = 
         handleAddFilter,
         handleDeleteFilter,
         handleChangeFilter,
+        handleStoreFiltersChange,
     } = useAutomationFilters({
         availableFilters,
         selectedFilters,
         onFiltersChange,
+        onStoreFiltersChange,
     });
 
     const numberOfSelectedFilters = visibleFilters.length;
@@ -62,7 +64,7 @@ export const AutomationFiltersSelect: React.FC<IAutomationFiltersSelectProps> = 
                 handleDeleteFilter={handleDeleteFilter}
                 handleChangeFilter={handleChangeFilter}
                 storeFilters={storeFilters}
-                onStoreFiltersChange={onStoreFiltersChange}
+                handleStoreFiltersChange={handleStoreFiltersChange}
                 isDashboardAutomation={isDashboardAutomation}
                 areFiltersMissing={areFiltersMissing}
             />

--- a/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/hooks/useEditScheduledEmail.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/hooks/useEditScheduledEmail.ts
@@ -69,6 +69,9 @@ export interface IUseEditScheduledEmailProps {
     // Dashboard filters at all times
     allDashboardFilters?: FilterContextItem[];
 
+    // New automation filters
+    automationFilters?: FilterContextItem[];
+
     // In case we are editing dashboard scheduled export
     dashboardFilters?: FilterContextItem[];
 
@@ -89,6 +92,7 @@ export function useEditScheduledEmail(props: IUseEditScheduledEmailProps) {
         insight,
         widget,
         allDashboardFilters,
+        automationFilters,
         dashboardFilters,
         widgetFilters,
         maxAutomationsRecipients,
@@ -124,17 +128,27 @@ export function useEditScheduledEmail(props: IUseEditScheduledEmailProps) {
         useAutomationWidgetFilters({
             widget,
             allDashboardFilters,
+            automationFilters,
             widgetFilters,
             allVisibleFiltersMetadata,
-            enableAutomationFilterContext,
         });
-    const { storeFilters, setStoreFilters, effectiveDashboardFilters, visibleDashboardFilters } =
+    const { storeFilters, setStoreFilters, automationDashboardFilters, visibleDashboardFilters } =
         useAutomationDashboardFilters({
             editAutomation: scheduledExportToEdit,
-            dashboardFilters,
+            automationFilters,
             allVisibleFiltersMetadata,
-            enableAutomationFilterContext,
         });
+
+    const effectiveWidgetFilters = enableAutomationFilterContext
+        ? [...dashboardExecutionFilters, ...insightExecutionFilters]
+        : widgetFilters;
+    const effectiveVisibleWidgetFilters = enableAutomationFilterContext ? visibleWidgetFilters : undefined;
+    const effectiveDashboardFilters = enableAutomationFilterContext
+        ? automationDashboardFilters
+        : dashboardFilters;
+    const effectiveVisibleDashboardFilters = enableAutomationFilterContext
+        ? visibleDashboardFilters
+        : undefined;
 
     const [editedAutomation, setEditedAutomation] = useState<IAutomationMetadataObjectDefinition>(
         scheduledExportToEdit ??
@@ -147,10 +161,8 @@ export function useEditScheduledEmail(props: IUseEditScheduledEmailProps) {
                           insight,
                           widget,
                           recipient: defaultRecipient,
-                          widgetFilters: enableAutomationFilterContext
-                              ? [...dashboardExecutionFilters, ...insightExecutionFilters]
-                              : widgetFilters,
-                          visibleFiltersMetadata: visibleWidgetFilters,
+                          widgetFilters: effectiveWidgetFilters,
+                          visibleFiltersMetadata: effectiveVisibleWidgetFilters,
                       }
                     : {
                           timezone,
@@ -159,7 +171,7 @@ export function useEditScheduledEmail(props: IUseEditScheduledEmailProps) {
                           title: dashboardTitle,
                           recipient: defaultRecipient,
                           dashboardFilters: effectiveDashboardFilters,
-                          visibleFiltersMetadata: visibleDashboardFilters,
+                          visibleFiltersMetadata: effectiveVisibleDashboardFilters,
                       },
             ),
     );


### PR DESCRIPTION
- use initial automation filters in all necessary hooks as these filters store the main filter information in schedule
- consider hidden filters when checking if any filter is missing on dashboard
- respect ignored widget filters by default
- add all time date filter when it is not present
- filter out all-valued widget filters when FF is on

JIRA: F1-1249
risk: low

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```

#### Commands for Bear platform working on branch rel/9.9

```
extended-test-legacy --backstop
extended-test-legacy --isolated
extended-test-legacy --record
```
