### PR TITLE
fix: use absolute position of headline in flexible layout

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/flexibleLayout/DefaultDashboardLayoutRenderer/DashboardLayout.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/flexibleLayout/DefaultDashboardLayoutRenderer/DashboardLayout.tsx
@@ -124,7 +124,7 @@ export function DashboardLayout<TWidget>(props: IDashboardLayoutRenderProps<TWid
                 />
             );
         },
-        [resizedItemPositions, widgetRenderer],
+        [resizedItemPositions, widgetRenderer, getLayoutDimensions],
     );
 
     const screenSize = useScreenSize();

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/ViewModeDashboardInsight/InsightDrillDialog/DrillDialogInsight.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/ViewModeDashboardInsight/InsightDrillDialog/DrillDialogInsight.tsx
@@ -2,7 +2,7 @@
 import React, { useCallback, useMemo, useState, CSSProperties, useEffect } from "react";
 import { IUserWorkspaceSettings } from "@gooddata/sdk-backend-spi";
 import { createSelector } from "@reduxjs/toolkit/dist/redux-toolkit.esm.js";
-import { IExecutionConfig, insightSetFilters, insightVisualizationUrl } from "@gooddata/sdk-model";
+import { IExecutionConfig, insightSetFilters } from "@gooddata/sdk-model";
 import {
     GoodDataSdkError,
     IPushData,
@@ -30,6 +30,7 @@ import { useDrillDialogInsightDrills } from "./useDrillDialogInsightDrills.js";
 import { CustomError } from "../CustomError/CustomError.js";
 import { IntlWrapper } from "../../../../localization/index.js";
 import { InsightBody } from "../../InsightBody.js";
+import { useInsightPositionStyle } from "../useInsightPositionStyle.js";
 
 const insightStyle: CSSProperties = { width: "100%", height: "100%", position: "relative", flex: "1 1 auto" };
 
@@ -121,17 +122,7 @@ export const DrillDialogInsight = (props: IDashboardInsightProps): JSX.Element =
     );
 
     // CSS
-    const insightPositionStyle: CSSProperties = useMemo(() => {
-        return {
-            width: "100%",
-            height: "100%",
-            position:
-                // Headline violates the layout contract.
-                // It should fit parent height and adapt to it as other visualizations.
-                // Now, it works differently for the Headline - parent container adapts to Headline size.
-                insight && insightVisualizationUrl(insight).includes("headline") ? "relative" : "absolute",
-        };
-    }, [insight]);
+    const insightPositionStyle = useInsightPositionStyle(insight);
 
     // Error handling
     const handleError = useCallback<OnError>(

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/ViewModeDashboardInsight/useInsightPositionStyle.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/ViewModeDashboardInsight/useInsightPositionStyle.ts
@@ -1,0 +1,34 @@
+// (C) 2025 GoodData Corporation
+
+import { CSSProperties, useMemo } from "react";
+import { IInsight, insightVisualizationType } from "@gooddata/sdk-model";
+
+import { useDashboardSelector, selectSettings } from "../../../../model/index.js";
+import { DASHBOARD_LAYOUT_RESPONSIVE_SMALL_WIDTH } from "../../../constants/index.js";
+
+export const useInsightPositionStyle = (insight: IInsight, clientWidth?: number) => {
+    const { enableKDWidgetCustomHeight, enableDashboardFlexibleLayout } =
+        useDashboardSelector(selectSettings);
+
+    const isPositionRelative =
+        insight &&
+        insightVisualizationType(insight) === "headline" &&
+        (clientWidth === undefined || clientWidth < DASHBOARD_LAYOUT_RESPONSIVE_SMALL_WIDTH) &&
+        !enableKDWidgetCustomHeight &&
+        // The relative positioning causes flickering of headline text when flexible layout is enabled.
+        // Everything works correctly when absolute position is used in this case.
+        !enableDashboardFlexibleLayout;
+
+    const insightPositionStyle: CSSProperties = useMemo(() => {
+        return {
+            width: "100%",
+            height: "100%",
+            // Headline violates the layout contract.
+            // It should fit parent height and adapt to it as other visualizations.
+            // Now, it works differently for the Headline - parent container adapts to Headline size.
+            position: isPositionRelative ? "relative" : "absolute",
+        };
+    }, [isPositionRelative]);
+
+    return insightPositionStyle;
+};


### PR DESCRIPTION
Switching between relative and absolute positioning of headline causes text flickering (infinite render loop where relative position changes font size that changes insight dimension, causing it change to absolute, which changes font size that changes insight dimension, and repeat...) when viewport width is changed to mobile size. It looks like absolute positioning works in all cases in flexible layouts, therefore this logic is disabled when new layout engine is enabled.

JIRA: LX-1144
risk: low

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```

#### Commands for Bear platform working on branch rel/9.9

```
extended-test-legacy --backstop
extended-test-legacy --isolated
extended-test-legacy --record
```
