### PR TITLE
fix: dashboard attribute filter

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/DefaultDashboardAttributeFilter.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/DefaultDashboardAttributeFilter.tsx
@@ -38,9 +38,7 @@ import {
     selectIsFilterFromCrossFilteringByLocalIdentifier,
     selectEnableDuplicatedLabelValuesInAttributeFilter,
     selectEnableImmediateAttributeFilterDisplayAsLabelMigration,
-    selectHasSomeExecutionResult,
     selectPreloadedAttributesWithReferences,
-    selectIsDashboardExecuted,
     selectDashboardFiltersApplyMode,
     selectEnableDashboardFiltersApplyModes,
 } from "../../../model/index.js";
@@ -71,14 +69,10 @@ import { useDependentDateFilters } from "./useDependentDateFilters.js";
 export const DefaultDashboardAttributeFilter = (
     props: IDashboardAttributeFilterProps,
 ): JSX.Element | null => {
-    // In case, dashboard contains lot of filters,
-    // these are spawning lot of requests (collectLabelElements), which are potentially blocking execution(s).
-    // Wait at least for one executed result until we start loading them, so they are not blocking execution(s).
     const isInEditMode = useDashboardSelector(selectIsInEditMode);
-    const hasSomeExecutionResult = useDashboardSelector(selectHasSomeExecutionResult);
+    // Wait for batch preload of the required attribute filter data (labels and datasets), otherwise, each filter will spawn its own request.
     const filtersPreloaded = useDashboardSelector(selectPreloadedAttributesWithReferences);
-    const isDashboardExecuted = useDashboardSelector(selectIsDashboardExecuted);
-    const showFilter = isInEditMode || isDashboardExecuted || (hasSomeExecutionResult && filtersPreloaded);
+    const showFilter = isInEditMode || filtersPreloaded;
 
     if (!showFilter) {
         return <AttributeFilterLoading />;


### PR DESCRIPTION
- Do not wait for executions resolution to start loading collect label elements, so dashboard can be filtered sooner than its fully loaded. We support executions cancelling now, so it should not cause any issues.

risk: low
JIRA: F1-1436

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```

#### Commands for Bear platform working on branch rel/9.9

```
extended-test-legacy --backstop
extended-test-legacy --isolated
extended-test-legacy --record
```
