### PR TITLE
fix: execution canceling

### DIFF
--- a/libs/sdk-backend-base/api/sdk-backend-base.api.md
+++ b/libs/sdk-backend-base/api/sdk-backend-base.api.md
@@ -421,7 +421,8 @@ export class DecoratedExecutionFactory implements IExecutionFactory {
 
 // @alpha
 export abstract class DecoratedExecutionResult implements IExecutionResult {
-    protected constructor(decorated: IExecutionResult, wrapper?: PreparedExecutionWrapper, signal?: AbortSignal | undefined);
+    protected constructor(decorated: IExecutionResult, wrapper?: PreparedExecutionWrapper);
+    protected abstract createNew(decorated: IExecutionResult): IExecutionResult;
     // (undocumented)
     definition: IExecutionDefinition;
     // (undocumented)
@@ -443,15 +444,17 @@ export abstract class DecoratedExecutionResult implements IExecutionResult {
     // (undocumented)
     readWindow(offset: number[], size: number[]): Promise<IDataView>;
     // (undocumented)
-    readonly signal: AbortSignal | undefined;
+    signal: AbortSignal | undefined;
     // (undocumented)
     transform(): IPreparedExecution;
+    // (undocumented)
+    withSignal(signal: AbortSignal): IExecutionResult;
 }
 
 // @alpha
 export abstract class DecoratedPreparedExecution implements IPreparedExecution {
-    protected constructor(decorated: IPreparedExecution, signal?: AbortSignal | undefined);
-    protected abstract createNew(decorated: IPreparedExecution, signal?: AbortSignal): IPreparedExecution;
+    protected constructor(decorated: IPreparedExecution);
+    protected abstract createNew(decorated: IPreparedExecution): IPreparedExecution;
     // (undocumented)
     protected readonly decorated: IPreparedExecution;
     // (undocumented)

--- a/libs/sdk-backend-base/src/customBackend/execution.ts
+++ b/libs/sdk-backend-base/src/customBackend/execution.ts
@@ -150,6 +150,10 @@ class CustomExecutionResult implements IExecutionResult {
         this.definition = execution.definition;
     }
 
+    public withSignal = (_signal: AbortSignal): IExecutionResult => {
+        return this;
+    };
+
     public readAll = (): Promise<IDataView> => {
         return this.state.authApiCall((client) => {
             if (!this.config.dataProvider) {

--- a/libs/sdk-backend-base/src/dummyBackend/index.ts
+++ b/libs/sdk-backend-base/src/dummyBackend/index.ts
@@ -472,6 +472,9 @@ function dummyExecutionResult(
         transform(): IPreparedExecution {
             return executionFactory.forDefinition(definition);
         },
+        withSignal(_signal: AbortSignal): IExecutionResult {
+            throw new NotSupported("canceling is not supported in dummy backend");
+        },
     };
 
     return result;

--- a/libs/sdk-backend-mockingbird/src/legacyRecordedBackend/index.ts
+++ b/libs/sdk-backend-mockingbird/src/legacyRecordedBackend/index.ts
@@ -417,6 +417,9 @@ function recordedExecutionResult(
         transform(): IPreparedExecution {
             return executionFactory.forDefinition(definition);
         },
+        withSignal(_signal: AbortSignal) {
+            throw new NotSupported("not supported");
+        },
     };
 
     return result;

--- a/libs/sdk-backend-mockingbird/src/recordedBackend/execution.ts
+++ b/libs/sdk-backend-mockingbird/src/recordedBackend/execution.ts
@@ -317,6 +317,10 @@ class RecordedExecutionResult implements IExecutionResult {
     public fingerprint = (): string => {
         return this._fp;
     };
+
+    public withSignal = (_signal: AbortSignal): IExecutionResult => {
+        return this;
+    };
 }
 
 class RecordedDataView implements IDataView {

--- a/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
+++ b/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
@@ -644,7 +644,7 @@ export interface IExecutionFactory {
 }
 
 // @public
-export interface IExecutionResult {
+export interface IExecutionResult extends ICancelable<IExecutionResult> {
     readonly definition: IExecutionDefinition;
     readonly dimensions: IDimensionDescriptor[];
     equals(other: IExecutionResult): boolean;

--- a/libs/sdk-backend-spi/src/workspace/execution/index.ts
+++ b/libs/sdk-backend-spi/src/workspace/execution/index.ts
@@ -377,7 +377,7 @@ export interface IPreparedExecution extends ICancelable<IPreparedExecution> {
  *
  * @public
  */
-export interface IExecutionResult {
+export interface IExecutionResult extends ICancelable<IExecutionResult> {
     /**
      * Full definition of execution that yielded this result.
      */

--- a/libs/sdk-backend-tiger/src/backend/workspace/execution/executionResult.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/execution/executionResult.ts
@@ -90,6 +90,18 @@ export class TigerExecutionResult implements IExecutionResult {
         this._fingerprint = SparkMD5.hash(this.resultId);
     }
 
+    public withSignal = (signal: AbortSignal): IExecutionResult => {
+        return new TigerExecutionResult(
+            this.authCall,
+            this.definition,
+            this.executionFactory,
+            this.execResponse,
+            this.dateFormatter,
+            signal,
+            this.resultCancelToken,
+        );
+    };
+
     public async readAll(): Promise<IDataView> {
         const executionResultPromise = this.authCall((client) =>
             client.executionResult

--- a/libs/sdk-ui-pivot/src/CorePivotTable.tsx
+++ b/libs/sdk-ui-pivot/src/CorePivotTable.tsx
@@ -239,18 +239,26 @@ export class CorePivotTableAgImpl extends React.Component<ICorePivotTableProps, 
         this.boundAgGridCallbacks = this.createBoundAgGridCallbacks();
         this.pivotTableId = uuidv4().replace(/-/g, "");
         this.onLoadingChanged = this.onLoadingChanged.bind(this);
+        if (this.props.config?.enableExecutionCancelling) {
+            this.abortController = new AbortController();
+        }
     }
 
     //
     // Lifecycle
     //
 
-    private abortController: AbortController = new AbortController();
+    private abortController: AbortController | undefined;
+
     private refreshAbortController = (): void => {
         if (this.props.config?.enableExecutionCancelling) {
-            this.abortController.abort();
+            this.abortController?.abort();
             this.abortController = new AbortController();
         }
+    };
+
+    private getCurrentAbortController = (): AbortController | undefined => {
+        return this.props.config?.enableExecutionCancelling ? this.abortController : undefined;
     };
 
     /**
@@ -274,7 +282,7 @@ export class CorePivotTableAgImpl extends React.Component<ICorePivotTableProps, 
             execution,
             this.getTableMethods(),
             this.props,
-            this.props.config?.enableExecutionCancelling ? this.abortController : undefined,
+            this.getCurrentAbortController,
         );
 
         initializer.initialize().then((result) => {

--- a/libs/sdk-ui-pivot/src/impl/tableFacade.ts
+++ b/libs/sdk-ui-pivot/src/impl/tableFacade.ts
@@ -130,7 +130,7 @@ export class TableFacade {
         dataView: IDataView,
         tableMethods: TableDataCallbacks & TableConfigAccessors,
         props: Readonly<ICorePivotTableProps>,
-        private readonly abortController?: AbortController,
+        private readonly getCurrentAbortController: () => AbortController | undefined,
     ) {
         this.intl = props.intl;
 
@@ -198,7 +198,6 @@ export class TableFacade {
         this.gridApi = undefined;
         this.columnApi = undefined;
         this.destroyed = true;
-        this.abortController?.abort();
     };
 
     public isFullyInitialized = (): boolean => {
@@ -267,7 +266,7 @@ export class TableFacade {
             this.visibleData,
             this.gridApiGuard,
             this.intl,
-            this.abortController,
+            this.getCurrentAbortController,
         );
     };
 

--- a/libs/sdk-ui-pivot/src/impl/tableFacadeInitializer.ts
+++ b/libs/sdk-ui-pivot/src/impl/tableFacadeInitializer.ts
@@ -26,7 +26,7 @@ export class TableFacadeInitializer {
         private readonly execution: IPreparedExecution,
         private readonly tableMethods: TableDataCallbacks & TableLegacyCallbacks & TableConfigAccessors,
         private readonly props: Readonly<ICorePivotTableProps>,
-        private readonly abortController?: AbortController | undefined,
+        private readonly getCurrentAbortController: () => AbortController | undefined,
     ) {}
 
     /**
@@ -63,8 +63,9 @@ export class TableFacadeInitializer {
         tableMethods.onLoadingChanged({ isLoading: true });
 
         let effectiveExecution = execution;
-        if (this.abortController) {
-            effectiveExecution = execution.withSignal(this.abortController.signal);
+        const abortController = this.getCurrentAbortController();
+        if (abortController) {
+            effectiveExecution = execution.withSignal(abortController.signal);
         }
 
         return effectiveExecution
@@ -147,6 +148,12 @@ export class TableFacadeInitializer {
     };
 
     private createTableFacade = (result: IExecutionResult, dataView: IDataView): TableFacade => {
-        return new TableFacade(result, dataView, this.tableMethods, this.props, this.abortController);
+        return new TableFacade(
+            result,
+            dataView,
+            this.tableMethods,
+            this.props,
+            this.getCurrentAbortController,
+        );
     };
 }

--- a/libs/sdk-ui-pivot/src/impl/tests/tableFacade.fixture.ts
+++ b/libs/sdk-ui-pivot/src/impl/tests/tableFacade.fixture.ts
@@ -1,4 +1,4 @@
-// (C) 2007-2021 GoodData Corporation
+// (C) 2007-2025 GoodData Corporation
 import { DataViewFacade, getIntl } from "@gooddata/sdk-ui";
 import { flatMap, noop } from "lodash";
 import { TableConfigAccessors, TableDataCallbacks, TableLegacyCallbacks } from "../privateTypes.js";
@@ -69,7 +69,12 @@ export async function createTestTableFacade(
 
     const testProps = createTestPivotTableProps(dv);
 
-    return new TableFacadeInitializer(dv.result().transform(), testTableMethods, testProps)
+    return new TableFacadeInitializer(
+        dv.result().transform(),
+        testTableMethods,
+        testProps,
+        () => new AbortController(),
+    )
         .initialize()
         .then((res) => {
             invariant(res);


### PR DESCRIPTION
fix: execution canceling
- Allow override signal of the execution result if needed
- If the execution result is cached, replace its signal
  with the current one, so abort signal is always up to date,
  even for cached results
- If the signal was aborted, do not use cached result and fetch again
- Always use up to date abort signal in PivotTable
- Correct `.equals()` execution method to use fingerprint

risk: low
JIRA: F1-1319

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```

#### Commands for Bear platform working on branch rel/9.9

```
extended-test-legacy --backstop
extended-test-legacy --isolated
extended-test-legacy --record
```
