### PR TITLE
feat: export dashboard to presentation commands

### DIFF
--- a/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
+++ b/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
@@ -481,6 +481,22 @@ export interface IDashboardExportImageOptions {
     widgetIds?: ObjRef[];
 }
 
+// @beta
+export interface IDashboardExportPresentationOptions {
+    // (undocumented)
+    filename?: string;
+    // (undocumented)
+    hideWidgetTitles?: boolean;
+    // (undocumented)
+    templateId?: string;
+    // (undocumented)
+    title?: string;
+    // (undocumented)
+    visualizationIds?: ObjRef[];
+    // (undocumented)
+    widgetIds?: ObjRef[];
+}
+
 // @alpha
 export interface IDashboardExportTabularOptions {
     dashboardFiltersOverride?: FilterContextItem[];
@@ -1438,10 +1454,7 @@ export interface IWorkspaceDashboardsService {
     exportDashboardToCSVRaw(definition: IExecutionDefinition, fileName: string, customOverrides?: IRawExportCustomOverrides): Promise<IExportResult>;
     exportDashboardToImage(ref: ObjRef, options?: IDashboardExportImageOptions): Promise<IExportResult>;
     exportDashboardToPdf(ref: ObjRef, filters?: FilterContextItem[]): Promise<IExportResult>;
-    exportDashboardToPresentation(ref: ObjRef, format: "PDF" | "PPTX", filters?: FilterContextItem[], options?: {
-        widgetIds?: ObjRef[];
-        filename?: string;
-    }): Promise<IExportResult>;
+    exportDashboardToPresentation(ref: ObjRef, format: "PDF" | "PPTX", filters?: FilterContextItem[], options?: IDashboardExportPresentationOptions): Promise<IExportResult>;
     exportDashboardToTabular(ref: ObjRef, options?: IDashboardExportTabularOptions): Promise<IExportResult>;
     getAllWidgetAlertsForCurrentUser(): Promise<IWidgetAlert[]>;
     getDashboard(ref: ObjRef, filterContextRef?: ObjRef, options?: IGetDashboardOptions): Promise<IDashboard>;

--- a/libs/sdk-backend-spi/src/index.ts
+++ b/libs/sdk-backend-spi/src/index.ts
@@ -184,6 +184,7 @@ export type {
     IRawExportCustomOverrides,
     IDashboardExportTabularOptions,
     IDashboardExportImageOptions,
+    IDashboardExportPresentationOptions,
 } from "./workspace/dashboards/index.js";
 export type { IWidgetWithLayoutPath, LayoutPath } from "./workspace/dashboards/utils.js";
 export {

--- a/libs/sdk-backend-spi/src/workspace/dashboards/index.ts
+++ b/libs/sdk-backend-spi/src/workspace/dashboards/index.ts
@@ -269,6 +269,20 @@ export interface IDashboardExportImageOptions {
 }
 
 /**
+ * Options for exporting a dashboard to a presentation.
+ *
+ * @beta
+ */
+export interface IDashboardExportPresentationOptions {
+    widgetIds?: ObjRef[];
+    visualizationIds?: ObjRef[];
+    templateId?: string;
+    title?: string;
+    hideWidgetTitles?: boolean;
+    filename?: string;
+}
+
+/**
  * Service to list, create and update analytical dashboards
  *
  * @alpha
@@ -398,10 +412,7 @@ export interface IWorkspaceDashboardsService {
         ref: ObjRef,
         format: "PDF" | "PPTX",
         filters?: FilterContextItem[],
-        options?: {
-            widgetIds?: ObjRef[];
-            filename?: string;
-        },
+        options?: IDashboardExportPresentationOptions,
     ): Promise<IExportResult>;
 
     /**

--- a/libs/sdk-backend-tiger/src/backend/workspace/dashboards/index.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/dashboards/index.ts
@@ -38,6 +38,7 @@ import {
     IDashboardWithReferences,
     IDashboardReferences,
     IDashboardExportImageOptions,
+    IDashboardExportPresentationOptions,
 } from "@gooddata/sdk-backend-spi";
 import {
     areObjRefsEqual,
@@ -481,14 +482,7 @@ export class TigerWorkspaceDashboards implements IWorkspaceDashboardsService {
         dashboardRef: ObjRef,
         format: "PDF" | "PPTX",
         filters?: FilterContextItem[],
-        options?: {
-            widgetIds?: ObjRef[];
-            visualizationIds?: ObjRef[];
-            templateId?: string;
-            filename?: string;
-            title?: string;
-            hideWidgetTitles?: boolean;
-        },
+        options?: IDashboardExportPresentationOptions,
     ): Promise<IExportResult> => {
         const dashboardId = await objRefToIdentifier(dashboardRef, this.authCall);
 

--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -181,6 +181,7 @@ import { IDashboardDateFilterConfig as IDashboardDateFilterConfig_2 } from '@goo
 import { IDashboardDateFilterConfigItem } from '@gooddata/sdk-model';
 import { IDashboardDefinition } from '@gooddata/sdk-model';
 import { IDashboardDrillEvent as IDashboardDrillEvent_2 } from '../../../types.js';
+import { IDashboardExportPresentationOptions } from '@gooddata/sdk-backend-spi';
 import { IDashboardFilterReference } from '@gooddata/sdk-model';
 import { IDashboardFilterView } from '@gooddata/sdk-model';
 import { IDashboardLayout } from '@gooddata/sdk-model';
@@ -3953,20 +3954,30 @@ export function exportDashboardToPdf(correlationId?: string): ExportDashboardToP
 // @beta (undocumented)
 export interface ExportDashboardToPdfPresentation extends IDashboardCommand {
     // (undocumented)
+    readonly payload?: ExportDashboardToPresentationPayload;
+    // (undocumented)
     readonly type: "GDC.DASH/CMD.EXPORT.PDF_PRESENTATION";
 }
 
 // @beta
-export function exportDashboardToPdfPresentation(correlationId?: string): ExportDashboardToPdfPresentation;
+export function exportDashboardToPdfPresentation(payload?: ExportDashboardToPresentationPayload, correlationId?: string): ExportDashboardToPdfPresentation;
 
 // @beta (undocumented)
 export interface ExportDashboardToPptPresentation extends IDashboardCommand {
+    // (undocumented)
+    readonly payload?: ExportDashboardToPresentationPayload;
     // (undocumented)
     readonly type: "GDC.DASH/CMD.EXPORT.PPT_PRESENTATION";
 }
 
 // @beta
-export function exportDashboardToPptPresentation(correlationId?: string): ExportDashboardToPptPresentation;
+export function exportDashboardToPptPresentation(payload?: ExportDashboardToPresentationPayload, correlationId?: string): ExportDashboardToPptPresentation;
+
+// @beta (undocumented)
+export interface ExportDashboardToPresentationPayload {
+    filters?: FilterContextItem[];
+    options?: IDashboardExportPresentationOptions;
+}
 
 // @alpha
 export type ExportElementType = "meta" | "dashboard" | "section" | "section-info" | "section-title" | "section-description" | "widget" | "widget-content" | "widget-title" | "widget-description";

--- a/libs/sdk-ui-dashboard/src/model/commands/dashboard.ts
+++ b/libs/sdk-ui-dashboard/src/model/commands/dashboard.ts
@@ -1,9 +1,11 @@
 // (C) 2021-2025 GoodData Corporation
 
 import { DashboardConfig } from "../types/commonTypes.js";
+import { IDashboardExportPresentationOptions } from "@gooddata/sdk-backend-spi";
 import {
     DashboardAttributeFilterConfigMode,
     DashboardDateFilterConfigMode,
+    FilterContextItem,
     IDashboard,
     IWorkspacePermissions,
     ObjRef,
@@ -481,8 +483,24 @@ export function exportDashboardToExcel(
 /**
  * @beta
  */
+export interface ExportDashboardToPresentationPayload {
+    /**
+     * Overrides current filter context filters with provided custom filters
+     */
+    filters?: FilterContextItem[];
+
+    /**
+     * Overrides export options with custom options.
+     */
+    options?: IDashboardExportPresentationOptions;
+}
+
+/**
+ * @beta
+ */
 export interface ExportDashboardToPdfPresentation extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.EXPORT.PDF_PRESENTATION";
+    readonly payload?: ExportDashboardToPresentationPayload;
 }
 
 /**
@@ -490,15 +508,20 @@ export interface ExportDashboardToPdfPresentation extends IDashboardCommand {
  * the dashboard to a Pdf presentation file. If successful, an instance of {@link DashboardExportToPdfPresentationResolved} will be emitted
  * with the URL of the resulting file.
  *
+ * @param payload - payload to override the dashboard export options. If not provided, the dashboard will be exported with the current filter context and options.
  * @param correlationId - specify correlation id to use for this command. this will be included in all
  *  events that will be emitted during the command processing
  *
  * @beta
  */
-export function exportDashboardToPdfPresentation(correlationId?: string): ExportDashboardToPdfPresentation {
+export function exportDashboardToPdfPresentation(
+    payload?: ExportDashboardToPresentationPayload,
+    correlationId?: string,
+): ExportDashboardToPdfPresentation {
     return {
         type: "GDC.DASH/CMD.EXPORT.PDF_PRESENTATION",
         correlationId,
+        payload,
     };
 }
 
@@ -507,6 +530,7 @@ export function exportDashboardToPdfPresentation(correlationId?: string): Export
  */
 export interface ExportDashboardToPptPresentation extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.EXPORT.PPT_PRESENTATION";
+    readonly payload?: ExportDashboardToPresentationPayload;
 }
 
 /**
@@ -514,15 +538,20 @@ export interface ExportDashboardToPptPresentation extends IDashboardCommand {
  * the dashboard to a Ppt presentation file. If successful, an instance of {@link DashboardExportToPptPresentationResolved} will be emitted
  * with the URL of the resulting file.
  *
+ * @param payload - payload to override the dashboard export options. If not provided, the dashboard will be exported with the current filter context and options.
  * @param correlationId - specify correlation id to use for this command. this will be included in all
  *  events that will be emitted during the command processing
  *
  * @beta
  */
-export function exportDashboardToPptPresentation(correlationId?: string): ExportDashboardToPptPresentation {
+export function exportDashboardToPptPresentation(
+    payload?: ExportDashboardToPresentationPayload,
+    correlationId?: string,
+): ExportDashboardToPptPresentation {
     return {
         type: "GDC.DASH/CMD.EXPORT.PPT_PRESENTATION",
         correlationId,
+        payload,
     };
 }
 

--- a/libs/sdk-ui-dashboard/src/model/commands/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/commands/index.ts
@@ -154,6 +154,7 @@ export type {
     SetDashboardAttributeFilterConfigDisplayAsLabelPayload,
     ChangeIgnoreExecutionTimestamp,
     ChangeIgnoreExecutionTimestampPayload,
+    ExportDashboardToPresentationPayload,
 } from "./dashboard.js";
 export {
     InitialLoadCorrelationId,


### PR DESCRIPTION
Allow extra options / overrides
in the export dashboard to presentation commands.

risk: low
JIRA: F1-1477

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```

#### Commands for Bear platform working on branch rel/9.9

```
extended-test-legacy --backstop
extended-test-legacy --isolated
extended-test-legacy --record
```
