### PR TITLE
fix: automation filters

### DIFF
--- a/libs/sdk-backend-base/src/normalizingBackend/index.ts
+++ b/libs/sdk-backend-base/src/normalizingBackend/index.ts
@@ -140,7 +140,8 @@ class DenormalizingExecutionResult extends DecoratedExecutionResult {
     };
 
     public export = async (options: IExportConfig): Promise<IExportResult> => {
-        const originalResult = await this.originalExecution.execute();
+        // Avoid abort signal to be out of sync
+        const originalResult = await this.originalExecution.withSignal(this.signal).execute();
 
         return originalResult.export(options);
     };

--- a/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
+++ b/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
@@ -419,7 +419,7 @@ export interface IBracketExpressionToken {
 // @beta
 export interface ICancelable<T> {
     // (undocumented)
-    withSignal(signal: AbortSignal): T;
+    withSignal(signal: AbortSignal | undefined): T;
 }
 
 // @beta

--- a/libs/sdk-backend-spi/src/cancelation/index.ts
+++ b/libs/sdk-backend-spi/src/cancelation/index.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2023 GoodData Corporation
+// (C) 2019-2025 GoodData Corporation
 
 /**
  * Options that is used for propagation cancellation signal / abort signal
@@ -18,5 +18,5 @@ export interface ICancelable<T> {
      * @param signal - Abort signal used for canceling requests
      * @returns Instance of object with interface
      */
-    withSignal(signal: AbortSignal): T;
+    withSignal(signal: AbortSignal | undefined): T;
 }

--- a/libs/sdk-ui-dashboard/src/model/react/useWidgetFilters.ts
+++ b/libs/sdk-ui-dashboard/src/model/react/useWidgetFilters.ts
@@ -263,7 +263,7 @@ export function useWidgetFilters(
      * This temporary workaround should be replaced by fixing useWidgetFiltersImpl in a future update.
      */
     return useMemo(() => {
-        if (!widget || !insight || previousWidgetRef !== widget?.ref) {
+        if (!(widget || insight) || !areObjRefsEqual(previousWidgetRef, widget?.ref)) {
             return {
                 result: undefined,
                 status: "pending",


### PR DESCRIPTION
Use proper equality check for widget ref.
Make export work with execution cancellation.

risk: low
JIRA: F1-1343

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```

#### Commands for Bear platform working on branch rel/9.9

```
extended-test-legacy --backstop
extended-test-legacy --isolated
extended-test-legacy --record
```
