### PR TITLE
fix: dialog close button label + dialog returns focus on close

### DIFF
--- a/libs/sdk-ui-kit/api/sdk-ui-kit.api.md
+++ b/libs/sdk-ui-kit/api/sdk-ui-kit.api.md
@@ -1426,6 +1426,8 @@ export interface IDialogBaseProps {
     // (undocumented)
     onSubmit?: (data?: any) => void;
     // (undocumented)
+    returnFocusAfterClose?: boolean;
+    // (undocumented)
     returnFocusTo?: React_2.RefObject<HTMLElement> | string;
     // (undocumented)
     shouldCloseOnClick?: (e: Event) => boolean;

--- a/libs/sdk-ui-kit/src/Dialog/ConfirmDialogBase.tsx
+++ b/libs/sdk-ui-kit/src/Dialog/ConfirmDialogBase.tsx
@@ -67,6 +67,7 @@ export const ConfirmDialogBase = React.memo<IConfirmDialogBaseProps>(function Co
             accessibilityConfig={accessibilityConfig}
             initialFocus={initialFocus}
             returnFocusTo={returnFocusTo}
+            returnFocusAfterClose={true}
         >
             <div className="gd-dialog-header-wrapper">
                 {headerLeftButtonRenderer?.()}

--- a/libs/sdk-ui-kit/src/Dialog/DialogBase.tsx
+++ b/libs/sdk-ui-kit/src/Dialog/DialogBase.tsx
@@ -34,6 +34,7 @@ export const DialogBase = React.memo<IDialogBaseProps>(function DialogBase({
     initialFocus,
     returnFocusTo,
     shouldCloseOnEscape = false,
+    returnFocusAfterClose = false,
 }) {
     const handleKeyDown = React.useCallback<React.KeyboardEventHandler<HTMLDivElement>>(
         (event) => {
@@ -60,6 +61,7 @@ export const DialogBase = React.memo<IDialogBaseProps>(function DialogBase({
             initialFocus={initialFocus}
             returnFocusTo={returnFocusTo}
             autofocusOnOpen={autofocusOnOpen}
+            returnFocusOnUnmount={returnFocusAfterClose}
         >
             <div
                 onKeyDown={handleKeyDown}

--- a/libs/sdk-ui-kit/src/Dialog/DialogCloseButton.tsx
+++ b/libs/sdk-ui-kit/src/Dialog/DialogCloseButton.tsx
@@ -2,19 +2,32 @@
 import React from "react";
 import { IDialogCloseButtonProps } from "./typings.js";
 import { Button } from "../Button/index.js";
-
-export const DialogCloseButton = React.memo<IDialogCloseButtonProps>(function DialogCloseButton({
+import { useIntl } from "react-intl";
+import { IntlWrapper } from "@gooddata/sdk-ui";
+const DialogCloseButtonCore = React.memo<IDialogCloseButtonProps>(function DialogCloseButton({
     accessibilityConfig,
     onClose,
 }) {
+    const intl = useIntl();
+    const closeButtonAccessibilityConfig = {
+        ariaLabel: intl.formatMessage({ id: "dialogs.closeLabel" }),
+        ...accessibilityConfig?.closeButton,
+    };
+
     return (
         <div className="gd-dialog-close">
             <Button
                 className="gd-button-link gd-button-icon-only gd-icon-cross s-dialog-close-button"
                 value=""
                 onClick={onClose}
-                accessibilityConfig={accessibilityConfig?.closeButton}
+                accessibilityConfig={closeButtonAccessibilityConfig}
             />
         </div>
     );
 });
+
+export const DialogCloseButton: React.FC<IDialogCloseButtonProps> = (props) => (
+    <IntlWrapper>
+        <DialogCloseButtonCore {...props} />
+    </IntlWrapper>
+);

--- a/libs/sdk-ui-kit/src/Dialog/ShareDialog/ShareDialogBase/AddGranteeBase.tsx
+++ b/libs/sdk-ui-kit/src/Dialog/ShareDialog/ShareDialogBase/AddGranteeBase.tsx
@@ -55,11 +55,6 @@ export const AddGranteeBase: React.FC<IAddGranteeBaseProps> = (props) => {
             onSubmit={onSubmit}
             onClose={onCancel}
             headerLeftButtonRenderer={backButtonRenderer}
-            accessibilityConfig={{
-                closeButton: {
-                    ariaLabel: intl.formatMessage({ id: "dialogs.closeLabel" }),
-                },
-            }}
         >
             <AddGranteeContent
                 currentUserPermissions={currentUserPermissions}

--- a/libs/sdk-ui-kit/src/Dialog/ShareDialog/ShareDialogBase/ShareGranteeBase.tsx
+++ b/libs/sdk-ui-kit/src/Dialog/ShareDialog/ShareDialogBase/ShareGranteeBase.tsx
@@ -81,11 +81,6 @@ export const ShareGranteeBase: React.FC<IShareGranteeBaseProps> = (props) => {
             onCancel={onCancel}
             onSubmit={onSubmit}
             initialFocus={ADD_GRANTEE_ID}
-            accessibilityConfig={{
-                closeButton: {
-                    ariaLabel: intl.formatMessage({ id: "dialogs.closeLabel" }),
-                },
-            }}
         >
             <ShareGranteeContent
                 currentUserPermissions={currentUserPermissions}

--- a/libs/sdk-ui-kit/src/Dialog/typings.ts
+++ b/libs/sdk-ui-kit/src/Dialog/typings.ts
@@ -39,6 +39,7 @@ export interface IDialogBaseProps {
     CloseButton?: React.ComponentType<IDialogCloseButtonProps>;
     initialFocus?: React.RefObject<HTMLElement> | string;
     returnFocusTo?: React.RefObject<HTMLElement> | string;
+    returnFocusAfterClose?: boolean;
 }
 
 /**


### PR DESCRIPTION
<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```

#### Commands for Bear platform working on branch rel/9.9

```
extended-test-legacy --backstop
extended-test-legacy --isolated
extended-test-legacy --record
```
