### PR TITLE
feat: enhance dashboard xlsx export

### DIFF
--- a/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
+++ b/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
@@ -483,6 +483,9 @@ export interface IDashboardExportImageOptions {
 
 // @alpha
 export interface IDashboardExportTabularOptions {
+    dashboardFiltersOverride?: FilterContextItem[];
+    exportInfo?: boolean;
+    mergeHeaders?: boolean;
     title?: string;
 }
 

--- a/libs/sdk-backend-spi/src/workspace/dashboards/index.ts
+++ b/libs/sdk-backend-spi/src/workspace/dashboards/index.ts
@@ -229,6 +229,21 @@ export interface IDashboardExportTabularOptions {
      * Title for the export. If not provided, the dashboard title will be fetched.
      */
     title?: string;
+
+    /**
+     * If true, the headers will be merged into a single row
+     */
+    mergeHeaders?: boolean;
+
+    /**
+     * If true, the export info will be included in the EXCEL file
+     */
+    exportInfo?: boolean;
+
+    /**
+     * If true, the dashboard filters will be applied to the exported dashboard
+     */
+    dashboardFiltersOverride?: FilterContextItem[];
 }
 
 /**

--- a/libs/sdk-backend-tiger/src/backend/workspace/dashboards/index.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/dashboards/index.ts
@@ -102,6 +102,7 @@ import { convertApiError } from "../../../utils/errorHandling.js";
 import { convertDataSetItem } from "../../../convertors/fromBackend/DataSetConverter.js";
 import { toAfmExecution } from "../../../convertors/toBackend/afm/toAfmResultSpec.js";
 import { addFilterLocalIdentifier } from "../../../utils/filterLocalidentifier.js";
+import { cloneWithSanitizedIds } from "../../../convertors/toBackend/IdSanitization.js";
 
 const DEFAULT_POLL_DELAY = 5000;
 const MAX_POLL_ATTEMPTS = 50;
@@ -563,10 +564,19 @@ export class TigerWorkspaceDashboards implements IWorkspaceDashboardsService {
                 title = convertDashboard(dashboardResponse.data).title;
             }
 
+            const dashboardFiltersOverrideObj = options?.dashboardFiltersOverride
+                ? { dashboardFiltersOverride: cloneWithSanitizedIds(options?.dashboardFiltersOverride) }
+                : {};
+
             const slideshowExport = await client.export.createDashboardExportRequest({
                 dashboardTabularExportRequest: {
                     fileName: title || "export",
                     format: "XLSX",
+                    settings: {
+                        mergeHeaders: options?.mergeHeaders,
+                        exportInfo: options?.exportInfo,
+                    },
+                    ...dashboardFiltersOverrideObj,
                 },
                 workspaceId: this.workspace,
                 dashboardId,

--- a/libs/sdk-ui-dashboard/.dependency-cruiser.cjs
+++ b/libs/sdk-ui-dashboard/.dependency-cruiser.cjs
@@ -214,7 +214,7 @@ options = {
         depCruiser.moduleWithDependencies("topBar", "src/presentation/topBar", [
             "src/_staging/*",
             "src/model",
-            "src/presentation/dashboardContexts",
+            "src/presentation/dashboardContexts/*",
             "src/presentation/localization",
             "src/presentation/constants/*",
             "src/presentation/componentDefinition",

--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -3921,11 +3921,21 @@ export const EXPORT_VIS_WARNING_MINIMAL_FONT_SIZE = 0.8;
 // @beta (undocumented)
 export interface ExportDashboardToExcel extends IDashboardCommand {
     // (undocumented)
+    readonly payload: ExportDashboardToExcelPayload;
+    // (undocumented)
     readonly type: "GDC.DASH/CMD.EXPORT.EXCEL";
 }
 
 // @beta
-export function exportDashboardToExcel(correlationId?: string): ExportDashboardToExcel;
+export function exportDashboardToExcel(mergeHeaders: boolean, exportInfo: boolean, correlationId?: string): ExportDashboardToExcel;
+
+// @beta (undocumented)
+export interface ExportDashboardToExcelPayload {
+    // (undocumented)
+    exportInfo: boolean;
+    // (undocumented)
+    mergeHeaders: boolean;
+}
 
 // @beta (undocumented)
 export interface ExportDashboardToPdf extends IDashboardCommand {

--- a/libs/sdk-ui-dashboard/src/model/commands/dashboard.ts
+++ b/libs/sdk-ui-dashboard/src/model/commands/dashboard.ts
@@ -432,6 +432,15 @@ export function exportDashboardToPdf(correlationId?: string): ExportDashboardToP
  */
 export interface ExportDashboardToExcel extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.EXPORT.EXCEL";
+    readonly payload: ExportDashboardToExcelPayload;
+}
+
+/**
+ * @beta
+ */
+export interface ExportDashboardToExcelPayload {
+    mergeHeaders: boolean;
+    exportInfo: boolean;
 }
 
 /**
@@ -439,15 +448,25 @@ export interface ExportDashboardToExcel extends IDashboardCommand {
  * the dashboard to a EXCEL file. If successful, an instance of {@link DashboardExportToExcelResolved} will be emitted
  * with the URL of the resulting file.
  *
+ * @param mergeHeaders - if true, the headers will be merged into a single row
+ * @param exportInfo - if true, the export info will be included in the EXCEL file
  * @param correlationId - specify correlation id to use for this command. this will be included in all
  *  events that will be emitted during the command processing
  *
  * @beta
  */
