### PR TITLE
feat: add method to set metadata locale to settings services

### DIFF
--- a/common/changes/@gooddata/sdk-ui-all/pji-metadata-locale_2025-06-09-13-19.json
+++ b/common/changes/@gooddata/sdk-ui-all/pji-metadata-locale_2025-06-09-13-19.json
@@ -1,0 +1,10 @@
+{
+    "changes": [
+        {
+            "packageName": "@gooddata/sdk-ui-all",
+            "comment": "Added method for setting metadata locale to settings services",
+            "type": "none"
+        }
+    ],
+    "packageName": "@gooddata/sdk-ui-all"
+}

--- a/libs/sdk-backend-base/api/sdk-backend-base.api.md
+++ b/libs/sdk-backend-base/api/sdk-backend-base.api.md
@@ -668,6 +668,8 @@ export abstract class DecoratedWorkspaceSettingsService implements IWorkspaceSet
     // (undocumented)
     setLocale(locale: string): Promise<void>;
     // (undocumented)
+    setMetadataLocale(locale: string): Promise<void>;
+    // (undocumented)
     setSeparators(separators: ISeparators): Promise<void>;
     // (undocumented)
     setTheme(themeId: string): Promise<void>;

--- a/libs/sdk-backend-base/src/cachingBackend/index.ts
+++ b/libs/sdk-backend-base/src/cachingBackend/index.ts
@@ -607,6 +607,10 @@ class WithWorkspaceSettingsCaching extends DecoratedWorkspaceSettingsService {
         return super.setLocale(locale);
     }
 
+    public async setMetadataLocale(locale: string): Promise<void> {
+        return super.setMetadataLocale(locale);
+    }
+
     public async setSeparators(separators: ISeparators): Promise<void> {
         return super.setSeparators(separators);
     }

--- a/libs/sdk-backend-base/src/decoratedBackend/workspaceSettings.ts
+++ b/libs/sdk-backend-base/src/decoratedBackend/workspaceSettings.ts
@@ -28,6 +28,10 @@ export abstract class DecoratedWorkspaceSettingsService implements IWorkspaceSet
         return this.decorated.setLocale(locale);
     }
 
+    async setMetadataLocale(locale: string): Promise<void> {
+        return this.decorated.setMetadataLocale(locale);
+    }
+
     async setSeparators(separators: ISeparators): Promise<void> {
         return this.decorated.setSeparators(separators);
     }

