### PR TITLE
fix: Handle UiMenu with only groups at the top level

### DIFF
--- a/libs/sdk-ui-kit/src/@ui/UiMenu/hooks.tsx
+++ b/libs/sdk-ui-kit/src/@ui/UiMenu/hooks.tsx
@@ -72,7 +72,7 @@ export function useUiMenuContextValue<T extends IUiMenuItemData = object>(
     );
 
     const [focusedId, setFocusedId_internal] = React.useState<string | undefined>(
-        () => items.find(isItemFocusable)?.id,
+        () => unwrapGroupItems(items).find(isItemFocusable)?.id,
     );
     const setFocusedId = React.useCallback<typeof setFocusedId_internal>(
         (...args) => {
@@ -230,7 +230,7 @@ export function useKeyNavigation<T extends IUiMenuItemData = object>({
 
             setFocusedId((prevId) => {
                 if (prevId === undefined) {
-                    return items.find(isItemFocusable)?.id;
+                    return unwrapGroupItems(items).find(isItemFocusable)?.id;
                 }
 
                 return unwrapGroupItems(getSiblingItems(items, prevId) ?? []).find(isItemFocusable)?.id;
@@ -241,7 +241,7 @@ export function useKeyNavigation<T extends IUiMenuItemData = object>({
 
             setFocusedId((prevId) => {
                 if (prevId === undefined) {
-                    return [...items].reverse().find(isItemFocusable)?.id;
+                    return [...unwrapGroupItems(items)].reverse().find(isItemFocusable)?.id;
                 }
 
                 return [...unwrapGroupItems(getSiblingItems(items, prevId) ?? [])]

--- a/libs/sdk-ui-kit/src/@ui/UiMenu/tests/UiMenu.test.tsx
+++ b/libs/sdk-ui-kit/src/@ui/UiMenu/tests/UiMenu.test.tsx
@@ -431,4 +431,98 @@ describe("UiMenu", () => {
         expect(screen.getByText("Group Item 1")).toBeInTheDocument();
         expect(screen.getByText("Group Item 2")).toBeInTheDocument();
     });
+    it("should handle menu with only group items at top level", () => {
+        // Create a menu with only group items at the top level
+        const onlyGroupItems: IUiMenuItem[] = [
+            {
+                type: "group",
+                id: "group1",
+                stringTitle: "Group 1",
+                data: "Group 1 title",
+                subItems: [
+                    {
+                        type: "interactive",
+                        id: "group1item1",
+                        stringTitle: "Group 1 Item 1",
+                        data: "group1data1",
+                    },
+                    {
+                        type: "interactive",
+                        id: "group1item2",
+                        stringTitle: "Group 1 Item 2",
+                        data: "group1data2",
+                    },
+                ],
+            },
+            {
+                type: "group",
+                id: "group2",
+                stringTitle: "Group 2",
+                data: "Group 2 title",
+                subItems: [
+                    {
+                        type: "interactive",
+                        id: "group2item1",
+                        stringTitle: "Group 2 Item 1",
+                        data: "group2data1",
+                    },
+                    {
+                        type: "interactive",
+                        id: "group2item2",
+                        stringTitle: "Group 2 Item 2",
+                        data: "group2data2",
+                    },
+                ],
+            },
+        ];
+
+        const onSelect = vi.fn();
+        render(
+            <IntlProvider key={DefaultLocale} locale={DefaultLocale} messages={messages}>
+                <UiMenu
+                    items={onlyGroupItems}
+                    onSelect={onSelect}
+                    onClose={vi.fn()}
+                    ariaAttributes={{
+                        id: "test-group-menu",
+                        "aria-labelledby": "test-group-button",
+                    }}
+                />
+            </IntlProvider>,
+        );
+
+        // Check that all group items are rendered
+        expect(screen.getByText("Group 1")).toBeInTheDocument();
+        expect(screen.getByText("Group 2")).toBeInTheDocument();
+        expect(screen.getByText("Group 1 Item 1")).toBeInTheDocument();
+        expect(screen.getByText("Group 1 Item 2")).toBeInTheDocument();
+        expect(screen.getByText("Group 2 Item 1")).toBeInTheDocument();
+        expect(screen.getByText("Group 2 Item 2")).toBeInTheDocument();
+
+        const menu = screen.getByRole("menu");
+
+        // Initial focus should be on the first interactive item from the first group
+        expect(menu).toHaveAttribute("aria-activedescendant", expect.stringContaining("group1item1"));
+
+        // Navigate down
+        fireEvent.keyDown(menu, { code: "ArrowDown" });
+        expect(menu).toHaveAttribute("aria-activedescendant", expect.stringContaining("group1item2"));
+
+        // Navigate down again to reach the next group
+        fireEvent.keyDown(menu, { code: "ArrowDown" });
+        expect(menu).toHaveAttribute("aria-activedescendant", expect.stringContaining("group2item1"));
+
+        // Navigate to end
+        fireEvent.keyDown(menu, { code: "End" });
+        expect(menu).toHaveAttribute("aria-activedescendant", expect.stringContaining("group2item2"));
+
+        // Navigate to home
+        fireEvent.keyDown(menu, { code: "Home" });
+        expect(menu).toHaveAttribute("aria-activedescendant", expect.stringContaining("group1item1"));
+
+        // Select an item
+        fireEvent.keyDown(menu, { code: "ArrowDown" });
+        fireEvent.keyDown(menu, { code: "Enter" });
+        expect(onSelect).toHaveBeenCalledWith(expect.objectContaining({ id: "group1item2" }));
+    });
 });


### PR DESCRIPTION
JIRA: LX-1028
risk: low

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```

#### Commands for Bear platform working on branch rel/9.9

```
extended-test-legacy --backstop
extended-test-legacy --isolated
extended-test-legacy --record
```
