### PR TITLE
fix: use old alert attribute select in old edit alert dialog

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/alerting/DefaultAlertingDialog/components/AlertAttributeSelectOld.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/alerting/DefaultAlertingDialog/components/AlertAttributeSelectOld.tsx
@@ -1,0 +1,295 @@
+// (C) 2019-2025 GoodData Corporation
+import React, { useMemo, useRef, useState } from "react";
+import {
+    Button,
+    Menu,
+    ItemsWrapper,
+    Item,
+    SubMenu,
+    Separator,
+    InvertableSelectSearchBar,
+} from "@gooddata/sdk-ui-kit";
+import cx from "classnames";
+import { FormattedMessage, useIntl } from "react-intl";
+import { IAttributeMetadataObject, ICatalogAttribute, ICatalogDateDataset } from "@gooddata/sdk-model";
+
+import { AlertAttribute } from "../../types.js";
+import {
+    DASHBOARD_DIALOG_OVERS_Z_INDEX,
+    IGNORED_CONFIGURATION_MENU_CLICK_CLASS,
+} from "../../../constants/index.js";
+
+import { AttributeValue } from "../hooks/useAttributeValuesFromExecResults.js";
+import { getSelectedCatalogAttribute, getSelectedCatalogAttributeValue } from "../utils/getters.js";
+
+export interface IAlertAttributeSelectOldProps {
+    id: string;
+    selectedAttribute: AlertAttribute | undefined;
+    selectedValue: string | null | undefined;
+    onAttributeChange: (attribute: AlertAttribute | undefined, value: AttributeValue | undefined) => void;
+    attributes: AlertAttribute[];
+    catalogAttributes: ICatalogAttribute[];
+    catalogDateDatasets: ICatalogDateDataset[];
+    getAttributeValues: (attr: IAttributeMetadataObject) => AttributeValue[];
+    isResultLoading?: boolean;
+    showLabel?: boolean;
+    closeOnParentScroll?: boolean;
+}
+
+export const AlertAttributeSelectOld = ({
+    id,
+    selectedAttribute: selectedAttributeProp,
+    getAttributeValues,
+    isResultLoading,
+    selectedValue,
+    onAttributeChange,
+    attributes,
+    catalogAttributes,
+    catalogDateDatasets,
+    showLabel = true,
+    closeOnParentScroll,
+}: IAlertAttributeSelectOldProps) => {
+    const intl = useIntl();
+    const ref = useRef<HTMLElement | null>(null);
+
+    const availableAttributes = useMemo(() => {
+        return attributes.filter((attr) => attr.type === "attribute");
+    }, [attributes]);
+
+    const [searchString, setSearchString] = useState("");
+    const [isOpen, setIsOpen] = useState(false);
+    const [isOpenAttribute, setIsOpenAttribute] = useState<string | null>(null);
+
+    const selectedAttribute = useMemo(() => {
+        return (
+            selectedAttributeProp &&
+            getSelectedCatalogAttribute(catalogAttributes, catalogDateDatasets, selectedAttributeProp)
+        );
+    }, [selectedAttributeProp, catalogAttributes, catalogDateDatasets]);
+    const selectedAttributeValue = useMemo(
+        () => getSelectedCatalogAttributeValue(selectedAttribute, getAttributeValues, selectedValue),
+        [selectedAttribute, getAttributeValues, selectedValue],
+    );
+
+    const opened = Boolean(isOpen && !isResultLoading);
+
+    // if there are no attributes, return null
+    if (availableAttributes.length === 0) {
+        return null;
+    }
+
+    return (
+        <>
+            {showLabel ? (
+                <label htmlFor={id} className="gd-edit-alert__measure-label">
+                    <FormattedMessage id="insightAlert.config.for" />
+                </label>
+            ) : null}
+            <div className="gd-alert-attribute-select">
+                <Menu
+                    closeOnScroll={closeOnParentScroll}
+                    toggler={
+                        <div
+                            ref={(item) => {
+                                ref.current = item;
+                            }}
+                        >
+                            <Button
+                                id={id}
+                                className={cx("gd-alert-attribute-select__button s-alert-attribute-select", {
+                                    "is-active": opened,
+                                })}
+                                size="small"
+                                disabled={isResultLoading}
+                                variant="secondary"
+                                iconLeft="gd-icon-attribute"
+                                iconRight={`gd-icon-navigate${opened ? "up" : "down"}`}
+                                onClick={() => {
+                                    if (isResultLoading) {
+                                        return;
+                                    }
+                                    setIsOpen(!isOpen);
+                                    setIsOpenAttribute(null);
+                                }}
+                            >
+                                {selectedAttribute ? (
+                                    <span>
+                                        {selectedAttribute?.title}
+                                        <span>
+                                            {"\u00A0"}/{"\u00A0"}
+                                        </span>
+                                        {selectedAttributeValue
+                                            ? (selectedAttributeValue.title ?? selectedAttributeValue.name) ||
+                                              `(${intl.formatMessage({ id: "empty_value" })})`
+                                            : intl.formatMessage({
+                                                  id: "insightAlert.config.selectAttribute",
+                                              })}
+                                    </span>
+                                ) : (
+                                    <>{intl.formatMessage({ id: "insightAlert.config.selectAttribute" })}</>
+                                )}
+                            </Button>
+                        </div>
+                    }
+                    togglerWrapperClassName="gd-alert-attribute-select__button_wrapper"
+                    opened={opened}
+                    onOpenedChange={({ opened }) => {
+                        setIsOpen(opened);
+                    }}
+                    openAction={"click"}
+                >
+                    <ItemsWrapper
+                        style={{
+                            width: ref.current?.offsetWidth ?? 0,
+                            zIndex: DASHBOARD_DIALOG_OVERS_Z_INDEX,
+                        }}
+                        className={IGNORED_CONFIGURATION_MENU_CLICK_CLASS}
+                    >
+                        <div className="gd-alert-attribute-select__submenu s-alert-attribute-menu-content">
+                            <Item
+                                className="gd-alert-attribute-select__menu-item_wrapper"
+                                checked={!selectedAttribute}
+                                onClick={(e) => {
+                                    onAttributeChange(undefined, undefined);
+                                    setIsOpen(false);
+                                    setIsOpenAttribute(null);
+                                    e.preventDefault();
+                                    e.stopPropagation();
+                                }}
+                            >
+                                <div className="gd-alert-attribute-select__menu-item s-menu-alert-attribute-item-value">
+                                    {intl.formatMessage({ id: "insightAlert.config.selectAttribute" })}
+                                </div>
+                            </Item>
+                            <Separator />
+                            {availableAttributes.map((attribute, i) => {
+                                const item = getSelectedCatalogAttribute(
+                                    catalogAttributes,
+                                    catalogDateDatasets,
+                                    attribute,
+                                );
+
+                                if (!item) {
+                                    return null;
+                                }
+
+                                const isSelected = selectedAttribute?.id === item.id;
+                                const values = getAttributeValues(item);
+
+                                return (
+                                    <SubMenu
+                                        key={i}
+                                        toggler={
+                                            <Item
+                                                checked={isSelected}
+                                                subMenu={true}
+                                                className="gd-alert-attribute-select__menu-item_wrapper"
+                                            >
+                                                <div className="gd-alert-attribute-select__menu-item s-menu-alert-attribute-item">
+                                                    {item.title ||
+                                                        `(${intl.formatMessage({ id: "empty_value" })})`}
+                                                </div>
+                                            </Item>
+                                        }
+                                        openAction={"click"}
+                                        opened={
+                                            isOpenAttribute === attribute.attribute.attribute.localIdentifier
+                                        }
+                                        onOpenedChange={({ opened }) => {
+                                            setIsOpenAttribute(
+                                                opened ? attribute.attribute.attribute.localIdentifier : null,
+                                            );
+                                            setSearchString("");
+                                        }}
+                                    >
+                                        <ItemsWrapper
+                                            style={{
+                                                zIndex: DASHBOARD_DIALOG_OVERS_Z_INDEX + 1,
+                                            }}
+                                            className={IGNORED_CONFIGURATION_MENU_CLICK_CLASS}
+                                        >
+                                            <div
+                                                className={cx(
+                                                    "gd-alert-attribute-select__submenu-content",
+                                                    "s-alert-attribute-submenu-content",
+                                                )}
+                                            >
+                                                {values.length > 5 && (
+                                                    <div>
+                                                        <InvertableSelectSearchBar
+                                                            onSearch={setSearchString}
+                                                            searchString={searchString}
+                                                            searchPlaceholder={intl.formatMessage({
+                                                                id: "attributesDropdown.placeholder",
+                                                            })}
+                                                            className="gd-alert-attribute-select__menu-item_search"
+                                                        />
+                                                    </div>
+                                                )}
+                                                <Item
+                                                    className="gd-alert-attribute-select__menu-item_wrapper"
+                                                    checked={Boolean(isSelected && !selectedAttributeValue)}
+                                                    onClick={(e) => {
+                                                        onAttributeChange(attribute, undefined);
+                                                        setIsOpen(false);
+                                                        setIsOpenAttribute(null);
+                                                        e.preventDefault();
+                                                        e.stopPropagation();
+                                                    }}
+                                                >
+                                                    <div className="gd-alert-attribute-select__menu-item s-menu-alert-attribute-item-value">
+                                                        {intl.formatMessage({
+                                                            id: "insightAlert.config.selectAttribute",
+                                                        })}{" "}
+                                                        ({values.length})
+                                                    </div>
+                                                </Item>
+                                                <Separator />
+                                                <div className="gd-alert-attribute-select__menu-item__values">
+                                                    {values
+                                                        .filter((item) => {
+                                                            if (searchString) {
+                                                                return item.title
+                                                                    .toLowerCase()
+                                                                    .includes(searchString.toLowerCase());
+                                                            }
+                                                            return true;
+                                                        })
+                                                        .map((value, j) => (
+                                                            <Item
+                                                                key={j}
+                                                                checked={Boolean(
+                                                                    isSelected &&
+                                                                        value.value ===
+                                                                            selectedAttributeValue?.value,
+                                                                )}
+                                                                className="gd-alert-attribute-select__menu-item_wrapper"
+                                                                onClick={(e) => {
+                                                                    onAttributeChange(attribute, value);
+                                                                    setIsOpen(false);
+                                                                    setIsOpenAttribute(null);
+                                                                    e.preventDefault();
+                                                                    e.stopPropagation();
+                                                                }}
+                                                            >
+                                                                <div className="gd-alert-attribute-select__menu-item s-menu-alert-attribute-item-value">
+                                                                    {(value.title ?? value.name) ||
+                                                                        `(${intl.formatMessage({
+                                                                            id: "empty_value",
+                                                                        })})`}
+                                                                </div>
+                                                            </Item>
+                                                        ))}
+                                                </div>
+                                            </div>
+                                        </ItemsWrapper>
+                                    </SubMenu>
+                                );
+                            })}
+                        </div>
+                    </ItemsWrapper>
+                </Menu>
+            </div>
+        </>
+    );
+};

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/configuration/InsightAlertConfig/EditAlert.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/configuration/InsightAlertConfig/EditAlert.tsx
@@ -27,7 +27,6 @@ import { EditAlertConfiguration } from "./EditAlertConfiguration.js";
 import { AlertTitle } from "./AlertTitle.js";
 import { useEditAlert } from "./hooks/useEditAlert.js";
 import { AlertAttribute, AlertMetric } from "../../../../alerting/types.js";
