### PR TITLE
fix(sdk-ui-filters): reload filter when closing with search

### DIFF
--- a/common/changes/@gooddata/sdk-ui-all/ovel-fix-reload-filter-after-search_2025-05-19-10-14.json
+++ b/common/changes/@gooddata/sdk-ui-all/ovel-fix-reload-filter-after-search_2025-05-19-10-14.json
@@ -1,0 +1,10 @@
+{
+    "changes": [
+        {
+            "packageName": "@gooddata/sdk-ui-all",
+            "comment": "fix attribute filter not reloading values after dropdown close when some search query is not empty",
+            "type": "none"
+        }
+    ],
+    "packageName": "@gooddata/sdk-ui-all"
+}

--- a/libs/sdk-ui-filters/src/AttributeFilter/hooks/useAttributeFilterController.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilter/hooks/useAttributeFilterController.ts
@@ -889,10 +889,7 @@ function useCallbacks(
 
         if (handler.getSearch().length > 0) {
             handler.setSearch("");
-            if (handler.getInitStatus() === "loading" || !enableDashboardFiltersApplyModes) {
-                // if status is loading, updateNonResettingFilter takes care of clearing search and reloading elements.
-                handler.loadInitialElementsPage(RESET_CORRELATION);
-            }
+            handler.loadInitialElementsPage(RESET_CORRELATION);
         }
 
         /**


### PR DESCRIPTION
- attribute filter
- it will maybe load twice in some cases, but Im not able to improve without huge refactoring

JIRA: MC-3698
risk: low

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```

#### Commands for Bear platform working on branch rel/9.9

```
extended-test-legacy --backstop
extended-test-legacy --isolated
extended-test-legacy --record
```
