### PR TITLE
fix: add codesandbox to examples allowed hosts

### DIFF
--- a/examples/sdk-interactive-examples/examples-template/vite.config.js
+++ b/examples/sdk-interactive-examples/examples-template/vite.config.js
@@ -1,4 +1,4 @@
-// (C) 2007-2022 GoodData Corporation
+// (C) 2007-2025 GoodData Corporation
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react-swc";
 import { createHtmlPlugin } from "vite-plugin-html";
@@ -26,12 +26,13 @@ export default defineConfig({
             "~@gooddata": "/node_modules/@gooddata",
         },
     },
-    build:{
-        outDir: 'esm',
-        chunkSizeWarningLimit:10000
+    build: {
+        outDir: "esm",
+        chunkSizeWarningLimit: 10000,
     },
     server: {
         port: 8080,
+        allowedHosts: [".csb.app"],
         fs: {
             strict: false,
         },

--- a/examples/sdk-interactive-examples/examples/example-attributefilter/vite.config.js
+++ b/examples/sdk-interactive-examples/examples/example-attributefilter/vite.config.js
@@ -1,4 +1,4 @@
-// (C) 2007-2022 GoodData Corporation
+// (C) 2007-2025 GoodData Corporation
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react-swc";
 import { createHtmlPlugin } from "vite-plugin-html";
@@ -26,12 +26,13 @@ export default defineConfig({
             "~@gooddata": "/node_modules/@gooddata",
         },
     },
-    build:{
-        outDir: 'esm',
-        chunkSizeWarningLimit:10000
+    build: {
+        outDir: "esm",
+        chunkSizeWarningLimit: 10000,
     },
     server: {
         port: 8080,
+        allowedHosts: [".csb.app"],
         fs: {
             strict: false,
         },

--- a/examples/sdk-interactive-examples/examples/example-chartconfig/vite.config.js
+++ b/examples/sdk-interactive-examples/examples/example-chartconfig/vite.config.js
@@ -1,4 +1,4 @@
-// (C) 2007-2022 GoodData Corporation
+// (C) 2007-2025 GoodData Corporation
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react-swc";
 import { createHtmlPlugin } from "vite-plugin-html";
@@ -26,12 +26,13 @@ export default defineConfig({
             "~@gooddata": "/node_modules/@gooddata",
         },
     },
-    build:{
-        outDir: 'esm',
-        chunkSizeWarningLimit:10000
+    build: {
+        outDir: "esm",
+        chunkSizeWarningLimit: 10000,
     },
     server: {
         port: 8080,
+        allowedHosts: [".csb.app"],
         fs: {
             strict: false,
         },

--- a/examples/sdk-interactive-examples/examples/example-columnchart/vite.config.js
+++ b/examples/sdk-interactive-examples/examples/example-columnchart/vite.config.js
@@ -1,4 +1,4 @@
-// (C) 2007-2022 GoodData Corporation
+// (C) 2007-2025 GoodData Corporation
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react-swc";
 import { createHtmlPlugin } from "vite-plugin-html";
@@ -26,12 +26,13 @@ export default defineConfig({
             "~@gooddata": "/node_modules/@gooddata",
         },
     },
-    build:{
-        outDir: 'esm',
-        chunkSizeWarningLimit:10000
+    build: {
+        outDir: "esm",
+        chunkSizeWarningLimit: 10000,
     },
     server: {
         port: 8080,
+        allowedHosts: [".csb.app"],
         fs: {
             strict: false,
         },

--- a/examples/sdk-interactive-examples/examples/example-combochart/vite.config.js
+++ b/examples/sdk-interactive-examples/examples/example-combochart/vite.config.js
@@ -1,4 +1,4 @@
-// (C) 2007-2022 GoodData Corporation
+// (C) 2007-2025 GoodData Corporation
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react-swc";
 import { createHtmlPlugin } from "vite-plugin-html";
@@ -26,12 +26,13 @@ export default defineConfig({
             "~@gooddata": "/node_modules/@gooddata",
         },
     },
-    build:{
-        outDir: 'esm',
-        chunkSizeWarningLimit:10000
+    build: {
+        outDir: "esm",
+        chunkSizeWarningLimit: 10000,
     },
     server: {
         port: 8080,
+        allowedHosts: [".csb.app"],
         fs: {
             strict: false,
         },

--- a/examples/sdk-interactive-examples/examples/example-dashboard/vite.config.js
+++ b/examples/sdk-interactive-examples/examples/example-dashboard/vite.config.js
@@ -1,4 +1,4 @@
-// (C) 2007-2022 GoodData Corporation
+// (C) 2007-2025 GoodData Corporation
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react-swc";
 import { createHtmlPlugin } from "vite-plugin-html";
@@ -26,12 +26,13 @@ export default defineConfig({
             "~@gooddata": "/node_modules/@gooddata",
         },
     },
-    build:{
-        outDir: 'esm',
-        chunkSizeWarningLimit:10000
+    build: {
+        outDir: "esm",
+        chunkSizeWarningLimit: 10000,
     },
     server: {
         port: 8080,
+        allowedHosts: [".csb.app"],
         fs: {
             strict: false,
         },

--- a/examples/sdk-interactive-examples/examples/example-datefilter/vite.config.js
+++ b/examples/sdk-interactive-examples/examples/example-datefilter/vite.config.js
@@ -1,4 +1,4 @@
-// (C) 2007-2022 GoodData Corporation
+// (C) 2007-2025 GoodData Corporation
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react-swc";
 import { createHtmlPlugin } from "vite-plugin-html";
@@ -26,12 +26,13 @@ export default defineConfig({
             "~@gooddata": "/node_modules/@gooddata",
         },
     },
-    build:{
-        outDir: 'esm',
-        chunkSizeWarningLimit:10000
+    build: {
+        outDir: "esm",
+        chunkSizeWarningLimit: 10000,
     },
     server: {
         port: 8080,
+        allowedHosts: [".csb.app"],
         fs: {
             strict: false,
         },

--- a/examples/sdk-interactive-examples/examples/example-dependentfilters/vite.config.js
+++ b/examples/sdk-interactive-examples/examples/example-dependentfilters/vite.config.js
@@ -1,4 +1,4 @@
-// (C) 2007-2022 GoodData Corporation
+// (C) 2007-2025 GoodData Corporation
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react-swc";
 import { createHtmlPlugin } from "vite-plugin-html";
@@ -26,12 +26,13 @@ export default defineConfig({
             "~@gooddata": "/node_modules/@gooddata",
         },
     },
-    build:{
-        outDir: 'esm',
-        chunkSizeWarningLimit:10000
+    build: {
+        outDir: "esm",
+        chunkSizeWarningLimit: 10000,
     },
     server: {
         port: 8080,
+        allowedHosts: [".csb.app"],
         fs: {
             strict: false,
         },

--- a/examples/sdk-interactive-examples/examples/example-execute/vite.config.js
+++ b/examples/sdk-interactive-examples/examples/example-execute/vite.config.js
@@ -1,4 +1,4 @@
-// (C) 2007-2022 GoodData Corporation
+// (C) 2007-2025 GoodData Corporation
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react-swc";
 import { createHtmlPlugin } from "vite-plugin-html";
@@ -26,12 +26,13 @@ export default defineConfig({
             "~@gooddata": "/node_modules/@gooddata",
         },
     },
-    build:{
-        outDir: 'esm',
-        chunkSizeWarningLimit:10000
+    build: {
+        outDir: "esm",
+        chunkSizeWarningLimit: 10000,
     },
     server: {
         port: 8080,
+        allowedHosts: [".csb.app"],
         fs: {
             strict: false,
         },

--- a/examples/sdk-interactive-examples/examples/example-granularity/vite.config.js
+++ b/examples/sdk-interactive-examples/examples/example-granularity/vite.config.js
@@ -1,4 +1,4 @@
-// (C) 2007-2022 GoodData Corporation
+// (C) 2007-2025 GoodData Corporation
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react-swc";
 import { createHtmlPlugin } from "vite-plugin-html";
@@ -26,12 +26,13 @@ export default defineConfig({
             "~@gooddata": "/node_modules/@gooddata",
         },
     },
-    build:{
-        outDir: 'esm',
-        chunkSizeWarningLimit:10000
+    build: {
+        outDir: "esm",
+        chunkSizeWarningLimit: 10000,
     },
     server: {
         port: 8080,
+        allowedHosts: [".csb.app"],
         fs: {
             strict: false,
         },

--- a/examples/sdk-interactive-examples/examples/example-headline/vite.config.js
+++ b/examples/sdk-interactive-examples/examples/example-headline/vite.config.js
@@ -1,4 +1,4 @@
-// (C) 2007-2022 GoodData Corporation
+// (C) 2007-2025 GoodData Corporation
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react-swc";
 import { createHtmlPlugin } from "vite-plugin-html";
@@ -26,12 +26,13 @@ export default defineConfig({
             "~@gooddata": "/node_modules/@gooddata",
         },
     },
-    build:{
-        outDir: 'esm',
-        chunkSizeWarningLimit:10000
+    build: {
+        outDir: "esm",
+        chunkSizeWarningLimit: 10000,
     },
     server: {
         port: 8080,
+        allowedHosts: [".csb.app"],
         fs: {
             strict: false,
         },

--- a/examples/sdk-interactive-examples/examples/example-pivottable/vite.config.js
+++ b/examples/sdk-interactive-examples/examples/example-pivottable/vite.config.js
@@ -1,4 +1,4 @@
-// (C) 2007-2022 GoodData Corporation
+// (C) 2007-2025 GoodData Corporation
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react-swc";
 import { createHtmlPlugin } from "vite-plugin-html";
@@ -26,12 +26,13 @@ export default defineConfig({
             "~@gooddata": "/node_modules/@gooddata",
         },
     },
-    build:{
-        outDir: 'esm',
-        chunkSizeWarningLimit:10000
+    build: {
+        outDir: "esm",
+        chunkSizeWarningLimit: 10000,
     },
     server: {
         port: 8080,
+        allowedHosts: [".csb.app"],
         fs: {
             strict: false,
         },

--- a/examples/sdk-interactive-examples/examples/example-relativedatefilter/vite.config.js
+++ b/examples/sdk-interactive-examples/examples/example-relativedatefilter/vite.config.js
@@ -1,4 +1,4 @@
-// (C) 2007-2022 GoodData Corporation
+// (C) 2007-2025 GoodData Corporation
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react-swc";
 import { createHtmlPlugin } from "vite-plugin-html";
@@ -26,12 +26,13 @@ export default defineConfig({
             "~@gooddata": "/node_modules/@gooddata",
         },
     },
-    build:{
-        outDir: 'esm',
-        chunkSizeWarningLimit:10000
+    build: {
+        outDir: "esm",
+        chunkSizeWarningLimit: 10000,
     },
     server: {
         port: 8080,
+        allowedHosts: [".csb.app"],
         fs: {
             strict: false,
         },

--- a/examples/sdk-interactive-examples/examples/example-repeater/vite.config.js
+++ b/examples/sdk-interactive-examples/examples/example-repeater/vite.config.js
@@ -1,4 +1,4 @@
-// (C) 2007-2024 GoodData Corporation
+// (C) 2007-2025 GoodData Corporation
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react-swc";
 import { createHtmlPlugin } from "vite-plugin-html";
@@ -32,6 +32,7 @@ export default defineConfig({
     },
     server: {
         port: 8080,
+        allowedHosts: [".csb.app"],
         fs: {
             strict: false,
         },


### PR DESCRIPTION
This would allow running examples in csb

risk: low
JIRA: STL-1305


<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```

#### Commands for Bear platform working on branch rel/9.9

```
extended-test-legacy --backstop
extended-test-legacy --isolated
extended-test-legacy --record
```