### PR TITLE
RELATED: GDAI-288 analyzer can save vis

### DIFF
--- a/libs/sdk-ui-gen-ai/src/components/ConfigContext.tsx
+++ b/libs/sdk-ui-gen-ai/src/components/ConfigContext.tsx
@@ -3,12 +3,11 @@ import * as React from "react";
 import { CatalogItem } from "@gooddata/sdk-model";
 
 export type ConfigContext = {
-    allowCreateVisualization: boolean;
     allowNativeLinks: boolean;
+    canManage: boolean;
+    canAnalyze: boolean;
     linkHandler?: (linkClickEvent: LinkHandlerEvent) => void;
     catalogItems?: CatalogItem[];
-    canManage?: boolean;
-    canAnalyze?: boolean;
 };
 
 /**
@@ -24,13 +23,13 @@ export type LinkHandlerEvent = {
 };
 
 const configContext = React.createContext<ConfigContext>({
-    allowCreateVisualization: false,
     allowNativeLinks: false,
+    canManage: false,
+    canAnalyze: false,
 });
 
 export const ConfigProvider: React.FC<React.PropsWithChildren<ConfigContext>> = ({
     children,
-    allowCreateVisualization,
     allowNativeLinks,
     linkHandler,
     catalogItems,
@@ -39,14 +38,13 @@ export const ConfigProvider: React.FC<React.PropsWithChildren<ConfigContext>> = 
 }) => {
     const value = React.useMemo(
         () => ({
-            allowCreateVisualization,
             allowNativeLinks,
             linkHandler,
             catalogItems,
             canManage,
             canAnalyze,
         }),
-        [allowCreateVisualization, allowNativeLinks, linkHandler, catalogItems, canManage, canAnalyze],
+        [allowNativeLinks, linkHandler, catalogItems, canManage, canAnalyze],
     );
 
     return <configContext.Provider value={value}>{children}</configContext.Provider>;

--- a/libs/sdk-ui-gen-ai/src/components/GenAIChat.tsx
+++ b/libs/sdk-ui-gen-ai/src/components/GenAIChat.tsx
@@ -74,7 +74,6 @@ export const GenAIChat: React.FC<GenAIChatProps> = ({
                 <BackendProvider backend={effectiveBackend}>
                     <WorkspaceProvider workspace={effectiveWorkspace}>
                         <ConfigProvider
-                            allowCreateVisualization={false}
                             allowNativeLinks={false}
                             linkHandler={onLinkClick}
                             catalogItems={catalogItems}

--- a/libs/sdk-ui-gen-ai/src/components/GenAIChatDialog.tsx
+++ b/libs/sdk-ui-gen-ai/src/components/GenAIChatDialog.tsx
@@ -39,8 +39,8 @@ export const GenAIChatDialog: React.FC<GenAIChatDialogProps> = ({
     locale,
     isOpen,
     onClose,
-    canManage,
-    canAnalyze,
+    canManage = false,
+    canAnalyze = false,
     eventHandlers,
     catalogItems,
     colorPalette,
@@ -78,7 +78,6 @@ export const GenAIChatDialog: React.FC<GenAIChatDialogProps> = ({
                     <WorkspaceProvider workspace={effectiveWorkspace}>
                         <OverlayControllerProvider overlayController={chatOverlayController}>
                             <ConfigProvider
-                                allowCreateVisualization={canManage ?? false}
                                 allowNativeLinks={true}
                                 linkHandler={onLinkClick}
                                 catalogItems={catalogItems}

--- a/libs/sdk-ui-gen-ai/src/components/messages/contents/VisualizationContents.tsx
+++ b/libs/sdk-ui-gen-ai/src/components/messages/contents/VisualizationContents.tsx
@@ -182,7 +182,7 @@ const VisualizationContentsComponentCore: React.FC<VisualizationContentsProps> =
                             {visualization.title}
                         </MarkdownComponent>
                     </div>
-                    {config.allowCreateVisualization && !hasVisError && !visLoading
+                    {config.canAnalyze && !hasVisError && !visLoading
                         ? (() => {
                               const trigger = (
                                   <BubbleHoverTrigger


### PR DESCRIPTION
Fixed a bug when user with ANALYZE
permission could not save visualization
in AI Assistant

risk: nonprod
jira: GDAI-288

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```

#### Commands for Bear platform working on branch rel/9.9

```
extended-test-legacy --backstop
extended-test-legacy --isolated
extended-test-legacy --record
```
