### PR TITLE
fix: sankey chart

### DIFF
--- a/libs/sdk-ui-charts/src/highcharts/adapter/Chart.tsx
+++ b/libs/sdk-ui-charts/src/highcharts/adapter/Chart.tsx
@@ -43,6 +43,15 @@ export class Chart extends React.Component<IChartProps> {
 
     public componentDidMount(): void {
         this.createChart(this.props.config);
+
+        // hacky fix for sankey chart https://github.com/highcharts/highcharts/issues/9818,
+        // should've be resolved in 12.2.0, but it's not https://github.com/highcharts/highcharts/commit/240c21fa7153a26dbed91d3f27a35fe1301b9647
+        const isSankey = this.props?.config?.chart?.type === "sankey";
+        if (this.chart && isSankey) {
+            const currentWidth = this.chart.chartWidth;
+            this.chart.setSize(currentWidth - 1, undefined, false);
+            this.chart.setSize(currentWidth, undefined, false);
+        }
     }
 
     public shouldComponentUpdate(nextProps: IChartProps): boolean {


### PR DESCRIPTION
Add workaround for wrongly rendered sankey chart.
Related issue: https://github.com/highcharts/highcharts/issues/9818, Should be resolved in 12.2.0, so we can remove it after upgrade.

risk: low
JIRA: F1-1406

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```

#### Commands for Bear platform working on branch rel/9.9

```
extended-test-legacy --backstop
extended-test-legacy --isolated
extended-test-legacy --record
```
