### PR TITLE
fix: widget automation filters

### DIFF
--- a/libs/sdk-model/api/sdk-model.api.md
+++ b/libs/sdk-model/api/sdk-model.api.md
@@ -4602,7 +4602,7 @@ export function measureValueFilterMeasure(filter: IMeasureValueFilter): ObjRefIn
 export function measureValueFilterOperator(filter: IMeasureValueFilter): ComparisonConditionOperator | RangeConditionOperator | undefined;
 
 // @internal
-export function mergeFilters(originalFilters: IFilter[], addedFilters: INullableFilter[] | undefined): IFilter[];
+export function mergeFilters(originalFilters: IFilter[], addedFilters: INullableFilter[] | undefined, commonDateFilterId?: string): IFilter[];
 
 // @public
 export type MetadataObject = IAttributeMetadataObject | IAttributeDisplayFormMetadataObject | IFactMetadataObject | IMeasureMetadataObject | IDataSetMetadataObject | IVariableMetadataObject | IDashboardMetadataObject | IAttributeHierarchyMetadataObject;

--- a/libs/sdk-ui-dashboard/src/presentation/alerting/DefaultAlertingDialog/hooks/useEditAlert.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/alerting/DefaultAlertingDialog/hooks/useEditAlert.ts
@@ -34,6 +34,7 @@ import {
     selectDashboardId,
     selectSeparators,
     selectDashboardHiddenFilters,
+    selectAutomationCommonDateFilterId,
 } from "../../../../model/index.js";
 import {
     convertCurrentUserToAutomationRecipient,
@@ -113,6 +114,8 @@ export function useEditAlert(props: IUseEditAlertProps) {
     const dashboardId = useDashboardSelector(selectDashboardId);
     const separators = useDashboardSelector(selectSeparators);
     const dashboardHiddenFilters = useDashboardSelector(selectDashboardHiddenFilters);
+    const commonDateFilterId = useDashboardSelector(selectAutomationCommonDateFilterId);
+
     // Computed values
     const isNewAlert = !alertToEdit;
 
@@ -156,6 +159,7 @@ export function useEditAlert(props: IUseEditAlertProps) {
                     dashboardHiddenFilters,
                     widget!,
                     insight!,
+                    commonDateFilterId,
                 ),
                 supportedMeasures,
                 defaultMeasure,
@@ -349,6 +353,7 @@ export function useEditAlert(props: IUseEditAlertProps) {
                     dashboardHiddenFilters,
                     widget,
                     insight,
+                    commonDateFilterId,
                 );
                 const visibleFilters = getVisibleFiltersByFilters(
                     filters,
@@ -379,6 +384,7 @@ export function useEditAlert(props: IUseEditAlertProps) {
             widget,
             insight,
             dashboardHiddenFilters,
+            commonDateFilterId,
         ],
     );
 

--- a/libs/sdk-ui-dashboard/src/presentation/automationFilters/hooks/test/validateExistingAutomationFilters.test.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/automationFilters/hooks/test/validateExistingAutomationFilters.test.ts
@@ -91,6 +91,13 @@ const changedNonAllTimeDateFilterContextItem: FilterContextItem = newRelativeDas
     nonCommonDataSetRef,
     nonCommonDateFilterLocalIdentifier,
 );
+const nonCommonFilterContextItemWithCommonDataSet: FilterContextItem = newRelativeDashboardDateFilter(
+    "GDC.time.date",
+    1,
+    2,
+    commonDataSetRef,
+    nonCommonDateFilterLocalIdentifier,
+);
 
 const attributeFilterContextItem: FilterContextItem = {
     attributeFilter: {
@@ -169,6 +176,7 @@ const [
     changedCommonDateFilter,
     nonAllTimeDateFilter,
     changedNonAllTimeDateFilter,
+    nonCommonFilterWithCommonDataSet,
     attributeFilter,
     unchangedAttributeFilter,
     changedAttributeFilter,
@@ -180,6 +188,7 @@ const [
         // non-common date filters
         nonAllTimeDateFilterContextItem,
         changedNonAllTimeDateFilterContextItem,
+        nonCommonFilterContextItemWithCommonDataSet,
         // attribute filters
         attributeFilterContextItem,
         unchangedAttributeFilterContextItem,
@@ -195,6 +204,7 @@ const [
     // non-common date filters
     allTimeDateVisibleFilter,
     nonAllTimeDateVisibleFilter,
+    nonCommonFilterWithCommonDataSetVisibleFilter,
     // attribute filters
     attributeVisibleFilter,
 ] = [
@@ -204,6 +214,7 @@ const [
     // non-common date filters
     allTimeDateFilterContextItem,
     nonAllTimeDateFilterContextItem,
+    nonCommonFilterContextItemWithCommonDataSet,
     // attribute filters
     attributeFilterContextItem,
 ].map((filterContexItem): IAutomationVisibleFilter => {
@@ -1325,6 +1336,33 @@ describe("validateExistingAutomationFilters", () => {
             expect(isValid).toBe(false);
             expect(commonDateFilterIsMissingInSavedVisibleFilters).toBe(true);
             expect(visibleFilterIsMissingInSavedFilters).toBe(false);
+        });
+
+        //
+        // Multiple date filters
+        //
+
+        describe("multiple date filters", () => {
+            // This is possible when you have additional date filter in the dashboard filter context,
+            // which has the same date dataset as the common date filter.
+            it("should be valid with 2 date filters with the common date dataset", () => {
+                const result = validateExistingAutomationFilters({
+                    savedAutomationFilters: [nonAllTimeCommonDateFilter, nonCommonFilterWithCommonDataSet],
+                    savedAutomationVisibleFilters: [
+                        nonAllTimeCommonDateVisibleFilter,
+                        nonCommonFilterWithCommonDataSetVisibleFilter,
+                    ],
+                    hiddenFilters: [],
+                    lockedFilters: [],
+                    ignoredFilters: [],
+                    dashboardFilters: [
+                        nonAllTimeCommonDateFilterContextItem,
+                        nonCommonFilterContextItemWithCommonDataSet,
+                    ],
+                });
+
+                expect(result.isValid).toBe(true);
+            });
         });
     });
 });

--- a/libs/sdk-ui-dashboard/src/presentation/automationFilters/hooks/useValidateExistingAutomationFilters.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/automationFilters/hooks/useValidateExistingAutomationFilters.ts
@@ -318,7 +318,9 @@ function validateLockedFilters(
             continue;
         }
 
-        const storedLockedFilter = savedAutomationFilters.find((f) => isFilterMatch(f, lockedFilter));
+        const storedLockedFilter = savedAutomationFilters.find(
+            (f) => filterLocalIdentifier(f) === filterLocalIdentifier(lockedFilter),
+        );
 
         if (storedLockedFilter && !lockedFilterHasDifferentValueInSavedFilter) {
             lockedFilterHasDifferentValueInSavedFilter = !areFiltersEqual(storedLockedFilter, lockedFilter);

--- a/libs/sdk-ui-dashboard/src/presentation/automationFilters/utils.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/automationFilters/utils.ts
@@ -175,6 +175,7 @@ export const getAppliedWidgetFilters = (
     dashboardHiddenFilters: FilterContextItem[],
     widget: ExtendedDashboardWidget | undefined,
     insight: IInsight | undefined,
+    commonDateFilterId: string | undefined,
 ) => {
     // Hidden filters are never included in selectedAutomationFilters,
     // but we need them to construct proper execution filters, so merge them.
@@ -193,7 +194,11 @@ export const getAppliedWidgetFilters = (
 
     // Merge the selected filters with the insight filters.
     // This will construct proper filters that should be applied to alert/scheduled export execution.
-    const mergedFilters = mergeFilters(insight?.insight?.filters ?? [], selectedExecutionFilters);
+    const mergedFilters = mergeFilters(
+        insight?.insight?.filters ?? [],
+        selectedExecutionFilters,
+        commonDateFilterId,
+    );
 
     // And finally, strip all-time date filters - we don't want to save them, they have no effect on execution.
     return mergedFilters.filter((f) => {

--- a/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/hooks/useEditScheduledEmail.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/hooks/useEditScheduledEmail.ts
@@ -29,6 +29,7 @@ import {
     selectUsers,
     selectEnableExternalRecipients,
     selectDashboardHiddenFilters,
+    selectAutomationCommonDateFilterId,
 } from "../../../../model/index.js";
 import { WidgetAttachmentType } from "../types.js";
 import {
@@ -119,9 +120,16 @@ export function useEditScheduledEmail(props: IUseEditScheduledEmailProps) {
     const firstChannel = notificationChannels[0]?.id;
 
     const dashboardHiddenFilters = useDashboardSelector(selectDashboardHiddenFilters);
+    const commonDateFilterId = useDashboardSelector(selectAutomationCommonDateFilterId);
 
     const effectiveWidgetFilters = enableAutomationFilterContext
-        ? getAppliedWidgetFilters(editedAutomationFilters ?? [], dashboardHiddenFilters, widget, insight)
+        ? getAppliedWidgetFilters(
+              editedAutomationFilters ?? [],
+              dashboardHiddenFilters,
+              widget,
+              insight,
+              commonDateFilterId,
+          )
         : widgetFilters;
 
     const effectiveVisibleWidgetFilters = enableAutomationFilterContext
@@ -382,6 +390,7 @@ export function useEditScheduledEmail(props: IUseEditScheduledEmailProps) {
                         dashboardHiddenFilters,
                         widget,
                         insight,
+                        commonDateFilterId,
                     );
                     const visibleFilters = getVisibleFiltersByFilters(
                         filters,
@@ -428,6 +437,7 @@ export function useEditScheduledEmail(props: IUseEditScheduledEmailProps) {
             widget,
             insight,
             isWidget,
+            commonDateFilterId,
         ],
     );
 


### PR DESCRIPTION
- Fix case with second date filter with the same date dataset as the one set on the widget (common date filter).

risk: low
JIRA: F1-1446

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```

#### Commands for Bear platform working on branch rel/9.9

```
extended-test-legacy --backstop
extended-test-legacy --isolated
extended-test-legacy --record
```
