### PR TITLE
fix(sdk-ui-filters): irrelevant values when apply all at once

### DIFF
--- a/common/changes/@gooddata/sdk-ui-all/ovel-fix-dependent-filter-in-apply-all_2025-05-13-13-21.json
+++ b/common/changes/@gooddata/sdk-ui-all/ovel-fix-dependent-filter-in-apply-all_2025-05-13-13-21.json
@@ -1,0 +1,10 @@
+{
+    "changes": [
+        {
+            "packageName": "@gooddata/sdk-ui-all",
+            "comment": "Fix irrelevant values info in attribute filter when apply all at once is on",
+            "type": "none"
+        }
+    ],
+    "packageName": "@gooddata/sdk-ui-all"
+}

--- a/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/DefaultDashboardAttributeFilter.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/DefaultDashboardAttributeFilter.tsx
@@ -395,10 +395,6 @@ const DefaultDashboardAttributeFilterInner = (props: IDashboardAttributeFilterPr
                 userInteraction.attributeFilterInteraction("attributeFilterShowAllValuesClicked");
             };
 
-            if (filtersApplyMode.mode === "ALL_AT_ONCE" && enableDashboardFiltersApplyModes) {
-                return null;
-            }
-
             if (filter.attributeFilter.selectionMode === "single") {
                 return (
                     <SingleSelectionAttributeFilterStatusBar
@@ -434,8 +430,6 @@ const DefaultDashboardAttributeFilterInner = (props: IDashboardAttributeFilterPr
         filter.attributeFilter.validateElementsBy,
         capabilities.supportsShowingFilteredElements,
         userInteraction,
-        filtersApplyMode.mode,
-        enableDashboardFiltersApplyModes,
     ]);
 
     const AttributeFilterComponent = props.AttributeFilterComponent ?? AttributeFilterButton;

--- a/libs/sdk-ui-filters/api/sdk-ui-filters.api.md
+++ b/libs/sdk-ui-filters/api/sdk-ui-filters.api.md
@@ -615,6 +615,7 @@ export interface IAttributeFilterHandlerOptionsBase {
     enableDuplicatedLabelValuesInAttributeFilter?: boolean;
     hiddenElements?: string[];
     staticElements?: IAttributeElement[];
+    withoutApply?: boolean;
 }
 
 // @public
@@ -1127,6 +1128,8 @@ export interface IUseAttributeFilterHandlerProps {
     hiddenElements?: string[];
     // (undocumented)
     staticElements?: IAttributeElement[];
+    // (undocumented)
+    withoutApply?: boolean;
     // (undocumented)
     workspace: string;
 }

--- a/libs/sdk-ui-filters/src/AttributeFilter/Components/ElementsSelect/StatusBar/AttributeFilterStatusBar.tsx
+++ b/libs/sdk-ui-filters/src/AttributeFilter/Components/ElementsSelect/StatusBar/AttributeFilterStatusBar.tsx
@@ -1,109 +1,12 @@
-// (C) 2021-2024 GoodData Corporation
-import { IAttributeElement } from "@gooddata/sdk-model";
+// (C) 2021-2025 GoodData Corporation
 import React from "react";
 import { AttributeFilterFilteredStatus } from "./AttributeFilterFilteredStatus.js";
 import { AttributeFilterSelectionStatus } from "./AttributeFilterSelectionStatus.js";
 import { AttributeFilterShowFilteredElements } from "./AttributeFilterShowFilteredElements.js";
 import { AttributeFilterIrrelevantSelectionStatus } from "./AttributeFilterIrrelevantSelectionStatus.js";
 import noop from "lodash/noop.js";
-
-/**
- * It represents component that display status of current selection.
- * @beta
- */
-export interface IAttributeFilterStatusBarProps {
-    /**
-     * Number of elements that respect current criteria.
-     */
-    totalElementsCountWithCurrentSettings: number;
-
-    /**
-     * Indicate that elements are filtered by parents filters or not.
-     */
-    isFilteredByParentFilters: boolean;
-
-    /**
-     * Indicate if the elements are filtered by limit validation items or not.
-     *
-     * @beta
-     * @remarks Use only when platform supports limiting validation items.
-     */
-    isFilteredByLimitingValidationItems?: boolean;
-
-    /**
-     * Indicates if the elements are filtered by dependent date filters or not.
-     *
-     * @beta
-     */
-    isFilteredByDependentDateFilters?: boolean;
-
-    /**
-     * List of parent filter titles that filter current elements.
-     *
-     * @beta
-     */
-    parentFilterTitles: string[];
-
-    /**
-     * Indicate that current filter is inverted {@link @gooddata/sdk-model#INegativeAttributeFilter} or not {@link @gooddata/sdk-model#IPositiveAttributeFilter}
-     *
-     * @beta
-     */
-    isInverted: boolean;
-
-    /**
-     * List of selected items
-     * @beta
-     */
-    selectedItems: IAttributeElement[];
-
-    /**
-     * Item title getter used to get translated item empty value
-     *
-     * @beta
-     */
-    getItemTitle: (item: IAttributeElement) => string;
-
-    /**
-     * Maximum selected items
-     *
-     * @beta
-     */
-    selectedItemsLimit: number;
-
-    /**
-     * This enables "show filtered elements" option which manages showing filtered elements.
-     */
-    enableShowingFilteredElements?: boolean;
-
-    /**
-     * Title of the attribute used for dependent filter configuration.
-     *
-     * @remarks Used only when showing filtered elements is enabled.
-     */
-    attributeTitle?: string;
-
-    /**
-     * Show filtered elements callback.
-     *
-     * @remarks Used only when showing filtered elements is enabled.
-     */
-    onShowFilteredElements?: () => void;
-
-    /**
-     * Irrelevant/filtered out selection elements which are still effective.
-     *
-     * @remarks Used only when showing filtered elements is enabled.
-     */
-    irrelevantSelection?: IAttributeElement[];
-
-    /**
-     * Clear irrelevant/filtered out selection callback.
-     *
-     * @remarks Used only when showing filtered elements is enabled.
-     */
-    onClearIrrelevantSelection?: () => void;
-}
+import { useAttributeFilterContext } from "../../../Context/AttributeFilterContext.js";
+import type { IAttributeFilterStatusBarProps } from "./types.js";
 
 /**
  * A component that displays status of current selection, like number of selected elements, if Attribute Filter is inverted and list of selected elements.
@@ -111,6 +14,7 @@ export interface IAttributeFilterStatusBarProps {
  * @beta
  */
 export const AttributeFilterStatusBar: React.FC<IAttributeFilterStatusBarProps> = (props) => {
+    const { withoutApply } = useAttributeFilterContext();
     const {
         attributeTitle,
         isFilteredByParentFilters,
@@ -141,12 +45,14 @@ export const AttributeFilterStatusBar: React.FC<IAttributeFilterStatusBarProps> 
                         isFilteredByLimitingValidationItems={isFilteredByLimitingValidationItems}
                     />
                 ) : null}
-                <AttributeFilterSelectionStatus
-                    isInverted={isInverted}
-                    getItemTitle={getItemTitle}
-                    selectedItems={selectedItems}
-                    selectedItemsLimit={selectedItemsLimit}
-                />
+                {!withoutApply ? (
+                    <AttributeFilterSelectionStatus
+                        isInverted={isInverted}
+                        getItemTitle={getItemTitle}
+                        selectedItems={selectedItems}
+                        selectedItemsLimit={selectedItemsLimit}
+                    />
+                ) : null}
                 <AttributeFilterIrrelevantSelectionStatus
                     parentFilterTitles={parentFilterTitles}
                     irrelevantSelection={irrelevantSelection}
@@ -158,12 +64,14 @@ export const AttributeFilterStatusBar: React.FC<IAttributeFilterStatusBarProps> 
 
     return (
         <div className="gd-attribute-filter-status-bar__next">
-            <AttributeFilterSelectionStatus
-                isInverted={isInverted}
-                getItemTitle={getItemTitle}
-                selectedItems={selectedItems}
-                selectedItemsLimit={selectedItemsLimit}
-            />
+            {!withoutApply ? (
+                <AttributeFilterSelectionStatus
+                    isInverted={isInverted}
+                    getItemTitle={getItemTitle}
+                    selectedItems={selectedItems}
+                    selectedItemsLimit={selectedItemsLimit}
+                />
+            ) : null}
             {isFilteredByParentFilters && totalElementsCountWithCurrentSettings > 0 ? (
                 <AttributeFilterFilteredStatus parentFilterTitles={parentFilterTitles} />
             ) : null}

--- a/libs/sdk-ui-filters/src/AttributeFilter/Components/ElementsSelect/StatusBar/SingleSelectionAttributeFilterStatusBar.tsx
+++ b/libs/sdk-ui-filters/src/AttributeFilter/Components/ElementsSelect/StatusBar/SingleSelectionAttributeFilterStatusBar.tsx
@@ -1,9 +1,9 @@
-// (C) 2023-2024 GoodData Corporation
+// (C) 2023-2025 GoodData Corporation
 import React from "react";
-import { IAttributeFilterStatusBarProps } from "./AttributeFilterStatusBar.js";
 import { AttributeFilterFilteredStatus } from "./AttributeFilterFilteredStatus.js";
 import { AttributeFilterIrrelevantSelectionStatus } from "./AttributeFilterIrrelevantSelectionStatus.js";
 import { AttributeFilterShowFilteredElements } from "./AttributeFilterShowFilteredElements.js";
+import type { IAttributeFilterStatusBarProps } from "./types.js";
 
 /**
  * A component that displays only effective parent filters.

--- a/libs/sdk-ui-filters/src/AttributeFilter/Components/ElementsSelect/StatusBar/types.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilter/Components/ElementsSelect/StatusBar/types.ts
@@ -1,0 +1,100 @@
+// (C) 2021-2025 GoodData Corporation
+import { IAttributeElement } from "@gooddata/sdk-model";
+
+/**
+ * It represents component that display status of current selection.
+ * @beta
+ */
+export interface IAttributeFilterStatusBarProps {
+    /**
+     * Number of elements that respect current criteria.
+     */
+    totalElementsCountWithCurrentSettings: number;
+
+    /**
+     * Indicate that elements are filtered by parents filters or not.
+     */
+    isFilteredByParentFilters: boolean;
+
+    /**
+     * Indicate if the elements are filtered by limit validation items or not.
+     *
+     * @beta
+     * @remarks Use only when platform supports limiting validation items.
+     */
+    isFilteredByLimitingValidationItems?: boolean;
+
+    /**
+     * Indicates if the elements are filtered by dependent date filters or not.
+     *
+     * @beta
+     */
+    isFilteredByDependentDateFilters?: boolean;
+
+    /**
+     * List of parent filter titles that filter current elements.
+     *
+     * @beta
+     */
+    parentFilterTitles: string[];
+
+    /**
+     * Indicate that current filter is inverted {@link @gooddata/sdk-model#INegativeAttributeFilter} or not {@link @gooddata/sdk-model#IPositiveAttributeFilter}
+     *
+     * @beta
+     */
+    isInverted: boolean;
+
+    /**
+     * List of selected items
+     * @beta
+     */
+    selectedItems: IAttributeElement[];
+
+    /**
+     * Item title getter used to get translated item empty value
+     *
+     * @beta
+     */
+    getItemTitle: (item: IAttributeElement) => string;
+
+    /**
+     * Maximum selected items
+     *
+     * @beta
+     */
+    selectedItemsLimit: number;
+
+    /**
+     * This enables "show filtered elements" option which manages showing filtered elements.
+     */
+    enableShowingFilteredElements?: boolean;
+
+    /**
+     * Title of the attribute used for dependent filter configuration.
+     *
+     * @remarks Used only when showing filtered elements is enabled.
+     */
+    attributeTitle?: string;
+
+    /**
+     * Show filtered elements callback.
+     *
+     * @remarks Used only when showing filtered elements is enabled.
+     */
+    onShowFilteredElements?: () => void;
+
+    /**
+     * Irrelevant/filtered out selection elements which are still effective.
+     *
+     * @remarks Used only when showing filtered elements is enabled.
+     */
+    irrelevantSelection?: IAttributeElement[];
+
+    /**
+     * Clear irrelevant/filtered out selection callback.
+     *
+     * @remarks Used only when showing filtered elements is enabled.
+     */
+    onClearIrrelevantSelection?: () => void;
+}

--- a/libs/sdk-ui-filters/src/AttributeFilter/Components/index.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilter/Components/index.ts
@@ -1,4 +1,4 @@
-// (C) 2021-2024 GoodData Corporation
+// (C) 2021-2025 GoodData Corporation
 
 export type { IAttributeFilterDropdownButtonProps } from "./DropdownButton/AttributeFilterDropdownButton.js";
 export { AttributeFilterDropdownButton } from "./DropdownButton/AttributeFilterDropdownButton.js";
@@ -36,7 +36,7 @@ export type { IAttributeFilterFilteredStatusProps } from "./ElementsSelect/Statu
 export { AttributeFilterFilteredStatus } from "./ElementsSelect/StatusBar/AttributeFilterFilteredStatus.js";
 export type { IAttributeFilterSelectionStatusProps } from "./ElementsSelect/StatusBar/AttributeFilterSelectionStatus.js";
 export { AttributeFilterSelectionStatus } from "./ElementsSelect/StatusBar/AttributeFilterSelectionStatus.js";
-export type { IAttributeFilterStatusBarProps } from "./ElementsSelect/StatusBar/AttributeFilterStatusBar.js";
+export type { IAttributeFilterStatusBarProps } from "./ElementsSelect/StatusBar/types.js";
 export { AttributeFilterStatusBar } from "./ElementsSelect/StatusBar/AttributeFilterStatusBar.js";
 export { SingleSelectionAttributeFilterStatusBar } from "./ElementsSelect/StatusBar/SingleSelectionAttributeFilterStatusBar.js";
 export type { IAttributeFilterErrorProps } from "./AttributeFilterError.js";

--- a/libs/sdk-ui-filters/src/AttributeFilter/hooks/useAttributeFilterController.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilter/hooks/useAttributeFilterController.ts
@@ -155,6 +155,7 @@ export const useAttributeFilterController = (
         staticElements,
         enableDuplicatedLabelValuesInAttributeFilter,
         displayAsLabel,
+        withoutApply,
     });
     const attributeFilterControllerData = useAttributeFilterControllerData(
         handler,

--- a/libs/sdk-ui-filters/src/AttributeFilter/hooks/useAttributeFilterHandler.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilter/hooks/useAttributeFilterHandler.ts
@@ -1,4 +1,4 @@
-// (C) 2022-2024 GoodData Corporation
+// (C) 2022-2025 GoodData Corporation
 import { useEffect, useRef, useState, useCallback } from "react";
 import isEqual from "lodash/isEqual.js";
 import { usePrevious } from "@gooddata/sdk-ui";
@@ -24,6 +24,7 @@ export interface IUseAttributeFilterHandlerProps {
     hiddenElements?: string[];
     staticElements?: IAttributeElement[];
     enableDuplicatedLabelValuesInAttributeFilter: boolean;
+    withoutApply?: boolean;
 }
 
 /**
@@ -42,6 +43,7 @@ export const useAttributeFilterHandler = (props: IUseAttributeFilterHandlerProps
         hiddenElements,
         staticElements,
         enableDuplicatedLabelValuesInAttributeFilter = true,
+        withoutApply = false,
     } = props;
 
     const [, setInvalidate] = useState(0);
@@ -63,6 +65,7 @@ export const useAttributeFilterHandler = (props: IUseAttributeFilterHandlerProps
                 staticElements,
                 enableDuplicatedLabelValuesInAttributeFilter,
                 displayAsLabel,
+                withoutApply,
             },
         );
     }, [
@@ -73,6 +76,7 @@ export const useAttributeFilterHandler = (props: IUseAttributeFilterHandlerProps
         staticElements,
         enableDuplicatedLabelValuesInAttributeFilter,
         displayAsLabel,
+        withoutApply,
     ]);
 
     if (!handlerRef.current) {

--- a/libs/sdk-ui-filters/src/AttributeFilter/types.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilter/types.ts
@@ -24,8 +24,8 @@ import {
 import { IAttributeFilterElementsSelectLoadingProps } from "./Components/ElementsSelect/AttributeFilterElementsSelectLoading.js";
 import { IAttributeFilterElementsSelectErrorProps } from "./Components/ElementsSelect/AttributeFilterElementsSelectError.js";
 import { IAttributeFilterEmptyResultProps } from "./Components/ElementsSelect/EmptyResult/AttributeFilterEmptyResult.js";
-import { IAttributeFilterStatusBarProps } from "./Components/ElementsSelect/StatusBar/AttributeFilterStatusBar.js";
 import { IFilterButtonCustomIcon } from "../shared/index.js";
+import { IAttributeFilterStatusBarProps } from "./Components/ElementsSelect/StatusBar/types.js";
 
 /**
  * @public

--- a/libs/sdk-ui-filters/src/AttributeFilterHandler/factory.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilterHandler/factory.ts
@@ -1,4 +1,4 @@
-// (C) 2022-2024 GoodData Corporation
+// (C) 2022-2025 GoodData Corporation
 import { IAnalyticalBackend } from "@gooddata/sdk-backend-spi";
 import { IAttributeElement, IAttributeFilter, ObjRef } from "@gooddata/sdk-model";
 import { MultiSelectAttributeFilterHandler, SingleSelectAttributeFilterHandler } from "./internal/index.js";
@@ -57,6 +57,12 @@ export interface IAttributeFilterHandlerOptionsBase {
      * If specified, the attribute filter will display the elements in specified label form.
      */
     displayAsLabel?: ObjRef;
+
+    /**
+     * if true, the attribute filter will not display the apply button
+     * Several other behaviours are also affected by this option like dependent filters
+     */
+    withoutApply?: boolean;
 }
 
 /**
@@ -115,6 +121,7 @@ export function newAttributeFilterHandler(
         selectionMode: "multi",
         displayAsLabel: undefined,
         enableDuplicatedLabelValuesInAttributeFilter: true,
+        withoutApply: false,
     },
 ): IAttributeFilterHandler {
     const {
@@ -123,6 +130,7 @@ export function newAttributeFilterHandler(
         staticElements,
         enableDuplicatedLabelValuesInAttributeFilter,
         displayAsLabel,
+        withoutApply,
     } = options;
 
     if (selectionMode === "multi") {
@@ -134,6 +142,7 @@ export function newAttributeFilterHandler(
             staticElements,
             enableDuplicatedLabelValuesInAttributeFilter,
             displayAsLabel,
+            withoutApply,
         });
     }
 
@@ -145,5 +154,6 @@ export function newAttributeFilterHandler(
         staticElements,
         enableDuplicatedLabelValuesInAttributeFilter,
         displayAsLabel,
+        withoutApply,
     });
 }

--- a/libs/sdk-ui-filters/src/AttributeFilterHandler/internal/redux/common/selectors.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilterHandler/internal/redux/common/selectors.ts
@@ -1,4 +1,4 @@
-// (C) 2021-2024 GoodData Corporation
+// (C) 2021-2025 GoodData Corporation
 import { IAttributeElement } from "@gooddata/sdk-model";
 import { AttributeFilterState } from "../store/state.js";
 
@@ -23,3 +23,8 @@ export const getElementCacheKey = (
  * @internal
  */
 export const selectElementsForm = (state: AttributeFilterState) => state.elementsForm;
+
+/**
+ * @internal
+ */
+export const selectWithoutApply = (state: AttributeFilterState) => state.config.withoutApply;

--- a/libs/sdk-ui-filters/src/AttributeFilterHandler/internal/redux/loadIrrelevantElements/loadIrrelevantElementsSaga.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilterHandler/internal/redux/loadIrrelevantElements/loadIrrelevantElementsSaga.ts
@@ -1,4 +1,4 @@
-// (C) 2023-2024 GoodData Corporation
+// (C) 2023-2025 GoodData Corporation
 
 import { SagaIterator } from "redux-saga";
 import { put, call, takeLatest, select, cancelled, SagaReturnType } from "redux-saga/effects";
@@ -6,12 +6,12 @@ import { CancelableOptions } from "@gooddata/sdk-backend-spi";
 import difference from "lodash/difference.js";
 
 import { getAttributeFilterContext } from "../common/sagas.js";
-import { selectElementsForm } from "../common/selectors.js";
+import { selectElementsForm, selectWithoutApply } from "../common/selectors.js";
 import { elementsSaga } from "../elements/elementsSaga.js";
 import { selectLoadElementsOptions } from "../elements/elementsSelectors.js";
 import { actions } from "../store/slice.js";
 import { ILoadElementsOptions } from "../../../types/index.js";
-import { selectCommittedSelection } from "../store/selectors.js";
+import { selectCommittedSelection, selectWorkingSelection } from "../store/selectors.js";
 import { shouldExcludePrimaryLabel } from "../utils.js";
 
 /**
@@ -52,8 +52,10 @@ export function* loadIrrelevantElementsSaga(
             selectLoadElementsOptions,
         );
 
+        const withoutApply = yield select(selectWithoutApply);
+
         const allSelectedElementTitles: SagaReturnType<typeof selectCommittedSelection> = yield select(
-            selectCommittedSelection,
+            withoutApply ? selectWorkingSelection : selectCommittedSelection,
         );
         const elements =
             elementsForm === "values"

--- a/libs/sdk-ui-filters/src/AttributeFilterHandler/internal/redux/store/createStore.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilterHandler/internal/redux/store/createStore.ts
@@ -1,4 +1,4 @@
-// (C) 2022-2024 GoodData Corporation
+// (C) 2022-2025 GoodData Corporation
 import { Action, AnyAction, configureStore, Middleware } from "@reduxjs/toolkit";
 import defaultReduxSaga from "redux-saga";
 import { actions, sliceReducer } from "./slice.js";
@@ -88,6 +88,7 @@ export function createAttributeFilterHandlerStore(
             config: {
                 hiddenElements: context.hiddenElements,
                 staticElements: context.staticElements,
+                withoutApply: context.withoutApply,
             },
             originalFilter: context.attributeFilter,
         },

--- a/libs/sdk-ui-filters/src/AttributeFilterHandler/internal/redux/store/state.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilterHandler/internal/redux/store/state.ts
@@ -1,4 +1,4 @@
-// (C) 2022-2024 GoodData Corporation
+// (C) 2022-2025 GoodData Corporation
 import { CaseReducer, AnyAction } from "@reduxjs/toolkit";
 import { IAttributeElement, ObjRef, IAttributeMetadataObject, IAttributeFilter } from "@gooddata/sdk-model";
 import { GoodDataSdkError } from "@gooddata/sdk-ui";
@@ -59,6 +59,7 @@ export interface AttributeFilterState {
     config: {
         hiddenElements?: string[];
         staticElements?: IAttributeElement[];
+        withoutApply?: boolean;
     };
     originalFilter?: IAttributeFilter;
 }

--- a/libs/sdk-ui-filters/src/AttributeFilterHandler/internal/redux/store/types.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilterHandler/internal/redux/store/types.ts
@@ -1,4 +1,4 @@
-// (C) 2022-2024 GoodData Corporation
+// (C) 2022-2025 GoodData Corporation
 import { IAnalyticalBackend } from "@gooddata/sdk-backend-spi";
 import { Action, AnyAction } from "@reduxjs/toolkit";
 import { IAttributeElement, IAttributeFilter, ObjRef } from "@gooddata/sdk-model";
@@ -41,4 +41,5 @@ export interface AttributeFilterHandlerStoreContext {
     staticElements?: IAttributeElement[];
     eventListener: AttributeFilterHandlerEventListener;
     enableDuplicatedLabelValuesInAttributeFilter?: boolean;
+    withoutApply?: boolean;
 }


### PR DESCRIPTION
- in attribute filters

JIRA: MC-3609
risk: low

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```

#### Commands for Bear platform working on branch rel/9.9

```
extended-test-legacy --backstop
extended-test-legacy --isolated
extended-test-legacy --record
```
