### PR TITLE
fix: execution cancelling

### DIFF
--- a/libs/sdk-ui-pivot/src/CorePivotTable.tsx
+++ b/libs/sdk-ui-pivot/src/CorePivotTable.tsx
@@ -463,7 +463,11 @@ export class CorePivotTableAgImpl extends React.Component<ICorePivotTableProps, 
             }
         }
 
-        return prevProps.execution.fingerprint() !== this.props.execution.fingerprint();
+        return this.props.config?.enableExecutionCancelling
+            ? prevProps.execution.fingerprint() !== this.props.execution.fingerprint()
+            : // this is triggering execution multiple times in some cases which is not good together with enabled execution cancelling
+              // on the other hand, without execution cancelling, fingerprint comparison only may lead to race conditions
+              !this.internal.table.isMatchingExecution(this.props.execution);
     }
 
     /**


### PR DESCRIPTION
Keep previous un-synced comparison without execution cancelling enabled. It triggers execution multiple-times, which is issue with cancelling, but only fingerprint comparison may lead to race conditions without cancelling.

risk: low
JIRA: F1-1377

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```

#### Commands for Bear platform working on branch rel/9.9

```
extended-test-legacy --backstop
extended-test-legacy --isolated
extended-test-legacy --record
```
