### PR TITLE
fix: Handle UiMenu submenu wrapped in a group

### DIFF
--- a/libs/sdk-ui-kit/src/@ui/UiMenu/hooks.tsx
+++ b/libs/sdk-ui-kit/src/@ui/UiMenu/hooks.tsx
@@ -143,7 +143,9 @@ export function useUiMenuContextValue<T extends IUiMenuItemData = object, M = ob
             }
 
             // Otherwise focus the first focusable child
-            const itemToFocus = getItemsByInteractiveParent(items, item.id)?.filter(isItemFocusable)[0];
+            const itemToFocus = unwrapGroupItems(getItemsByInteractiveParent(items, item.id) ?? []).filter(
+                isItemFocusable,
+            )[0];
 
             if (!itemToFocus) {
                 return;

--- a/libs/sdk-ui-kit/src/@ui/UiMenu/tests/UiMenu.test.tsx
+++ b/libs/sdk-ui-kit/src/@ui/UiMenu/tests/UiMenu.test.tsx
@@ -520,4 +520,69 @@ describe("UiMenu", () => {
         fireEvent.keyDown(menu, { code: "Enter" });
         expect(onSelect).toHaveBeenCalledWith(expect.objectContaining({ id: "group1item2" }));
     });
+
+    it("should open submenu with a group inside when top-level interactive item is clicked", () => {
+        const menuWithInteractiveAndGroup: IUiMenuItem[] = [
+            { type: "interactive", id: "item1", stringTitle: "Item 1", data: "data1" },
+            {
+                type: "interactive",
+                id: "item2",
+                stringTitle: "Item with submenu",
+                data: "data2",
+                subItems: [
+                    {
+                        type: "group",
+                        id: "group1",
+                        stringTitle: "Group 1",
+                        data: "Group title",
+                        subItems: [
+                            {
+                                type: "interactive",
+                                id: "groupitem1",
+                                stringTitle: "Group Item 1",
+                                data: "groupdata1",
+                            },
+                            {
+                                type: "interactive",
+                                id: "groupitem2",
+                                stringTitle: "Group Item 2",
+                                data: "groupdata2",
+                            },
+                        ],
+                    },
+                ],
+            },
+            { type: "interactive", id: "item3", stringTitle: "Item 3", data: "data3" },
+        ];
+
+        render(
+            <IntlProvider key={DefaultLocale} locale={DefaultLocale} messages={messages}>
+                <UiMenu
+                    items={menuWithInteractiveAndGroup}
+                    onSelect={vi.fn()}
+                    onClose={vi.fn()}
+                    ariaAttributes={{
+                        id: "test-interactive-with-group",
+                        "aria-labelledby": "test-interactive-with-group-button",
+                    }}
+                />
+            </IntlProvider>,
+        );
+
+        // Check that top-level items are rendered
+        expect(screen.getByText("Item 1")).toBeInTheDocument();
+        expect(screen.getByText("Item with submenu")).toBeInTheDocument();
+        expect(screen.getByText("Item 3")).toBeInTheDocument();
+
+        // Click on the item with submenu
+        fireEvent.click(screen.getByText("Item with submenu"));
+
+        // Verify that group items are now focused
+        const menu = screen.getByRole("menu");
+        expect(menu).toHaveAttribute("aria-activedescendant", expect.stringContaining("groupitem1"));
+
+        // Verify that we can interact with the group items
+        fireEvent.keyDown(menu, { code: "ArrowDown" });
+        expect(menu).toHaveAttribute("aria-activedescendant", expect.stringContaining("groupitem2"));
+    });
 });


### PR DESCRIPTION
risk: low

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```

#### Commands for Bear platform working on branch rel/9.9

```
extended-test-legacy --backstop
extended-test-legacy --isolated
extended-test-legacy --record
```
