### PR TITLE
fix: render dropzone spanning the rest of the row's empty space

### DIFF
--- a/libs/sdk-ui-dashboard/src/_staging/dashboard/flexibleLayout/facade/interfaces.ts
+++ b/libs/sdk-ui-dashboard/src/_staging/dashboard/flexibleLayout/facade/interfaces.ts
@@ -34,8 +34,9 @@ export interface IDashboardLayoutItemFacade<TWidget> {
     ref(): ObjRef | undefined;
     // item predicates
     indexIs(index: ILayoutItemPath): boolean;
-    isFirst(): boolean;
-    isLast(): boolean;
+    isFirstInSection(): boolean;
+    isLastInSection(): boolean;
+    isLastInRow(screen: ScreenSize): boolean;
     isEmpty(): boolean;
     testRaw(pred: (item: IDashboardLayoutItem<TWidget>) => boolean): boolean;
     test(pred: (item: IDashboardLayoutItemFacade<TWidget>) => boolean): boolean;

--- a/libs/sdk-ui-dashboard/src/_staging/dashboard/flexibleLayout/facade/item.ts
+++ b/libs/sdk-ui-dashboard/src/_staging/dashboard/flexibleLayout/facade/item.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2024 GoodData Corporation
+// (C) 2019-2025 GoodData Corporation
 import isEqual from "lodash/isEqual.js";
 import isNil from "lodash/isNil.js";
 import {
@@ -64,12 +64,19 @@ export class DashboardLayoutItemFacade<TWidget> implements IDashboardLayoutItemF
         return areLayoutPathsEqual(this.index(), index);
     }
 
-    public isFirst(): boolean {
+    public isFirstInSection(): boolean {
         return this.indexIs(updateItemIndex(this.itemIndex, 0));
     }
 
-    public isLast(): boolean {
+    public isLastInSection(): boolean {
         return this.indexIs(updateItemIndex(this.itemIndex, this.sectionFacade.items().count() - 1));
+    }
+
+    public isLastInRow(screen: ScreenSize): boolean {
+        const rows = this.section().items().asGridRows(screen);
+        return rows.some((rowItems) =>
+            areLayoutPathsEqual(rowItems[rowItems.length - 1].index(), this.index()),
+        );
     }
 
     public widget(): TWidget | undefined {

--- a/libs/sdk-ui-dashboard/src/presentation/flexibleLayout/DashboardLayoutWidget.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/flexibleLayout/DashboardLayoutWidget.tsx
@@ -195,7 +195,7 @@ export const DashboardLayoutWidget: IDashboardLayoutWidgetRenderer<
         "gd-first-container-row-dropzone": rowIndex === 0,
     });
 
-    const remainingGridWidth = isCustomWidget(widget) ? 0 : getRemainingWidthInRow(item, screen);
+    const remainingGridWidth = isCustomWidget(widget) ? 0 : getRemainingWidthInRow(item, screen, rowIndex);
 
     const { isValid, parentWidth } = useWidthValidation(item.size());
 
@@ -229,12 +229,7 @@ export const DashboardLayoutWidget: IDashboardLayoutWidgetRenderer<
                 ])}
             >
                 {canShowHotspot && !isAnyPlaceholderWidget(widget) && !isCustomWidget(widget) ? (
-                    <Hotspot
-                        dropZoneType="prev"
-                        layoutPath={item.index()}
-                        isLastInSection={false}
-                        classNames={hotspotClassNames}
-                    />
+                    <Hotspot dropZoneType="prev" layoutPath={item.index()} classNames={hotspotClassNames} />
                 ) : null}
                 <DashboardItemPathAndSizeProvider itemPath={item.index()} itemSize={item.size()}>
                     <HoverDetector widgetRef={widget.ref}>
@@ -271,9 +266,11 @@ export const DashboardLayoutWidget: IDashboardLayoutWidgetRenderer<
                                 <Hotspot
                                     dropZoneType="next"
                                     layoutPath={item.index()}