-export function exportDashboardToExcel(correlationId?: string): ExportDashboardToExcel {
+export function exportDashboardToExcel(
+    mergeHeaders: boolean,
+    exportInfo: boolean,
+    correlationId?: string,
+): ExportDashboardToExcel {
     return {
         type: "GDC.DASH/CMD.EXPORT.EXCEL",
         correlationId,
+        payload: {
+            mergeHeaders,
+            exportInfo,
+        },
     };
 }
 

--- a/libs/sdk-ui-dashboard/src/model/commands/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/commands/index.ts
@@ -136,6 +136,7 @@ export type {
     ExportDashboardToPptPresentation,
     ExportDashboardToPdfPresentation,
     ExportDashboardToExcel,
+    ExportDashboardToExcelPayload,
     DeleteDashboard,
     ChangeSharing,
     ChangeSharingPayload,

--- a/libs/sdk-ui-dashboard/src/presentation/dialogs/ExportDialogProvider.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/dialogs/ExportDialogProvider.tsx
@@ -13,7 +13,6 @@ export const ExportDialogProvider: React.FC = () => {
 
     return isOpen ? (
         <ExportDialog
-            {...dialogConfig}
             headline={intl.formatMessage({ id: "dialogs.export.headline" })}
             cancelButtonText={intl.formatMessage({ id: "cancel" })}
             submitButtonText={intl.formatMessage({ id: "dialogs.export.submit" })}
@@ -22,6 +21,7 @@ export const ExportDialogProvider: React.FC = () => {
             mergeHeadersText={intl.formatMessage({ id: "dialogs.export.mergeHeaders" })}
             mergeHeadersTitle={intl.formatMessage({ id: "dialogs.export.cells" })}
             onCancel={closeDialog}
+            {...dialogConfig}
         />
     ) : null;
 };

--- a/libs/sdk-ui-dashboard/src/presentation/localization/bundles/en-US.json
+++ b/libs/sdk-ui-dashboard/src/presentation/localization/bundles/en-US.json
@@ -162,6 +162,16 @@
         "comment": "Export whole KPI dashboard to PDF",
         "limit": 0
     },
+    "options.menu.export.dialog.EXCEL": {
+        "value": "Export Data (.xlsx)",
+        "comment": "Dialog title to export whole KPI dashboard to EXCEL",
+        "limit": 0
+    },
+    "options.menu.export.dialog.includeExportInfo": {
+        "value": "Include sheet with export info",
+        "comment": "Dialog checkbox to include sheet with export info",
+        "limit": 0
+    },
     "options.menu.export.EXCEL": {
         "value": "Data (.xlsx)",
         "comment": "Export whole KPI dashboard to EXCEL",

--- a/libs/sdk-ui-kit/api/sdk-ui-kit.api.md
+++ b/libs/sdk-ui-kit/api/sdk-ui-kit.api.md
@@ -2030,7 +2030,7 @@ export interface IExportDialogBaseProps extends Pick<IConfirmDialogBaseProps, "c
     // (undocumented)
     filterContextText?: string;
     // (undocumented)
-    filterContextTitle?: string;
+    filterContextTitle?: string | null;
     // (undocumented)
     filterContextVisible?: boolean;
     // (undocumented)
@@ -2042,7 +2042,7 @@ export interface IExportDialogBaseProps extends Pick<IConfirmDialogBaseProps, "c
     // (undocumented)
     mergeHeadersText?: string;
     // (undocumented)
-    mergeHeadersTitle?: string;
+    mergeHeadersTitle?: string | null;
     // (undocumented)
     onSubmit?: (data: IExportDialogData) => void;
 }

--- a/libs/sdk-ui-kit/src/Dialog/ExportDialogBase.tsx
+++ b/libs/sdk-ui-kit/src/Dialog/ExportDialogBase.tsx
@@ -60,7 +60,7 @@ export const ExportDialogBase = React.memo<IExportDialogBaseProps>(function Expo
             onSubmit={handleSubmit}
             initialFocus={mergeHeadersId}
         >
-            <h4>{mergeHeadersTitle}</h4>
+            {mergeHeadersTitle ? <h4>{mergeHeadersTitle}</h4> : null}
             <Checkbox
                 id={mergeHeadersId}
                 disabled={mergeHeadersDisabled}
@@ -70,15 +70,15 @@ export const ExportDialogBase = React.memo<IExportDialogBaseProps>(function Expo
                 onChange={setShouldMergeHeaders}
             />
             {filterContextVisible ? (
-                <>
-                    <h4>{filterContextTitle}</h4>
+                <div>
+                    {filterContextTitle ? <h4>{filterContextTitle}</h4> : null}
                     <Checkbox
                         name="gs.dialog.export.checkbox.includeFilterContext"
                         text={filterContextText}
                         value={isFilterContextIncluded}
                         onChange={setIsFilterContextIncluded}
                     />
-                </>
+                </div>
             ) : null}
         </ConfirmDialogBase>
     );

--- a/libs/sdk-ui-kit/src/Dialog/typings.ts
+++ b/libs/sdk-ui-kit/src/Dialog/typings.ts
@@ -107,13 +107,13 @@ export interface IExportDialogBaseProps
         | "onCancel"
     > {
     filterContextText?: string;
-    filterContextTitle?: string;
+    filterContextTitle?: string | null;
     filterContextVisible?: boolean;
     includeFilterContext?: boolean;
     mergeHeaders?: boolean;
     mergeHeadersDisabled?: boolean;
     mergeHeadersText?: string;
-    mergeHeadersTitle?: string;
+    mergeHeadersTitle?: string | null;
     onSubmit?: (data: IExportDialogData) => void;
 }
 


### PR DESCRIPTION
- Added `mergeHeaders` and `exportInfo` options to the `IDashboardExportTabularOptions` interface.
- Updated the export functionality to include these new options in the Excel export request.
- Enhanced the export dialog to allow users to select these options when exporting dashboards.
- Create new selector to check if filters are changed. The logic was moved from useResetButton hook.

JIRA: F1-1439
risk: low

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```

#### Commands for Bear platform working on branch rel/9.9

```
extended-test-legacy --backstop
extended-test-legacy --isolated
extended-test-legacy --record
```
