### PR TITLE
feat: schedule export dialog accessible labels

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/alerting/DefaultAlertingDialog/DefaultAlertingDialogNew.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/alerting/DefaultAlertingDialog/DefaultAlertingDialogNew.tsx
@@ -367,9 +367,6 @@ export function AlertingDialogRenderer({
                                         onBlur={onBlur}
                                         type="number"
                                         suffix={getValueSuffix(editedAutomation?.alert)}
-                                        accessibilityConfig={{
-                                            ariaDescribedBy: "alert.value",
-                                        }}
                                     />
                                 </FormField>
                                 {isChangeOrDifferenceOperator(editedAutomation?.alert) && (

--- a/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/components/ErrorWrapper/ErrorWrapper.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/components/ErrorWrapper/ErrorWrapper.tsx
@@ -25,7 +25,7 @@ export const ErrorWrapper: React.FC<IErrorWrapperProps> = ({
 }) => {
     return (
         <div className={className}>
-            <label id={labelId} className="gd-label">
+            <label htmlFor={labelId} className="gd-label">
                 {label}
             </label>
             <div className={labelWrapperClassName}>

--- a/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/components/MessageForm/MessageForm.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/components/MessageForm/MessageForm.tsx
@@ -78,6 +78,7 @@ export const MessageForm: React.FC<IMessageFormProps> = ({ value, onChange }) =>
             errorClassName="gd-notifications-channels-dialog-message-error"
         >
             <Textarea
+                id={labelId}
                 ref={textareaRef}
                 autocomplete="off"
                 placeholder={intl.formatMessage({
@@ -91,7 +92,6 @@ export const MessageForm: React.FC<IMessageFormProps> = ({ value, onChange }) =>
                 validationError={messageError}
                 hasError={!!messageError}
                 accessibilityConfig={{
-                    ariaLabelledBy: labelId,
                     ariaDescribedBy: messageError ? errorId : undefined,
                 }}
             />

--- a/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/components/SubjectForm/SubjectForm.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/components/SubjectForm/SubjectForm.tsx
@@ -76,7 +76,7 @@ export const SubjectForm: React.FC<ISubjectFormProps> = ({ dashboardTitle, edite
             errorClassName="gd-notifications-channels-dialog-subject-error"
         >
             <Input
-                id="schedule.subject"
+                id={labelId}
                 hasError={!!subjectError}
                 maxlength={300}
                 type="text"
@@ -94,7 +94,6 @@ export const SubjectForm: React.FC<ISubjectFormProps> = ({ dashboardTitle, edite
                 autocomplete="off"
                 onBlur={handleOnBlur}
                 accessibilityConfig={{
-                    ariaLabelledBy: labelId,
                     ariaDescribedBy: subjectError ? errorId : undefined,
                 }}
             />

--- a/libs/sdk-ui-kit/src/RecurrenceForm/Recurrence.tsx
+++ b/libs/sdk-ui-kit/src/RecurrenceForm/Recurrence.tsx
@@ -88,12 +88,13 @@ export const Recurrence: React.FC<IRecurrenceProps> = (props) => {
         <>
             <div className={recurrenceFormClasses}>
                 {label ? (
-                    <label id={labelId} className="gd-label">
+                    <label htmlFor={labelId} className="gd-label">
                         {label}
                     </label>
                 ) : null}
                 <div className="gd-recurrence-form-repeat-inner">
                     <RepeatTypeSelect
+                        id={labelId}
                         repeatType={recurrenceType}
                         startDate={startDate}
                         onChange={onRepeatTypeChange}

--- a/libs/sdk-ui-kit/src/RecurrenceForm/RepeatTypeSelect.tsx
+++ b/libs/sdk-ui-kit/src/RecurrenceForm/RepeatTypeSelect.tsx
@@ -112,6 +112,7 @@ const getRepeatItems = (
 };
 
 export interface IRepeatTypeSelectProps {
+    id: string;
     repeatType: RecurrenceType;
     showInheritValue?: boolean;
     startDate?: Date | null;
@@ -123,6 +124,7 @@ export interface IRepeatTypeSelectProps {
 
 export const RepeatTypeSelect: React.FC<IRepeatTypeSelectProps> = (props) => {
     const {
+        id,
         onChange,
         repeatType,
         startDate = null,
@@ -145,6 +147,7 @@ export const RepeatTypeSelect: React.FC<IRepeatTypeSelectProps> = (props) => {
             autofocusOnOpen={true}
             renderButton={({ toggleDropdown, isOpen, dropdownId, buttonRef }) => (
                 <DropdownButton
+                    id={id}
                     value={repeatTypeItem.title}
                     onClick={() => {
                         !isOpen && onRepeatDropdownOpen?.();


### PR DESCRIPTION
- use "for - id" instead of "id - aria-labeledby"
- fix labels for some dropdown
- remove one unnecessary aria-describedby

risk: low

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```

#### Commands for Bear platform working on branch rel/9.9

```
extended-test-legacy --backstop
extended-test-legacy --isolated
extended-test-legacy --record
```
