### PR TITLE
fix: ignore browser timezone

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/filterBar/filterBar/useExecutionTimestampMessage.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/filterBar/filterBar/useExecutionTimestampMessage.ts
@@ -2,7 +2,6 @@
 
 import { ILocale } from "@gooddata/sdk-ui";
 import { useCallback } from "react";
-import { toModifiedISOStringToTimezone } from "../../scheduledEmail/utils/date.js";
 import {
     selectLocale,
     selectExecutionTimestamp,
@@ -12,23 +11,37 @@ import {
     selectTimezone,
 } from "../../../model/index.js";
 
+/**
+ * Formats a date using the provided locale and timezone from backend settings,
+ * explicitly avoiding browser timezone settings to ensure consistent display
+ * regardless of the user's device configuration.
+ */
 function formatDate(isoString: string | undefined, locale: ILocale, timezone?: string) {
     if (!isoString) {
         return undefined;
     }
 
-    const { date } = toModifiedISOStringToTimezone(new Date(isoString), timezone);
+    // Parse the ISO string and create Date object only once
+    const timestamp = new Date(isoString);
 
-    const formattedDate = date.toLocaleDateString(locale, {
+    // IMPORTANT: We use Intl.DateTimeFormat with explicit timeZone parameter
+    // to ensure we only rely on backend settings and not the browser's timezone
+    const dateFormatter = new Intl.DateTimeFormat(locale, {
         year: "numeric",
         month: "long",
         day: "numeric",
+        timeZone: timezone || "UTC",
     });
 
-    const formattedTime = date.toLocaleTimeString(locale, {
+    // Using the same approach for time to maintain consistency across browser environments
+    const timeFormatter = new Intl.DateTimeFormat(locale, {
         hour: "2-digit",
         minute: "2-digit",
+        timeZone: timezone || "UTC",
     });
+
+    const formattedDate = dateFormatter.format(timestamp);
+    const formattedTime = timeFormatter.format(timestamp);
 
     return `${formattedDate}, ${formattedTime}`;
 }


### PR DESCRIPTION
- rely only on BE settings when formatting timestamp message

JIRA: F1-1229
risk: low

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```

#### Commands for Bear platform working on branch rel/9.9

```
extended-test-legacy --backstop
extended-test-legacy --isolated
extended-test-legacy --record
```
