### PR TITLE
fix: automation filters

### DIFF
--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -8372,6 +8372,9 @@ export const selectAutomationAvailableDashboardFilters: DashboardSelector<Filter
 // @alpha (undocumented)
 export const selectAutomationCommonDateFilterId: DashboardSelector<string | undefined>;
 
+// @alpha (undocumented)
+export const selectAutomationDefaultSelectedFilters: DashboardSelector<FilterContextItem[]>;
+
 // @alpha
 export const selectAutomationsError: DashboardSelector<GoodDataSdkError | undefined>;
 

--- a/libs/sdk-ui-dashboard/src/model/react/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/react/index.ts
@@ -47,6 +47,7 @@ export { useAutomationAvailableDashboardFilters } from "./filtering/useAutomatio
 export {
     selectAutomationCommonDateFilterId,
     selectAutomationAvailableDashboardFilters,
+    selectAutomationDefaultSelectedFilters,
     selectDashboardFiltersWithoutCrossFiltering,
     selectDashboardHiddenFilters,
     selectDashboardLockedFilters,

--- a/libs/sdk-ui-dashboard/src/model/react/useDashboardAlerting/useEnableAutomationFilterContext.ts
+++ b/libs/sdk-ui-dashboard/src/model/react/useDashboardAlerting/useEnableAutomationFilterContext.ts
@@ -3,7 +3,7 @@ import { useMemo } from "react";
 import { selectEnableAutomationFilterContext } from "../../store/index.js";
 import { useDashboardSelector } from "../DashboardStoreProvider.js";
 import { FilterContextItem, isDashboardAttributeFilter, isDashboardDateFilter } from "@gooddata/sdk-model";
-import { selectAutomationAvailableDashboardFilters } from "../filtering/selectors.js";
+import { selectDashboardFiltersWithoutCrossFiltering } from "../filtering/selectors.js";
 
 export const getFilterLocalIdentifier = (filter: FilterContextItem): string | undefined => {
     if (isDashboardAttributeFilter(filter)) {
@@ -22,7 +22,7 @@ export const validateAllFilterLocalIdentifiers = (filters: FilterContextItem[]):
  * @internal
  */
 export const useEnableAlertingAutomationFilterContext = () => {
-    const filters = useDashboardSelector(selectAutomationAvailableDashboardFilters);
+    const filters = useDashboardSelector(selectDashboardFiltersWithoutCrossFiltering);
     const enableAutomationFilterContextFlag = useDashboardSelector(selectEnableAutomationFilterContext);
 
     return useMemo(() => {

--- a/libs/sdk-ui-dashboard/src/presentation/automationFilters/hooks/useDefaultSelectedFiltersForNewAutomation.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/automationFilters/hooks/useDefaultSelectedFiltersForNewAutomation.ts
@@ -2,11 +2,11 @@
 import {
     ExtendedDashboardWidget,
     useDashboardSelector,
-    selectAutomationAvailableDashboardFilters,
+    selectAutomationDefaultSelectedFilters,
 } from "../../../model/index.js";
 import { removeIgnoredWidgetFilters } from "../utils.js";
 
 export function useDefaultSelectedFiltersForNewAutomation(widget?: ExtendedDashboardWidget) {
-    const availableDashboardFilters = useDashboardSelector(selectAutomationAvailableDashboardFilters);
+    const availableDashboardFilters = useDashboardSelector(selectAutomationDefaultSelectedFilters);
     return removeIgnoredWidgetFilters(availableDashboardFilters, widget);
 }

--- a/libs/sdk-ui-dashboard/src/presentation/automationFilters/utils.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/automationFilters/utils.ts
@@ -227,8 +227,8 @@ export const getAppliedDashboardFilters = (
 
     // And finally, strip all-time date filters - we don't want to save them, they have no effect on execution.
     return selectedFiltersWithHiddenFilters.filter((f) => {
-        if (isDateFilter(f)) {
-            return !isAllTimeDateFilterFixed(f);
+        if (isDashboardDateFilter(f)) {
+            return !isAllTimeDashboardDateFilter(f);
         }
 
         return true;

--- a/libs/sdk-ui-dashboard/styles/scss/notifications_channels_dialog.scss
+++ b/libs/sdk-ui-dashboard/styles/scss/notifications_channels_dialog.scss
@@ -19,11 +19,17 @@ $min-content-height: 110px;
 @media #{kit-variables.$small-only} {
     .gd-notifications-channels-dialog-overlay {
         overflow-y: auto;
+        overflow-x: hidden;
         max-height: 99vh;
     }
 }
 .gd-notifications-channels-dialog-overlay.truncated {
     overflow-y: auto;
+    overflow-x: hidden;
+
+    .gd-notification-channel-dialog-with-automation-filters {
+        overflow: hidden;
+    }
 }
 
 .gd-dialog:not(.gd-dropdown).gd-notifications-channels-dialog {


### PR DESCRIPTION
fix: automation filters
- Do not remove locked all-value attribute filters
- Fix removing all-time date filters from dashboard scheduled export
- Fix local identifiers validation in useEnableAutomationFilterContext

risk: low
JIRA: F1-1461

fix: automation filters scrollbars
- Avoid multiple vertical scrollbars in schedule/alert dialogs
- Avoid horizontal scrollbars in schedule/alert dialogs

risk: low
JIRA: F1-1411

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```

#### Commands for Bear platform working on branch rel/9.9

```
extended-test-legacy --backstop
extended-test-legacy --isolated
extended-test-legacy --record
```
