### PR TITLE
fix: multiple date filters with automationId

### DIFF
--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/scheduledEmail/initializeAutomationsHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/scheduledEmail/initializeAutomationsHandler.ts
@@ -217,18 +217,22 @@ function getDashboardFiltersOnly(
         widget,
     );
 
+    // Find common date filter by local id, or use the first date filter in the list if no local ids match.
+    const dateFilters = withoutInsightDateFilters.filter(isDateFilter);
+    const foundCommonFilter =
+        dateFilters.find((f) => {
+            if (isRelativeDateFilter(f)) {
+                return f.relativeDateFilter.localIdentifier === common?.dateFilter.localIdentifier;
+            }
+            return f.absoluteDateFilter.localIdentifier === common?.dateFilter.localIdentifier;
+        }) ?? dateFilters[0];
+
     // Remove dataSet from date filters, as it's not relevant for the dashboard date filter.
     return withoutInsightDateFilters.map((f) => {
-        if (isDateFilter(f)) {
-            if (
-                isRelativeDateFilter(f) &&
-                common?.dateFilter.localIdentifier === f.relativeDateFilter.localIdentifier
-            ) {
+        if (f === foundCommonFilter) {
+            if (isRelativeDateFilter(f)) {
                 return omit(f, "relativeDateFilter.dataSet");
-            } else if (
-                isAbsoluteDateFilter(f) &&
-                common?.dateFilter.localIdentifier === f.absoluteDateFilter.localIdentifier
-            ) {
+            } else if (isAbsoluteDateFilter(f)) {
                 return omit(f, "absoluteDateFilter.dataSet");
             }
         }


### PR DESCRIPTION
Multiple date filter didn't change when accessing DB with automationId

risk: low
JIRA: F1-1292

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```

#### Commands for Bear platform working on branch rel/9.9

```
extended-test-legacy --backstop
extended-test-legacy --isolated
extended-test-legacy --record
```
