### PR TITLE
feat: enhance widget xlsx export

### DIFF
--- a/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
+++ b/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
@@ -487,6 +487,7 @@ export interface IDashboardExportTabularOptions {
     exportInfo?: boolean;
     mergeHeaders?: boolean;
     title?: string;
+    widgetIds?: string[];
 }
 
 // @alpha

--- a/libs/sdk-backend-spi/src/workspace/dashboards/index.ts
+++ b/libs/sdk-backend-spi/src/workspace/dashboards/index.ts
@@ -241,6 +241,11 @@ export interface IDashboardExportTabularOptions {
     exportInfo?: boolean;
 
     /**
+     * Widgets to export. If not provided, all widgets will be exported.
+     */
+    widgetIds?: string[];
+
+    /**
      * If true, the dashboard filters will be applied to the exported dashboard
      */
     dashboardFiltersOverride?: FilterContextItem[];

--- a/libs/sdk-backend-tiger/src/backend/workspace/dashboards/index.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/dashboards/index.ts
@@ -576,6 +576,7 @@ export class TigerWorkspaceDashboards implements IWorkspaceDashboardsService {
                         mergeHeaders: options?.mergeHeaders,
                         exportInfo: options?.exportInfo,
                     },
+                    widgetIds: options?.widgetIds,
                     ...dashboardFiltersOverrideObj,
                 },
                 workspaceId: this.workspace,

--- a/libs/sdk-ui-dashboard/.dependency-cruiser.cjs
+++ b/libs/sdk-ui-dashboard/.dependency-cruiser.cjs
@@ -241,6 +241,7 @@ options = {
             "src/presentation/export",
             "src/presentation/scheduledEmail/*",
             "src/presentation/alerting/*",
+            "src/presentation/topBar/*",
             "src/types.ts",
             "src/widgets",
             "src/presentation/dashboard/components/DashboardScreenSizeContext.tsx",

--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -3927,7 +3927,7 @@ export interface ExportDashboardToExcel extends IDashboardCommand {
 }
 
 // @beta
-export function exportDashboardToExcel(mergeHeaders: boolean, exportInfo: boolean, correlationId?: string): ExportDashboardToExcel;
+export function exportDashboardToExcel(mergeHeaders: boolean, exportInfo: boolean, widgetIds?: string[], correlationId?: string): ExportDashboardToExcel;
 
 // @beta (undocumented)
 export interface ExportDashboardToExcelPayload {
@@ -3935,6 +3935,8 @@ export interface ExportDashboardToExcelPayload {
     exportInfo: boolean;
     // (undocumented)
     mergeHeaders: boolean;
+    // (undocumented)
+    widgetIds?: string[];
 }
 
 // @beta (undocumented)

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/exportDashboardToExcelHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/exportDashboardToExcelHandler.ts
@@ -26,6 +26,7 @@ function exportDashboardToTabular(
     title?: string,
     mergeHeaders?: boolean,
     exportInfo?: boolean,
+    widgetIds?: string[],
     dashboardFiltersOverride?: FilterContextItem[],
 ): Promise<IExportResult> {
     const { backend, workspace } = ctx;
@@ -34,6 +35,7 @@ function exportDashboardToTabular(
         mergeHeaders,
         exportInfo,
         dashboardFiltersOverride,
+        widgetIds,
     });
 }
 
@@ -48,7 +50,7 @@ export function* exportDashboardToExcelHandler(
         throw invalidArgumentsProvided(ctx, cmd, "Dashboard to export to EXCEL must have an ObjRef.");
     }
 
-    const { mergeHeaders, exportInfo } = cmd.payload;
+    const { mergeHeaders, exportInfo, widgetIds } = cmd.payload;
     const title = yield select(selectDashboardTitle);
     const isFilterContextChanged: SagaReturnType<typeof selectIsFiltersChanged> = yield select(
         selectIsFiltersChanged,
@@ -63,6 +65,7 @@ export function* exportDashboardToExcelHandler(
         title,
         mergeHeaders,
         exportInfo,
+        widgetIds,
         isFilterContextChanged ? filterContext : undefined,
     );
 

--- a/libs/sdk-ui-dashboard/src/model/commands/dashboard.ts
+++ b/libs/sdk-ui-dashboard/src/model/commands/dashboard.ts
@@ -441,6 +441,7 @@ export interface ExportDashboardToExcel extends IDashboardCommand {
 export interface ExportDashboardToExcelPayload {
     mergeHeaders: boolean;
     exportInfo: boolean;
+    widgetIds?: string[];
 }
 
 /**
@@ -450,6 +451,7 @@ export interface ExportDashboardToExcelPayload {
  *
  * @param mergeHeaders - if true, the headers will be merged into a single row
  * @param exportInfo - if true, the export info will be included in the EXCEL file
+ * @param widgetIds - if provided, the widgets with the given ids will be exported
  * @param correlationId - specify correlation id to use for this command. this will be included in all
  *  events that will be emitted during the command processing
  *
@@ -458,6 +460,7 @@ export interface ExportDashboardToExcelPayload {
 export function exportDashboardToExcel(
     mergeHeaders: boolean,
     exportInfo: boolean,
+    widgetIds?: string[],
     correlationId?: string,
 ): ExportDashboardToExcel {
     return {
@@ -466,6 +469,7 @@ export function exportDashboardToExcel(
         payload: {
             mergeHeaders,
             exportInfo,
+            widgetIds,
         },
     };
 }

--- a/libs/sdk-ui-dashboard/src/presentation/localization/bundles/en-US.json
+++ b/libs/sdk-ui-dashboard/src/presentation/localization/bundles/en-US.json
@@ -167,6 +167,11 @@
         "comment": "Dialog title to export whole KPI dashboard to EXCEL",
         "limit": 0
     },
+    "options.menu.export.dialog.widget.EXCEL": {
+        "value": "Export Formatted data (.xlsx)",
+        "comment": "Dialog title to export widget to EXCEL",
+        "limit": 0
+    },
     "options.menu.export.dialog.includeExportInfo": {
         "value": "Include sheet with export info",
         "comment": "Dialog checkbox to include sheet with export info",

--- a/libs/sdk-ui-dashboard/src/presentation/topBar/menuButton/useExportDashboardToExcel.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/topBar/menuButton/useExportDashboardToExcel.ts
@@ -8,7 +8,7 @@ import { exportDashboardToExcel, useDashboardCommandProcessing } from "../../../
 import { messages } from "../../../locales.js";
 import { downloadFile } from "../../../_staging/fileUtils/downloadFile.js";
 
-export const useExportDashboardToExcel = () => {
+export const useExportDashboardToExcel = (onSuccess?: () => void) => {
     const { addSuccess, addError, addProgress, removeMessage } = useToastMessage();
     const lastExportMessageId = useRef("");
     const { run: exportDashboard, status } = useDashboardCommandProcessing({
@@ -26,6 +26,7 @@ export const useExportDashboardToExcel = () => {
             if (lastExportMessageId.current) {
                 removeMessage(lastExportMessageId.current);
             }
+            onSuccess?.();
             addSuccess(messages.messagesExportResultSuccess);
             downloadFile(event.payload.result);
         },


### PR DESCRIPTION
- Introduced `widgetIds` parameter to the `IDashboardExportTabularOptions` interface for more granular control over exported widgets.
- Updated the Excel export function to accept `widgetIds`, allowing users to specify which widgets to include in the export.

JIRA: F1-1439
risk: low

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```

#### Commands for Bear platform working on branch rel/9.9

```
extended-test-legacy --backstop
extended-test-legacy --isolated
extended-test-legacy --record
```
