### PR TITLE
fix: add s-classes to the visualization switcher

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/widget/widget/VisualizationSwitcherWidget/VisualizationSwitcherNavigationHeader.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/widget/VisualizationSwitcherWidget/VisualizationSwitcherNavigationHeader.tsx
@@ -74,6 +74,8 @@ export const VisualizationSwitcherNavigationHeader: React.FC<IVisualizationSwitc
                     onClose={closeDropdown}
                     ariaAttributes={ariaAttributes}
                     maxWidth={clientWidth ?? 200}
+                    className={"s-visualization-switcher-widget-list"}
+                    itemClassName={"s-visualization-switcher-widget-list-item"}
                 />
             )}
             renderButton={({ toggleDropdown, isOpen, ariaAttributes, buttonRef }) => (
@@ -107,7 +109,7 @@ const VisualizationSwitcherNavigationHeaderButton = React.forwardRef<
     { isOpen, toggleDropdown, title, clientHeight, ariaAttributes, exportData },
     ref,
 ) {
-    const classNames = cx("gd-visualization-switcher-widget-header", {
+    const classNames = cx("gd-visualization-switcher-widget-header s-visualization-switcher-widget-header", {
         "is-open": isOpen,
     });
     return (

--- a/libs/sdk-ui-kit/api/sdk-ui-kit.api.md
+++ b/libs/sdk-ui-kit/api/sdk-ui-kit.api.md
@@ -5207,7 +5207,7 @@ export interface UiIconProps {
 }
 
 // @internal
-export function UiListbox<InteractiveItemData, StaticItemData>({ items, className, maxWidth, onSelect, onClose, selectedItemId, ariaAttributes, shouldKeyboardActionPreventDefault, shouldKeyboardActionStopPropagation, shouldCloseOnSelect, isDisabledFocusable, InteractiveItemComponent, StaticItemComponent, onUnhandledKeyDown, }: UiListboxProps<InteractiveItemData, StaticItemData>): React_2.ReactNode;
+export function UiListbox<InteractiveItemData, StaticItemData>({ items, className, itemClassName, maxWidth, onSelect, onClose, onUnhandledKeyDown, selectedItemId, InteractiveItemComponent, StaticItemComponent, shouldKeyboardActionPreventDefault, shouldKeyboardActionStopPropagation, shouldCloseOnSelect, isDisabledFocusable, ariaAttributes, }: UiListboxProps<InteractiveItemData, StaticItemData>): React_2.ReactNode;
 
 // @internal (undocumented)
 export interface UiListboxInteractiveItemProps<T> {
@@ -5231,6 +5231,8 @@ export interface UiListboxProps<InteractiveItemData, StaticItemData = React_2.Re
     InteractiveItemComponent?: React_2.ComponentType<UiListboxInteractiveItemProps<InteractiveItemData>>;
     // (undocumented)
     isDisabledFocusable?: boolean;
+    // (undocumented)
+    itemClassName?: string;
     // (undocumented)
     items: IUiListboxItem<InteractiveItemData, StaticItemData>[];
     // (undocumented)

--- a/libs/sdk-ui-kit/src/@ui/UiListbox/UiListbox.tsx
+++ b/libs/sdk-ui-kit/src/@ui/UiListbox/UiListbox.tsx
@@ -19,22 +19,26 @@ import { DefaultUiListboxStaticItemComponent } from "./defaults/DefaultUiListbox
  */
 export function UiListbox<InteractiveItemData, StaticItemData>({
     items,
+
     className,
+    itemClassName,
     maxWidth,
+
     onSelect,
     onClose,
+    onUnhandledKeyDown = firstCharacterSearch,
+
     selectedItemId,
-    ariaAttributes,
+
+    InteractiveItemComponent = DefaultUiListboxInteractiveItemComponent,
+    StaticItemComponent = DefaultUiListboxStaticItemComponent,
 
     shouldKeyboardActionPreventDefault,
     shouldKeyboardActionStopPropagation,
     shouldCloseOnSelect = true,
     isDisabledFocusable = false,
 
-    InteractiveItemComponent = DefaultUiListboxInteractiveItemComponent,
-    StaticItemComponent = DefaultUiListboxStaticItemComponent,
-
-    onUnhandledKeyDown = firstCharacterSearch,
+    ariaAttributes,
 }: UiListboxProps<InteractiveItemData, StaticItemData>): React.ReactNode {
     const isItemFocusable = React.useCallback(
         (item?: IUiListboxItem<InteractiveItemData, StaticItemData>) => {
@@ -185,6 +189,7 @@ export function UiListbox<InteractiveItemData, StaticItemData>({
                             aria-disabled={item.isDisabled}
                             tabIndex={-1}
                             id={makeItemId(listboxId, item)}
+                            className={itemClassName}
                         >
                             <InteractiveItemComponent
                                 onSelect={() => {
@@ -196,7 +201,11 @@ export function UiListbox<InteractiveItemData, StaticItemData>({
                             />
                         </li>
                     ) : (
-                        <li key={item.id ?? index} ref={(el) => (itemRefs.current[index] = el)}>
+                        <li
+                            key={item.id ?? index}
+                            ref={(el) => (itemRefs.current[index] = el)}
+                            className={itemClassName}
+                        >
                             <StaticItemComponent item={item} />
                         </li>
                     ),

--- a/libs/sdk-ui-kit/src/@ui/UiListbox/tests/UiListbox.test.tsx
+++ b/libs/sdk-ui-kit/src/@ui/UiListbox/tests/UiListbox.test.tsx
@@ -478,4 +478,17 @@ describe("UiListbox", () => {
         // onClose should not be called
         expect(onClose).not.toHaveBeenCalled();
     });
+
+    it("should add itemClassName to items", () => {
+        renderListbox({
+            itemClassName: "test-item-class",
+            items: [
+                { type: "interactive", id: "item1", stringTitle: "Item 1", data: "data1" },
+                { type: "static", data: "Static Item" },
+            ],
+        });
+
+        const items = screen.getByRole("listbox").querySelectorAll(".test-item-class");
+        expect(items).toHaveLength(2);
+    });
 });

--- a/libs/sdk-ui-kit/src/@ui/UiListbox/types.ts
+++ b/libs/sdk-ui-kit/src/@ui/UiListbox/types.ts
@@ -70,6 +70,7 @@ export interface UiListboxProps<InteractiveItemData, StaticItemData = React.Reac
     items: IUiListboxItem<InteractiveItemData, StaticItemData>[];
 
     className?: string;
+    itemClassName?: string;
     maxWidth?: number;
 
     onSelect?: (item: IUiListboxInteractiveItem<InteractiveItemData>) => void;


### PR DESCRIPTION
risk: low
JIRA: LX-1038

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```

#### Commands for Bear platform working on branch rel/9.9

```
extended-test-legacy --backstop
extended-test-legacy --isolated
extended-test-legacy --record
```