-                                    isLastInSection={item.isLast()}
                                     classNames={hotspotClassNames}
-                                    hideBorder={item.isLast() && shouldShowRowEndDropZone(remainingGridWidth)}
+                                    hideBorder={
+                                        (item.isLastInSection() || item.isLastInRow(screen)) &&
+                                        shouldShowRowEndDropZone(remainingGridWidth)
+                                    }
                                 />
                             </>
                         )}

--- a/libs/sdk-ui-dashboard/src/presentation/flexibleLayout/DefaultDashboardLayoutRenderer/utils/emptyFacade.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/flexibleLayout/DefaultDashboardLayoutRenderer/utils/emptyFacade.ts
@@ -1,8 +1,9 @@
-// (C) 2022-2024 GoodData Corporation
+// (C) 2022-2025 GoodData Corporation
 
 import { IDashboardLayoutItemFacade } from "../../../../_staging/dashboard/flexibleLayout/index.js";
 import { ILayoutSectionPath } from "../../../../types.js";
 import { asLayoutItemPath } from "../../../../_staging/layout/coordinates.js";
+import { ScreenSize } from "@gooddata/sdk-model";
 
 export const buildEmptyItemFacadeWithSetSize = (
     gridWidth: number,
@@ -16,12 +17,13 @@ export const buildEmptyItemFacadeWithSetSize = (
     size: () => ({ xl: { gridWidth } }),
     sizeForScreen: () => ({ gridWidth }),
     sizeForScreenWithFallback: () => ({ gridWidth }),
-    isLast: () => true,
+    isLastInSection: () => true,
+    isLastInRow: (_screen: ScreenSize) => true,
     widgetEquals: () => false,
     widgetIs: () => false,
     hasSizeForScreen: () => false,
     indexIs: () => false,
-    isFirst: () => true,
+    isFirstInSection: () => true,
     test: () => false,
     testRaw: () => false,
     isCustomItem: () => false,

--- a/libs/sdk-ui-dashboard/src/presentation/flexibleLayout/dragAndDrop/draggableWidget/Hotspot.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/flexibleLayout/dragAndDrop/draggableWidget/Hotspot.tsx
@@ -19,13 +19,17 @@ import { useRichTextPlaceholderDropHandler } from "./useRichTextPlaceholderDropH
 import { useVisualizationSwitcherPlaceholderDropHandler } from "./useVisualizationSwitcherPlaceholderDropHandler.js";
 import { useDashboardLayoutPlaceholderDropHandler } from "./useDashboardLayoutPlaceholderDropHandler.js";
 import { ILayoutItemPath } from "../../../../types.js";
-import { areLayoutPathsEqual, updateItem, getItemIndex } from "../../../../_staging/layout/coordinates.js";
+import {
+    areLayoutPathsEqual,
+    updateItem,
+    getItemIndex,
+    serializeLayoutItemPath,
+} from "../../../../_staging/layout/coordinates.js";
 import { draggableWidgetDropHandler } from "../../../dragAndDrop/draggableWidget/draggableWidgetDropHandler.js";
 import { useWidgetDragHoverHandlers } from "./useWidgetDragHoverHandlers.js";
 
 interface IHotspotProps {
     layoutPath: ILayoutItemPath;
-    isLastInSection?: boolean;
     isEndingHotspot?: boolean;
     classNames?: string;
     dropZoneType: "prev" | "next";
@@ -126,18 +130,13 @@ export const Hotspot: React.FC<IHotspotProps> = (props) => {
         [isEndingHotspot, layoutPath],
     );
 
-    const pathItems = layoutPath
-        ? layoutPath.map((pathItem) => `-${pathItem.sectionIndex}_${pathItem.itemIndex}`).join("")
-        : "";
-
-    const testClass = layoutPath ? `s-dropzone${pathItems}` : undefined;
-
     return (
         <div
-            className={cx(classNames, "dropzone", dropZoneType, testClass, {
+            className={cx(classNames, "dropzone", dropZoneType, {
                 hidden: !canDrop || !canDropSafe(item),
                 full: isEndingHotspot,
                 active: isOver,
+                [`s-dropzone-${serializeLayoutItemPath(layoutPath)}`]: !!layoutPath,
             })}
             style={debugStyle}
             ref={dropRef}

--- a/libs/sdk-ui-dashboard/src/presentation/flexibleLayout/dragAndDrop/draggableWidget/RowEndHotspot.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/flexibleLayout/dragAndDrop/draggableWidget/RowEndHotspot.tsx
@@ -24,9 +24,8 @@ export const RowEndHotspot = (props: RowEndHotspotProps<unknown>) => {
     const isInEditMode = useDashboardSelector(selectIsInEditMode);
     const screen = useScreenSize();
     const layoutPath = item.index();
-
-    const isLastInSection = item.isLast();
-    const showEndingHotspot = isLastInSection && isInEditMode;
+    const isLastInRow = item.isLastInRow(screen);
+    const showEndingHotspot = (item.isLastInSection() || isLastInRow) && isInEditMode;
 
     if (!showEndingHotspot) {
         return null;
@@ -38,20 +37,19 @@ export const RowEndHotspot = (props: RowEndHotspotProps<unknown>) => {
         layoutPath[layoutPath.length - 1].itemIndex + 1,
     ); // increment item index manually as end hotspot is rendered as prev type
 
-    const remainingGridWidth = getRemainingWidthInRow(item, screen);
-
-    const isDropZoneVisible = shouldShowRowEndDropZone(remainingGridWidth);
+    const remainingRowGridWidth = getRemainingWidthInRow(item, screen, rowIndex);
+    const isDropZoneVisible = shouldShowRowEndDropZone(remainingRowGridWidth);
 
     return (
         <>
             <GridLayoutElement
                 type="item"
                 layoutItemSize={{
-                    xl: { gridWidth: remainingGridWidth },
-                    lg: { gridWidth: remainingGridWidth },
-                    md: { gridWidth: remainingGridWidth },
-                    sm: { gridWidth: remainingGridWidth },
-                    xs: { gridWidth: remainingGridWidth },
+                    xl: { gridWidth: remainingRowGridWidth },
+                    lg: { gridWidth: remainingRowGridWidth },
+                    md: { gridWidth: remainingRowGridWidth },
+                    sm: { gridWidth: remainingRowGridWidth },
+                    xs: { gridWidth: remainingRowGridWidth },
                 }}
                 className={cx(
                     "gd-fluidlayout-column",
@@ -59,7 +57,7 @@ export const RowEndHotspot = (props: RowEndHotspotProps<unknown>) => {
                     "s-fluid-layout-column",
                     "gd-fluidlayout-column-row-end-hotspot",
                     {
-                        "gd-fluidlayout-column-dropzone__text--hidden": remainingGridWidth < 2,
+                        "gd-fluidlayout-column-dropzone__text--hidden": remainingRowGridWidth < 2,
                         "gd-first-container-row-dropzone": rowIndex === 0,
                     },
                 )}
@@ -68,15 +66,14 @@ export const RowEndHotspot = (props: RowEndHotspotProps<unknown>) => {
                     <WidgetDropZoneColumn
                         layoutPath={layoutPathForEndHotspot}
                         isLastInSection={true}
-                        gridWidthOverride={remainingGridWidth}
+                        gridWidthOverride={remainingRowGridWidth}
                     />
                 ) : null}
                 <Hotspot
                     dropZoneType="prev"
                     isEndingHotspot
                     layoutPath={layoutPathForEndHotspot}
-                    isLastInSection={item.isLast()}
-                    hideBorder={isDropZoneVisible}
+                    hideBorder={isDropZoneVisible || isLastInRow}
                 />
             </GridLayoutElement>
         </>

--- a/libs/sdk-ui-dashboard/src/presentation/flexibleLayout/dragAndDrop/draggableWidget/useWidgetDragHoverHandlers.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/flexibleLayout/dragAndDrop/draggableWidget/useWidgetDragHoverHandlers.ts
@@ -1,4 +1,4 @@
-// (C) 2022-2024 GoodData Corporation
+// (C) 2022-2025 GoodData Corporation
 import { useCallback } from "react";
 
 import { uiActions, useDashboardDispatch } from "../../../../model/index.js";
@@ -11,8 +11,8 @@ export function useWidgetDragHoverHandlers() {
     const dispatch = useDashboardDispatch();
 
     const handleDragHoverStart = useCallback(
-        (coordinations: ILayoutItemPath) => {
-            dispatch(uiActions.setDraggingWidgetTarget(coordinations));
+        (coordinates: ILayoutItemPath) => {
+            dispatch(uiActions.setDraggingWidgetTarget(coordinates));
         },
         [dispatch],
     );

--- a/libs/sdk-ui-dashboard/src/presentation/flexibleLayout/rowEndHotspotHelper.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/flexibleLayout/rowEndHotspotHelper.ts
@@ -1,4 +1,4 @@
-// (C) 2022-2024 GoodData Corporation
+// (C) 2022-2025 GoodData Corporation
 
 import { ScreenSize } from "@gooddata/sdk-model";
 import { DASHBOARD_LAYOUT_GRID_COLUMNS_COUNT } from "../../_staging/dashboard/flexibleLayout/config.js";
@@ -7,11 +7,11 @@ import { IDashboardLayoutItemFacade } from "../../_staging/dashboard/flexibleLay
 export function getRemainingWidthInRow(
     item: IDashboardLayoutItemFacade<unknown>,
     screen: ScreenSize,
+    rowIndex: number,
 ): number {
     const parentWidth = item.section().layout().size()?.gridWidth ?? DASHBOARD_LAYOUT_GRID_COLUMNS_COUNT;
     const rows = item.section().items().asGridRows(screen);
-    const lastRow = rows[rows.length - 1];
-    const lastRowLength = lastRow.reduce(
+    const lastRowLength = rows[rowIndex].reduce(
         (acc, item) => acc + item.sizeForScreenWithFallback(screen).gridWidth,
         0,
     );

--- a/libs/sdk-ui-dashboard/src/presentation/flexibleLayout/test/useInKD/DashboardEditLayout/DashboardEditLayoutItemRenderer.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/flexibleLayout/test/useInKD/DashboardEditLayout/DashboardEditLayoutItemRenderer.tsx
@@ -1,4 +1,4 @@
-// (C) 2007-2024 GoodData Corporation
+// (C) 2007-2025 GoodData Corporation
 import React from "react";
 import cx from "classnames";
 
@@ -26,7 +26,7 @@ export const RenderDashboardEditLayoutItemRenderer: React.FC<IDashboardEditLayou
 
     const content = item.widget();
 
-    const isLastInSection = item.isLast();
+    const isLastInSection = item.isLastInSection();
     const isLastSection = item.section().isLast();
     const isLast = isLastSection && isLastInSection;
 
@@ -37,7 +37,6 @@ export const RenderDashboardEditLayoutItemRenderer: React.FC<IDashboardEditLayou
     const isHidden = content && isHiddenContent(content, hiddenWidgetRef);
 
     return (
-        // @ts-expect-error types are not compatible
         <DashboardLayoutItemViewRenderer isHidden={isHidden} {...props} className={className}>
             {children}
         </DashboardLayoutItemViewRenderer>

--- a/libs/sdk-ui-dashboard/src/presentation/flexibleLayout/test/useInKD/DashboardEditLayout/DashboardEditLayoutSectionHeaderRenderer.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/flexibleLayout/test/useInKD/DashboardEditLayout/DashboardEditLayoutSectionHeaderRenderer.tsx
@@ -1,4 +1,4 @@
-// (C) 2007-2024 GoodData Corporation
+// (C) 2007-2025 GoodData Corporation
 import React from "react";
 
 import {
@@ -8,6 +8,7 @@ import {
 } from "../../../DefaultDashboardLayoutRenderer/index.js";
 import { DashboardEditLayoutSectionHeader } from "./DashboardEditLayoutSectionHeader.js";
 import { IDashboardEditLayoutContent } from "./DashboardEditLayoutTypes.js";
+import { ScreenSize } from "@gooddata/sdk-model";
 
 type IDashboardLayoutSectionHeaderRendererOwnProps =
     IDashboardLayoutSectionHeaderRenderProps<IDashboardEditLayoutContent>;
@@ -16,21 +17,20 @@ type IDashboardLayoutSectionHeaderRendererProps = IDashboardLayoutSectionHeaderR
 
 const emptyItemFacadeWithFullSize: IDashboardLayoutItemFacade<any> = {
     ref: () => undefined,
-    index: () => 0,
-    // @ts-expect-error this is mock
+    index: () => [{ sectionIndex: 0, itemIndex: 0 }],
     raw: () => null,
     widget: () => null,
-    // @ts-expect-error this is mock
     section: () => undefined,
     size: () => ({ xl: { gridWidth: 12 } }),
     sizeForScreen: () => ({ gridWidth: 12 }),
-    isLast: () => true,
+    isLastInSection: () => true,
+    isLastInRow: (_screen: ScreenSize) => true,
     widgetEquals: () => false,
     widgetIs: () => false,
     isEmpty: () => false,
     hasSizeForScreen: () => false,
     indexIs: () => false,
-    isFirst: () => true,
+    isFirstInSection: () => true,
     test: () => false,
     testRaw: () => false,
     isCustomItem: () => false,
@@ -44,6 +44,7 @@ const emptyItemFacadeWithFullSize: IDashboardLayoutItemFacade<any> = {
     isWidgetItemWithInsightRef: () => false,
     isWidgetItemWithKpiRef: () => false,
     isWidgetItemWithRef: () => false,
+    sizeForScreenWithFallback: (_screen: ScreenSize) => undefined,
 };
 
 export const RenderDashboardEditLayoutSectionHeaderRenderer: React.FC<
@@ -66,7 +67,7 @@ export const RenderDashboardEditLayoutSectionHeaderRenderer: React.FC<
             <DashboardLayoutItemViewRenderer
                 DefaultItemRenderer={DashboardLayoutItemViewRenderer}
                 item={emptyItemFacadeWithFullSize}
-                screen={screen}
+                rowIndex={0}
             >
                 <DashboardEditLayoutSectionHeader
                     title={header?.title || ""}

--- a/libs/sdk-ui-dashboard/src/presentation/flexibleLayout/test/useInKD/DashboardEditLayout/DashboardEditLayoutWidgetRenderer.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/flexibleLayout/test/useInKD/DashboardEditLayout/DashboardEditLayoutWidgetRenderer.tsx
@@ -1,6 +1,6 @@
-// (C) 2007-2024 GoodData Corporation
-import cx from "classnames";
+// (C) 2007-2025 GoodData Corporation
 import React, { useRef } from "react";
+import cx from "classnames";
 
 import {
     getDashboardLayoutItemHeightForRatioAndScreen,
@@ -29,9 +29,8 @@ export const RenderDashboardEditLayoutWidgetRenderer: React.FC<IDashboardEditLay
 
     const { heightAsRatio = 100, gridHeight = 12 } = currentSize;
 
-    const isLastInSection = item.isLast();
     const isLastSection = item.section().isLast();
-    const isLast = isLastSection && isLastInSection;
+    const isLast = isLastSection && item.isLastInSection();
     const classNames = cx({
         last: widget?.type === "widget" ? isLast : false,
         "custom-height": isEnableKDWidgetCustomHeight,


### PR DESCRIPTION
JIRA: LX-777
risk: low

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```

#### Commands for Bear platform working on branch rel/9.9

```
extended-test-legacy --backstop
extended-test-legacy --isolated
extended-test-legacy --record
```