--- a/libs/sdk-backend-base/src/dummyBackend/index.ts
+++ b/libs/sdk-backend-base/src/dummyBackend/index.ts
@@ -848,6 +848,7 @@ class DummyOrganization implements IOrganization {
         return {
             setWhiteLabeling: () => Promise.resolve(),
             setLocale: () => Promise.resolve(),
+            setMetadataLocale: () => Promise.resolve(),
             setSeparators: () => Promise.resolve(),
             setActiveLlmEndpoint: () => Promise.resolve(),
             deleteActiveLlmEndpoint: () => Promise.resolve(),
@@ -994,6 +995,10 @@ class DummyWorkspaceSettingsService implements IWorkspaceSettingsService {
     }
 
     setLocale(_locale: string): Promise<void> {
+        return Promise.resolve();
+    }
+
+    setMetadataLocale(_locale: string): Promise<void> {
         return Promise.resolve();
     }
 

--- a/libs/sdk-backend-mockingbird/src/recordedBackend/index.ts
+++ b/libs/sdk-backend-mockingbird/src/recordedBackend/index.ts
@@ -246,6 +246,9 @@ function recordedWorkspace(
                 async setLocale(): Promise<void> {
                     return Promise.resolve();
                 },
+                async setMetadataLocale(): Promise<void> {
+                    return Promise.resolve();
+                },
                 async setSeparators(): Promise<void> {
                     return Promise.resolve();
                 },
@@ -458,6 +461,7 @@ function recordedOrganization(organizationId: string, implConfig: RecordedBacken
             return {
                 setWhiteLabeling: () => Promise.resolve(),
                 setLocale: () => Promise.resolve(),
+                setMetadataLocale: () => Promise.resolve(),
                 setSeparators: () => Promise.resolve(),
                 setActiveLlmEndpoint: () => Promise.resolve(),
                 deleteActiveLlmEndpoint: () => Promise.resolve(),
@@ -616,6 +620,7 @@ function recordedUserService(implConfig: RecordedBackendConfig): IUserService {
                     ...(implConfig.globalSettings ?? {}),
                 }),
                 setLocale: () => Promise.resolve(),
+                setMetadataLocale: () => Promise.resolve(),
                 setSeparators: () => Promise.resolve(),
             };
         },

--- a/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
+++ b/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
@@ -1065,6 +1065,7 @@ export interface IOrganizationSettingsService {
     setDashboardFiltersApplyMode(dashboardFiltersApplyMode: DashboardFiltersApplyMode): Promise<void>;
     setDateFormat(dateFormat: string): Promise<void>;
     setLocale(locale: string): Promise<void>;
+    setMetadataLocale(locale: string): Promise<void>;
     // @alpha
     setOpenAiConfig(config: IOpenAiConfig): Promise<void>;
     setSeparators(separators: ISeparators): Promise<void>;
@@ -1307,6 +1308,7 @@ export interface IUserSettings extends ISettings {
 export interface IUserSettingsService {
     getSettings(): Promise<IUserSettings>;
     setLocale(locale: string): Promise<void>;
+    setMetadataLocale(locale: string): Promise<void>;
     setSeparators(separators: ISeparators): Promise<void>;
 }
 
@@ -1607,6 +1609,7 @@ export interface IWorkspaceSettingsService {
     setDashboardFiltersApplyMode(dashboardFiltersApplyMode: DashboardFiltersApplyMode): Promise<void>;
     setDateFormat(dateFormat: string): Promise<void>;
     setLocale(locale: string): Promise<void>;
+    setMetadataLocale(locale: string): Promise<void>;
     setSeparators(separators: ISeparators): Promise<void>;
     setTheme(themeId: string): Promise<void>;
     setTimezone(timezone: string): Promise<void>;

--- a/libs/sdk-backend-spi/src/organization/settings/index.ts
+++ b/libs/sdk-backend-spi/src/organization/settings/index.ts
@@ -34,6 +34,15 @@ export interface IOrganizationSettingsService {
     setLocale(locale: string): Promise<void>;
 
     /**
+     * Sets metadata locale for organization.
+     *
+     * @param locale - IETF BCP 47 Code locale ID, for example "en-US", "cs-CZ", etc.
+     *
+     * @returns promise
+     */
+    setMetadataLocale(locale: string): Promise<void>;
+
+    /**
      * Set separators for the organization
      *
      * @param separators - separators for the organization

--- a/libs/sdk-backend-spi/src/user/settings/index.ts
+++ b/libs/sdk-backend-spi/src/user/settings/index.ts
@@ -1,4 +1,4 @@
-// (C) 2020-2024 GoodData Corporation
+// (C) 2020-2025 GoodData Corporation
 import { ISeparators } from "@gooddata/sdk-model";
 import { IUserSettings } from "../../common/settings.js";
 
@@ -23,6 +23,15 @@ export interface IUserSettingsService {
      * @returns promise
      */
     setLocale(locale: string): Promise<void>;
+
+    /**
+     * Set metadata locale for the current user
+     *
+     * @param locale - IETF BCP 47 Code locale ID, for example "en-US", "cs-CZ", etc.
+     *
+     * @returns promise
+     */
+    setMetadataLocale(locale: string): Promise<void>;
 
     /**
      * Set separators for the current user

--- a/libs/sdk-backend-spi/src/workspace/settings/index.ts
+++ b/libs/sdk-backend-spi/src/workspace/settings/index.ts
@@ -41,6 +41,15 @@ export interface IWorkspaceSettingsService {
     setLocale(locale: string): Promise<void>;
 
     /**
+     * Sets metadata locale for current workspace.
+     *
+     * @param locale - IETF BCP 47 Code locale ID, for example "en-US", "cs-CZ", etc.
+     *
+     * @returns promise
+     */
+    setMetadataLocale(locale: string): Promise<void>;
+
+    /**
      * Set separators for the current workspace
      *
      * @param separators - separators for the current workspace

--- a/libs/sdk-backend-tiger/src/backend/organization/settings.ts
+++ b/libs/sdk-backend-tiger/src/backend/organization/settings.ts
@@ -25,6 +25,14 @@ export class OrganizationSettingsService
         return this.setSetting("WHITE_LABELING", whiteLabeling);
     }
 
+    public async setLocale(locale: string): Promise<void> {
+        return this.setSetting("LOCALE", { value: locale });
+    }
+
+    public async setMetadataLocale(locale: string): Promise<void> {
+        return this.setSetting("METADATA_LOCALE", { value: locale });
+    }
+
     public async setTimezone(timezone: string): Promise<void> {
         return this.setSetting("TIMEZONE", { value: timezone });
     }

--- a/libs/sdk-backend-tiger/src/backend/settings/mapping.ts
+++ b/libs/sdk-backend-tiger/src/backend/settings/mapping.ts
@@ -22,6 +22,8 @@ export function mapTypeToKey(
             return "locale";
         case "MAPBOX_TOKEN":
             return "mapboxToken";
+        case "METADATA_LOCALE":
+            return "metadataLocale";
         case "TIMEZONE":
             return "timezone";
         case "WEEK_START":
@@ -46,7 +48,6 @@ export function mapTypeToKey(
             return "attachmentSizeLimit";
         // These cases are intentionally not mapped to maintain an exhaustive check.
         // This ensures we're notified when new properties are added, allowing us to decide if they need mapping.
-        case "METADATA_LOCALE":
         case "OPERATOR_OVERRIDES":
         case "TIMEZONE_VALIDATION_ENABLED":
         case "ENABLE_FILE_ANALYTICS":

--- a/libs/sdk-backend-tiger/src/backend/settings/settings.ts
+++ b/libs/sdk-backend-tiger/src/backend/settings/settings.ts
@@ -1,4 +1,4 @@
-// (C) 2020-2024 GoodData Corporation
+// (C) 2020-2025 GoodData Corporation
 import { UnexpectedError } from "@gooddata/sdk-backend-spi";
 import { IAlertDefault, ISeparators } from "@gooddata/sdk-model";
 import { v4 as uuidv4 } from "uuid";
@@ -15,6 +15,10 @@ export class TigerSettingsService<T> {
 
     public async setLocale(locale: string): Promise<void> {
         return this.setSetting("LOCALE", { value: locale });
+    }
+
+    public async setMetadataLocale(locale: string): Promise<void> {
+        return this.setSetting("METADATA_LOCALE", { value: locale });
     }
 
     public async setSeparators(separators: ISeparators): Promise<void> {

--- a/libs/sdk-backend-tiger/src/backend/workspace/settings/index.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/settings/index.ts
@@ -104,6 +104,10 @@ export class TigerWorkspaceSettings
         return this.setSetting("LOCALE", { value: locale });
     }
 
+    public async setMetadataLocale(locale: string): Promise<void> {
+        return this.setSetting("METADATA_LOCALE", { value: locale });
+    }
+
     public async setSeparators(separators: ISeparators): Promise<void> {
         return this.setSetting("SEPARATORS", separators);
     }


### PR DESCRIPTION
risk: low

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```

#### Commands for Bear platform working on branch rel/9.9

```
extended-test-legacy --backstop
extended-test-legacy --isolated
extended-test-legacy --record
```
