### PR TITLE
fix: fix legend index even when no threshold zones are generated

### DIFF
--- a/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartOptions/chartThresholds.ts
+++ b/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartOptions/chartThresholds.ts
@@ -128,6 +128,9 @@ export function setupThresholdZones(
 const areZonesValid = (zones: IZone[]) =>
     !(zones.length === 0 || (zones.length === 1 && zones[0].dashStyle === "solid"));
 
+const fixLegendIndex = (series: ISeriesItem[]) =>
+    series.map((series, index) => ({ ...series, legendIndex: index }));
+
 function computeZonesForNonStackedChart(
     series: ISeriesItem[],
     thresholdMeasureIndex: number,
@@ -138,8 +141,8 @@ function computeZonesForNonStackedChart(
     const zones = generateZones(thresholdSeries.data);
 
     if (!areZonesValid(zones)) {
-        // no zone was generated, there's no need to update series, just don't render the threshold series
-        return { series: renderedSeries };
+        // no zone was generated, just don't render the threshold series, and fix legend index for the rest
+        return { series: fixLegendIndex(renderedSeries) };
     }
 
     return {
@@ -185,8 +188,10 @@ function computeZonesForStackedChart(
         ];
     });
 
-    // compute zone per series pair, hide threshold series, even when no zone was generated
-    const zonedSeries: ISeriesItem[] = pairedSeries.map(([dataSeries, thresholdSeries], index) => {
+    // compute zone per series pair, hide threshold series, even when no zone was generated, no need to touch
+    // legend index as the legend contains segments, not the metrics, and there's still the same amount of
+    // segments
+    const zonedSeries: ISeriesItem[] = pairedSeries.map(([dataSeries, thresholdSeries]) => {
         const zones = generateZones(thresholdSeries.data);
         if (!areZonesValid(zones)) {
             return dataSeries;
@@ -194,7 +199,6 @@ function computeZonesForStackedChart(
 
         return {
             ...dataSeries,
-            legendIndex: index,
             zoneAxis: "x",
             zones,
         };


### PR DESCRIPTION
The fix of legend was applied only when zones were generated. When threshold series was hidden, and index was broken, it was not fixed in this case.

Also, "fix" for zones were removed from stacked chart where it did not make sense as there are no series omitted from rendering (just odd or even numbers from each series and instead categories are filtered out). Legend contains attribute segments, not metrics names anyway.

JIRA: LX-1090
risk: low

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```

#### Commands for Bear platform working on branch rel/9.9

```
extended-test-legacy --backstop
extended-test-legacy --isolated
extended-test-legacy --record
```
