### PR TITLE
fix: chatbot does not respect color palette

### DIFF
--- a/libs/sdk-ui-gen-ai/api/sdk-ui-gen-ai.api.md
+++ b/libs/sdk-ui-gen-ai/api/sdk-ui-gen-ai.api.md
@@ -7,10 +7,10 @@
 import { GenAIChatInteractionUserFeedback } from '@gooddata/sdk-model';
 import { GenAIChatRoutingUseCase } from '@gooddata/sdk-model';
 import { IAnalyticalBackend } from '@gooddata/sdk-backend-spi';
+import { IColorPalette } from '@gooddata/sdk-model';
 import { IGenAIVisualization } from '@gooddata/sdk-model';
 import { ISemanticSearchResultItem } from '@gooddata/sdk-model';
 import { default as React_2 } from 'react';
-
 import { SdkErrorType } from '@gooddata/sdk-ui';
 
 // @alpha (undocumented)
@@ -100,6 +100,7 @@ export const GenAIChat: React_2.FC<GenAIChatProps>;
 // @alpha
 export interface GenAIChatProps {
     backend?: IAnalyticalBackend;
+    colorPalette?: IColorPalette;
     eventHandlers?: ChatEventHandler[];
     onLinkClick?: (linkClickEvent: LinkHandlerEvent) => void;
     workspace?: string;

--- a/libs/sdk-ui-gen-ai/src/components/GenAIChat.tsx
+++ b/libs/sdk-ui-gen-ai/src/components/GenAIChat.tsx
@@ -2,11 +2,14 @@
 import React from "react";
 import { IAnalyticalBackend } from "@gooddata/sdk-backend-spi";
 import { BackendProvider, useBackendStrict, useWorkspaceStrict, WorkspaceProvider } from "@gooddata/sdk-ui";
+import { IColorPalette } from "@gooddata/sdk-model";
 import { Provider as StoreProvider } from "react-redux";
+
 import { useGenAIStore } from "../hooks/useGenAIStore.js";
 import { IntlWrapper } from "../localization/IntlWrapper.js";
-import { GenAIChatWrapper } from "./GenAIChatWrapper.js";
 import { ChatEventHandler } from "../store/events.js";
+
+import { GenAIChatWrapper } from "./GenAIChatWrapper.js";
 import { ConfigProvider, LinkHandlerEvent } from "./ConfigContext.js";
 
 /**
@@ -23,6 +26,10 @@ export interface GenAIChatProps {
      */
     workspace?: string;
     /**
+     * Color palette to use for the chat UI.
+     */
+    colorPalette?: IColorPalette;
+    /**
      * Event handlers to subscribe to chat events.
      */
     eventHandlers?: ChatEventHandler[];
@@ -37,10 +44,19 @@ export interface GenAIChatProps {
  * UI component that renders the Gen AI chat.
  * @alpha
  */
-export const GenAIChat: React.FC<GenAIChatProps> = ({ backend, workspace, eventHandlers, onLinkClick }) => {
+export const GenAIChat: React.FC<GenAIChatProps> = ({
+    backend,
+    workspace,
+    colorPalette,
+    eventHandlers,
+    onLinkClick,
+}) => {
     const effectiveBackend = useBackendStrict(backend);
     const effectiveWorkspace = useWorkspaceStrict(workspace);
-    const genAIStore = useGenAIStore(effectiveBackend, effectiveWorkspace, eventHandlers);
+    const genAIStore = useGenAIStore(effectiveBackend, effectiveWorkspace, {
+        colorPalette,
+        eventHandlers,
+    });
 
     return (
         <IntlWrapper>

--- a/libs/sdk-ui-gen-ai/src/components/GenAIChatDialog.tsx
+++ b/libs/sdk-ui-gen-ai/src/components/GenAIChatDialog.tsx
@@ -35,7 +35,9 @@ export const GenAIChatDialog: React.FC<GenAIChatDialogProps> = ({
 }) => {
     const effectiveBackend = useBackendStrict(backend);
     const effectiveWorkspace = useWorkspaceStrict(workspace);
-    const genAIStore = useGenAIStore(effectiveBackend, effectiveWorkspace, eventHandlers);
+    const genAIStore = useGenAIStore(effectiveBackend, effectiveWorkspace, {
+        eventHandlers,
+    });
 
     React.useEffect(() => {
         // Save the open state into the store

--- a/libs/sdk-ui-gen-ai/src/components/GenAIChatOverlay.tsx
+++ b/libs/sdk-ui-gen-ai/src/components/GenAIChatOverlay.tsx
@@ -1,7 +1,10 @@
-// (C) 2024 GoodData Corporation
+// (C) 2024-2025 GoodData Corporation
 import React from "react";
-import { GenAIChatWrapper } from "./GenAIChatWrapper.js";
+import { connect } from "react-redux";
+import { injectIntl, WrappedComponentProps } from "react-intl";
 import { Icon, Overlay } from "@gooddata/sdk-ui-kit";
+import cx from "classnames";
+
 import {
     clearThreadAction,
     hasMessagesSelector,
@@ -9,10 +12,9 @@ import {
     RootState,
     setFullscreenAction,
 } from "../store/index.js";
-import cx from "classnames";
+
+import { GenAIChatWrapper } from "./GenAIChatWrapper.js";
 import { HeaderIcon } from "./HeaderIcon.js";
-import { connect } from "react-redux";
-import { injectIntl, WrappedComponentProps } from "react-intl";
 
 type GenAIChatOverlayOwnProps = {
     onClose: () => void;

--- a/libs/sdk-ui-gen-ai/src/components/messages/AssistantMessage.tsx
+++ b/libs/sdk-ui-gen-ai/src/components/messages/AssistantMessage.tsx
@@ -2,13 +2,15 @@
 
 import React from "react";
 import cx from "classnames";
-import { AssistantMessage, isErrorContents } from "../../model.js";
-import { AgentIcon } from "./AgentIcon.js";
-import { MessageContents } from "./MessageContents.js";
-import { defineMessage, injectIntl, WrappedComponentProps } from "react-intl";
 import { Icon } from "@gooddata/sdk-ui-kit";
+import { defineMessage, injectIntl, WrappedComponentProps } from "react-intl";
 import { connect } from "react-redux";
+
+import { AssistantMessage, isErrorContents } from "../../model.js";
 import { setUserFeedback } from "../../store/index.js";
+
+import { MessageContents } from "./MessageContents.js";
+import { AgentIcon } from "./AgentIcon.js";
 
 type AssistantMessageProps = {
     message: AssistantMessage;

--- a/libs/sdk-ui-gen-ai/src/components/messages/MessageContents.tsx
+++ b/libs/sdk-ui-gen-ai/src/components/messages/MessageContents.tsx
@@ -1,23 +1,23 @@
 // (C) 2024-2025 GoodData Corporation
 
 import React from "react";
-import Skeleton from "react-loading-skeleton";
+import { Typography } from "@gooddata/sdk-ui-kit";
+import { FormattedMessage } from "react-intl";
+
 import { Contents } from "../../model.js";
 import { TextContentsComponent } from "./contents/TextContents.js";
 import { ErrorContentsComponent } from "./contents/ErrorContents.js";
 import { RoutingContentsComponent } from "./contents/RoutingContents.js";
 import { SearchContentsComponent } from "./contents/SearchContents.js";
 import { VisualizationContentsComponent } from "./contents/VisualizationContents.js";
-import { Typography } from "@gooddata/sdk-ui-kit";
-import { FormattedMessage } from "react-intl";
 
 type MessageContentsProps = {
     content: Contents[];
+    messageId: string;
     isComplete?: boolean;
     isCancelled?: boolean;
     isLastMessage?: boolean;
     useMarkdown?: boolean;
-    messageId: string;
 };
 
 export const MessageContents: React.FC<MessageContentsProps> = ({
@@ -61,7 +61,11 @@ export const MessageContents: React.FC<MessageContentsProps> = ({
                         return assertNever(type);
                 }
             })}
-            {!isComplete ? <Skeleton /> : null}
+            {!isComplete ? (
+                <Typography tagName="p">
+                    <FormattedMessage id="gd.gen-ai.state.generating" />
+                </Typography>
+            ) : null}
             {isCancelled ? (
                 <Typography tagName="p">
                     <FormattedMessage id="gd.gen-ai.state.cancelled" />

--- a/libs/sdk-ui-gen-ai/src/components/messages/contents/VisualizationContents.tsx
+++ b/libs/sdk-ui-gen-ai/src/components/messages/contents/VisualizationContents.tsx
@@ -2,18 +2,11 @@
 
 import React from "react";
 import cx from "classnames";
-import { IAttribute, IFilter, IMeasure } from "@gooddata/sdk-model";
-import { PivotTable } from "@gooddata/sdk-ui-pivot";
-import { BarChart, ColumnChart, Headline, LineChart, PieChart } from "@gooddata/sdk-ui-charts";
-import { makeTextContents, makeUserMessage, VisualizationContents } from "../../../model.js";
-import { useExecution } from "./useExecution.js";
-import { VisualizationErrorBoundary } from "./VisualizationErrorBoundary.js";
-import { MarkdownComponent } from "./Markdown.js";
+import { IAttribute, IColorPalette, IFilter, IMeasure } from "@gooddata/sdk-model";
 import { Bubble, BubbleHoverTrigger, Button, Icon } from "@gooddata/sdk-ui-kit";
-import { useDispatch } from "react-redux";
-import { newMessageAction, visualizationErrorAction } from "../../../store/index.js";
-import { useConfig } from "../../ConfigContext.js";
-import { VisualizationSaveDialog } from "./VisualizationSaveDialog.js";
+import { PivotTable } from "@gooddata/sdk-ui-pivot";
+import { connect, useDispatch } from "react-redux";
+import { BarChart, ColumnChart, Headline, LineChart, PieChart } from "@gooddata/sdk-ui-charts";
 import { FormattedMessage } from "react-intl";
 import {
     GoodDataSdkError,
@@ -22,6 +15,20 @@ import {
     OnLoadingChanged,
     useWorkspaceStrict,
 } from "@gooddata/sdk-ui";
+
+import { makeTextContents, makeUserMessage, VisualizationContents } from "../../../model.js";
+import { useConfig } from "../../ConfigContext.js";
+import {
+    RootState,
+    newMessageAction,
+    visualizationErrorAction,
+    colorPaletteSelector,
+} from "../../../store/index.js";
+
+import { VisualizationErrorBoundary } from "./VisualizationErrorBoundary.js";
+import { VisualizationSaveDialog } from "./VisualizationSaveDialog.js";
+import { useExecution } from "./useExecution.js";
+import { MarkdownComponent } from "./Markdown.js";
 
 const VIS_HEIGHT = 250;
 
@@ -34,12 +41,14 @@ export type VisualizationContentsProps = {
     messageId: string;
     useMarkdown?: boolean;
     showSuggestions?: boolean;
+    colorPalette?: IColorPalette;
 };
 
-export const VisualizationContentsComponent: React.FC<VisualizationContentsProps> = ({
+const VisualizationContentsComponentCore: React.FC<VisualizationContentsProps> = ({
     content,
     messageId,
     useMarkdown,
+    colorPalette,
     showSuggestions = false,
 }) => {
     const dispatch = useDispatch();
@@ -107,6 +116,7 @@ export const VisualizationContentsComponent: React.FC<VisualizationContentsProps
                                             metrics,
                                             dimensions,
                                             filters,
+                                            colorPalette,
                                             handleSdkError,
                                             handleLoadingChanged,
                                         );
@@ -115,6 +125,7 @@ export const VisualizationContentsComponent: React.FC<VisualizationContentsProps
                                             metrics,
                                             dimensions,
                                             filters,
+                                            colorPalette,
                                             handleSdkError,
                                             handleLoadingChanged,
                                         );
@@ -123,6 +134,7 @@ export const VisualizationContentsComponent: React.FC<VisualizationContentsProps
                                             metrics,
                                             dimensions,
                                             filters,
+                                            colorPalette,
                                             handleSdkError,
                                             handleLoadingChanged,
                                         );
@@ -131,6 +143,7 @@ export const VisualizationContentsComponent: React.FC<VisualizationContentsProps
                                             metrics,
                                             dimensions,
                                             filters,
+                                            colorPalette,
                                             handleSdkError,
                                             handleLoadingChanged,
                                         );
@@ -147,6 +160,7 @@ export const VisualizationContentsComponent: React.FC<VisualizationContentsProps
                                             metrics,
                                             dimensions,
                                             filters,
+                                            colorPalette,
                                             handleSdkError,
                                             handleLoadingChanged,
                                         );
@@ -255,6 +269,7 @@ const renderBarChart = (
     metrics: IMeasure[],
     dimensions: IAttribute[],
     filters: IFilter[],
+    colorPalette: IColorPalette | undefined,
     onError: OnError,
     onLoadingChanged: OnLoadingChanged,
 ) => (
@@ -266,6 +281,7 @@ const renderBarChart = (
         config={{
             ...visualizationTooltipOptions,
             ...legendTooltipOptions,
+            colorPalette,
             // Better visibility with stacked bars if there are multiple metrics and dimensions
             stackMeasures: metrics.length > 1 && dimensions.length === 2,
         }}
@@ -279,6 +295,7 @@ const renderColumnChart = (
     metrics: IMeasure[],
     dimensions: IAttribute[],
     filters: IFilter[],
+    colorPalette: IColorPalette | undefined,
     onError: OnError,
     onLoadingChanged: OnLoadingChanged,
 ) => (
@@ -290,6 +307,7 @@ const renderColumnChart = (
         config={{
             ...visualizationTooltipOptions,
             ...legendTooltipOptions,
+            colorPalette,
             // Better visibility with stacked bars if there are multiple metrics and dimensions
             stackMeasures: metrics.length > 1 && dimensions.length === 2,
         }}
@@ -303,6 +321,7 @@ const renderLineChart = (
     metrics: IMeasure[],
     dimensions: IAttribute[],
     filters: IFilter[],
+    colorPalette: IColorPalette | undefined,
     onError: OnError,
     onLoadingChanged: OnLoadingChanged,
 ) => (
@@ -315,6 +334,7 @@ const renderLineChart = (
         config={{
             ...visualizationTooltipOptions,
             ...legendTooltipOptions,
+            colorPalette,
         }}
         onError={onError}
         onLoadingChanged={onLoadingChanged}
@@ -325,6 +345,7 @@ const renderPieChart = (
     metrics: IMeasure[],
     dimensions: IAttribute[],
     filters: IFilter[],
+    colorPalette: IColorPalette | undefined,
     onError: OnError,
     onLoadingChanged: OnLoadingChanged,
 ) => (
@@ -335,6 +356,7 @@ const renderPieChart = (
         filters={filters}
         config={{
             ...visualizationTooltipOptions,
+            colorPalette,
         }}
         onError={onError}
         onLoadingChanged={onLoadingChanged}
@@ -361,6 +383,7 @@ const renderHeadline = (
     metrics: IMeasure[],
     _dimensions: IAttribute[],
     filters: IFilter[],
+    colorPalette: IColorPalette | undefined,
     onError: OnError,
     onLoadingChanged: OnLoadingChanged,
 ) => (
@@ -370,8 +393,18 @@ const renderHeadline = (
         filters={filters}
         config={{
             ...visualizationTooltipOptions,
+            colorPalette,
         }}
         onError={onError}
         onLoadingChanged={onLoadingChanged}
     />
 );
+
+const mapStateToProps = (state: RootState): Pick<VisualizationContentsProps, "colorPalette"> => ({
+    colorPalette: colorPaletteSelector(state),
+});
+
+export const VisualizationContentsComponent = connect(
+    mapStateToProps,
+    undefined,
+)(VisualizationContentsComponentCore);

--- a/libs/sdk-ui-gen-ai/src/hooks/useGenAIStore.ts
+++ b/libs/sdk-ui-gen-ai/src/hooks/useGenAIStore.ts
@@ -1,15 +1,20 @@
-// (C) 2024 GoodData Corporation
+// (C) 2024-2025 GoodData Corporation
 
 import React from "react";
-import { getStore } from "../store/index.js";
 import { IAnalyticalBackend } from "@gooddata/sdk-backend-spi";
+import { IColorPalette } from "@gooddata/sdk-model";
 import { ChatEventHandler, EventDispatcher } from "../store/events.js";
+import { getStore } from "../store/index.js";
 
 export const useGenAIStore = (
     backend: IAnalyticalBackend,
     workspace: string,
-    eventHandlers?: ChatEventHandler[],
+    opts: {
+        eventHandlers?: ChatEventHandler[];
+        colorPalette?: IColorPalette;
+    },
 ) => {
+    const { eventHandlers, colorPalette } = opts;
     // Instantiate EventDispatcher. It's a designed to hold a reference to the handlers, so that
     // we don't update the context every time a new array of handlers is passed.
     // Similar to how React handles event listeners.
@@ -18,8 +23,8 @@ export const useGenAIStore = (
     // Initialize new Redux Store for each instance of GenAI Chat
     // It OK to discard the store when backend or workspace changes
     const store = React.useMemo(() => {
-        return getStore(backend, workspace, eventDispatcher);
-    }, [backend, workspace, eventDispatcher]);
+        return getStore(backend, workspace, eventDispatcher, { colorPalette });
+    }, [backend, workspace, eventDispatcher, colorPalette]);
 
     React.useEffect(() => {
         if (eventHandlers) {

--- a/libs/sdk-ui-gen-ai/src/localization/bundles/en-US.json
+++ b/libs/sdk-ui-gen-ai/src/localization/bundles/en-US.json
@@ -104,6 +104,11 @@
         "comment": "Use ellipsis at the end …",
         "limit": 0
     },
+    "gd.gen-ai.state.generating": {
+        "value": "Generating your response…",
+        "comment": "Use ellipsis at the end …",
+        "limit": 0
+    },
     "gd.gen-ai.button.send": {
         "value": "Send",
         "comment": "",

--- a/libs/sdk-ui-gen-ai/src/store/chatWindow/chatWindowSelectors.ts
+++ b/libs/sdk-ui-gen-ai/src/store/chatWindow/chatWindowSelectors.ts
@@ -1,5 +1,7 @@
-// (C) 2024 GoodData Corporation
+// (C) 2024-2025 GoodData Corporation
 import { createSelector } from "@reduxjs/toolkit";
+import { IColorPalette } from "@gooddata/sdk-model";
+
 import { RootState } from "../types.js";
 import { chatWindowSliceName } from "./chatWindowSlice.js";
 
@@ -13,4 +15,9 @@ export const isOpenSelector: (state: RootState) => boolean = createSelector(
 export const isFullscreenSelector: (state: RootState) => boolean = createSelector(
     chatWindowSliceSelector,
     (state) => state.isFullscreen,
+);
+
+export const colorPaletteSelector: (state: RootState) => IColorPalette | undefined = createSelector(
+    chatWindowSliceSelector,
+    (state) => state.colorPalette,
 );

--- a/libs/sdk-ui-gen-ai/src/store/chatWindow/chatWindowSlice.ts
+++ b/libs/sdk-ui-gen-ai/src/store/chatWindow/chatWindowSlice.ts
@@ -1,5 +1,6 @@
-// (C) 2024 GoodData Corporation
+// (C) 2024-2025 GoodData Corporation
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+import { IColorPalette } from "@gooddata/sdk-model";
 
 type ChatWindowSliceState = {
     /**
@@ -10,6 +11,10 @@ type ChatWindowSliceState = {
      * Defines if the chat window is in fullscreen mode.
      */
     isFullscreen: boolean;
+    /**
+     * Color palette to use for the chat UI.
+     */
+    colorPalette?: IColorPalette;
 };
 
 export const chatWindowSliceName = "chatWindow";
@@ -17,6 +22,7 @@ export const chatWindowSliceName = "chatWindow";
 const initialState: ChatWindowSliceState = {
     isOpen: false,
     isFullscreen: false,
+    colorPalette: undefined,
 };
 
 const chatWindowSlice = createSlice({
@@ -32,8 +38,14 @@ const chatWindowSlice = createSlice({
         ) => {
             state.isFullscreen = isFullscreen;
         },
+        setColorPaletteAction: (
+            state,
+            { payload: { colorPalette } }: PayloadAction<{ colorPalette?: IColorPalette }>,
+        ) => {
+            state.colorPalette = colorPalette;
+        },
     },
 });
 
 export const chatWindowSliceReducer = chatWindowSlice.reducer;
-export const { setOpenAction, setFullscreenAction } = chatWindowSlice.actions;
+export const { setOpenAction, setFullscreenAction, setColorPaletteAction } = chatWindowSlice.actions;

--- a/libs/sdk-ui-gen-ai/src/store/index.ts
+++ b/libs/sdk-ui-gen-ai/src/store/index.ts
@@ -37,4 +37,8 @@ export {
 
 export { setOpenAction, setFullscreenAction } from "./chatWindow/chatWindowSlice.js";
 
-export { isOpenSelector, isFullscreenSelector } from "./chatWindow/chatWindowSelectors.js";
+export {
+    isOpenSelector,
+    isFullscreenSelector,
+    colorPaletteSelector,
+} from "./chatWindow/chatWindowSelectors.js";

--- a/libs/sdk-ui-gen-ai/src/store/sideEffects/index.ts
+++ b/libs/sdk-ui-gen-ai/src/store/sideEffects/index.ts
@@ -1,6 +1,7 @@
 // (C) 2024-2025 GoodData Corporation
 
-import { fork, takeEvery, takeLatest } from "redux-saga/effects";
+import { call, fork, takeEvery, takeLatest } from "redux-saga/effects";
+import { IColorPalette } from "@gooddata/sdk-model";
 import {
     setVerboseAction,
     loadThreadAction,
@@ -16,12 +17,13 @@ import { onUserMessage } from "./onUserMessage.js";
 import { onUserFeedback } from "./onUserFeedback.js";
 import { onEvent } from "./onEvent.js";
 import { onVisualizationSave } from "./onVisualizationSave.js";
+import { loadColorPalette } from "./loadColorPalette.js";
 
 /**
  * One saga to rule them all.
  * @internal
  */
-export function* rootSaga() {
+export function* rootSaga(opts: { colorPalette?: IColorPalette }) {
     yield takeEvery(setVerboseAction.type, onVerboseStore);
     yield takeLatest(loadThreadAction.type, onThreadLoad);
     yield takeLatest(clearThreadAction.type, onThreadClear);
@@ -29,4 +31,5 @@ export function* rootSaga() {
     yield takeEvery(setUserFeedback.type, onUserFeedback);
     yield takeEvery(saveVisualizationAction.type, onVisualizationSave);
     yield fork(onEvent);
+    yield call(loadColorPalette, opts.colorPalette);
 }

--- a/libs/sdk-ui-gen-ai/src/store/sideEffects/loadColorPalette.ts
+++ b/libs/sdk-ui-gen-ai/src/store/sideEffects/loadColorPalette.ts
@@ -1,0 +1,45 @@
+// (C) 2024-2025 GoodData Corporation
+
+import { IAnalyticalBackend } from "@gooddata/sdk-backend-spi";
+import { call, getContext, put } from "redux-saga/effects";
+import { IColorPalette } from "@gooddata/sdk-model";
+import { setColorPaletteAction } from "../chatWindow/chatWindowSlice.js";
+
+/**
+ * Load color palette from the backend.
+ * @internal
+ */
+export function* loadColorPalette(colorPalette?: IColorPalette) {
+    try {
+        if (colorPalette) {
+            // If color palette is already provided, just set it to the store
+            yield put(
+                setColorPaletteAction({
+                    colorPalette,
+                }),
+            );
+            return;
+        }
+
+        // Retrieve backend from context
+        const backend: IAnalyticalBackend = yield getContext("backend");
+        const workspace: string = yield getContext("workspace");
+
+        const colorPaletteCall = backend.workspace(workspace).styling().getColorPalette;
+
+        const results: Awaited<ReturnType<typeof colorPaletteCall>> = yield call(colorPaletteCall);
+
+        yield put(
+            setColorPaletteAction({
+                colorPalette: results,
+            }),
+        );
+    } catch (e) {
+        //TODO: handle error somehow? Default color palette will be used in this case
+        yield put(
+            setColorPaletteAction({
+                colorPalette: undefined,
+            }),
+        );
+    }
+}

--- a/libs/sdk-ui-gen-ai/src/store/store.ts
+++ b/libs/sdk-ui-gen-ai/src/store/store.ts
@@ -1,8 +1,9 @@
-// (C) 2024 GoodData Corporation
+// (C) 2024-2025 GoodData Corporation
 import { configureStore } from "@reduxjs/toolkit";
 import defaultReduxSaga from "redux-saga";
 import { defaultImport } from "default-import";
 import { IAnalyticalBackend } from "@gooddata/sdk-backend-spi";
+import { IColorPalette } from "@gooddata/sdk-model";
 import { messagesSliceName, messagesSliceReducer } from "./messages/messagesSlice.js";
 import { chatWindowSliceName, chatWindowSliceReducer } from "./chatWindow/chatWindowSlice.js";
 import { rootSaga } from "./sideEffects/index.js";
@@ -17,7 +18,12 @@ export const getStore = (
     backend: IAnalyticalBackend,
     workspace: string,
     eventDispatcher: EventDispatcher,
+    opts: {
+        colorPalette?: IColorPalette;
+    },
 ) => {
+    const { colorPalette } = opts;
+
     const sagaMiddleware = createSagaMiddleware({
         context: {
             backend,
@@ -36,7 +42,7 @@ export const getStore = (
         },
     });
 
-    sagaMiddleware.run(rootSaga);
+    sagaMiddleware.run(rootSaga, { colorPalette });
 
     return store;
 };

--- a/libs/sdk-ui-gen-ai/styles/scss/agentIcon.scss
+++ b/libs/sdk-ui-gen-ai/styles/scss/agentIcon.scss
@@ -1,4 +1,4 @@
-// (C) 2024 GoodData Corporation
+// (C) 2024-2025 GoodData Corporation
 
 @use "sass:color";
 @use "variables" as variables;
@@ -9,7 +9,7 @@
 // Needed for spinner as a mid-point color
 $gd-palette-primary-base-midpoint: color-mix(
     in sRGB,
-    kit-variables.$gd-color-highlight 50%,
+    kit-variables.$gd-palette-primary-base 50%,
     kit-variables.$gd-palette-primary-dimmed 50%
 );
 
@@ -121,12 +121,12 @@ $gd-palette-primary-base-midpoint: color-mix(
 
 @keyframes gd-gen-ai-chat__agent_icon--appear--error {
     0% {
-        fill: #fff0;
+        fill: kit-variables.$gd-color-text-light;
     }
     50% {
         fill: kit-variables.$gd-palette-error-dimmed;
     }
     100% {
-        fill: #fff0;
+        fill: kit-variables.$gd-color-text-light;
     }
 }

--- a/libs/sdk-ui-gen-ai/styles/scss/messages.scss
+++ b/libs/sdk-ui-gen-ai/styles/scss/messages.scss
@@ -225,6 +225,10 @@
         border-radius: 3px;
         height: 35px;
         width: 40px;
+
+        svg path {
+            fill: kit-variables.$gd-color-white;
+        }
     }
 
     &:hover &__save {

--- a/libs/sdk-ui-gen-ai/styles/scss/window.scss
+++ b/libs/sdk-ui-gen-ai/styles/scss/window.scss
@@ -1,4 +1,4 @@
-// (C) 2024 GoodData Corporation
+// (C) 2024-2025 GoodData Corporation
 
 @use "sass:color";
 @use "variables" as variables;
@@ -12,8 +12,7 @@
     background-color: kit-variables.$gd-color-light;
     border: 1px solid kit-variables.$gd-border-color;
     border-radius: 3px;
-    // TODO - use color from variables
-    box-shadow: 0 1px 20px 0 #14385d26;
+    box-shadow: 0 1px 20px 0 color-mix(in sRGB, kit-variables.$gd-palette-primary-base 20%, transparent);
     display: flex;
     flex-direction: column;
     margin: 0 1em 1em 0;

--- a/libs/sdk-ui-kit/src/Header/Header.tsx
+++ b/libs/sdk-ui-kit/src/Header/Header.tsx
@@ -554,7 +554,13 @@ class AppHeaderCore extends Component<IAppHeaderProps & WrappedComponentProps, I
 
                 {this.renderTrialItems()}
 
-                {this.props.showChatItem ? <HeaderChatButton onClick={this.props.onChatItemClick} /> : null}
+                {this.props.showChatItem ? (
+                    <HeaderChatButton
+                        title={this.props.intl.formatMessage({ id: "gs.header.ai" })}
+                        color={this.props.theme?.palette?.primary?.base}
+                        onClick={this.props.onChatItemClick}
+                    />
+                ) : null}
 
                 {this.props.notificationsPanel
                     ? this.props.notificationsPanel({

--- a/libs/sdk-ui-kit/src/Header/HeaderChatButton.tsx
+++ b/libs/sdk-ui-kit/src/Header/HeaderChatButton.tsx
@@ -6,16 +6,18 @@ import { Icon } from "../Icon/index.js";
 import { Button } from "../Button/index.js";
 
 type HeaderChatButtonProps = {
+    title?: string;
+    color?: string;
     onClick: (e: React.MouseEvent) => void;
 };
 
-export const HeaderChatButton: React.FC<HeaderChatButtonProps> = ({ onClick }) => {
+export const HeaderChatButton: React.FC<HeaderChatButtonProps> = ({ color, title, onClick }) => {
     const classNames = cx("gd-header-measure", "gd-header-button", "gd-header-chat");
 
     // The text is not l18n-ed because it is not final
     return (
-        <Button title="Open AI Assistant" className={classNames} onClick={onClick}>
-            <Icon.GenAI width={32} height={32} ariaHidden />
+        <Button title={title} className={classNames} onClick={onClick}>
+            <Icon.GenAI color={color} width={32} height={32} ariaHidden />
         </Button>
     );
 };

--- a/libs/sdk-ui/src/base/localization/bundles/en-US.json
+++ b/libs/sdk-ui/src/base/localization/bundles/en-US.json
@@ -29,6 +29,11 @@
         "comment": "A global semantic search button label in the main menu",
         "limit": 0
     },
+    "gs.header.ai": {
+        "value": "Open AI Assistant",
+        "comment": "A global open AI Assistant button label in the main menu",
+        "limit": 0
+    },
     "gs.header.logo.title.accessibility": {
         "value": "Application logo",
         "comment": "",


### PR DESCRIPTION
Chatbot does not respect color palette when rendering charts Some other theming issues

risk: low
JIRA: GDAI-197

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```

#### Commands for Bear platform working on branch rel/9.9

```
extended-test-legacy --backstop
extended-test-legacy --isolated
extended-test-legacy --record
```
