### PR TITLE
fix: information that ad-hoc visualization is saved is stored permane…

### DIFF
--- a/libs/sdk-backend-base/api/sdk-backend-base.api.md
+++ b/libs/sdk-backend-base/api/sdk-backend-base.api.md
@@ -15,6 +15,7 @@ import { ExplainConfig } from '@gooddata/sdk-backend-spi';
 import { ExplainType } from '@gooddata/sdk-backend-spi';
 import { FilterContextItem } from '@gooddata/sdk-model';
 import { GenAIChatInteractionUserFeedback } from '@gooddata/sdk-model';
+import { GenAIChatInteractionUserVisualisation } from '@gooddata/sdk-model';
 import { GenAIObjectType } from '@gooddata/sdk-model';
 import { IAlertDefault } from '@gooddata/sdk-model';
 import { IAnalyticalBackend } from '@gooddata/sdk-backend-spi';
@@ -723,6 +724,8 @@ export class DummyGenAIChatThread implements IChatThread {
     reset(): Promise<void>;
     // (undocumented)
     saveUserFeedback(_interactionId: string, _feedback: GenAIChatInteractionUserFeedback): Promise<void>;
+    // (undocumented)
+    saveUserVisualisation(_interactionId: string, _visualization: GenAIChatInteractionUserVisualisation): Promise<void>;
 }
 
 // @internal

--- a/libs/sdk-backend-base/src/dummyBackend/DummyGenAIChatThread.ts
+++ b/libs/sdk-backend-base/src/dummyBackend/DummyGenAIChatThread.ts
@@ -5,7 +5,7 @@ import {
     IChatThreadQuery,
     IGenAIChatEvaluation,
 } from "@gooddata/sdk-backend-spi";
-import { GenAIChatInteractionUserFeedback } from "@gooddata/sdk-model";
+import { GenAIChatInteractionUserFeedback, GenAIChatInteractionUserVisualisation } from "@gooddata/sdk-model";
 
 /**
  * Dummy chat thread interface for testing.
@@ -25,6 +25,10 @@ export class DummyGenAIChatThread implements IChatThread {
     async reset(): Promise<void> {
         await cancellableTimeout(100);
     }
+    async saveUserVisualisation(
+        _interactionId: string,
+        _visualization: GenAIChatInteractionUserVisualisation,
+    ): Promise<void> {}
     async saveUserFeedback(
         _interactionId: string,
         _feedback: GenAIChatInteractionUserFeedback,

--- a/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
+++ b/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
@@ -12,6 +12,7 @@ import { DataValue } from '@gooddata/sdk-model';
 import { DimensionGenerator } from '@gooddata/sdk-model';
 import { FilterContextItem } from '@gooddata/sdk-model';
 import { GenAIChatInteractionUserFeedback } from '@gooddata/sdk-model';
+import { GenAIChatInteractionUserVisualisation } from '@gooddata/sdk-model';
 import { GenAIObjectType } from '@gooddata/sdk-model';
 import { IAbsoluteDateFilter } from '@gooddata/sdk-model';
 import { IAccessGrantee } from '@gooddata/sdk-model';
@@ -430,6 +431,7 @@ export interface IChatThread {
     query(userMessage: string): IChatThreadQuery;
     reset(): Promise<void>;
     saveUserFeedback(interactionId: string, feedback: GenAIChatInteractionUserFeedback): Promise<void>;
+    saveUserVisualisation(interactionId: string, visualization: GenAIChatInteractionUserVisualisation): Promise<void>;
 }
 
 // @beta

--- a/libs/sdk-backend-spi/src/workspace/genAI/index.ts
+++ b/libs/sdk-backend-spi/src/workspace/genAI/index.ts
@@ -10,6 +10,7 @@ import {
     IGenAIFoundObjects,
     IGenAICreatedVisualizations,
     GenAIChatInteractionUserFeedback,
+    GenAIChatInteractionUserVisualisation,
 } from "@gooddata/sdk-model";
 
 /**
@@ -90,6 +91,13 @@ export interface IChatThread {
      * Save user feedback for the interaction.
      */
     saveUserFeedback(interactionId: string, feedback: GenAIChatInteractionUserFeedback): Promise<void>;
