### PR TITLE
fix: execution cancelling

### DIFF
--- a/libs/sdk-backend-tiger/src/backend/workspace/execution/preparedExecution.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/execution/preparedExecution.ts
@@ -60,7 +60,10 @@ export class TigerPreparedExecution implements IPreparedExecution {
                 { ...new TigerCancellationConverter(this.options?.signal ?? null).forAxios() },
             ),
         ).then((response) => {
-            const resultCancelToken = response?.headers["x-gdc-cancel-token"];
+            let resultCancelToken: string | undefined = undefined;
+            if (this.options?.signal) {
+                resultCancelToken = response?.headers["x-gdc-cancel-token"];
+            }
             return new TigerExecutionResult(
                 this.authCall,
                 this.definition,

--- a/libs/sdk-backend-tiger/src/cancelation/index.ts
+++ b/libs/sdk-backend-tiger/src/cancelation/index.ts
@@ -1,5 +1,5 @@
 // (C) 2019-2025 GoodData Corporation
-import axios, { AxiosRequestConfig } from "axios";
+import { AxiosRequestConfig } from "axios";
 
 export class TigerCancellationConverter {
     constructor(private readonly signal: AbortSignal | null) {}
@@ -11,12 +11,7 @@ export class TigerCancellationConverter {
             return {};
         }
 
-        const source = axios.CancelToken.source();
-
-        signal.addEventListener("abort", () => source.cancel());
-
         return {
-            cancelToken: source.token,
             signal,
         };
     }


### PR DESCRIPTION
- propagate cancel token header only if abort signal is provided
- remove axios cancel token, keep only abort signal

risk: low
JIRA: F1-1321

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```

#### Commands for Bear platform working on branch rel/9.9

```
extended-test-legacy --backstop
extended-test-legacy --isolated
extended-test-legacy --record
```
