### PR TITLE
fix: do not show hidden filters in automation filters select

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/automationFilters/useAutomationFilters.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/automationFilters/useAutomationFilters.ts
@@ -47,13 +47,13 @@ export const useAutomationFilters = ({
     );
 
     const attributes = useMemo(
-        () => getCatalogAttributesByFilters(nonSelectedFilters, allAttributes),
-        [nonSelectedFilters, allAttributes],
+        () => getCatalogAttributesByFilters(nonSelectedFilters, allAttributes, attributeConfigs),
+        [nonSelectedFilters, allAttributes, attributeConfigs],
     );
 
     const dateDatasets = useMemo(
-        () => getCatalogDateDatasetsByFilters(nonSelectedFilters, allDateDatasets),
-        [nonSelectedFilters, allDateDatasets],
+        () => getCatalogDateDatasetsByFilters(nonSelectedFilters, allDateDatasets, dateConfigs),
+        [nonSelectedFilters, allDateDatasets, dateConfigs],
     );
 
     const handleChangeFilter = useCallback(

--- a/libs/sdk-ui-dashboard/src/presentation/automationFilters/utils.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/automationFilters/utils.ts
@@ -63,13 +63,23 @@ export const getNonSelectedFilters = (
 export const getCatalogAttributesByFilters = (
     filters: FilterContextItem[],
     attributes: ICatalogAttribute[],
+    attributeConfigs: IDashboardAttributeFilterConfig[],
 ): ICatalogAttribute[] => {
+    const ignoredLocalIdentifiers = attributeConfigs
+        .filter((config) => config.mode === "hidden")
+        .map((config) => config.localIdentifier);
+
     return attributes.filter((attribute) => {
         return filters.some((filter) => {
             if (isDashboardAttributeFilter(filter)) {
-                return attribute.displayForms.some((displayForm) => {
-                    return areObjRefsEqual(displayForm.ref, filter.attributeFilter.displayForm);
-                });
+                const localIdentifier = filter.attributeFilter.localIdentifier;
+                return (
+                    localIdentifier &&
+                    !ignoredLocalIdentifiers.includes(localIdentifier) &&
+                    attribute.displayForms.some((displayForm) => {
+                        return areObjRefsEqual(displayForm.ref, filter.attributeFilter.displayForm);
+                    })
+                );
             }
 
             return false;
@@ -80,11 +90,22 @@ export const getCatalogAttributesByFilters = (
 export const getCatalogDateDatasetsByFilters = (
     filters: FilterContextItem[],
     dateDataset: ICatalogDateDataset[],
+    dateConfigs: IDashboardDateFilterConfigItem[],
 ): ICatalogDateDataset[] => {
+    const ignoredDateDatasets = dateConfigs
+        .filter((config) => {
+            return config.config.mode === "hidden";
+        })
+        .map((config) => config.dateDataSet);
+
     return dateDataset.filter((dateDataset) => {
         return filters.some((filter) => {
             if (isDashboardDateFilter(filter)) {
-                return areObjRefsEqual(dateDataset.dataSet.ref, filter.dateFilter.dataSet);
+                return (
+                    !ignoredDateDatasets.some((ignoredDataset) =>
+                        areObjRefsEqual(dateDataset.dataSet.ref, ignoredDataset),
+                    ) && areObjRefsEqual(dateDataset.dataSet.ref, filter.dateFilter.dataSet)
+                );
             }
 
             return false;


### PR DESCRIPTION
JIRA: F1-1364
risk: low

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```

#### Commands for Bear platform working on branch rel/9.9

```
extended-test-legacy --backstop
extended-test-legacy --isolated
extended-test-legacy --record
```