+    /**
+     * Save user feedback for the interaction.
+     */
+    saveUserVisualisation(
+        interactionId: string,
+        visualization: GenAIChatInteractionUserVisualisation,
+    ): Promise<void>;
     /**
      * Add a user message to the chat thread.
      */

--- a/libs/sdk-backend-tiger/src/backend/workspace/genAI/ChatThread.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/genAI/ChatThread.ts
@@ -1,6 +1,10 @@
 // (C) 2024-2025 GoodData Corporation
 
-import { GenAIChatInteractionUserFeedback, IGenAIUserContext } from "@gooddata/sdk-model";
+import {
+    GenAIChatInteractionUserFeedback,
+    GenAIChatInteractionUserVisualisation,
+    IGenAIUserContext,
+} from "@gooddata/sdk-model";
 import {
     IChatThread,
     IChatThreadHistory,
@@ -60,6 +64,24 @@ export class ChatThreadService implements IChatThread {
                 chatHistoryRequest: {
                     chatHistoryInteractionId,
                     userFeedback,
+                },
+            });
+        });
+    }
+
+    async saveUserVisualisation(
+        chatHistoryInteractionId: string,
+        savedVisualization: GenAIChatInteractionUserVisualisation,
+    ): Promise<void> {
+        await this.authCall((client) => {
+            return client.genAI.aiChatHistory({
+                workspaceId: this.workspaceId,
+                chatHistoryRequest: {
+                    chatHistoryInteractionId,
+                    savedVisualization: {
+                        createdVisualizationId: savedVisualization.createdId,
+                        savedVisualizationId: savedVisualization.savedId,
+                    },
                 },
             });
         });

--- a/libs/sdk-model/api/sdk-model.api.md
+++ b/libs/sdk-model/api/sdk-model.api.md
@@ -549,6 +549,12 @@ export type GenAIAbsoluteDateFilter = {
 export type GenAIChatInteractionUserFeedback = "POSITIVE" | "NEGATIVE" | "NONE";
 
 // @internal
+export type GenAIChatInteractionUserVisualisation = {
+    createdId: string;
+    savedId: string;
+};
+
+// @internal
 export type GenAIChatRole = "USER" | "AI";
 
 // @internal

--- a/libs/sdk-model/src/genAI/chat.ts
+++ b/libs/sdk-model/src/genAI/chat.ts
@@ -16,6 +16,21 @@ export type GenAIChatRole = "USER" | "AI";
 export type GenAIChatInteractionUserFeedback = "POSITIVE" | "NEGATIVE" | "NONE";
 
 /**
+ * User visualization for the chat interaction.
+ * @internal
+ */
+export type GenAIChatInteractionUserVisualisation = {
+    /**
+     * ID of the visualization that server created.
+     */
+    createdId: string;
+    /**
+     * ID of the visualization that was saved by the user.
+     */
+    savedId: string;
+};
+
+/**
  * A route that was detected by the assistant based on the user question.
  * @internal
  */

--- a/libs/sdk-model/src/index.ts
+++ b/libs/sdk-model/src/index.ts
@@ -1070,6 +1070,7 @@ export type {
     IGenAISuggestion,
     GenAIChatRoutingUseCase,
     GenAIChatInteractionUserFeedback,
+    GenAIChatInteractionUserVisualisation,
     GenAIChatRole,
     GenAIVisualizationType,
     GenAIMetricAggregation,

--- a/libs/sdk-ui-gen-ai/src/components/messages/contents/VisualizationContents.tsx
+++ b/libs/sdk-ui-gen-ai/src/components/messages/contents/VisualizationContents.tsx
@@ -28,8 +28,8 @@ import {
 } from "@gooddata/sdk-ui";
 
 import { makeTextContents, makeUserMessage, VisualizationContents } from "../../../model.js";
+import { getAbsoluteVisualizationHref, getVisualizationHref } from "../../../utils.js";
 import { useConfig } from "../../ConfigContext.js";
-import { getVisualizationHref } from "../../../utils.js";
 import {
     RootState,
     newMessageAction,
@@ -176,7 +176,10 @@ const VisualizationContentsComponentCore: React.FC<VisualizationContentsProps> =
                 break;
             case "button-copy":
                 if (visualization?.savedVisualizationId) {
-                    const link = getVisualizationHref(workspaceId, visualization.savedVisualizationId);
+                    const link = getAbsoluteVisualizationHref(
+                        workspaceId,
+                        visualization.savedVisualizationId,
+                    );
                     copy(link);
                     onCopyToClipboard?.({ content: link });
                 }

--- a/libs/sdk-ui-gen-ai/src/store/sideEffects/onUserFeedback.ts
+++ b/libs/sdk-ui-gen-ai/src/store/sideEffects/onUserFeedback.ts
@@ -26,7 +26,9 @@ export function* onUserFeedback({
         const messages: Message[] = yield select(messagesSelector);
         const message = messages.find((message) => message.localId === payload.assistantMessageId);
 
-        if (!message?.id) return;
+        if (!message?.id) {
+            return;
+        }
 
         const chatThread = backend.workspace(workspace).genAI().getChatThread();
 

--- a/libs/sdk-ui-gen-ai/src/store/sideEffects/onVisualizationSuccessSave.ts
+++ b/libs/sdk-ui-gen-ai/src/store/sideEffects/onVisualizationSuccessSave.ts
@@ -1,9 +1,13 @@
 // (C) 2025 GoodData Corporation
 
+import { IAnalyticalBackend } from "@gooddata/sdk-backend-spi";
+import { GenAIChatInteractionUserVisualisation } from "@gooddata/sdk-model";
 import { PayloadAction } from "@reduxjs/toolkit/dist/redux-toolkit.esm.js";
-import { getContext } from "redux-saga/effects";
+import { call, getContext, select } from "redux-saga/effects";
 
+import { messagesSelector } from "../messages/messagesSelectors.js";
 import { getVisualizationHref } from "../../utils.js";
+import { Message } from "../../model.js";
 
 export function* onVisualizationSuccessSave({
     payload,
@@ -13,9 +17,24 @@ export function* onVisualizationSuccessSave({
     savedVisualizationId: string;
     explore: boolean;
 }>) {
-    const workspaceId: string = yield getContext("workspace");
+    // Retrieve backend from context
+    const backend: IAnalyticalBackend = yield getContext("backend");
+    const workspace: string = yield getContext("workspace");
+    const messages: Message[] = yield select(messagesSelector);
+    const message = messages.find((message) => message.localId === payload.assistantMessageId);
 
     if (payload.explore) {
-        window.location.href = getVisualizationHref(workspaceId, payload.savedVisualizationId);
+        window.location.href = getVisualizationHref(workspace, payload.savedVisualizationId);
     }
+
+    if (!message?.id) {
+        return;
+    }
+
+    const chatThread = backend.workspace(workspace).genAI().getChatThread();
+
+    yield call([chatThread, chatThread.saveUserVisualisation], message.id, {
+        createdId: payload.visualizationId,
+        savedId: payload.savedVisualizationId,
+    } as GenAIChatInteractionUserVisualisation);
 }

--- a/libs/sdk-ui-gen-ai/src/utils.ts
+++ b/libs/sdk-ui-gen-ai/src/utils.ts
@@ -3,3 +3,7 @@
 export function getVisualizationHref(wsId: string, visId: string) {
     return `/analyze/#/${wsId}/${visId}/edit`;
 }
+
+export function getAbsoluteVisualizationHref(wsId: string, visId: string) {
+    return `${window.location.origin}${getVisualizationHref(wsId, visId)}`;
+}


### PR DESCRIPTION
…ntly

Information that ad-hoc visualization is saved is stored permanently and is not lost with chatbot or page reload

JIRA: GDAI-317
risk: low

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```

#### Commands for Bear platform working on branch rel/9.9

```
extended-test-legacy --backstop
extended-test-legacy --isolated
extended-test-legacy --record
```
