### PR TITLE
fix: mark older schedule/alerts as invalid

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/alerting/DefaultAlertingDialog/DefaultAlertingDialogNew.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/alerting/DefaultAlertingDialog/DefaultAlertingDialogNew.tsx
@@ -14,7 +14,7 @@ import {
     ScrollablePanel,
 } from "@gooddata/sdk-ui-kit";
 import cx from "classnames";
-import React, { useMemo, useRef, useState } from "react";
+import React, { useRef, useState } from "react";
 import { defineMessage, FormattedMessage, useIntl } from "react-intl";
 import {
     selectEntitlementMaxAutomationRecipients,
@@ -53,7 +53,6 @@ import { DeleteAlertConfirmDialog } from "../DefaultAlertingManagementDialog/com
 import { convertError } from "@gooddata/sdk-ui";
 import { getDescription, getValueSuffix } from "./utils/getters.js";
 import { isChangeOrDifferenceOperator } from "./utils/guards.js";
-import { isLatestAutomationVersion } from "../../automationFilters/utils.js";
 import { useValidateExistingAutomationFilters } from "../../automationFilters/hooks/useValidateExistingAutomationFilters.js";
 import { ApplyCurrentFiltersConfirmDialog } from "../../automationFilters/components/ApplyLatestFiltersConfirmDialog.js";
 
@@ -161,10 +160,6 @@ export function AlertingDialogRenderer({
         enableAutomationFilterContext,
     });
     const [isApplyCurrentFiltersDialogOpen, setIsApplyCurrentFiltersDialogOpen] = useState(!isValid);
-
-    const isLatestVersionOfAutomation = useMemo(() => {
-        return isLatestAutomationVersion(alertToEdit);
-    }, [alertToEdit]);
 
     const { isSavingAlert, handleCreateAlert, handleUpdateAlert } = useSaveAlertToBackend({
         onCreateSuccess: (alert) => {
@@ -293,7 +288,7 @@ export function AlertingDialogRenderer({
                             })}
                         >
                             <div className="gd-divider-with-margin" />
-                            {enableAutomationFilterContext && isLatestVersionOfAutomation ? (
+                            {enableAutomationFilterContext ? (
                                 <>
                                     <AutomationFiltersSelect
                                         availableFilters={availableFilters}

--- a/libs/sdk-ui-dashboard/src/presentation/automationFilters/hooks/test/validateExistingAutomationFilters.test.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/automationFilters/hooks/test/validateExistingAutomationFilters.test.ts
@@ -1169,7 +1169,7 @@ describe("validateExistingAutomationFilters", () => {
     // Visible filters
     //
 
-    describe("removed filters", () => {
+    describe("visible filters", () => {
         it("should be valid with empty filters", () => {
             const {
                 isValid,
@@ -1338,31 +1338,47 @@ describe("validateExistingAutomationFilters", () => {
             expect(visibleFilterIsMissingInSavedFilters).toBe(false);
         });
 
-        //
-        // Multiple date filters
-        //
-
-        describe("multiple date filters", () => {
-            // This is possible when you have additional date filter in the dashboard filter context,
-            // which has the same date dataset as the common date filter.
-            it("should be valid with 2 date filters with the common date dataset", () => {
-                const result = validateExistingAutomationFilters({
-                    savedAutomationFilters: [nonAllTimeCommonDateFilter, nonCommonFilterWithCommonDataSet],
-                    savedAutomationVisibleFilters: [
-                        nonAllTimeCommonDateVisibleFilter,
-                        nonCommonFilterWithCommonDataSetVisibleFilter,
-                    ],
-                    hiddenFilters: [],
-                    lockedFilters: [],
-                    ignoredFilters: [],
-                    dashboardFilters: [
-                        nonAllTimeCommonDateFilterContextItem,
-                        nonCommonFilterContextItemWithCommonDataSet,
-                    ],
-                });
-
-                expect(result.isValid).toBe(true);
+        it("should be invalid when visible filters are missing", () => {
+            const { isValid, visibleFiltersAreMissing } = validateExistingAutomationFilters({
+                savedAutomationFilters: [],
+                savedAutomationVisibleFilters: undefined,
+                hiddenFilters: [],
+                lockedFilters: [],
+                ignoredFilters: [],
+                dashboardFilters: [nonAllTimeCommonDateFilterContextItem],
+                widget: widget,
+                insight,
             });
+
+            expect(isValid).toBe(false);
+            expect(visibleFiltersAreMissing).toBe(true);
+        });
+    });
+
+    //
+    // Multiple date filters
+    //
+
+    describe("multiple date filters", () => {
+        // This is possible when you have additional date filter in the dashboard filter context,
+        // which has the same date dataset as the common date filter.
+        it("should be valid with 2 date filters with the common date dataset", () => {
+            const result = validateExistingAutomationFilters({
+                savedAutomationFilters: [nonAllTimeCommonDateFilter, nonCommonFilterWithCommonDataSet],
+                savedAutomationVisibleFilters: [
+                    nonAllTimeCommonDateVisibleFilter,
+                    nonCommonFilterWithCommonDataSetVisibleFilter,
+                ],
+                hiddenFilters: [],
+                lockedFilters: [],
+                ignoredFilters: [],
+                dashboardFilters: [
+                    nonAllTimeCommonDateFilterContextItem,
+                    nonCommonFilterContextItemWithCommonDataSet,
+                ],
+            });
+
+            expect(result.isValid).toBe(true);
         });
     });
 });

--- a/libs/sdk-ui-dashboard/src/presentation/automationFilters/utils.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/automationFilters/utils.ts
@@ -8,7 +8,6 @@ import {
     filterLocalIdentifier,
     filterObjRef,
     getAttributeElementsItems,
-    IAutomationMetadataObject,
     IAutomationVisibleFilter,
     ICatalogAttribute,
     ICatalogDateDataset,
@@ -270,35 +269,6 @@ export const getFilterByLocalIdentifier = (
         const filterLocalIdentifier = getFilterLocalIdentifier(filter);
         return filterLocalIdentifier === localIdentifier;
     });
-};
-
-/**
- * Check if the automation is latest version. Latest version means that it has visible filters defined
- * in case there are some filters in automation. Sometimes there may be filters but visible
- * filters may be still empty. In this case we should not care about rendering filters
- * as only visible filters are used for rendering.
- *
- * @param automation - The automation to check.
- * @returns True if the automation is latest version, false otherwise.
- */
-export const isLatestAutomationVersion = (automation?: IAutomationMetadataObject) => {
-    if (!automation) {
-        return true;
-    }
-
-    if (!!automation.schedule && !automation.alert) {
-        // scheduling
-        const scheduleHasFilters = automation.exportDefinitions?.some((exportDef) => {
-            return !!exportDef.requestPayload.content.filters?.length;
-        });
-
-        return scheduleHasFilters ? !!automation?.metadata?.visibleFilters : true;
-    } else {
-        // alerting
-        const alertHasFilters = !!automation.alert?.execution.filters?.length;
-
-        return alertHasFilters ? !!automation?.metadata?.visibleFilters : true;
-    }
 };
 
 /**

--- a/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/DefaultScheduledEmailDialog.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/DefaultScheduledEmailDialog.tsx
@@ -35,10 +35,7 @@ import {
     useDashboardSelector,
 } from "../../../model/index.js";
 import { AutomationFiltersSelect } from "../../automationFilters/components/AutomationFiltersSelect.js";
-import {
-    isLatestAutomationVersion,
-    validateAllFilterLocalIdentifiers,
-} from "../../automationFilters/utils.js";
+import { validateAllFilterLocalIdentifiers } from "../../automationFilters/utils.js";
 import { useAutomationFiltersSelect } from "../../automationFilters/useAutomationFiltersSelect.js";
 import { useValidateExistingAutomationFilters } from "../../automationFilters/hooks/useValidateExistingAutomationFilters.js";
 import { ApplyCurrentFiltersConfirmDialog } from "../../automationFilters/components/ApplyLatestFiltersConfirmDialog.js";
@@ -166,7 +163,7 @@ export function ScheduledMailDialogRenderer({
         isCrossFiltering,
         isExecutionTimestampMode,
         enableAutomationFilterContext,
-    } = useDefaultScheduledEmailDialogData({ filters: availableFilters ?? [], scheduledExportToEdit });
+    } = useDefaultScheduledEmailDialogData({ filters: availableFilters ?? [] });
 
     const {
         defaultUser,
@@ -483,13 +480,7 @@ export const DefaultScheduledEmailDialog: React.FC<IScheduledEmailDialogProps> =
     );
 };
 
-function useDefaultScheduledEmailDialogData({
-    filters,
-    scheduledExportToEdit,
-}: {
-    filters: FilterContextItem[];
-    scheduledExportToEdit?: IAutomationMetadataObject;
-}) {
+function useDefaultScheduledEmailDialogData({ filters }: { filters: FilterContextItem[] }) {
     const locale = useDashboardSelector(selectLocale);
     const dashboardTitle = useDashboardSelector(selectDashboardTitle);
     const dateFormat = useDashboardSelector(selectDateFormat);
@@ -510,17 +501,10 @@ function useDefaultScheduledEmailDialogData({
     const isCrossFiltering = useDashboardSelector(selectIsCrossFiltering);
     const isExecutionTimestampMode = !!useDashboardSelector(selectExecutionTimestamp);
     const enableAutomationFilterContextFlag = useDashboardSelector(selectEnableAutomationFilterContext);
-    const isLatestVersionOfAutomation = useMemo(() => {
-        return isLatestAutomationVersion(scheduledExportToEdit);
-    }, [scheduledExportToEdit]);
     const enableAutomationFilterContext = useMemo(() => {
         const doAllDashboardFiltersHaveLocalIdentifiers = validateAllFilterLocalIdentifiers(filters);
-        return (
-            enableAutomationFilterContextFlag &&
-            doAllDashboardFiltersHaveLocalIdentifiers &&
-            isLatestVersionOfAutomation
-        );
-    }, [filters, enableAutomationFilterContextFlag, isLatestVersionOfAutomation]);
+        return enableAutomationFilterContextFlag && doAllDashboardFiltersHaveLocalIdentifiers;
+    }, [filters, enableAutomationFilterContextFlag]);
 
     return {
         locale,


### PR DESCRIPTION
- When visible filters are missing (should be sufficient check for older created schedules/alerts), mark filters as invalid and show the dialog to apply the current dashboard filters.

risk: low
JIRA: F1-1451

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```

#### Commands for Bear platform working on branch rel/9.9

```
extended-test-legacy --backstop
extended-test-legacy --isolated
extended-test-legacy --record
```
