### PR TITLE
fix: chatbot does not respect color palette

### DIFF
--- a/libs/sdk-ui-gen-ai/src/components/GenAIChatDialog.tsx
+++ b/libs/sdk-ui-gen-ai/src/components/GenAIChatDialog.tsx
@@ -4,11 +4,14 @@ import { Provider as StoreProvider } from "react-redux";
 import { IAnalyticalBackend } from "@gooddata/sdk-backend-spi";
 import { BackendProvider, useBackendStrict, useWorkspaceStrict, WorkspaceProvider } from "@gooddata/sdk-ui";
 import { OverlayController, OverlayControllerProvider, useOverlayController } from "@gooddata/sdk-ui-kit";
+import { IColorPalette } from "@gooddata/sdk-model";
+
 import { useGenAIStore } from "../hooks/useGenAIStore.js";
 import { IntlWrapper } from "../localization/IntlWrapper.js";
-import { GenAIChatOverlay } from "./GenAIChatOverlay.js";
 import { ChatEventHandler } from "../store/events.js";
 import { isOpenSelector, setOpenAction } from "../store/index.js";
+
+import { GenAIChatOverlay } from "./GenAIChatOverlay.js";
 import { ConfigProvider, LinkHandlerEvent } from "./ConfigContext.js";
 
 export type GenAIChatDialogProps = {
@@ -17,6 +20,7 @@ export type GenAIChatDialogProps = {
     isOpen: boolean;
     onClose: () => void;
     eventHandlers?: ChatEventHandler[];
+    colorPalette?: IColorPalette;
     onLinkClick?: (linkClickEvent: LinkHandlerEvent) => void;
 };
 
@@ -31,12 +35,14 @@ export const GenAIChatDialog: React.FC<GenAIChatDialogProps> = ({
     isOpen,
     onClose,
     eventHandlers,
+    colorPalette,
     onLinkClick,
 }) => {
     const effectiveBackend = useBackendStrict(backend);
     const effectiveWorkspace = useWorkspaceStrict(workspace);
     const genAIStore = useGenAIStore(effectiveBackend, effectiveWorkspace, {
         eventHandlers,
+        colorPalette,
     });
 
     React.useEffect(() => {


### PR DESCRIPTION
Chatbot does not respect color palette when rendering charts Some other theming issues

risk: low
JIRA: GDAI-197

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```

#### Commands for Bear platform working on branch rel/9.9

```
extended-test-legacy --backstop
extended-test-legacy --isolated
extended-test-legacy --record
```