-import { AlertAttributeSelect } from "../../../../alerting/DefaultAlertingDialog/components/AlertAttributeSelect.js";
 import { AlertComparisonOperatorSelect } from "../../../../alerting/DefaultAlertingDialog/components/AlertComparisonOperatorSelect.js";
 import { AlertComparisonPeriodSelect } from "../../../../alerting/DefaultAlertingDialog/components/AlertComparisonPeriodSelect.js";
 import { AlertDestinationSelect } from "../../../../alerting/DefaultAlertingDialog/components/AlertDestinationSelect.js";
@@ -50,6 +49,7 @@ import {
 } from "../../../../alerting/DefaultAlertingDialog/utils/getters.js";
 import { translateGranularity } from "../../../../alerting/DefaultAlertingDialog/utils/granularity.js";
 import { isChangeOrDifferenceOperator } from "../../../../alerting/DefaultAlertingDialog/utils/guards.js";
+import { AlertAttributeSelectOld } from "../../../../alerting/DefaultAlertingDialog/components/AlertAttributeSelectOld.js";
 
 const TOOLTIP_ALIGN_POINTS = [{ align: "cl cr" }, { align: "cr cl" }];
 
@@ -205,7 +205,7 @@ export const EditAlert: React.FC<IEditAlertProps> = ({
 
                         {Boolean(canManageAttributes) && (
                             <>
-                                <AlertAttributeSelect
+                                <AlertAttributeSelectOld
                                     id="alert.attribute"
                                     selectedAttribute={selectedAttribute}
                                     selectedValue={selectedValue}


### PR DESCRIPTION
- this brings back historical version of AlertAttributeSelect
- edit alert is used when old automation filters is not turned on and uses all necessary
test selectors
- can be removed on enableAutomationFilterContext is on

JIRA: F1-1381
risk: low

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```

#### Commands for Bear platform working on branch rel/9.9

```
extended-test-legacy --backstop
extended-test-legacy --isolated
extended-test-legacy --record
```
