### PR TITLE
feat: use aria-labeled-by instead of aria-label

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/alerting/DefaultAlertingDialog/DefaultAlertingDialogNew.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/alerting/DefaultAlertingDialog/DefaultAlertingDialogNew.tsx
@@ -346,9 +346,7 @@ export function AlertingDialogRenderer({
                                         type="number"
                                         suffix={getValueSuffix(editedAutomation?.alert)}
                                         accessibilityConfig={{
-                                            ariaLabel: intl.formatMessage({
-                                                id: "insightAlert.config.accessbility.input",
-                                            }),
+                                            ariaDescribedBy: "alert.value",
                                         }}
                                     />
                                 </FormField>

--- a/libs/sdk-ui-dashboard/src/presentation/alerting/DefaultAlertingDialog/components/AlertComparisonOperatorSelect.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/alerting/DefaultAlertingDialog/components/AlertComparisonOperatorSelect.tsx
@@ -58,10 +58,6 @@ export const AlertComparisonOperatorSelect = (props: IAlertComparisonOperatorSel
         return null;
     }
 
-    const accessibilityAriaLabel = intl.formatMessage({
-        id: "insightAlert.config.accessbility.dropdown",
-    });
-
     return (
         <Dropdown
             closeOnParentScroll={closeOnParentScroll}
@@ -86,9 +82,6 @@ export const AlertComparisonOperatorSelect = (props: IAlertComparisonOperatorSel
                             iconLeft={selectedComparisonItem?.icon ?? selectedRelativeItem?.icon}
                             iconRight={`gd-icon-navigate${isOpen ? "up" : "down"}`}
                             onClick={toggleDropdown}
-                            accessibilityConfig={{
-                                ariaLabel: accessibilityAriaLabel,
-                            }}
                         >
                             {intl.formatMessage({
                                 id: selectedComparisonItem?.title ?? selectedRelativeItem?.title,

--- a/libs/sdk-ui-dashboard/src/presentation/localization/bundles/en-US.json
+++ b/libs/sdk-ui-dashboard/src/presentation/localization/bundles/en-US.json
@@ -524,7 +524,7 @@
         "limit": 0
     },
     "filters.configurationPanel.header": {
-        "value": "Filters Configuration",
+        "value": "Filters",
         "comment": "Filtering configuration panel - header.",
         "limit": 0
     },
@@ -3249,11 +3249,6 @@
     },
     "insightAlert.config.accessbility.input": {
         "value": "Condition value",
-        "comment": "",
-        "limit": 0
-    },
-    "insightAlert.config.accessbility.dropdown": {
-        "value": "Condition type",
         "comment": "",
         "limit": 0
     },

--- a/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/components/RecipientsSelect/RecipientsSelectRenderer.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/components/RecipientsSelect/RecipientsSelectRenderer.tsx
@@ -285,7 +285,7 @@ export class RecipientsSelectRenderer extends React.PureComponent<
                 )}
             >
                 {this.props.showLabel ? (
-                    <label htmlFor="form.destination" className="gd-label">
+                    <label htmlFor={id} className="gd-label">
                         <FormattedMessage id="dialogs.schedule.email.recipients.label" />
                     </label>
                 ) : null}
@@ -723,7 +723,7 @@ export class RecipientsSelectRenderer extends React.PureComponent<
 
         const props: InputProps<IAutomationRecipient> = {
             ...inputProps,
-            id: "form.destination",
+            id: this.props.id,
             "aria-controls": MENU_LIST_ID,
             onBlur: this.onBlur,
         };


### PR DESCRIPTION
1. remove aria-label were not needed (buttons using id) (more acccessible dropdown buttons would be solved elsewhere)
2. replace aria-label with aria-labeled-by when possible
3. recipient field inherit id from top level (further a11y might be needed) – labels become easier when we refactor after removing old alert dialog
4. copy change oneliner from [ticket F1-1369](https://gooddata.atlassian.net/browse/F1-1369)

risk: low
JIRA: F1-1353

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```

#### Commands for Bear platform working on branch rel/9.9

```
extended-test-legacy --backstop
extended-test-legacy --isolated
extended-test-legacy --record
```
