### PR TITLE
fix: place threshold zones at correct index

### DIFF
--- a/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartOptions/test/__snapshots__/chartThresholds.test.ts.snap
+++ b/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartOptions/test/__snapshots__/chartThresholds.test.ts.snap
@@ -1,0 +1,255 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`generateZones > should generate expected zones and plot lines for threshold series [ +0 ] 1`] = `
+{
+  "plotLines": [],
+  "zones": [
+    {
+      "dashStyle": "shortDash",
+    },
+  ],
+}
+`;
+
+exports[`generateZones > should generate expected zones and plot lines for threshold series [ +0, +0 ] 1`] = `
+{
+  "plotLines": [],
+  "zones": [
+    {
+      "dashStyle": "shortDash",
+    },
+  ],
+}
+`;
+
+exports[`generateZones > should generate expected zones and plot lines for threshold series [ +0, +0, 1 ] 1`] = `
+{
+  "plotLines": [
+    2,
+  ],
+  "zones": [
+    {
+      "dashStyle": "shortDash",
+      "value": 2,
+    },
+    {
+      "dashStyle": "solid",
+    },
+  ],
+}
+`;
+
+exports[`generateZones > should generate expected zones and plot lines for threshold series [ +0, 1 ] 1`] = `
+{
+  "plotLines": [
+    1,
+  ],
+  "zones": [
+    {
+      "dashStyle": "shortDash",
+      "value": 1,
+    },
+    {
+      "dashStyle": "solid",
+    },
+  ],
+}
+`;
+
+exports[`generateZones > should generate expected zones and plot lines for threshold series [ +0, 1, +0, 1 ] 1`] = `
+{
+  "plotLines": [
+    1,
+    1,
+    3,
+  ],
+  "zones": [
+    {
+      "dashStyle": "shortDash",
+      "value": 1,
+    },
+    {
+      "dashStyle": "solid",
+      "value": 1,
+    },
+    {
+      "dashStyle": "shortDash",
+      "value": 3,
+    },
+    {
+      "dashStyle": "solid",
+    },
+  ],
+}
+`;
+
+exports[`generateZones > should generate expected zones and plot lines for threshold series [ +0, 1, 1 ] 1`] = `
+{
+  "plotLines": [
+    1,
+  ],
+  "zones": [
+    {
+      "dashStyle": "shortDash",
+      "value": 1,
+    },
+    {
+      "dashStyle": "solid",
+    },
+  ],
+}
+`;
+
+exports[`generateZones > should generate expected zones and plot lines for threshold series [ 1 ] 1`] = `
+{
+  "plotLines": [],
+  "zones": [],
+}
+`;
+
+exports[`generateZones > should generate expected zones and plot lines for threshold series [ 1, +0 ] 1`] = `
+{
+  "plotLines": [
+    0,
+  ],
+  "zones": [
+    {
+      "dashStyle": "solid",
+      "value": 0,
+    },
+    {
+      "dashStyle": "shortDash",
+    },
+  ],
+}
+`;
+
+exports[`generateZones > should generate expected zones and plot lines for threshold series [ 1, +0, +0 ] 1`] = `
+{
+  "plotLines": [
+    0,
+  ],
+  "zones": [
+    {
+      "dashStyle": "solid",
+      "value": 0,
+    },
+    {
+      "dashStyle": "shortDash",
+    },
+  ],
+}
+`;
+
+exports[`generateZones > should generate expected zones and plot lines for threshold series [ 1, +0, 1, +0 ] 1`] = `
+{
+  "plotLines": [
+    0,
+    2,
+    2,
+  ],
+  "zones": [
+    {
+      "dashStyle": "solid",
+      "value": 0,
+    },
+    {
+      "dashStyle": "shortDash",
+      "value": 2,
+    },
+    {
+      "dashStyle": "solid",
+      "value": 2,
+    },
+    {
+      "dashStyle": "shortDash",
+    },
+  ],
+}
+`;
+
+exports[`generateZones > should generate expected zones and plot lines for threshold series [ 1, +0, 1, 1 ] 1`] = `
+{
+  "plotLines": [
+    0,
+    2,
+  ],
+  "zones": [
+    {
+      "dashStyle": "solid",
+      "value": 0,
+    },
+    {
+      "dashStyle": "shortDash",
+      "value": 2,
+    },
+    {
+      "dashStyle": "solid",
+    },
+  ],
+}
+`;
+
+exports[`generateZones > should generate expected zones and plot lines for threshold series [ 1, 1 ] 1`] = `
+{
+  "plotLines": [],
+  "zones": [],
+}
+`;
+
+exports[`generateZones > should generate expected zones and plot lines for threshold series [ 1, 1, +0 ] 1`] = `
+{
+  "plotLines": [
+    1,
+  ],
+  "zones": [
+    {
+      "dashStyle": "solid",
+      "value": 1,
+    },
+    {
+      "dashStyle": "shortDash",
+    },
+  ],
+}
+`;
+
+exports[`generateZones > should generate expected zones and plot lines for threshold series [ 1, 1, +0, 1 ] 1`] = `
+{
+  "plotLines": [
+    1,
+    3,
+  ],
+  "zones": [
+    {
+      "dashStyle": "solid",
+      "value": 1,
+    },
+    {
+      "dashStyle": "shortDash",
+      "value": 3,
+    },
+    {
+      "dashStyle": "solid",
+    },
+  ],
+}
+`;
+
+exports[`generateZones > should generate expected zones and plot lines for threshold series [ null ] 1`] = `
+{
+  "plotLines": [],
+  "zones": [
+    {
+      "dashStyle": "shortDash",
+    },
+  ],
+}
+`;
+
+exports[`generateZones > should generate expected zones and plot lines for threshold series [] 1`] = `
+{
+  "plotLines": [],
+  "zones": [],
+}
+`;

--- a/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartOptions/test/chartThresholds.test.ts
+++ b/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartOptions/test/chartThresholds.test.ts
@@ -1,0 +1,35 @@
+// (C) 2025 GoodData Corporation
+import { describe, it, expect } from "vitest";
+import { generateZones, getTrendDividerPlotLines } from "../chartThresholds";
+
+const generateZonesFromData = (data: (number | null)[]) => {
+    const thresholdSeries = data.map((value) => ({ y: value }));
+    return {
+        zones: generateZones(thresholdSeries),
+        plotLines: getTrendDividerPlotLines(thresholdSeries),
+    };
+};
+
+describe("generateZones", () => {
+    it.each([
+        [[]],
+        [[1]],
+        [[0]],
+        [[null]],
+        [[1, 1]],
+        [[0, 0]],
+        [[0, 1]],
+        [[1, 0]],
+        [[1, 0, 0]],
+        [[1, 1, 0]],
+        [[0, 1, 1]],
+        [[0, 0, 1]],
+        [[1, 0, 1, 1]],
+        [[1, 1, 0, 1]],
+        [[0, 1, 0, 1]],
+        [[1, 0, 1, 0]],
+    ])("should generate expected zones and plot lines for threshold series %s", (data: (number | null)[]) => {
+        const zones = generateZonesFromData(data);
+        expect(zones).toMatchSnapshot();
+    });
+});


### PR DESCRIPTION
When zone changed from dashed to solid, the threshold point
was placed correctly. When zone changed from solid to dashed,
the threshold point was on index+1 than it should be. Technically,
the placement was correct but it was misleading.

Also, fix issue when threshold measure was rendered when
no zone was generated.

JIRA: LX-1072
risk: low

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```

#### Commands for Bear platform working on branch rel/9.9

```
extended-test-legacy --backstop
extended-test-legacy --isolated
extended-test-legacy --record
```
