### PR TITLE
fix: do not propagate delete action to parent in automation filters

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/automationFilters/components/AutomationAttributeFilter.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/automationFilters/components/AutomationAttributeFilter.tsx
@@ -116,6 +116,10 @@ function AutomationAttributeFilterDropdownButtonComponent(props: IAttributeFilte
                 isDeletable={!isLocked}
                 onClick={props.onClick}
                 onDelete={() => onDelete?.(filter!)}
+                onDeleteKeyDown={(event) => {
+                    // Do not propagate event to parent as attribute filter would always open
+                    event.stopPropagation();
+                }}
                 accessibilityConfig={{
                     isExpanded: props.isOpen,
                     deleteAriaLabel,

--- a/libs/sdk-ui-dashboard/src/presentation/automationFilters/components/AutomationDateFilter.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/automationFilters/components/AutomationDateFilter.tsx
@@ -62,6 +62,10 @@ export const AutomationDateFilter: React.FC<{
                             isLocked={isLocked}
                             isDeletable={!isLocked && !isCommonDateFilter}
                             onDelete={() => onDelete(filter)}
+                            onDeleteKeyDown={(event) => {
+                                // Do not propagate event to parent as date filter would always open
+                                event.stopPropagation();
+                            }}
                             accessibilityConfig={{
                                 isExpanded: props.isOpen,
                                 deleteAriaLabel: intl.formatMessage({ id: "delete" }),

--- a/libs/sdk-ui-kit/api/sdk-ui-kit.api.md
+++ b/libs/sdk-ui-kit/api/sdk-ui-kit.api.md
@@ -5562,7 +5562,7 @@ export interface UiButtonProps {
 }
 
 // @internal (undocumented)
-export const UiChip: ({ label, tag, isDeletable, isActive, isLocked, iconBefore, onClick, onDelete, accessibilityConfig, }: UiChipProps) => React_2.JSX.Element;
+export const UiChip: ({ label, tag, isDeletable, isActive, isLocked, iconBefore, onClick, onDelete, onDeleteKeyDown, accessibilityConfig, }: UiChipProps) => React_2.JSX.Element;
 
 // @internal (undocumented)
 export interface UiChipProps {
@@ -5582,6 +5582,8 @@ export interface UiChipProps {
     onClick?: () => void;
     // (undocumented)
     onDelete?: () => void;
+    // (undocumented)
+    onDeleteKeyDown?: (event: React_2.KeyboardEvent<HTMLButtonElement>) => void;
     // (undocumented)
     tag?: string;
 }

--- a/libs/sdk-ui-kit/src/@ui/UiChip/UiChip.tsx
+++ b/libs/sdk-ui-kit/src/@ui/UiChip/UiChip.tsx
@@ -28,6 +28,7 @@ export interface UiChipProps {
     iconBefore?: IconType;
     onClick?: () => void;
     onDelete?: () => void;
+    onDeleteKeyDown?: (event: React.KeyboardEvent<HTMLButtonElement>) => void;
     accessibilityConfig?: IUiChipAccessibilityConfig;
 }
 
@@ -45,6 +46,7 @@ export const UiChip = ({
     iconBefore,
     onClick,
     onDelete,
+    onDeleteKeyDown,
     accessibilityConfig,
 }: UiChipProps) => {
     const buttonRef = useRef<HTMLButtonElement>(null);
@@ -103,7 +105,12 @@ export const UiChip = ({
                 )}
             </button>
             {isDeletable ? (
-                <button aria-label={deleteAriaLabel} className={e("delete")} onClick={onDelete}>
+                <button
+                    aria-label={deleteAriaLabel}
+                    className={e("delete")}
+                    onClick={onDelete}
+                    onKeyDown={onDeleteKeyDown}
+                >
                     <span className={e("icon-delete")}>
                         <UiIcon type="cross" color="complementary-6" size={14} ariaHidden={true} />
                     </span>


### PR DESCRIPTION
JIRA: F1-1380
risk: low

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```

#### Commands for Bear platform working on branch rel/9.9

```
extended-test-legacy --backstop
extended-test-legacy --isolated
extended-test-legacy --record
```
