### PR TITLE
feat: Allow focusing back button when creating a saved view

### DIFF
--- a/libs/sdk-ui-dashboard/setupTests.ts
+++ b/libs/sdk-ui-dashboard/setupTests.ts
@@ -34,6 +34,24 @@ global.ResizeObserver = class ResizeObserver {
     }
 };
 
+global.IntersectionObserver = class IntersectionObserver {
+    observe() {
+        return null;
+    }
+    unobserve() {
+        return null;
+    }
+    disconnect() {
+        return null;
+    }
+    takeRecords() {
+        return null;
+    }
+    root = null;
+    rootMargin = "";
+    thresholds = [];
+};
+
 expect.extend(matchers);
 
 afterEach(() => {

--- a/libs/sdk-ui-dashboard/src/presentation/filterBar/filterBar/filterViews/AddFilterView.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/filterBar/filterBar/filterViews/AddFilterView.tsx
@@ -1,4 +1,4 @@
-// (C) 2024 GoodData Corporation
+// (C) 2024-2025 GoodData Corporation
 
 import React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
@@ -28,16 +28,14 @@ export const AddFilterView: React.FC<IAddFilterViewProps> = ({ onClose }) => {
     return (
         <div className="configuration-panel configuration-panel__filter-view__add">
             <div className="configuration-panel-header">
-                <Typography
-                    tagName="h3"
-                    className="configuration-panel-header-title clickable"
-                    onClick={onClose}
-                >
-                    <div className="gd-title-with-icon">
-                        <span className="gd-icon-navigateleft" />
-                        <FormattedMessage id="filters.filterViews.add.title" />
-                    </div>
-                </Typography>
+                <Button onClick={onClose} className={"configuration-panel-header-title-button"}>
+                    <Typography tagName="h3" className="configuration-panel-header-title">
+                        <div className="gd-title-with-icon">
+                            <span className="gd-icon-navigateleft" />
+                            <FormattedMessage id="filters.filterViews.add.title" />
+                        </div>
+                    </Typography>
+                </Button>
             </div>
             <div className="configuration-category">
                 <Input

--- a/libs/sdk-ui-dashboard/src/presentation/filterBar/filterBar/filterViews/FilterViews.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/filterBar/filterBar/filterViews/FilterViews.tsx
@@ -4,14 +4,7 @@ import React, { useCallback, useMemo } from "react";
 import { FormattedMessage } from "react-intl";
 import cx from "classnames";
 import { v4 as uuid } from "uuid";
-import {
-    DropdownButton,
-    useMediaQuery,
-    IAlignPoint,
-    UiFocusTrap,
-    useIdPrefixed,
-    AutofocusOnMount,
-} from "@gooddata/sdk-ui-kit";
+import { DropdownButton, useMediaQuery, IAlignPoint, UiFocusTrap, useIdPrefixed } from "@gooddata/sdk-ui-kit";
 import { IDashboardFilterView } from "@gooddata/sdk-model";
 
 import { ConfigurationBubble } from "../../../widget/common/configuration/ConfigurationBubble.js";
@@ -168,18 +161,22 @@ export const FilterViews: React.FC = () => {
                     alignTo={`.${dropdownAnchorClassName}`}
                     alignPoints={BUBBLE_ALIGN_POINTS}
                 >
-                    <UiFocusTrap returnFocusTo={triggerId} returnFocusOnUnmount onDeactivate={closeDialog}>
-                        <AutofocusOnMount key={dialogMode}>
-                            {dialogMode === "add" ? (
-                                <AddFilterView onClose={openListDialog} />
-                            ) : (
-                                <FilterViewsList
-                                    filterViews={filterViews}
-                                    onAddNew={openAddDialog}
-                                    onClose={closeDialog}
-                                />
-                            )}
-                        </AutofocusOnMount>
+                    <UiFocusTrap
+                        returnFocusTo={triggerId}
+                        returnFocusOnUnmount
+                        onDeactivate={closeDialog}
+                        autofocusOnOpen
+                        refocusKey={dialogMode}
+                    >
+                        {dialogMode === "add" ? (
+                            <AddFilterView onClose={openListDialog} />
+                        ) : (
+                            <FilterViewsList
+                                filterViews={filterViews}
+                                onAddNew={openAddDialog}
+                                onClose={closeDialog}
+                            />
+                        )}
                     </UiFocusTrap>
                 </ConfigurationBubble>
             ) : null}

--- a/libs/sdk-ui-dashboard/styles/scss/configurationPanel.scss
+++ b/libs/sdk-ui-dashboard/styles/scss/configurationPanel.scss
@@ -139,6 +139,17 @@
             }
         }
 
+        .configuration-panel-header-title-button {
+            border: none;
+            padding: 0;
+            background: transparent;
+            cursor: pointer;
+
+            &:hover {
+                background: transparent;
+            }
+        }
+
         .configuration-panel-header-title {
             flex-grow: 1;
             color: kit-variables.$gd-color-state-blank;

--- a/libs/sdk-ui-ext/setupTests.ts
+++ b/libs/sdk-ui-ext/setupTests.ts
@@ -34,6 +34,24 @@ global.ResizeObserver = class ResizeObserver {
     }
 };
 
+global.IntersectionObserver = class IntersectionObserver {
+    observe() {
+        return null;
+    }
+    unobserve() {
+        return null;
+    }
+    disconnect() {
+        return null;
+    }
+    takeRecords() {
+        return null;
+    }
+    root = null;
+    rootMargin = "";
+    thresholds = [];
+};
+
 expect.extend(matchers);
 
 afterEach(() => {

--- a/libs/sdk-ui-filters/setupTests.ts
+++ b/libs/sdk-ui-filters/setupTests.ts
@@ -1,4 +1,4 @@
-// (C) 2023-2024 GoodData Corporation
+// (C) 2023-2025 GoodData Corporation
 import { cleanup } from "@testing-library/react";
 import { afterEach, expect, vi } from "vitest";
 
@@ -34,6 +34,24 @@ global.ResizeObserver = class ResizeObserver {
     disconnect() {
         return null;
     }
+};
+
+global.IntersectionObserver = class IntersectionObserver {
+    observe() {
+        return null;
+    }
+    unobserve() {
+        return null;
+    }
+    disconnect() {
+        return null;
+    }
+    takeRecords() {
+        return null;
+    }
+    root = null;
+    rootMargin = "";
+    thresholds = [];
 };
 
 afterEach(() => {

--- a/libs/sdk-ui-filters/src/DateFilter/DateFilterBody/DateFilterHeader.tsx
+++ b/libs/sdk-ui-filters/src/DateFilter/DateFilterBody/DateFilterHeader.tsx
@@ -1,13 +1,13 @@
 // (C) 2019-2025 GoodData Corporation
 import React from "react";
 import { DateFilterRoute } from "./types.js";
-import { useAutofocusOnMount } from "@gooddata/sdk-ui-kit";
+import { useAutofocusOnMountRef } from "@gooddata/sdk-ui-kit";
 
 export const DateFilterHeader: React.FC<{
     children: any;
     changeRoute: (route: DateFilterRoute) => void;
 }> = ({ children, changeRoute, ...otherProps }) => {
-    const autofocusRef = useAutofocusOnMount();
+    const autofocusRef = useAutofocusOnMountRef();
 
     return (
         <button

--- a/libs/sdk-ui-gen-ai/setupTests.ts
+++ b/libs/sdk-ui-gen-ai/setupTests.ts
@@ -1,4 +1,4 @@
-// (C) 2023-2024 GoodData Corporation
+// (C) 2023-2025 GoodData Corporation
 import { cleanup } from "@testing-library/react";
 import { expect, afterEach, vi } from "vitest";
 
@@ -56,4 +56,22 @@ global.ResizeObserver = class ResizeObserver {
     disconnect() {
         return null;
     }
+};
+
+global.IntersectionObserver = class IntersectionObserver {
+    observe() {
+        return null;
+    }
+    unobserve() {
+        return null;
+    }
+    disconnect() {
+        return null;
+    }
+    takeRecords() {
+        return null;
+    }
+    root = null;
+    rootMargin = "";
+    thresholds = [];
 };

--- a/libs/sdk-ui-kit/api/sdk-ui-kit.api.md
+++ b/libs/sdk-ui-kit/api/sdk-ui-kit.api.md
@@ -105,8 +105,10 @@ export type ArrowOffsets = Record<string, ArrowOffset>;
 // @internal (undocumented)
 export function AsyncList<T>(props: IAsyncListProps<T>): React_2.JSX.Element;
 
-// @internal (undocumented)
-export const AutofocusOnMount: React_2.FC<React_2.HTMLProps<HTMLDivElement>>;
+// @internal
+export const AutofocusOnMount: React_2.FC<{
+    children: React_2.ReactNode;
+} & IAutofocusOptions>;
 
 // @internal (undocumented)
 export class AutoSize extends Component<IAutoSizeProps> {
@@ -632,7 +634,7 @@ export const getDefaultEmbedTypeOptions: (embedType: EmbedType) => EmbedOptionsT
 
 // @internal
 export const getFocusableElements: (element?: HTMLElement | null) => {
-    focusableElements: NodeListOf<HTMLElement>;
+    focusableElements: HTMLElement[];
     firstElement: HTMLElement;
     lastElement: HTMLElement;
 };
@@ -989,6 +991,14 @@ export interface IAsyncListProps<T> {
     renderLoadingItem?: (props: IRenderListItemProps<T>) => JSX.Element;
     // (undocumented)
     width?: number;
+}
+
+// @internal (undocumented)
+export interface IAutofocusOptions {
+    // (undocumented)
+    isDisabled?: boolean;
+    // (undocumented)
+    refocusKey?: unknown;
 }
 
 // @internal (undocumented)
@@ -5691,6 +5701,7 @@ export interface UiFocusTrapProps {
     initialFocus?: React_2.RefObject<HTMLElement> | string;
     // (undocumented)
     onDeactivate?: () => void;
+    refocusKey?: unknown;
     returnFocusOnUnmount?: boolean;
     returnFocusTo?: React_2.RefObject<HTMLElement> | string;
 }
@@ -5885,7 +5896,10 @@ export const unrelatedHeader: IDateDatasetHeader;
 export function unwrapGroupItems<T extends IUiMenuItemData = object>(items: IUiMenuItem<T>[]): IUiMenuItem<T>[];
 
 // @internal
-export const useAutofocusOnMount: () => (node: HTMLElement | null) => void;
+export const useAutofocusOnMount: (element: HTMLElement | null | undefined, { isDisabled, refocusKey }?: IAutofocusOptions) => void;
+
+// @internal
+export const useAutofocusOnMountRef: ({ isDisabled, refocusKey }?: IAutofocusOptions) => (node: HTMLElement | null) => void;
 
 // @internal
 export const useDebouncedState: <T>(initialValue: T, delay: number) => UseDebouncedStateOutput<T>;

--- a/libs/sdk-ui-kit/setupTests.ts
+++ b/libs/sdk-ui-kit/setupTests.ts
@@ -59,3 +59,21 @@ global.ResizeObserver = class ResizeObserver {
         return null;
     }
 };
+
+global.IntersectionObserver = class IntersectionObserver {
+    observe() {
+        return null;
+    }
+    unobserve() {
+        return null;
+    }
+    disconnect() {
+        return null;
+    }
+    takeRecords() {
+        return null;
+    }
+    root = null;
+    rootMargin = "";
+    thresholds = [];
+};

--- a/libs/sdk-ui-kit/src/@ui/UiFocusTrap/UiFocusTrap.tsx
+++ b/libs/sdk-ui-kit/src/@ui/UiFocusTrap/UiFocusTrap.tsx
@@ -2,7 +2,9 @@
 
 import React, { useEffect, useRef, useCallback } from "react";
 import { makeDialogKeyboardNavigation } from "../@utils/keyboardNavigation.js";
-import { getFocusableElements, isElementTextInput } from "../../utils/domUtilities.js";
+import { getFocusableElements } from "../../utils/domUtilities.js";
+import { useAutofocusOnMount } from "../../utils/useAutofocusOnMount.js";
+import { useCombineRefs } from "@gooddata/sdk-ui";
 
 type NavigationDirection = "forward" | "backward";
 
@@ -30,6 +32,10 @@ export interface UiFocusTrapProps {
      */
     initialFocus?: React.RefObject<HTMLElement> | string;
     /**
+     * You can retrigger focusing on `initialFocus` by changing the value of this key.
+     */
+    refocusKey?: unknown;
+    /**
      * Specify a custom keyboard navigation handler.
      * If not provided, the default keyboard navigation handler will be used.
      */
@@ -42,7 +48,7 @@ export interface UiFocusTrapProps {
  */
 const focusAndEnsureReachableElement = (
     initialElement: HTMLElement,
-    focusableElements: NodeListOf<HTMLElement>,
+    focusableElements: HTMLElement[],
     direction: NavigationDirection,
 ): void => {
     let nextElement = initialElement;
@@ -65,11 +71,11 @@ const focusAndEnsureReachableElement = (
 
 const useDialogKeyboardNavigation = (
     trapRef: React.RefObject<HTMLDivElement>,
-    returnFocus,
+    returnFocus: () => void,
     onDeactivate?: () => void,
 ) => {
     const handleFocusNavigation = useCallback(
-        (focusableElements: NodeListOf<HTMLElement>, direction: NavigationDirection) => {
+        (focusableElements: HTMLElement[], direction: NavigationDirection) => {
             const elements = Array.from(focusableElements);
             const currentIndex = elements.indexOf(document.activeElement as HTMLElement);
             const firstElement = elements[0];
@@ -138,9 +144,11 @@ export const UiFocusTrap: React.FC<UiFocusTrapProps> = ({
     autofocusOnOpen = false,
     returnFocusOnUnmount = true,
     initialFocus,
+    refocusKey,
     customKeyboardNavigationHandler,
 }) => {
-    const trapRef = useRef<HTMLDivElement>(null);
+    const trapRef = useRef<HTMLDivElement | null>(null);
+    const [trapElement, setTrapElement] = React.useState<HTMLDivElement | null>(null);
     const defaultReturnFocusToRef = useRef<HTMLElement | null>(document.activeElement as HTMLElement);
 
     const returnFocusTo = returnFocusToProp ?? defaultReturnFocusToRef;
@@ -175,41 +183,14 @@ export const UiFocusTrap: React.FC<UiFocusTrapProps> = ({
         };
     }, [returnFocusOnUnmount, returnFocus]);
 
-    useEffect(() => {
-        const focusTrapTimeout = setTimeout(() => {
-            if (!autofocusOnOpen) {
-                return;
-            }
+    const elementToFocus = React.useMemo(() => {
+        if (typeof initialFocus === "string") {
+            return document.getElementById(initialFocus);
+        }
+        return initialFocus?.current ?? trapElement;
+    }, [initialFocus, trapElement]);
 
-            if (trapRef.current?.contains(document.activeElement)) {
-                // Do not change focus, if the focused element is already inside the trap
-                return;
-            }
-
-            if (isElementTextInput(document.activeElement)) {
-                return;
-            }
-
-            if (initialFocus) {
-                if (typeof initialFocus === "string") {
-                    const element = document.getElementById(initialFocus);
-                    element?.focus();
-                    return;
-                } else if (initialFocus.current) {
-                    initialFocus.current.focus();
-                    return;
-                }
-            }
-
-            // Move focus to the first element in the trap at start
-            const { firstElement } = getFocusableElements(trapRef.current);
-            firstElement?.focus();
-        }, 100);
-
-        return () => {
-            clearTimeout(focusTrapTimeout);
-        };
-    }, [autofocusOnOpen, initialFocus, returnFocus, keyboardHandler, returnFocusOnUnmount]);
+    useAutofocusOnMount(elementToFocus, { isDisabled: !autofocusOnOpen, refocusKey });
 
     useEffect(() => {
         document.addEventListener("keydown", keyboardHandler);
@@ -220,7 +201,7 @@ export const UiFocusTrap: React.FC<UiFocusTrapProps> = ({
     }, [keyboardHandler]);
 
     return (
-        <div className="gd-focus-trap" ref={trapRef}>
+        <div className="gd-focus-trap" ref={useCombineRefs(trapRef, setTrapElement)}>
             {children}
         </div>
     );

--- a/libs/sdk-ui-kit/src/@ui/UiMenu/UiMenu.tsx
+++ b/libs/sdk-ui-kit/src/@ui/UiMenu/UiMenu.tsx
@@ -6,19 +6,17 @@ import { IUiMenuItemData, UiMenuProps } from "./types.js";
 import { getContentItem, getSiblingItems } from "./itemUtils.js";
 import { useCustomContentKeyNavigation, useKeyNavigation, useUiMenuContextValue } from "./hooks.js";
 import { typedUiMenuContextStore } from "./context.js";
-import { useAutofocusOnMount } from "../../utils/useAutofocusOnMount.js";
+import { AutofocusOnMount } from "../../utils/useAutofocusOnMount.js";
 
 const ContentWrapper: FC<{
     keyboardNavigationHandler: (event: React.KeyboardEvent) => void;
     children?: React.ReactNode;
 }> = (props) => {
-    // autofocus always first element in the custom content for now
-    const autofocusRef = useAutofocusOnMount();
-
     return (
-        <div onKeyDown={props.keyboardNavigationHandler} ref={autofocusRef}>
-            {props.children}
-        </div>
+        // autofocus always first element in the custom content for now
+        <AutofocusOnMount>
+            <div onKeyDown={props.keyboardNavigationHandler}>{props.children}</div>
+        </AutofocusOnMount>
     );
 };
 

--- a/libs/sdk-ui-kit/src/utils/domUtilities.ts
+++ b/libs/sdk-ui-kit/src/utils/domUtilities.ts
@@ -164,7 +164,7 @@ const focusableElementsSelector = [
     "area[href]",
 
     // Custom elements with tabindex
-    '[tabindex]:not([tabindex="-1"]):not(:disabled):not([aria-disabled="true"])',
+    '[tabindex]:not(:disabled):not([aria-disabled="true"])',
 
     // Media with controls
     "audio[controls]",
@@ -174,6 +174,8 @@ const focusableElementsSelector = [
     '[contenteditable]:not([contenteditable="false"])',
 ].join(",");
 
+const isNotNegativeTabIndex = (element: HTMLElement) => !element.tabIndex || element.tabIndex >= 0;
+
 /**
  * @internal
  * Returns the focusable elements of the given element
@@ -181,7 +183,9 @@ const focusableElementsSelector = [
  * @returns an object containing the focusable elements, the first focusable element, and the last focusable element
  */
 export const getFocusableElements = (element?: HTMLElement | null) => {
-    const focusableElements = element?.querySelectorAll<HTMLElement>(focusableElementsSelector);
+    const focusableElements = Array.from(
+        element?.querySelectorAll<HTMLElement>(focusableElementsSelector) ?? [],
+    ).filter(isNotNegativeTabIndex);
     const firstElement = focusableElements?.[0];
     const lastElement = focusableElements?.[focusableElements.length - 1];
     return { focusableElements, firstElement, lastElement };
@@ -193,5 +197,5 @@ export const getFocusableElements = (element?: HTMLElement | null) => {
  * @returns whether or not the supplied element is focusable
  */
 export const isElementFocusable = (element?: HTMLElement | null) => {
-    return element?.matches(focusableElementsSelector);
+    return element?.matches(focusableElementsSelector) && isNotNegativeTabIndex(element);
 };

--- a/libs/sdk-ui-kit/src/utils/useAutofocusOnMount.tsx
+++ b/libs/sdk-ui-kit/src/utils/useAutofocusOnMount.tsx
@@ -1,64 +1,90 @@
 // (C) 2025 GoodData Corporation
 
 import React from "react";
-import { getFocusableElements, isElementFocusable } from "./domUtilities.js";
+import { getFocusableElements, isElementFocusable, isElementTextInput } from "./domUtilities.js";
 
 /**
- * Focuses the element when it mounts.
+ * @internal
+ */
+export interface IAutofocusOptions {
+    isDisabled?: boolean;
+    refocusKey?: unknown;
+}
+
+/**
+ * Provides a ref that will autofocus the element when it is mounted, or when `refocusKey` changes.
  *
  * @internal
  */
-export const useAutofocusOnMount = () => {
+export const useAutofocusOnMountRef = ({ isDisabled, refocusKey }: IAutofocusOptions = {}) => {
     const [element, setElement] = React.useState<HTMLElement | null>(null);
 
-    const hasFiredRef = React.useRef(false);
-
-    // If the element is outside of the viewport, calling focus() will not work.
-    // This can happen for example with floating elements, that are repositioned after they mount
-    React.useEffect(() => {
-        if (!element || element.contains(document.activeElement)) {
-            return undefined;
-        }
-
-        const observer = new IntersectionObserver(() => {
-            if (!element) {
-                return;
-            }
-
-            const elementToFocus = isElementFocusable(element)
-                ? element
-                : getFocusableElements(element).firstElement;
-
-            // Focusing a newly created element sometimes fails if not done through requestAnimationFrame()
-            window.requestAnimationFrame(() => {
-                elementToFocus.focus();
-
-                if (document.activeElement === elementToFocus) {
-                    observer.disconnect();
-                }
-            });
-        });
-
-        observer.observe(element);
-
-        return () => observer.disconnect();
-    }, [element]);
+    useAutofocusOnMount(element, { isDisabled, refocusKey });
 
     return React.useCallback((node: HTMLElement | null) => {
-        if (hasFiredRef.current || !node) {
-            return;
-        }
-        hasFiredRef.current = true;
-
         setElement(node);
     }, []);
 };
 
 /**
+ * Focuses the element on mount or when `refocusKey` changes.
+ *
  * @internal
  */
-export const AutofocusOnMount: React.FC<React.HTMLProps<HTMLDivElement>> = ({ ...props }) => {
-    const ref = useAutofocusOnMount();
+export const useAutofocusOnMount = (
+    element: HTMLElement | null | undefined,
+    { isDisabled, refocusKey }: IAutofocusOptions = {},
+) => {
+    // If the element is outside of the viewport, calling focus() will not work.
+    // This can happen for example with floating elements, that are repositioned after they mount
+    React.useEffect(() => {
+        const elementToFocus = getElementToFocus(element);
 
-    return <div ref={ref} {...props} />;
+        if (isDisabled || !elementToFocus) {
+            return undefined;
+        }
+
+        const observer = new IntersectionObserver(([{ target }]) => {
+            if (target.contains(document.activeElement) || isElementTextInput(document.activeElement)) {
+                observer.disconnect();
+                return;
+            }
+
+            // Focusing a newly created element sometimes fails if not done through requestAnimationFrame()
+            window.requestAnimationFrame(() => {
+                (target as HTMLElement).focus();
+
+                if (document.activeElement === target) {
+                    observer.disconnect();
+                }
+            });
+        });
+
+        observer.observe(elementToFocus);
+
+        return () => observer.disconnect();
+    }, [refocusKey, isDisabled, element]);
+};
+
+function getElementToFocus(element: HTMLElement | null | undefined) {
+    return isElementFocusable(element) ? element : getFocusableElements(element).firstElement;
+}
+
+/**
+ * Wrapper that focuses the first focusable child when it mounts, or when `refocusKey` changes.
+ *
+ * @internal
+ */
+export const AutofocusOnMount: React.FC<
+    {
+        children: React.ReactNode;
+    } & IAutofocusOptions
+> = ({ isDisabled, refocusKey, children }) => {
+    const ref = useAutofocusOnMountRef({ isDisabled, refocusKey });
+
+    return (
+        <div ref={ref} style={{ display: "contents" }}>
+            {children}
+        </div>
+    );
 };

--- a/libs/sdk-ui-semantic-search/setupTests.ts
+++ b/libs/sdk-ui-semantic-search/setupTests.ts
@@ -1,4 +1,4 @@
-// (C) 2023-2024 GoodData Corporation
+// (C) 2023-2025 GoodData Corporation
 import { cleanup } from "@testing-library/react";
 import { expect, afterEach, vi } from "vitest";
 
@@ -56,4 +56,22 @@ global.ResizeObserver = class ResizeObserver {
     disconnect() {
         return null;
     }
+};
+
+global.IntersectionObserver = class IntersectionObserver {
+    observe() {
+        return null;
+    }
+    unobserve() {
+        return null;
+    }
+    disconnect() {
+        return null;
+    }
+    takeRecords() {
+        return null;
+    }
+    root = null;
+    rootMargin = "";
+    thresholds = [];
 };

--- a/libs/sdk-ui-vis-commons/src/legend/PopUpLegend/LegendDialog.tsx
+++ b/libs/sdk-ui-vis-commons/src/legend/PopUpLegend/LegendDialog.tsx
@@ -7,8 +7,8 @@ import {
     useIsZoomed,
     ZOOM_THRESHOLD,
     useIdPrefixed,
-    useAutofocusOnMount,
     DialogCloseButton,
+    AutofocusOnMount,
 } from "@gooddata/sdk-ui-kit";
 import { legendDialogAlignPoints, legendMobileDialogAlignPoints } from "./alignPoints.js";
 
@@ -27,7 +27,6 @@ interface ILegendDialogContent {
 const LegendDialogContent: React.FC<ILegendDialogContent> = ({ title, onCloseDialog, children, id }) => {
     const isZoomed = useIsZoomed(ZOOM_THRESHOLD);
 
-    const autofocusRef = useAutofocusOnMount();
     const dialogRef = React.useRef<HTMLDivElement>(null);
 
     const handleClose = React.useCallback<React.MouseEventHandler>(
@@ -75,9 +74,9 @@ const LegendDialogContent: React.FC<ILegendDialogContent> = ({ title, onCloseDia
                     onClose={handleClose}
                 />
             </div>
-            <div className="legend-content" ref={autofocusRef}>
-                {children}
-            </div>
+            <AutofocusOnMount>
+                <div className="legend-content">{children}</div>
+            </AutofocusOnMount>
         </div>
     );
 };

--- a/libs/sdk-ui/api/sdk-ui.api.md
+++ b/libs/sdk-ui/api/sdk-ui.api.md
@@ -1770,6 +1770,9 @@ export const useClientWorkspaceInitialized: () => boolean;
 // @alpha
 export const useClientWorkspaceStatus: () => UseCancelablePromiseStatus;
 
+// @internal (undocumented)
+export const useCombineRefs: <T>(...refs: (React_2.MutableRefObject<T> | ((instance: T) => void) | null | undefined)[]) => (instance: T) => void;
+
 // @public
 export function useComposedPlaceholder<TContext, TPlaceholder extends IComposedPlaceholder<any, any, TContext>>(placeholder: TPlaceholder, resolutionContext?: TContext): PlaceholderResolvedValue<TPlaceholder>;
 

--- a/libs/sdk-ui/src/base/index.tsx
+++ b/libs/sdk-ui/src/base/index.tsx
@@ -183,6 +183,7 @@ export { resolveLCMWorkspaceIdentifiers } from "./react/ClientWorkspaceContext/r
 export { usePrevious } from "./react/usePrevious.js";
 export { usePropState } from "./react/usePropState.js";
 export { useAutoupdateRef } from "./react/useAutoupdateRef.js";
+export { useCombineRefs } from "./react/useCombineRefs.js";
 export { useLocalStorage } from "./react/useLocalStorage.js";
 /*
  * Localization exports

--- a/libs/sdk-ui/src/base/react/useCombineRefs.ts
+++ b/libs/sdk-ui/src/base/react/useCombineRefs.ts
@@ -1,0 +1,25 @@
+// (C) 2025 GoodData Corporation
+import React from "react";
+
+/**
+ * @internal
+ */
+export const useCombineRefs = <T>(
+    ...refs: Array<React.MutableRefObject<T> | ((instance: T) => void) | undefined | null>
+) => {
+    return React.useCallback((instance: T) => {
+        refs.forEach((ref) => {
+            if (!ref) {
+                return;
+            }
+
+            if (typeof ref === "function") {
+                ref(instance);
+            } else {
+                ref.current = instance;
+            }
+        });
+        // This is actually correct
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, refs);
+};


### PR DESCRIPTION
risk: low
JIRA: LX-1034

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```

#### Commands for Bear platform working on branch rel/9.9

```
extended-test-legacy --backstop
extended-test-legacy --isolated
extended-test-legacy --record
```
