### PR TITLE
fix(sdk-ui-filters): failing storybook tests

### DIFF
--- a/common/changes/@gooddata/sdk-ui-all/ovel-fix-storybook-StatusBar_2025-05-20-09-37.json
+++ b/common/changes/@gooddata/sdk-ui-all/ovel-fix-storybook-StatusBar_2025-05-20-09-37.json
@@ -1,0 +1,10 @@
+{
+    "changes": [
+        {
+            "packageName": "@gooddata/sdk-ui-all",
+            "comment": "fix failing storybook test for AttributeFilterStatusBar",
+            "type": "none"
+        }
+    ],
+    "packageName": "@gooddata/sdk-ui-all"
+}

--- a/libs/sdk-ui-filters/api/sdk-ui-filters.api.md
+++ b/libs/sdk-ui-filters/api/sdk-ui-filters.api.md
@@ -578,6 +578,7 @@ export interface IAttributeFilterElementsSelectProps {
     selectedItems: IAttributeElement[];
     totalItemsCount: number;
     totalItemsCountWithCurrentSettings: number;
+    withoutApply?: boolean;
 }
 
 // @beta
@@ -671,6 +672,7 @@ export interface IAttributeFilterStatusBarProps {
     selectedItems: IAttributeElement[];
     selectedItemsLimit: number;
     totalElementsCountWithCurrentSettings: number;
+    withoutApply?: boolean;
 }
 
 // @public

--- a/libs/sdk-ui-filters/src/AttributeFilter/Components/Dropdown/AttributeFilterDropdownActions.tsx
+++ b/libs/sdk-ui-filters/src/AttributeFilter/Components/Dropdown/AttributeFilterDropdownActions.tsx
@@ -30,7 +30,7 @@ export interface IAttributeFilterDropdownActionsProps {
     isApplyDisabled?: boolean;
 
     /**
-     * If true, the Apply button is not rendered and Cancel button is renamed to Close.
+     * If true, the Apply button is not rendered, Cancel button is renamed to Close and status bar is not rendered.
      *
      * @alpha
      */

--- a/libs/sdk-ui-filters/src/AttributeFilter/Components/Dropdown/AttributeFilterDropdownBody.tsx
+++ b/libs/sdk-ui-filters/src/AttributeFilter/Components/Dropdown/AttributeFilterDropdownBody.tsx
@@ -92,6 +92,7 @@ export const AttributeFilterDropdownBody: React.FC<IAttributeFilterDropdownBodyP
                 onShowFilteredElements={onShowFilteredElements}
                 irrelevantSelection={irrelevantSelection}
                 onClearIrrelevantSelection={onClearIrrelevantSelection}
+                withoutApply={withoutApply}
             />
             <DropdownActionsComponent
                 onApplyButtonClick={onApplyButtonClick}

--- a/libs/sdk-ui-filters/src/AttributeFilter/Components/ElementsSelect/AttributeFilterElementsSelect.tsx
+++ b/libs/sdk-ui-filters/src/AttributeFilter/Components/ElementsSelect/AttributeFilterElementsSelect.tsx
@@ -1,4 +1,4 @@
-// (C) 2019-2024 GoodData Corporation
+// (C) 2019-2025 GoodData Corporation
 import React, { useMemo } from "react";
 import { useIntl } from "react-intl";
 import { InvertableSelect, useMediaQuery } from "@gooddata/sdk-ui-kit";
@@ -55,6 +55,7 @@ export const AttributeFilterElementsSelect: React.FC<IAttributeFilterElementsSel
         onClearIrrelevantSelection,
 
         isFilteredByDependentDateFilters,
+        withoutApply,
     } = props;
 
     const intl = useIntl();
@@ -165,6 +166,7 @@ export const AttributeFilterElementsSelect: React.FC<IAttributeFilterElementsSel
                             onShowFilteredElements={onShowFilteredElements}
                             irrelevantSelection={irrelevantSelection}
                             onClearIrrelevantSelection={onClearIrrelevantSelection}
+                            withoutApply={withoutApply}
                         />
                     );
                 }}

--- a/libs/sdk-ui-filters/src/AttributeFilter/Components/ElementsSelect/StatusBar/AttributeFilterStatusBar.tsx
+++ b/libs/sdk-ui-filters/src/AttributeFilter/Components/ElementsSelect/StatusBar/AttributeFilterStatusBar.tsx
@@ -5,7 +5,6 @@ import { AttributeFilterSelectionStatus } from "./AttributeFilterSelectionStatus
 import { AttributeFilterShowFilteredElements } from "./AttributeFilterShowFilteredElements.js";
 import { AttributeFilterIrrelevantSelectionStatus } from "./AttributeFilterIrrelevantSelectionStatus.js";
 import noop from "lodash/noop.js";
-import { useAttributeFilterContext } from "../../../Context/AttributeFilterContext.js";
 import type { IAttributeFilterStatusBarProps } from "./types.js";
 
 /**
@@ -14,7 +13,6 @@ import type { IAttributeFilterStatusBarProps } from "./types.js";
  * @beta
  */
 export const AttributeFilterStatusBar: React.FC<IAttributeFilterStatusBarProps> = (props) => {
-    const { withoutApply } = useAttributeFilterContext();
     const {
         attributeTitle,
         isFilteredByParentFilters,
@@ -30,6 +28,7 @@ export const AttributeFilterStatusBar: React.FC<IAttributeFilterStatusBarProps> 
         onClearIrrelevantSelection = noop,
         isFilteredByLimitingValidationItems,
         isFilteredByDependentDateFilters,
+        withoutApply = false,
     } = props;
 
     if (enableShowingFilteredElements) {

--- a/libs/sdk-ui-filters/src/AttributeFilter/Components/ElementsSelect/StatusBar/types.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilter/Components/ElementsSelect/StatusBar/types.ts
@@ -97,4 +97,11 @@ export interface IAttributeFilterStatusBarProps {
      * @remarks Used only when showing filtered elements is enabled.
      */
     onClearIrrelevantSelection?: () => void;
+
+    /**
+     * Whether the filter is rendered without apply button.
+     *
+     * @remarks Usually true (in case of dashboard) when filtersApplyMode.mode === "ALL_AT_ONCE"
+     */
+    withoutApply?: boolean;
 }

--- a/libs/sdk-ui-filters/src/AttributeFilter/Components/ElementsSelect/types.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilter/Components/ElementsSelect/types.ts
@@ -1,4 +1,4 @@
-// (C) 2022-2024 GoodData Corporation
+// (C) 2022-2025 GoodData Corporation
 import { IAttributeElement } from "@gooddata/sdk-model";
 import { GoodDataSdkError } from "@gooddata/sdk-ui";
 
@@ -153,6 +153,13 @@ export interface IAttributeFilterElementsSelectProps {
      * @remarks Used only when showing filtered elements is enabled.
      */
     onClearIrrelevantSelection?: () => void;
+
+    /**
+     * Whether the filter is rendered without apply button.
+     *
+     * @remarks Usually true (in case of dashboard) when filtersApplyMode.mode === "ALL_AT_ONCE"
+     */
+    withoutApply?: boolean;
 }
 
 /**


### PR DESCRIPTION
- AttributeFilterStatusBar is not expected to use context

JIRA: LX-935
risk: low

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```

#### Commands for Bear platform working on branch rel/9.9

```
extended-test-legacy --backstop
extended-test-legacy --isolated
extended-test-legacy --record
```
