### PR TITLE
test: enable COLOR for cypress test console log

### DIFF
--- a/common/scripts/ci/run_cypress_integrated_tests.sh
+++ b/common/scripts/ci/run_cypress_integrated_tests.sh
@@ -43,7 +43,7 @@ cleanup() {
 }
 
 trap cleanup EXIT
-
+  
 pushd $E2E_TEST_DIR
 
 # Use Dockerfile_local as scenarios have been build in previous steps
@@ -55,6 +55,6 @@ if [[ "$GITHUB_ACTIONS" != "true" ]]; then
 fi
 
 PROJECT_NAME=tiger-sdk-ui-tests-e2e-${EXECUTOR_NUMBER:-default}
-NO_COLOR=1 docker compose -f docker-compose-integrated.yaml -p "$PROJECT_NAME" up \
+docker compose -f docker-compose-integrated.yaml -p "$PROJECT_NAME" up \
   --abort-on-container-exit --exit-code-from integrated-tests \
-  --force-recreate --always-recreate-deps --renew-anon-volumes --no-color
+  --force-recreate --always-recreate-deps --renew-anon-volumes


### PR DESCRIPTION
JIRA: QA-24815
risk: nonprod

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```

#### Commands for Bear platform working on branch rel/9.9

```
extended-test-legacy --backstop
extended-test-legacy --isolated
extended-test-legacy --record
```
