### PR TITLE
feat: customize Tab behavior on Pivot and Repeater

### DIFF
--- a/libs/sdk-ui-charts/src/charts/repeater/hooks/useFocusMng.ts
+++ b/libs/sdk-ui-charts/src/charts/repeater/hooks/useFocusMng.ts
@@ -1,0 +1,21 @@
+// (C) 2025 GoodData Corporation
+import { useCallback } from "react";
+import { FocusGridInnerElementParams } from "ag-grid-community";
+
+/**
+ * Hook that manages focus handling for the grid
+ */
+export function useFocusMng() {
+    const switchToBrowserDefault = useCallback(() => false, []);
+
+    const focusGridInnerElement = useCallback((params: FocusGridInnerElementParams) => {
+        const firstColumn = params.api.getAllDisplayedColumns()[0];
+        params.api.setFocusedHeader(firstColumn.getId());
+        return true;
+    }, []);
+
+    return {
+        switchToBrowserDefault,
+        focusGridInnerElement,
+    };
+}

--- a/libs/sdk-ui-charts/src/charts/repeater/internal/InlineColumnChart.tsx
+++ b/libs/sdk-ui-charts/src/charts/repeater/internal/InlineColumnChart.tsx
@@ -32,6 +32,9 @@ function createOptions({
         credits: {
             enabled: false,
         },
+        accessibility: {
+            enabled: false,
+        },
         title: {
             text: undefined,
             style: {

--- a/libs/sdk-ui-charts/src/charts/repeater/internal/InlineLineChart.tsx
+++ b/libs/sdk-ui-charts/src/charts/repeater/internal/InlineLineChart.tsx
@@ -1,4 +1,4 @@
-// (C) 2023-2024 GoodData Corporation
+// (C) 2023-2025 GoodData Corporation
 import React from "react";
 import Highcharts from "highcharts";
 import { HighchartsReact } from "highcharts-react-official";
@@ -29,6 +29,9 @@ function createOptions({
     color,
 }: IInlineLineChartOptions): Highcharts.Options {
     return {
+        accessibility: {
+            enabled: false,
+        },
         credits: {
             enabled: false,
         },

--- a/libs/sdk-ui-charts/src/charts/repeater/internal/RepeaterChart.tsx
+++ b/libs/sdk-ui-charts/src/charts/repeater/internal/RepeaterChart.tsx
@@ -38,6 +38,7 @@ import { RepeaterInlineVisualizationDataPoint } from "./dataViewToRepeaterData.j
 import isNil from "lodash/isNil.js";
 import { useDrilling } from "../hooks/useDrilling.js";
 import { useRenderWatcher } from "../hooks/useRenderWatcher.js";
+import { useFocusMng } from "../hooks/useFocusMng.js";
 
 // Register all Community features
 ModuleRegistry.registerModules([AllCommunityModule]);
@@ -163,6 +164,8 @@ export const RepeaterChart: React.FC<IRepeaterChartProps> = (props) => {
 
     const { onFirstDataRendered } = useRenderWatcher(afterRender);
 
+    const { switchToBrowserDefault, focusGridInnerElement } = useFocusMng();
+
     return (
         <div className="gd-repeater s-repeater" ref={containerRef}>
             <AgGridReact
@@ -188,6 +191,9 @@ export const RepeaterChart: React.FC<IRepeaterChartProps> = (props) => {
                 suppressMovableColumns={true}
                 onCellClicked={onCellClicked}
                 onCellKeyDown={onCellKeyDown}
+                focusGridInnerElement={focusGridInnerElement}
+                tabToNextHeader={switchToBrowserDefault}
+                tabToNextCell={switchToBrowserDefault}
                 onGridReady={(e) => {
                     onResizingGridReady(e);
                     onDrillingGridReady(e);

--- a/libs/sdk-ui-pivot/src/impl/gridOptions.ts
+++ b/libs/sdk-ui-pivot/src/impl/gridOptions.ts
@@ -36,6 +36,7 @@ import {
 } from "./structure/colDefTemplates.js";
 import { TableFacade } from "./tableFacade.js";
 import { ICorePivotTableProps } from "../publicTypes.js";
+import { FocusGridInnerElementParams } from "ag-grid-community";
 
 export function createGridOptions(
     table: TableFacade,
@@ -109,6 +110,28 @@ export function createGridOptions(
         onGridColumnsChanged: tableMethods.onGridColumnsChanged,
         onModelUpdated: tableMethods.onModelUpdated,
         onPinnedRowDataChanged: tableMethods.onPinnedRowDataChanged,
+
+        focusGridInnerElement: (params: FocusGridInnerElementParams) => {
+            // Don't set focused header when table is transposed with headers on left (no header cells to focus)
+            const isTransposedWithNoHeaders =
+                tableMethods.getColumnHeadersPosition() === "left" && table.tableDescriptor.isTransposed();
+            const firstColumn = params.api.getAllDisplayedColumns()[0];
+
+            if (isTransposedWithNoHeaders) {
+                params.api.setFocusedCell(0, firstColumn.getId());
+            } else {
+                params.api.setFocusedHeader(firstColumn.getId());
+            }
+
+            return true;
+        },
+        // fallback of Tab key to browser default
+        tabToNextHeader: () => {
+            return false;
+        },
+        tabToNextCell: () => {
+            return false;
+        },
 
         // Basic options
         suppressMovableColumns: true,


### PR DESCRIPTION
Tab now enters first cell and then moves focus out of the table. So Tab is no longer used for navigation among cells as it is by default.

JIRA: LX-1036
risk: low

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```

#### Commands for Bear platform working on branch rel/9.9

```
extended-test-legacy --backstop
extended-test-legacy --isolated
extended-test-legacy --record
```
