### PR TITLE
feat: filters in notifications

### DIFF
--- a/libs/sdk-ui-ext/src/internal/translations/en-US.json
+++ b/libs/sdk-ui-ext/src/internal/translations/en-US.json
@@ -2069,12 +2069,12 @@
         "limit": 0
     },
     "notifications.filters.buttonLabel": {
-        "value": "Show filters",
+        "value": "{count, plural, one {# filter} other {# filters}}",
         "comment": "",
         "limit": 0
     },
     "notifications.filters.dialog.title": {
-        "value": "Applied filters",
+        "value": "Filters",
         "comment": "",
         "limit": 0
     },

--- a/libs/sdk-ui-ext/src/notificationsPanel/Notification/AlertNotification.tsx
+++ b/libs/sdk-ui-ext/src/notificationsPanel/Notification/AlertNotification.tsx
@@ -1,13 +1,14 @@
 // (C) 2024-2025 GoodData Corporation
-import React, { useCallback } from "react";
 import { IAlertDescription, IAlertNotification, INotification } from "@gooddata/sdk-model";
-import { getDateTimeConfig, IDateConfig, UiIcon, isActionKey } from "@gooddata/sdk-ui-kit";
+import { getDateTimeConfig, IDateConfig, isActionKey, UiIcon } from "@gooddata/sdk-ui-kit";
+import React, { useCallback } from "react";
 import { bem } from "../bem.js";
-import { Tooltip } from "../components/Tooltip.js";
 import { Popup } from "../components/Popup.js";
+import { Tooltip } from "../components/Tooltip.js";
 // import { NotificationFiltersDetail } from "../NotificationFiltersDetail/NotificationFiltersDetail.js";
-import { NotificationTriggerDetail } from "../NotificationTriggersDetail/NotificationTriggersDetail.js";
 import { defineMessages, FormattedDate, FormattedMessage, FormattedTime, useIntl } from "react-intl";
+import { NotificationFiltersDetail } from "../NotificationFiltersDetail/NotificationFiltersDetail.js";
+import { NotificationTriggerDetail } from "../NotificationTriggersDetail/NotificationTriggersDetail.js";
 
 /**
  * @internal
@@ -58,16 +59,22 @@ export function AlertNotification({
         }
     };
 
-    // Hide filters for now, as there is lot of unresolved cases to consider
-    // const filterCount = notification.details.data.alert.filterCount;
-    // const isSliced = notification.details.data.alert.attribute;
-    // const showSeparator = filterCount && filterCount > 0 && isSliced;
     const notificationTitle = getNotificationTitle(notification);
+
+    const filters = notification.details.data.filters;
+    const hasFilters = !!filters?.length;
+
     const isSliced = notification.details.data.alert.attribute;
-    const hasTriggers = notification.details.data.alert.totalValueCount > 0;
+    const hasTriggers = !!notification.details.data.alert.totalValueCount;
+
     const isError = notification.details.data.alert.status !== "SUCCESS";
     const errorMessage = notification.details.data.alert.errorMessage;
     const traceId = notification.details.data.alert.traceId;
+
+    const actions = [
+        hasFilters && <NotificationFiltersDetail filters={filters} />,
+        hasTriggers && isSliced && <NotificationTriggerDetail notification={notification} />,
+    ].filter((x): x is React.JSX.Element => !!x);
 
     return (
         <div
@@ -103,25 +110,21 @@ export function AlertNotification({
                                 }
                             >
                                 {({ toggle, id }) => (
-                                    <u
-                                        data-id="notification-error"
-                                        id={id}
-                                        onClick={() => {
-                                            toggle();
-                                        }}
-                                    >
+                                    <u data-id="notification-error" id={id} onClick={toggle}>
                                         <FormattedMessage id="notifications.panel.error.learnMore" />
                                     </u>
                                 )}
                             </Popup>
                         </div>
                     </div>
-                ) : null}
-                {!isError && isSliced && hasTriggers ? (
+                ) : actions.length ? (
                     <div className={e("links")}>
-                        {/* <NotificationFiltersDetail notification={notification} />
-                        {showSeparator ? "・" : null} */}
-                        <NotificationTriggerDetail notification={notification} />
+                        {actions.map((action, index) => (
+                            <React.Fragment key={index}>
+                                {!!index && "・"}
+                                {action}
+                            </React.Fragment>
+                        ))}
                     </div>
                 ) : null}
             </div>

