### PR TITLE
automation filter ids conversion (SDK -> AFM)

### DIFF
--- a/libs/sdk-backend-tiger/src/backend/workspace/dashboards/index.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/dashboards/index.ts
@@ -244,7 +244,13 @@ export class TigerWorkspaceDashboards implements IWorkspaceDashboardsService {
             return null;
         }
 
-        const convertedExportMetadata = convertFromBackendExportMetadata(metadata);
+        const userSettings = await getSettingsForCurrentUser(this.authCall, this.workspace);
+        const enableAutomationFilterContext = userSettings.enableAutomationFilterContext ?? false;
+
+        const convertedExportMetadata = convertFromBackendExportMetadata(
+            metadata,
+            enableAutomationFilterContext,
+        );
 
         return {
             ...(convertedExportMetadata?.filters

--- a/libs/sdk-backend-tiger/src/convertors/fromBackend/AutomationConverter.ts
+++ b/libs/sdk-backend-tiger/src/convertors/fromBackend/AutomationConverter.ts
@@ -70,6 +70,7 @@ function convertExternalRecipient(
 export function convertAutomation(
     automation: JsonApiAutomationOutWithLinks,
     included: JsonApiAutomationOutIncludes[],
+    enableAutomationFilterContext: boolean,
 ): IAutomationMetadataObject {
     const { id, attributes = {}, relationships = {} } = automation;
     const {
@@ -99,10 +100,18 @@ export function convertAutomation(
 
     const exportDefinitions = [
         ...includedExportDefinitions.map((ed) =>
-            convertExportDefinitionMdObjectFromBackend(ed as JsonApiExportDefinitionOutWithLinks),
+            convertExportDefinitionMdObjectFromBackend(
+                ed as JsonApiExportDefinitionOutWithLinks,
+                undefined,
+                enableAutomationFilterContext,
+            ),
         ),
-        ...(visualExports?.map((ve) => convertInlineExportDefinitionMdObject(ve)) ?? []),
-        ...(tabularExports?.map((te) => convertInlineExportDefinitionMdObject(te)) ?? []),
+        ...(visualExports?.map((ve) =>
+            convertInlineExportDefinitionMdObject(ve, enableAutomationFilterContext),
+        ) ?? []),
+        ...(tabularExports?.map((te) =>
+            convertInlineExportDefinitionMdObject(te, enableAutomationFilterContext),
+        ) ?? []),
     ];
 
     const recipients = [
@@ -161,9 +170,10 @@ export function convertAutomation(
 
 export const convertAutomationListToAutomations = (
     automationList: JsonApiAutomationOutList,
+    enableAutomationFilterContext: boolean,
 ): IAutomationMetadataObject[] => {
     return automationList.data.map((automationObject) =>
-        convertAutomation(automationObject, automationList.included ?? []),
+        convertAutomation(automationObject, automationList.included ?? [], enableAutomationFilterContext),
     );
 };
 

--- a/libs/sdk-backend-tiger/src/convertors/fromBackend/ExportDefinitionsConverter.ts
+++ b/libs/sdk-backend-tiger/src/convertors/fromBackend/ExportDefinitionsConverter.ts
@@ -121,7 +121,7 @@ const convertExportDefinitionRequestPayload = (
         };
     } else {
         const metadata = exportRequest.metadata as MetadataObjectDefinition | undefined;
-        const filters = metadata?.filters;
+        const filters = metadata?.filters?.map(cloneWithSanitizedIds);
         const filtersObj = filters ? { filters } : {};
 
         return {

--- a/libs/sdk-backend-tiger/src/convertors/fromBackend/ExportDefinitionsConverter.ts
+++ b/libs/sdk-backend-tiger/src/convertors/fromBackend/ExportDefinitionsConverter.ts
@@ -29,6 +29,7 @@ type MetadataObjectDefinition = {
 export const convertExportDefinitionMdObject = (
     exportDefinitionOut: JsonApiExportDefinitionOutWithLinks,
     included: JsonApiExportDefinitionOutIncludes[] = [],
+    enableAutomationFilterContext: boolean,
 ): IExportDefinitionMetadataObject => {
     const { id, attributes, links, relationships = {} } = exportDefinitionOut;
     const { createdBy, modifiedBy } = relationships;
@@ -42,6 +43,7 @@ export const convertExportDefinitionMdObject = (
     } = attributes ?? {};
     const request = convertExportDefinitionRequestPayload(
         requestPayload as VisualExportRequest | TabularExportRequest,
+        enableAutomationFilterContext,
     );
 
     return {
@@ -67,10 +69,12 @@ export const convertInlineExportDefinitionMdObject = (
     exportDefinitionOut:
         | JsonApiAutomationOutAttributesTabularExports
         | JsonApiAutomationOutAttributesVisualExports,
+    enableAutomationFilterContext: boolean,
 ): IExportDefinitionMetadataObject => {
     const id = uuid();
     const request = convertExportDefinitionRequestPayload(
         exportDefinitionOut.requestPayload as VisualExportRequest | TabularExportRequest,
+        enableAutomationFilterContext,
     );
     const metadata = exportDefinitionOut.requestPayload.metadata as MetadataObjectDefinition | undefined;
 
@@ -91,6 +95,7 @@ export const convertInlineExportDefinitionMdObject = (
 
 const convertExportDefinitionRequestPayload = (
     exportRequest: VisualExportRequest | TabularExportRequest,
+    enableAutomationFilterContext: boolean,
 ): IExportDefinitionRequestPayload => {
     if (isTabularRequest(exportRequest)) {
         const { widget } = (exportRequest.metadata as MetadataObjectDefinition) ?? {};
@@ -121,7 +126,9 @@ const convertExportDefinitionRequestPayload = (
         };
     } else {
         const metadata = exportRequest.metadata as MetadataObjectDefinition | undefined;
-        const filters = metadata?.filters?.map(cloneWithSanitizedIds);
+        const filters = enableAutomationFilterContext
+            ? metadata?.filters?.map(cloneWithSanitizedIds)
+            : metadata?.filters;
         const filtersObj = filters ? { filters } : {};
 
         return {

--- a/libs/sdk-backend-tiger/src/convertors/fromBackend/ExportMetadataConverter.ts
+++ b/libs/sdk-backend-tiger/src/convertors/fromBackend/ExportMetadataConverter.ts
@@ -1,10 +1,12 @@
 // (C) 2023-2025 GoodData Corporation
 
 import { IExportMetadata } from "../../types/index.js";
+import { cloneWithSanitizedIds } from "./IdSanitization.js";
+
 export const convertExportMetadata = (exportMetadata: any): Partial<IExportMetadata> | null => {
     // Filters, or empty filters === override default filters
     return {
-        ...(exportMetadata?.filters ? { filters: exportMetadata.filters } : {}),
+        ...(exportMetadata?.filters ? { filters: exportMetadata.filters.map(cloneWithSanitizedIds) } : {}),
         ...(exportMetadata?.title ? { title: exportMetadata.title } : {}),
         ...(exportMetadata?.hideWidgetTitles ? { hideWidgetTitles: exportMetadata.hideWidgetTitles } : {}),
     };

--- a/libs/sdk-backend-tiger/src/convertors/fromBackend/ExportMetadataConverter.ts
+++ b/libs/sdk-backend-tiger/src/convertors/fromBackend/ExportMetadataConverter.ts
@@ -3,10 +3,19 @@
 import { IExportMetadata } from "../../types/index.js";
 import { cloneWithSanitizedIds } from "./IdSanitization.js";
 
-export const convertExportMetadata = (exportMetadata: any): Partial<IExportMetadata> | null => {
+export const convertExportMetadata = (
+    exportMetadata: any,
+    enableAutomationFilterContext: boolean,
+): Partial<IExportMetadata> | null => {
     // Filters, or empty filters === override default filters
     return {
-        ...(exportMetadata?.filters ? { filters: exportMetadata.filters.map(cloneWithSanitizedIds) } : {}),
+        ...(exportMetadata?.filters
+            ? {
+                  filters: enableAutomationFilterContext
+                      ? exportMetadata.filters.map(cloneWithSanitizedIds)
+                      : exportMetadata.filters,
+              }
+            : {}),
         ...(exportMetadata?.title ? { title: exportMetadata.title } : {}),
         ...(exportMetadata?.hideWidgetTitles ? { hideWidgetTitles: exportMetadata.hideWidgetTitles } : {}),
     };

--- a/libs/sdk-backend-tiger/src/convertors/toBackend/AutomationConverter.ts
+++ b/libs/sdk-backend-tiger/src/convertors/toBackend/AutomationConverter.ts
@@ -27,6 +27,7 @@ import { convertExportDefinitionRequestPayload } from "./ExportDefinitionsConver
 
 export function convertAutomation(
     automation: IAutomationMetadataObject | IAutomationMetadataObjectDefinition,
+    enableAutomationFilterContext: boolean,
 ): JsonApiAutomationIn {
     const {
         id,
@@ -86,12 +87,20 @@ export function convertAutomation(
     const tabularExports = exportDefinitions
         ?.filter((ed) => isExportDefinitionVisualizationObjectRequestPayload(ed.requestPayload))
         .map((ed) => ({
-            requestPayload: convertExportDefinitionRequestPayload(ed.requestPayload, ed.title),
+            requestPayload: convertExportDefinitionRequestPayload(
+                ed.requestPayload,
+                enableAutomationFilterContext,
+                ed.title,
+            ),
         }));
     const visualExports = exportDefinitions
         ?.filter((ed) => isExportDefinitionDashboardRequestPayload(ed.requestPayload))
         .map((ed) => ({
-            requestPayload: convertExportDefinitionRequestPayload(ed.requestPayload, ed.title),
+            requestPayload: convertExportDefinitionRequestPayload(
+                ed.requestPayload,
+                enableAutomationFilterContext,
+                ed.title,
+            ),
         }));
 
     const attributes = omitBy(

--- a/libs/sdk-backend-tiger/src/convertors/toBackend/ExportDefinitionsConverter.ts
+++ b/libs/sdk-backend-tiger/src/convertors/toBackend/ExportDefinitionsConverter.ts
@@ -42,7 +42,7 @@ export const convertExportDefinitionRequestPayload = (
             ...(isMetadataFilled
                 ? {
                       metadata: {
-                          ...(exportRequest.content.filters ? { filters } : {}),
+                          ...(filters ? { filters: filters.map(cloneWithSanitizedIds) } : {}),
                           ...(title ? { title } : {}),
                       },
                   }

--- a/libs/sdk-backend-tiger/src/convertors/toBackend/ExportDefinitionsConverter.ts
+++ b/libs/sdk-backend-tiger/src/convertors/toBackend/ExportDefinitionsConverter.ts
@@ -15,6 +15,7 @@ import { cloneWithSanitizedIds } from "./IdSanitization.js";
 
 export const convertExportDefinitionMdObjectDefinition = (
     exportDefinition: IExportDefinitionMetadataObjectDefinition,
+    enableAutomationFilterContext: boolean,
 ): JsonApiExportDefinitionPostOptionalIdDocument => {
     const { title, description, tags, requestPayload } = exportDefinition;
 
@@ -25,7 +26,11 @@ export const convertExportDefinitionMdObjectDefinition = (
                 title,
                 description,
                 tags,
-                requestPayload: convertExportDefinitionRequestPayload(requestPayload, title),
+                requestPayload: convertExportDefinitionRequestPayload(
+                    requestPayload,
+                    enableAutomationFilterContext,
+                    title,
+                ),
             },
         },
     };
@@ -33,6 +38,7 @@ export const convertExportDefinitionMdObjectDefinition = (
 
 export const convertExportDefinitionRequestPayload = (
     exportRequest: IExportDefinitionRequestPayload,
+    enableAutomationFilterContext: boolean,
     title?: string,
 ): TabularExportRequest | VisualExportRequest => {
     if (isExportDefinitionDashboardRequestPayload(exportRequest)) {
@@ -42,7 +48,13 @@ export const convertExportDefinitionRequestPayload = (
             ...(isMetadataFilled
                 ? {
                       metadata: {
-                          ...(filters ? { filters: filters.map(cloneWithSanitizedIds) } : {}),
+                          ...(filters
+                              ? {
+                                    filters: enableAutomationFilterContext
+                                        ? filters.map(cloneWithSanitizedIds)
+                                        : filters,
+                                }
+                              : {}),
                           ...(title ? { title } : {}),
                       },
                   }
@@ -82,8 +94,12 @@ export const convertExportDefinitionRequestPayload = (
 export const convertExportDefinitionMdObject = (
     exportDefinition: IExportDefinitionMetadataObjectDefinition,
     identifier: string,
+    enableAutomationFilterContext: boolean,
 ): JsonApiExportDefinitionInDocument => {
-    const postDefinition = convertExportDefinitionMdObjectDefinition(exportDefinition);
+    const postDefinition = convertExportDefinitionMdObjectDefinition(
+        exportDefinition,
+        enableAutomationFilterContext,
+    );
 
     return {
         data: {


### PR DESCRIPTION
<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```

#### Commands for Bear platform working on branch rel/9.9

```
extended-test-legacy --backstop
extended-test-legacy --isolated
extended-test-legacy --record
```
