### PR TITLE
fix: sanitize all-time date filters

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/hooks/useSaveScheduledEmailToBackend.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/hooks/useSaveScheduledEmailToBackend.ts
@@ -1,12 +1,22 @@
 // (C) 2019-2025 GoodData Corporation
 import { useCallback, useState } from "react";
-import { IAutomationMetadataObject, IAutomationMetadataObjectDefinition } from "@gooddata/sdk-model";
+import {
+    IAutomationMetadataObject,
+    IAutomationMetadataObjectDefinition,
+    isExportDefinitionVisualizationObjectRequestPayload,
+    IExportDefinitionMetadataObject,
+    IExportDefinitionMetadataObjectDefinition,
+    isAllTimeDateFilter,
+    isExportDefinitionDashboardRequestPayload,
+    isAllTimeDashboardDateFilter,
+} from "@gooddata/sdk-model";
 import { GoodDataSdkError } from "@gooddata/sdk-ui";
 import { useCreateScheduledEmail } from "./useCreateScheduledEmail.js";
 import { useUpdateScheduledEmail } from "./useUpdateScheduledEmail.js";
 import { IScheduledEmailDialogProps } from "../../types.js";
 import { IntlShape, useIntl } from "react-intl";
 import omit from "lodash/omit.js";
+import { selectEnableAutomationFilterContext, useDashboardSelector } from "../../../../model/index.js";
 
 export function useSaveScheduledEmailToBackend(
     automation: IAutomationMetadataObject | IAutomationMetadataObjectDefinition,
@@ -23,6 +33,7 @@ export function useSaveScheduledEmailToBackend(
     >,
 ) {
     const intl = useIntl();
+    const enableAutomationFilterContext = useDashboardSelector(selectEnableAutomationFilterContext);
     const [savingErrorMessage, setSavingErrorMessage] = useState<string | undefined>(undefined);
     const scheduledEmailCreator = useCreateScheduledEmail({
         onSuccess: (scheduledEmail: IAutomationMetadataObject) => {
@@ -46,10 +57,14 @@ export function useSaveScheduledEmailToBackend(
     });
     const handleCreateScheduledEmail = useCallback(
         (scheduledEmail: IAutomationMetadataObject | IAutomationMetadataObjectDefinition) => {
-            const sanitizedAutomation = sanitizeAutomation(scheduledEmail, intl);
+            const sanitizedAutomation = sanitizeAutomation(
+                scheduledEmail,
+                intl,
+                enableAutomationFilterContext,
+            );
             scheduledEmailCreator.create(sanitizedAutomation as IAutomationMetadataObjectDefinition);
         },
-        [scheduledEmailCreator, intl],
+        [scheduledEmailCreator, enableAutomationFilterContext, intl],
     );
 
     const scheduledEmailUpdater = useUpdateScheduledEmail({
@@ -73,14 +88,18 @@ export function useSaveScheduledEmailToBackend(
 
     const handleUpdateScheduledEmail = useCallback(
         (scheduledEmail: IAutomationMetadataObject | IAutomationMetadataObjectDefinition) => {
-            const sanitizedAutomation = sanitizeAutomation(scheduledEmail, intl);
+            const sanitizedAutomation = sanitizeAutomation(
+                scheduledEmail,
+                intl,
+                enableAutomationFilterContext,
+            );
             scheduledEmailUpdater.save(sanitizedAutomation as IAutomationMetadataObject);
         },
-        [scheduledEmailUpdater, intl],
+        [scheduledEmailUpdater, enableAutomationFilterContext, intl],
     );
 
     const handleSaveScheduledEmail = (): void => {
-        const sanitizedAutomation = sanitizeAutomation(automation, intl);
+        const sanitizedAutomation = sanitizeAutomation(automation, intl, enableAutomationFilterContext);
 
         if (sanitizedAutomation.id) {
             handleUpdateScheduledEmail(sanitizedAutomation);
@@ -99,6 +118,7 @@ export function useSaveScheduledEmailToBackend(
 function sanitizeAutomation(
     automationToSave: IAutomationMetadataObject | IAutomationMetadataObjectDefinition,
     intl: IntlShape,
+    enableAutomationFilterContext: boolean,
 ) {
     const automation = {
         ...automationToSave,
@@ -114,5 +134,52 @@ function sanitizeAutomation(
         automation.schedule = omit(automation.schedule, ["cronDescription"]);
     }
 
+    /**
+     * Remove all-time date filters from export definitions.
+     * They are not required for the execution and not event valid as AFM date granularity.
+     * They are added ad-hoc to be visible in the UI in useAutomationFiltersSelect hook,
+     * depending on whether they are ignored or not.
+     */
+    if (automation.exportDefinitions && !enableAutomationFilterContext) {
+        automation.exportDefinitions = removeAllTimeDateFiltersFromExportDefinitions(
+            automation.exportDefinitions,
+        );
+    }
+
     return automation;
+}
+
+function removeAllTimeDateFiltersFromExportDefinitions(
+    exportDefinitions: (IExportDefinitionMetadataObject | IExportDefinitionMetadataObjectDefinition)[],
+) {
+    return exportDefinitions.map((exportDefinition) => {
+        if (isExportDefinitionVisualizationObjectRequestPayload(exportDefinition.requestPayload)) {
+            return {
+                ...exportDefinition,
+                requestPayload: {
+                    ...exportDefinition.requestPayload,
+                    content: {
+                        ...exportDefinition.requestPayload.content,
+                        filters: exportDefinition.requestPayload.content.filters?.filter(
+                            (f) => !isAllTimeDateFilter(f),
+                        ),
+                    },
+                },
+            };
+        } else if (isExportDefinitionDashboardRequestPayload(exportDefinition.requestPayload)) {
+            return {
+                ...exportDefinition,
+                requestPayload: {
+                    ...exportDefinition.requestPayload,
+                    content: {
+                        ...exportDefinition.requestPayload.content,
+                        filters: exportDefinition.requestPayload.content.filters?.filter(
+                            (f) => !isAllTimeDashboardDateFilter(f),
+                        ),
+                    },
+                },
+            };
+        }
+        return exportDefinition;
+    });
 }


### PR DESCRIPTION
- Keep all-time date sanitization when enableAutomationFilterContext is not enabled.

risk: low
JIRA: F1-1444

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```

#### Commands for Bear platform working on branch rel/9.9

```
extended-test-legacy --backstop
extended-test-legacy --isolated
extended-test-legacy --record
```
