### PR TITLE
fix: remove schedule property from alerts

### DIFF
--- a/libs/sdk-ui-dashboard/src/model/store/automations/automationsSelectors.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/automations/automationsSelectors.ts
@@ -1,4 +1,4 @@
-// (C) 2024 GoodData Corporation
+// (C) 2024-2025 GoodData Corporation
 
 import { createSelector } from "@reduxjs/toolkit";
 import { GoodDataSdkError } from "@gooddata/sdk-ui";
@@ -52,7 +52,7 @@ export const selectDashboardUserAutomationAlerts: DashboardSelector<IAutomationM
  */
 export const selectDashboardUserAutomationSchedules: DashboardSelector<IAutomationMetadataObject[]> =
     createSelector(selectSelf, (state) => {
-        return state.userAutomations.filter((automation) => !!automation.schedule);
+        return state.userAutomations.filter((automation) => !!automation.schedule && !automation.alert);
     });
 
 /**


### PR DESCRIPTION
Fixed an issue where alerts were incorrectly displaying in the scheduled exports dialog. The issue was caused by alerts having both the schedule and alert properties.

- Updated selectors to properly filter alerts vs scheduled exports

risk: low
JIRA: F1-1344

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```

#### Commands for Bear platform working on branch rel/9.9

```
extended-test-legacy --backstop
extended-test-legacy --isolated
extended-test-legacy --record
```
