### PR TITLE
fix: handle reset of filter by parent during init load phase

### DIFF
--- a/libs/sdk-ui-filters/src/AttributeFilter/hooks/useAttributeFilterController.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilter/hooks/useAttributeFilterController.ts
@@ -702,8 +702,13 @@ function refreshByType(
             // be used by re-execution widgets, which is correct, but will not be set to filter's button
             // value, confusing the users.
             if (shouldReloadElements.current) {
-                handler.loadInitialElementsPage(PARENT_FILTERS_CORRELATION);
-                handler.loadIrrelevantElements(IRRELEVANT_SELECTION);
+                if (handler.getInitStatus() === "success") {
+                    handler.loadInitialElementsPage(PARENT_FILTERS_CORRELATION);
+                    handler.loadIrrelevantElements(IRRELEVANT_SELECTION);
+                } else {
+                    // if filter resets by its parent but it is not fully loaded yet, we need to re-init it fully again
+                    handler.init(PARENT_FILTERS_CORRELATION);
+                }
                 setShouldReloadElements(false);
             }
             return;

--- a/libs/sdk-ui-filters/src/AttributeFilterHandler/internal/loader.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilterHandler/internal/loader.ts
@@ -1,4 +1,4 @@
-// (C) 2022-2024 GoodData Corporation
+// (C) 2022-2025 GoodData Corporation
 import { v4 as uuid } from "uuid";
 import { invariant } from "ts-invariant";
 import { IElementsQueryAttributeFilter } from "@gooddata/sdk-backend-spi";
@@ -189,14 +189,15 @@ export class AttributeFilterLoader implements IAttributeFilterLoader {
     // Initial elements page
 
     loadInitialElementsPage = (correlation: Correlation = uuid()): void => {
-        if (this.bridge.getInitStatus() === "error") {
+        const initStatus = this.bridge.getInitStatus();
+        if (initStatus === "error") {
             // do not try to fetch any elements when filter is in error state as we would end up with
             // "blank page" error in production. This can happen when user sets limiting metric that
             // is not LDM compatible (cannot be sliced) with the attribute filter's attribute.
             return;
         }
         invariant(
-            this.bridge.getInitStatus() === "success",
+            initStatus === "success",
             "Cannot call loadInitialElementsPage() before successful initialization.",
         );
         this.validateStaticElementsLoad();


### PR DESCRIPTION
JIRA: LX-1123
risk: low

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```

#### Commands for Bear platform working on branch rel/9.9

```
extended-test-legacy --backstop
extended-test-legacy --isolated
extended-test-legacy --record
```