--- a/libs/sdk-ui-ext/src/notificationsPanel/Notification/DefaultNotification.scss
+++ b/libs/sdk-ui-ext/src/notificationsPanel/Notification/DefaultNotification.scss
@@ -138,6 +138,7 @@
         flex-direction: row;
         align-items: center;
         height: 16px;
+        color: var(--gd-palette-complementary-7);
     }
 
     &__error {

--- a/libs/sdk-ui-ext/src/notificationsPanel/NotificationFiltersDetail/NotificationFiltersDetail.tsx
+++ b/libs/sdk-ui-ext/src/notificationsPanel/NotificationFiltersDetail/NotificationFiltersDetail.tsx
@@ -1,9 +1,9 @@
 // (C) 2024-2025 GoodData Corporation
+import { AlertFilters } from "@gooddata/sdk-model";
 import { alignConfigToAlignPoint, Overlay, UiButton } from "@gooddata/sdk-ui-kit";
 import React, { useRef, useState } from "react";
-import { IAlertNotification } from "@gooddata/sdk-model";
-import { NotificationFiltersDetailDialog } from "./NotificationFiltersDetailDialog.js";
 import { defineMessages, useIntl } from "react-intl";
+import { NotificationFiltersDetailDialog } from "./NotificationFiltersDetailDialog.js";
 
 const ALIGN_POINTS = [
     alignConfigToAlignPoint({
@@ -17,7 +17,7 @@ const ALIGN_POINTS = [
  * @internal
  */
 export interface INotificationFiltersDetailProps {
-    notification: IAlertNotification;
+    filters: AlertFilters[];
 }
 
 const messages = defineMessages({
@@ -29,11 +29,11 @@ const messages = defineMessages({
 /**
  * @internal
  */
-export function NotificationFiltersDetail({ notification }: INotificationFiltersDetailProps) {
+export function NotificationFiltersDetail({ filters }: INotificationFiltersDetailProps) {
     const [isFiltersDialogOpen, setIsFiltersDialogOpen] = useState(false);
     const intl = useIntl();
     const ref = useRef<HTMLButtonElement>(null);
-    const filterCount = 0;
+
     const closeFiltersDialog = () => setIsFiltersDialogOpen(false);
     const toggleFiltersDialog = () => setIsFiltersDialogOpen((x) => !x);
     const onButtonClick = (e: React.MouseEvent<HTMLButtonElement>) => {
@@ -43,13 +43,13 @@ export function NotificationFiltersDetail({ notification }: INotificationFilters
 
     return (
         <>
-            {filterCount && filterCount > 0 ? (
+            {filters.length ? (
                 <UiButton
                     buttonRef={ref}
                     onClick={onButtonClick}
                     variant="tertiary"
                     size="small"
-                    label={intl.formatMessage(messages.buttonLabel)}
+                    label={intl.formatMessage(messages.buttonLabel, { count: filters.length })}
                 />
             ) : null}
             {isFiltersDialogOpen ? (
@@ -63,10 +63,7 @@ export function NotificationFiltersDetail({ notification }: INotificationFilters
                     closeOnMouseDrag={false}
                     onClose={closeFiltersDialog}
                 >
-                    <NotificationFiltersDetailDialog
-                        notification={notification}
-                        onClose={closeFiltersDialog}
-                    />
+                    <NotificationFiltersDetailDialog filters={filters} onClose={closeFiltersDialog} />
                 </Overlay>
             ) : null}
         </>

--- a/libs/sdk-ui-ext/src/notificationsPanel/NotificationFiltersDetail/NotificationFiltersDetailDialog.tsx
+++ b/libs/sdk-ui-ext/src/notificationsPanel/NotificationFiltersDetail/NotificationFiltersDetailDialog.tsx
@@ -1,11 +1,9 @@
 // (C) 2024-2025 GoodData Corporation
-import { IAlertNotification } from "@gooddata/sdk-model";
+import { AlertFilters } from "@gooddata/sdk-model";
 import React from "react";
-import { UiSkeleton } from "@gooddata/sdk-ui-kit";
-import { DetailsDialog } from "../components/DetailsDialog.js";
-import { useNotificationsFilterDetail } from "../data/useNotificationFiltersDetail.js";
-import { bem } from "../bem.js";
 import { defineMessages, useIntl } from "react-intl";
+import { bem } from "../bem.js";
+import { DetailsDialog } from "../components/DetailsDialog.js";
 
 const { b, e } = bem("gd-ui-ext-notification-filters-detail-dialog");
 
@@ -19,36 +17,27 @@ const messages = defineMessages({
  * @internal
  */
 export interface INotificationFiltersDetailDialogProps {
-    notification: IAlertNotification;
+    filters: AlertFilters[];
     onClose: () => void;
 }
 
 /**
  * @internal
  */
-export function NotificationFiltersDetailDialog({
-    notification,
-    onClose,
-}: INotificationFiltersDetailDialogProps) {
+export function NotificationFiltersDetailDialog({ filters, onClose }: INotificationFiltersDetailDialogProps) {
     const intl = useIntl();
-    const { filtersInfo, automationPromise } = useNotificationsFilterDetail(notification);
-    const filtersCount = 0;
 
     return (
         <DetailsDialog
-            title={intl.formatMessage(messages.title)}
+            title={`${intl.formatMessage(messages.title)} (${filters.length})`}
             content={
                 <div className={b()}>
-                    {automationPromise.status !== "success" ? (
-                        <UiSkeleton itemHeight={32} itemsCount={filtersCount} />
-                    ) : (
-                        filtersInfo?.map(({ title, subtitle }, idx) => (
-                            <div className={e("item")} key={idx}>
-                                <div className={e("label")}>{title}</div>
-                                <div className={e("values")}>{subtitle}</div>
-                            </div>
-                        ))
-                    )}
+                    {filters.map(({ title, filter }, idx) => (
+                        <div className={e("item")} key={idx}>
+                            <div className={e("label")}>{title}</div>
+                            <div className={e("values")}>{filter}</div>
+                        </div>
+                    ))}
                 </div>
             }
             onClose={onClose}

--- a/libs/sdk-ui-ext/src/notificationsPanel/components/DetailsDialog.scss
+++ b/libs/sdk-ui-ext/src/notificationsPanel/components/DetailsDialog.scss
@@ -1,4 +1,4 @@
-// (C) 2024 GoodData Corporation
+// (C) 2024-2025 GoodData Corporation
 
 .gd-ui-ext-notification-details-dialog {
     width: 245px;
@@ -39,6 +39,8 @@
 
     &__content {
         padding: 10px;
+        max-height: 350px;
+        overflow: auto;
     }
 
     &__footer {

--- a/libs/sdk-ui-ext/src/notificationsPanel/data/useNotifications.tsx
+++ b/libs/sdk-ui-ext/src/notificationsPanel/data/useNotifications.tsx
@@ -46,10 +46,10 @@ export function useNotifications({ workspace, refreshInterval, itemsPerPage }: I
 
     const {
         notifications,
-        hasNextPage: notificationsHasNextPage,
         error: notificationsError,
-        loadNextPage: notificationsLoadNextPage,
         status: notificationsStatus,
+        hasNextPage: notificationsHasNextPage,
+        loadNextPage: notificationsLoadNextPage,
         reset: notificationsReset,
     } = useFetchNotifications({
         workspace: effectiveWorkspace,
@@ -57,11 +57,11 @@ export function useNotifications({ workspace, refreshInterval, itemsPerPage }: I
         itemsPerPage,
     });
     const {
+        notifications: unreadNotifications,
         error: unreadNotificationsError,
+        status: unreadNotificationsStatus,
         hasNextPage: unreadNotificationsHasNextPage,
         loadNextPage: unreadNotificationsLoadNextPage,
-        notifications: unreadNotifications,
-        status: unreadNotificationsStatus,
         totalNotificationsCount: unreadNotificationsCount,
         reset: unreadNotificationsReset,
     } = useFetchNotifications({


### PR DESCRIPTION
1. API: `filters` field introduced in notifications
2. API: 'filterCount` field removed
3. show "visible" filters applied with alert notification if applied

risk: low
JIRA: GDP-2929

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```

#### Commands for Bear platform working on branch rel/9.9

```
extended-test-legacy --backstop
extended-test-legacy --isolated
extended-test-legacy --record
```
