### PR TITLE
fix: reset cross filtering when filter context changes

### DIFF
--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/filterContext/changeFilterContextSelectionHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/filterContext/changeFilterContextSelectionHandler.ts
@@ -13,7 +13,7 @@ import {
 } from "../../store/filterContext/filterContextSelectors.js";
 import { batchActions } from "redux-batched-actions";
 import { AnyAction } from "@reduxjs/toolkit";
-import { canApplyDateFilter, dispatchFilterContextChanged } from "./common.js";
+import { canApplyDateFilter, dispatchFilterContextChanged, resetCrossFiltering } from "./common.js";
 import partition from "lodash/partition.js";
 import uniqBy from "lodash/uniqBy.js";
 import compact from "lodash/compact.js";
@@ -59,6 +59,7 @@ import { IDashboardFilter } from "../../../types.js";
 import { selectEnableDuplicatedLabelValuesInAttributeFilter } from "../../store/config/configSelectors.js";
 import { attributeFilterConfigsActions } from "../../store/attributeFilterConfigs/index.js";
 import { selectAttributeFilterConfigsOverrides } from "../../store/attributeFilterConfigs/attributeFilterConfigsSelectors.js";
+import { selectIsCrossFiltering } from "../../store/drill/drillSelectors.js";
 
 function dashboardFilterToFilterContextItem(
     filter: IDashboardFilter,
@@ -104,6 +105,11 @@ export function* changeFilterContextSelectionHandler(
     cmd: ChangeFilterContextSelection,
 ): SagaIterator<void> {
     const { filters, resetOthers, attributeFilterConfigs = [] } = cmd.payload;
+
+    const isCrossFiltering = yield select(selectIsCrossFiltering);
+    if (isCrossFiltering) {
+        yield call(resetCrossFiltering, cmd);
+    }
 
     const normalizedFilters: FilterContextItem[] = filters.map((filter) => {
         if (isDashboardAttributeFilter(filter) || isDashboardDateFilter(filter)) {


### PR DESCRIPTION
- cross filtering should be removed when filter context changes
- the same already happens in specific attr and date filter handlers

JIRA: F1-1083
risk: low

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```

#### Commands for Bear platform working on branch rel/9.9

```
extended-test-legacy --backstop
extended-test-legacy --isolated
extended-test-legacy --record
```
