### PR TITLE
feat(sdk-ui-dashboard): pass drillStep into InsightBody

### DIFF
--- a/common/changes/@gooddata/sdk-ui-all/ovel-drill-ctx-insight-body_2025-04-28-16-02.json
+++ b/common/changes/@gooddata/sdk-ui-all/ovel-drill-ctx-insight-body_2025-04-28-16-02.json
@@ -1,0 +1,10 @@
+{
+    "changes": [
+        {
+            "packageName": "@gooddata/sdk-ui-all",
+            "comment": "add property drillStep into InsightBody component so dashboard customizations can behave based on drill context",
+            "type": "none"
+        }
+    ],
+    "packageName": "@gooddata/sdk-ui-all"
+}

--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -3709,7 +3709,7 @@ export interface DrillState {
     drillableItems: ExplicitDrill[];
 }
 
-// @internal (undocumented)
+// @beta (undocumented)
 export interface DrillStep {
     // (undocumented)
     drillDefinition: IDrillToInsight | IDrillDownDefinition;
@@ -4787,6 +4787,7 @@ export interface IDashboardInsightProps {
     clientHeight?: number;
     // @alpha (undocumented)
     clientWidth?: number;
+    drillStep?: DrillStep;
     // @alpha
     ErrorComponent: ComponentType<IErrorProps>;
     // @alpha (undocumented)
@@ -5293,6 +5294,7 @@ export interface IInsightBodyProps extends Partial<IVisualizationCallbacks> {
         selectedPoints?: IDrillEventIntersectionElement[][];
     };
     drillableItems: ExplicitDrill[] | undefined;
+    drillStep?: DrillStep;
     ErrorComponent: React.ComponentType<IErrorProps>;
     execConfig?: IExecutionConfig;
     insight: IInsight;

--- a/libs/sdk-ui-dashboard/src/presentation/drill/types.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/drill/types.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2024 GoodData Corporation
+// (C) 2019-2025 GoodData Corporation
 import { IAvailableDrillTargetMeasure, IAvailableDrillTargets } from "@gooddata/sdk-ui";
 import isEmpty from "lodash/isEmpty.js";
 import {
@@ -114,7 +114,7 @@ export type OnDrillToLegacyDashboard = (cmd: DrillToLegacyDashboard) => void;
 export type OnDrillToLegacyDashboardSuccess = (event: DashboardDrillToLegacyDashboardResolved) => void;
 
 /**
- * @internal
+ * @beta
  */
 export interface DrillStep {
     drillEvent: IDashboardDrillEvent;

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/ViewModeDashboardInsight/DashboardInsightWithDrillDialog.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/ViewModeDashboardInsight/DashboardInsightWithDrillDialog.tsx
@@ -84,6 +84,7 @@ export const DashboardInsightWithDrillDialog = (props: IDashboardInsightProps): 
                     onBackButtonClick={goBack}
                     onClose={onClose}
                     enableDrillDescription={enableDrillDescription}
+                    drillStep={activeDrillStep}
                 />
             ) : null}
         </>

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/ViewModeDashboardInsight/InsightDrillDialog/DrillDialogInsight.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/ViewModeDashboardInsight/InsightDrillDialog/DrillDialogInsight.tsx
@@ -61,6 +61,7 @@ export const DrillDialogInsight = (props: IDashboardInsightProps): JSX.Element =
         widget,
         backend,
         workspace,
+        drillStep,
         onError,
         onDrill: onDrillFn,
         onExportReady,
@@ -188,6 +189,7 @@ export const DrillDialogInsight = (props: IDashboardInsightProps): JSX.Element =
                                 ErrorComponent={ErrorComponent}
                                 LoadingComponent={LoadingComponent}
                                 execConfig={execConfig}
+                                drillStep={drillStep}
                             />
                         </div>
                     ) : null}

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/ViewModeDashboardInsight/InsightDrillDialog/InsightDrillDialog.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/ViewModeDashboardInsight/InsightDrillDialog/InsightDrillDialog.tsx
@@ -24,7 +24,7 @@ import cx from "classnames";
 
 import { DOWNLOADER_ID } from "../../../../../_staging/fileUtils/downloadFile.js";
 import { useInsightExport } from "../../../common/index.js";
-import { OnDrillDownSuccess, WithDrillSelect } from "../../../../drill/index.js";
+import { OnDrillDownSuccess, WithDrillSelect, DrillStep } from "../../../../drill/index.js";
 import { IntlWrapper } from "../../../../localization/index.js";
 import { useDashboardComponentsContext } from "../../../../dashboardContexts/index.js";
 import {
@@ -54,6 +54,7 @@ export interface InsightDrillDialogProps {
     breadcrumbs: string[];
     widget: IInsightWidget;
     insight: IInsight;
+    drillStep: DrillStep;
     onDrillDown?: OnDrillDownSuccess;
     onClose: () => void;
     onBackButtonClick: () => void;
@@ -100,6 +101,7 @@ export const InsightDrillDialog = (props: InsightDrillDialogProps): JSX.Element 
         breadcrumbs,
         insight,
         enableDrillDescription,
+        drillStep,
         onClose,
         onBackButtonClick,
         onDrillDown,
@@ -213,6 +215,7 @@ export const InsightDrillDialog = (props: InsightDrillDialogProps): JSX.Element 
                                                 pushData={executionsHandler.onPushData}
                                                 ErrorComponent={ErrorComponent}
                                                 LoadingComponent={LoadingComponent}
+                                                drillStep={drillStep}
                                             />
                                         </div>
                                     </div>
@@ -225,6 +228,7 @@ export const InsightDrillDialog = (props: InsightDrillDialogProps): JSX.Element 
                                         pushData={executionsHandler.onPushData}
                                         ErrorComponent={ErrorComponent}
                                         LoadingComponent={LoadingComponent}
+                                        drillStep={drillStep}
                                     />
                                 );
                             }}

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/types.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/types.ts
@@ -32,6 +32,7 @@ import {
     OnDrillToDashboardSuccess,
     OnDrillToInsightSuccess,
     OnWidgetDrill,
+    DrillStep,
 } from "../../drill/types.js";
 import { WidgetExportDataAttributes } from "../../export/index.js";
 
@@ -191,6 +192,14 @@ export interface IDashboardInsightProps {
      * @internal
      */
     minimalWidth?: number;
+
+    /**
+     * This property contains current drill step context.
+     *
+     * It is undefined if rendered insight is placed directly in the dashboard.
+     * It is defined when the insight is rendered in a drill dialog.
+     */
+    drillStep?: DrillStep;
 }
 
 /**
@@ -267,6 +276,14 @@ export interface IInsightBodyProps extends Partial<IVisualizationCallbacks> {
      * Contains configuration that should be part of insight execution
      */
     execConfig?: IExecutionConfig;
+
+    /**
+     * This property contains current drill step context.
+     *
+     * It is undefined if rendered insight is placed directly in the dashboard.
+     * It is defined when the insight is rendered in a drill dialog.
+     */
+    drillStep?: DrillStep;
 }
 
 ///


### PR DESCRIPTION
- so dashboard InsightBody customizations can behave based on drill context

JIRA: MC-3609
risk: low

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```

#### Commands for Bear platform working on branch rel/9.9

```
extended-test-legacy --backstop
extended-test-legacy --isolated
extended-test-legacy --record
```
