### PR TITLE
feat: filter automations by external recipient

### DIFF
--- a/libs/sdk-backend-base/src/cachingBackend/index.ts
+++ b/libs/sdk-backend-base/src/cachingBackend/index.ts
@@ -1121,6 +1121,7 @@ class CachedAutomationsQueryFactory extends DecoratedAutomationsQuery {
         page: number;
         author: string | null;
         recipient: string | null;
+        externalRecipient: string | null;
         user: string | null;
         dashboard: string | null;
         filter: { title?: string };
@@ -1132,6 +1133,7 @@ class CachedAutomationsQueryFactory extends DecoratedAutomationsQuery {
         page: 0,
         author: null,
         recipient: null,
+        externalRecipient: null,
         user: null,
         dashboard: null,
         filter: {},
@@ -1188,6 +1190,12 @@ class CachedAutomationsQueryFactory extends DecoratedAutomationsQuery {
     withRecipient(recipient: string): IAutomationsQuery {
         this.settings.recipient = recipient;
         super.withRecipient(recipient);
+        return this;
+    }
+
+    withExternalRecipient(externalRecipient: string): IAutomationsQuery {
+        this.settings.externalRecipient = externalRecipient;
+        super.withExternalRecipient(externalRecipient);
         return this;
     }
 

--- a/libs/sdk-backend-base/src/decoratedBackend/automations.ts
+++ b/libs/sdk-backend-base/src/decoratedBackend/automations.ts
@@ -1,4 +1,4 @@
-// (C) 2021-2024 GoodData Corporation
+// (C) 2021-2025 GoodData Corporation
 
 import {
     IWorkspaceAutomationService,
@@ -33,6 +33,9 @@ export abstract class DecoratedAutomationsQuery implements IAutomationsQuery {
     }
     withRecipient(recipient: string): IAutomationsQuery {
         return this.decorated.withRecipient(recipient);
+    }
+    withExternalRecipient(externalRecipient: string): IAutomationsQuery {
+        return this.decorated.withExternalRecipient(externalRecipient);
     }
     withUser(user: string): IAutomationsQuery {
         return this.decorated.withUser(user);

--- a/libs/sdk-backend-base/src/dummyBackend/index.ts
+++ b/libs/sdk-backend-base/src/dummyBackend/index.ts
@@ -1352,6 +1352,7 @@ class DummyAutomationsQuery implements IAutomationsQuery {
         author: string | null;
         user: string | null;
         recipient: string | null;
+        externalRecipient: string | null;
         dashboard: string | null;
         filter: { title?: string };
         sort: NonNullable<unknown>;
@@ -1363,6 +1364,7 @@ class DummyAutomationsQuery implements IAutomationsQuery {
         author: null,
         user: null,
         recipient: null,
+        externalRecipient: null,
         dashboard: null,
         filter: {},
         sort: {},
@@ -1413,6 +1415,11 @@ class DummyAutomationsQuery implements IAutomationsQuery {
 
     withRecipient(recipient: string): IAutomationsQuery {
         this.settings.recipient = recipient;
+        return this;
+    }
+
+    withExternalRecipient(externalRecipient: string): IAutomationsQuery {
+        this.settings.externalRecipient = externalRecipient;
         return this;
     }
 

--- a/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
+++ b/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
@@ -339,6 +339,7 @@ export interface IAutomationsQuery {
     queryAll(): Promise<IAutomationMetadataObject[]>;
     withAuthor(author: string): IAutomationsQuery;
     withDashboard(dashboard: string): IAutomationsQuery;
+    withExternalRecipient(externalRecipient: string): IAutomationsQuery;
     withFilter(filter: {
         title?: string;
     }): IAutomationsQuery;

--- a/libs/sdk-backend-spi/src/workspace/automations/index.ts
+++ b/libs/sdk-backend-spi/src/workspace/automations/index.ts
@@ -1,4 +1,4 @@
-// (C) 2023-2024 GoodData Corporation
+// (C) 2023-2025 GoodData Corporation
 
 import { IAutomationMetadataObject, IAutomationMetadataObjectDefinition } from "@gooddata/sdk-model";
 import { IPagedResource } from "../../common/paging.js";
@@ -190,6 +190,14 @@ export interface IAutomationsQuery {
      * @returns automations query
      */
     withRecipient(recipient: string): IAutomationsQuery;
+
+    /**
+     * Sets external recipient of the automation for the query.
+     *
+     * @param externalRecipient - external recipient of the automation
+     * @returns automations query
+     */
+    withExternalRecipient(externalRecipient: string): IAutomationsQuery;
 
     /**
      * This filter gets automations if either author or recipient of the automation is the provided user.

--- a/libs/sdk-backend-tiger/src/backend/workspace/automations/automationsQuery.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/automations/automationsQuery.ts
@@ -14,6 +14,7 @@ export class AutomationsQuery implements IAutomationsQuery {
     private page = 0;
     private author: string | null = null;
     private recipient: string | null = null;
+    private externalRecipient: string | null = null;
     private user: string | null = null;
     private dashboard: string | null = null;
     private filter: { title?: string } = {};
@@ -64,6 +65,11 @@ export class AutomationsQuery implements IAutomationsQuery {
 
     withRecipient(recipient: string): IAutomationsQuery {
         this.recipient = recipient;
+        return this;
+    }
+
+    withExternalRecipient(externalRecipient: string): IAutomationsQuery {
+        this.externalRecipient = externalRecipient;
         return this;
     }
 
@@ -149,6 +155,10 @@ export class AutomationsQuery implements IAutomationsQuery {
 
         if (this.recipient) {
             allFilters.push(`recipients.id=='${this.recipient}'`);
+        }
+
+        if (this.externalRecipient) {
+            allFilters.push(`externalRecipients.email=='${this.externalRecipient}'`);
         }
 
         if (this.user) {

--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -1675,6 +1675,8 @@ export interface DashboardConfig {
     // @internal
     exportId?: string;
     exportType?: "visual" | "slides";
+    // @alpha
+    externalRecipient?: string;
     // @beta
     focusObject?: DashboardFocusObject;
     // @internal
@@ -8060,7 +8062,7 @@ export interface ResolveAsyncRenderPayload {
 }
 
 // @public
-export type ResolvedDashboardConfig = Omit<Required<DashboardConfig>, "mapboxToken" | "exportId" | "exportType" | "focusObject" | "slideConfig" | "references" | "entitlements" | "initialContent" | "executionTimestamp" | "overrideDefaultFilters" | "overrideTitle" | "hideWidgetTitles" | "workspaceDescriptor" | "evaluationFrequency"> & DashboardConfig;
+export type ResolvedDashboardConfig = Omit<Required<DashboardConfig>, "mapboxToken" | "exportId" | "exportType" | "focusObject" | "slideConfig" | "references" | "entitlements" | "initialContent" | "executionTimestamp" | "overrideDefaultFilters" | "overrideTitle" | "hideWidgetTitles" | "workspaceDescriptor" | "evaluationFrequency" | "externalRecipient"> & DashboardConfig;
 
 // @alpha (undocumented)
 export type ResolvedDateFilterValues = IResolvedDateFilterValue[];
@@ -8930,6 +8932,9 @@ export const selectExecutionResultByRef: (ref: ObjRef | undefined) => DashboardS
 
 // @internal (undocumented)
 export const selectExecutionTimestamp: DashboardSelector<string | undefined>;
+
+// @internal
+export const selectExternalRecipient: DashboardSelector<string | undefined>;
 
 // @alpha
 export const selectFilterableWidgetByRef: (ref: ObjRef | undefined) => DashboardSelector<IWidget | ICustomWidget | undefined>;

--- a/libs/sdk-ui-dashboard/src/_staging/automation/index.ts
+++ b/libs/sdk-ui-dashboard/src/_staging/automation/index.ts
@@ -191,3 +191,14 @@ export const convertUserToAutomationRecipient = (user: IUser): IAutomationRecipi
         type: "user",
     };
 };
+
+export const convertExternalRecipientToAutomationRecipient = (
+    externalRecipient: string,
+): IAutomationRecipient => {
+    return {
+        id: externalRecipient,
+        email: externalRecipient,
+        name: externalRecipient,
+        type: "externalUser",
+    };
+};

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/initializeDashboardHandler/resolveDashboardConfig.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/initializeDashboardHandler/resolveDashboardConfig.ts
@@ -231,6 +231,7 @@ function applyConfigDefaults<T extends DashboardConfig>(config: T) {
         disableCrossFiltering: config.disableCrossFiltering ?? false,
         disableUserFilterReset: config.disableUserFilterReset ?? false,
         widgetsOverlay: config.widgetsOverlay ?? {},
+        externalRecipient: config.externalRecipient ?? undefined,
     };
 }
 

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/initializeDashboardHandler/tests/__snapshots__/handler.test.ts.snap
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/initializeDashboardHandler/tests/__snapshots__/handler.test.ts.snap
@@ -182,6 +182,7 @@ exports[`initialize dashboard handler > for any dashboard > should resolve confi
   "disableDefaultDrills": false,
   "disableUserFilterReset": false,
   "enableFilterValuesResolutionInDrillEvents": false,
+  "externalRecipient": undefined,
   "hideSaveAsNewButton": false,
   "hideShareButton": false,
   "initialRenderMode": "view",

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/scheduledEmail/initializeAutomationsHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/scheduledEmail/initializeAutomationsHandler.ts
@@ -12,6 +12,7 @@ import {
     selectEnableInPlatformNotifications,
     selectEnableScheduling,
     selectIsReadOnly,
+    selectExternalRecipient,
 } from "../../store/config/configSelectors.js";
 import { automationsActions } from "../../store/automations/index.js";
 import { selectDashboardId } from "../../store/meta/metaSelectors.js";
@@ -79,6 +80,9 @@ export function* initializeAutomationsHandler(
     );
     const isReadOnly: ReturnType<typeof selectIsReadOnly> = yield select(selectIsReadOnly);
     const { automationId }: ReturnType<typeof selectFocusObject> = yield select(selectFocusObject);
+    const externalRecipient: ReturnType<typeof selectExternalRecipient> = yield select(
+        selectExternalRecipient,
+    );
 
     if (
         !dashboardId ||
@@ -99,7 +103,14 @@ export function* initializeAutomationsHandler(
             PromiseFnReturnType<typeof loadWorkspaceAutomationsCount>,
             PromiseFnReturnType<typeof loadNotificationChannels>,
         ] = yield all([
-            call(loadDashboardUserAutomations, ctx, dashboardId, user.login, !canManageAutomations),
+            call(
+                loadDashboardUserAutomations,
+                ctx,
+                dashboardId,
+                user.login,
+                !canManageAutomations,
+                externalRecipient,
+            ),
             call(loadWorkspaceAutomationsCount, ctx),
             call(loadNotificationChannels, ctx, enableInPlatformNotifications),
         ]);

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/scheduledEmail/loadAutomations.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/scheduledEmail/loadAutomations.ts
@@ -1,4 +1,4 @@
-// (C) 2021-2024 GoodData Corporation
+// (C) 2021-2025 GoodData Corporation
 import { IAutomationMetadataObject } from "@gooddata/sdk-model";
 import { DashboardContext } from "../../types/commonTypes.js";
 
@@ -15,6 +15,7 @@ export function loadDashboardUserAutomations(
     dashboardId: string,
     userId: string,
     filterByUser: boolean,
+    externalRecipient: string | undefined,
 ): Promise<IAutomationMetadataObject[]> {
     const { backend, workspace } = ctx;
 
@@ -25,7 +26,10 @@ export function loadDashboardUserAutomations(
         .withSorting(["title,asc", "createdAt,asc"])
         .withDashboard(dashboardId);
 
-    if (filterByUser) {
+    // External recipients from context are prioritized to signed-in user
+    if (externalRecipient) {
+        dashboardQuery = dashboardQuery.withExternalRecipient(externalRecipient);
+    } else if (filterByUser) {
         dashboardQuery = dashboardQuery.withUser(userId);
     }
 

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/scheduledEmail/refreshAutomationsHandlers.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/scheduledEmail/refreshAutomationsHandlers.ts
@@ -10,6 +10,7 @@ import { loadDashboardUserAutomations, loadWorkspaceAutomationsCount } from "./l
 import {
     selectEnableAlerting,
     selectEnableScheduling,
+    selectExternalRecipient,
     selectIsReadOnly,
 } from "../../store/config/configSelectors.js";
 import { automationsActions } from "../../store/automations/index.js";
@@ -28,6 +29,9 @@ export function* refreshAutomationsHandlers(ctx: DashboardContext, cmd: RefreshA
     );
     const isReadOnly: ReturnType<typeof selectIsReadOnly> = yield select(selectIsReadOnly);
     const enableAutomations = enableScheduling || enableAlerting;
+    const externalRecipient: ReturnType<typeof selectExternalRecipient> = yield select(
+        selectExternalRecipient,
+    );
 
     if (!dashboardId || !user || !enableAutomations || isReadOnly) {
         return;
@@ -40,7 +44,14 @@ export function* refreshAutomationsHandlers(ctx: DashboardContext, cmd: RefreshA
             PromiseFnReturnType<typeof loadDashboardUserAutomations>,
             PromiseFnReturnType<typeof loadWorkspaceAutomationsCount>,
         ] = yield all([
-            call(loadDashboardUserAutomations, ctx, dashboardId, user.login, !canManageAutomations),
+            call(
+                loadDashboardUserAutomations,
+                ctx,
+                dashboardId,
+                user.login,
+                !canManageAutomations,
+                externalRecipient,
+            ),
             call(loadWorkspaceAutomationsCount, ctx),
         ]);
 

--- a/libs/sdk-ui-dashboard/src/model/store/config/configSelectors.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/config/configSelectors.ts
@@ -1060,3 +1060,15 @@ export const selectEnableExportToDocumentStorage: DashboardSelector<boolean> = c
         return Boolean(state.settings?.enableExportToDocumentStorage) ?? false;
     },
 );
+
+/**
+ * Returns the external recipient from the dashboard config
+ *
+ * @internal
+ */
+export const selectExternalRecipient: DashboardSelector<string | undefined> = createSelector(
+    selectConfig,
+    (state) => {
+        return state.externalRecipient;
+    },
+);

--- a/libs/sdk-ui-dashboard/src/model/store/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/index.ts
@@ -119,6 +119,7 @@ export {
     selectEnableDateFilterIdentifiers,
     selectEnableSnapshotExportAccessibility,
     selectEnableExportToDocumentStorage,
+    selectExternalRecipient,
 } from "./config/configSelectors.js";
 export type { EntitlementsState } from "./entitlements/entitlementsState.js";
 export {

--- a/libs/sdk-ui-dashboard/src/model/types/commonTypes.ts
+++ b/libs/sdk-ui-dashboard/src/model/types/commonTypes.ts
@@ -378,6 +378,13 @@ export interface DashboardConfig {
     workspaceDescriptor?: {
         title: string;
     };
+
+    /**
+     * @alpha
+     *
+     * Customized recipient context for automations
+     */
+    externalRecipient?: string;
 }
 
 /**
@@ -456,6 +463,7 @@ export type ResolvedDashboardConfig = Omit<
     | "hideWidgetTitles"
     | "workspaceDescriptor"
     | "evaluationFrequency"
+    | "externalRecipient"
 > &
     DashboardConfig;
 

--- a/libs/sdk-ui-dashboard/src/presentation/alerting/DefaultAlertingDialog/DefaultAlertingDialogNew.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/alerting/DefaultAlertingDialog/DefaultAlertingDialogNew.tsx
@@ -19,6 +19,7 @@ import { defineMessage, FormattedMessage, useIntl } from "react-intl";
 import {
     selectEntitlementMaxAutomationRecipients,
     selectExecutionTimestamp,
+    selectExternalRecipient,
     selectIsWhiteLabeled,
     selectLocale,
     useDashboardSelector,
@@ -81,6 +82,7 @@ export function AlertingDialogRenderer({
     const dialogTitleRef = useRef<HTMLInputElement | null>(null);
 
     const isWhiteLabeled = useDashboardSelector(selectIsWhiteLabeled);
+    const externalRecipientOverride = useDashboardSelector(selectExternalRecipient);
 
     const [alertToDelete, setAlertToDelete] = useState<IAutomationMetadataObject | null>(null);
 
@@ -151,6 +153,7 @@ export function AlertingDialogRenderer({
         setEditedAutomationFilters,
         notificationChannels,
         filtersForNewAutomation,
+        externalRecipientOverride,
     });
 
     const { isValid } = useValidateExistingAutomationFilters({
@@ -439,6 +442,7 @@ export function AlertingDialogRenderer({
                                         notificationChannels={notificationChannels}
                                         notificationChannelId={editedAutomation.notificationChannel}
                                         showLabel={false}
+                                        externalRecipientOverride={externalRecipientOverride}
                                     />
                                 </FormField>
                             </FormFieldGroup>

--- a/libs/sdk-ui-dashboard/src/presentation/alerting/DefaultAlertingDialog/hooks/useEditAlert.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/alerting/DefaultAlertingDialog/hooks/useEditAlert.ts
@@ -39,6 +39,7 @@ import {
 import {
     convertCurrentUserToAutomationRecipient,
     convertCurrentUserToWorkspaceUser,
+    convertExternalRecipientToAutomationRecipient,
 } from "../../../../_staging/automation/index.js";
 import { useIntl } from "react-intl";
 import { getAppliedWidgetFilters, getVisibleFiltersByFilters } from "../../../automationFilters/utils.js";
@@ -83,6 +84,7 @@ export interface IUseEditAlertProps {
     setEditedAutomationFilters: (filters: FilterContextItem[]) => void;
     availableFiltersAsVisibleFilters?: IAutomationVisibleFilter[] | undefined;
     filtersForNewAutomation: FilterContextItem[];
+    externalRecipientOverride?: string;
 }
 
 export function useEditAlert(props: IUseEditAlertProps) {
@@ -96,6 +98,7 @@ export function useEditAlert(props: IUseEditAlertProps) {
         setEditedAutomationFilters,
         availableFiltersAsVisibleFilters,
         filtersForNewAutomation,
+        externalRecipientOverride,
     } = props;
     const intl = useIntl();
 
@@ -144,7 +147,9 @@ export function useEditAlert(props: IUseEditAlertProps) {
     // Default values
     const defaultMeasure = supportedMeasures[0];
     const defaultUser = convertCurrentUserToWorkspaceUser(users ?? [], currentUser);
-    const defaultRecipient = convertCurrentUserToAutomationRecipient(users ?? [], currentUser);
+    const defaultRecipient = externalRecipientOverride
+        ? convertExternalRecipientToAutomationRecipient(externalRecipientOverride)
+        : convertCurrentUserToAutomationRecipient(users ?? [], currentUser);
     const defaultNotificationChannelId = notificationChannels[0]?.id;
 
     // Local state
@@ -164,7 +169,7 @@ export function useEditAlert(props: IUseEditAlertProps) {
                 supportedMeasures,
                 defaultMeasure,
                 defaultNotificationChannelId,
-                convertCurrentUserToAutomationRecipient(users ?? [], currentUser),
+                defaultRecipient,
                 measureFormatMap,
                 undefined,
                 descriptor.evaluationFrequency

--- a/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/DefaultScheduledEmailDialog.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/DefaultScheduledEmailDialog.tsx
@@ -28,6 +28,7 @@ import {
     selectEntitlementMaxAutomationRecipients,
     selectEntitlementMinimumRecurrenceMinutes,
     selectExecutionTimestamp,
+    selectExternalRecipient,
     selectIsCrossFiltering,
     selectIsWhiteLabeled,
     selectLocale,
@@ -135,6 +136,7 @@ export function ScheduledMailDialogRenderer({
     >(null);
 
     const isWhiteLabeled = useDashboardSelector(selectIsWhiteLabeled);
+    const externalRecipientOverride = useDashboardSelector(selectExternalRecipient);
 
     const handleScheduleDeleteSuccess = () => {
         onDeleteSuccess?.();
@@ -207,6 +209,7 @@ export function ScheduledMailDialogRenderer({
         availableFiltersAsVisibleFilters,
         enableAutomationFilterContext,
         filtersForNewAutomation,
+        externalRecipientOverride,
     });
 
     const { isValid } = useValidateExistingAutomationFilters({
@@ -397,6 +400,7 @@ export function ScheduledMailDialogRenderer({
                                 notificationChannels={notificationChannels}
                                 notificationChannelId={editedAutomation.notificationChannel}
                                 onKeyDownSubmit={handleSubmitForm}
+                                externalRecipientOverride={externalRecipientOverride}
                             />
                             {!isInPlatformChannel ? (
                                 <>

--- a/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/components/RecipientsSelect/RecipientsSelect.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/components/RecipientsSelect/RecipientsSelect.tsx
@@ -94,6 +94,11 @@ interface IRecipientsSelectProps {
      * Handle keyboard submit
      */
     onKeyDownSubmit?: (e: React.KeyboardEvent) => void;
+
+    /**
+     * Override recipients with an external recipient
+     */
+    externalRecipientOverride?: string;
 }
 
 export const RecipientsSelect: React.FC<IRecipientsSelectProps> = (props) => {
@@ -114,6 +119,7 @@ export const RecipientsSelect: React.FC<IRecipientsSelectProps> = (props) => {
         notificationChannelId,
         showLabel = true,
         onKeyDownSubmit,
+        externalRecipientOverride,
     } = props;
 
     const [search, setSearch] = useState<string>();
@@ -143,7 +149,7 @@ export const RecipientsSelect: React.FC<IRecipientsSelectProps> = (props) => {
             id={id}
             canListUsersInProject
             isMulti
-            options={options}
+            options={externalRecipientOverride ? [] : options}
             value={value}
             originalValue={originalValue}
             onChange={onChange}
@@ -160,6 +166,7 @@ export const RecipientsSelect: React.FC<IRecipientsSelectProps> = (props) => {
             usersError={usersError}
             showLabel={showLabel}
             onKeyDownSubmit={onKeyDownSubmit}
+            externalRecipientOverride={externalRecipientOverride}
         />
     );
 };

--- a/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/components/RecipientsSelect/RecipientsSelectRenderer.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/components/RecipientsSelect/RecipientsSelectRenderer.tsx
@@ -158,6 +158,11 @@ export interface IRecipientsSelectRendererProps {
      * Handle keyboard submit
      */
     onKeyDownSubmit?: (e: React.KeyboardEvent) => void;
+
+    /**
+     * Override recipients with an external recipient
+     */
+    externalRecipientOverride?: string;
 }
 
 interface IRecipientsSelectRendererState {
@@ -245,6 +250,7 @@ export class RecipientsSelectRenderer extends React.PureComponent<
             usersError,
             allowOnlyLoggedUserRecipients,
             id,
+            externalRecipientOverride,
         } = this.props;
         const creatableSelectComponent: SelectComponentsConfig<
             IAutomationRecipient,
@@ -285,6 +291,7 @@ export class RecipientsSelectRenderer extends React.PureComponent<
             missingEmailError;
 
         const someExternalRecipients = value.some((v) => v.type === "externalUser");
+        const renderExternalRecipientsNote = someExternalRecipients && !externalRecipientOverride;
 
         return (
             <div
@@ -343,7 +350,7 @@ export class RecipientsSelectRenderer extends React.PureComponent<
                             maxRecipients,
                             usersError,
                         })
-                    ) : someExternalRecipients ? (
+                    ) : renderExternalRecipientsNote ? (
                         <div className="gd-recipients-field-note">
                             <FormattedMessage id="dialogs.schedule.email.recipients.note" />
                         </div>
@@ -446,6 +453,10 @@ export class RecipientsSelectRenderer extends React.PureComponent<
     }
 
     private renderNoOptionsContainer = (): React.ReactElement | null => {
+        if (this.props.externalRecipientOverride) {
+            return null;
+        }
+
         return (
             <div className="gd-recipients-no-match">
                 <FormattedMessage id="dialogs.schedule.email.user.noMatch" />

--- a/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/hooks/useEditScheduledEmail.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/hooks/useEditScheduledEmail.ts
@@ -36,6 +36,7 @@ import {
     areAutomationsEqual,
     convertCurrentUserToAutomationRecipient,
     convertCurrentUserToWorkspaceUser,
+    convertExternalRecipientToAutomationRecipient,
     getAutomationVisualizationFilters,
     isCsvVisualizationAutomation,
     isCsvVisualizationExportDefinition,
@@ -76,6 +77,7 @@ export interface IUseEditScheduledEmailProps {
     setStoreFilters: (storeFilters: boolean) => void;
     enableAutomationFilterContext?: boolean;
     filtersForNewAutomation: FilterContextItem[];
+    externalRecipientOverride?: string;
 }
 
 export function useEditScheduledEmail(props: IUseEditScheduledEmailProps) {
@@ -94,6 +96,7 @@ export function useEditScheduledEmail(props: IUseEditScheduledEmailProps) {
         setStoreFilters,
         enableAutomationFilterContext,
         filtersForNewAutomation,
+        externalRecipientOverride,
     } = props;
 
     const intl = useIntl();
@@ -114,7 +117,9 @@ export function useEditScheduledEmail(props: IUseEditScheduledEmailProps) {
     const users = useDashboardSelector(selectUsers);
     const defaultUser = convertCurrentUserToWorkspaceUser(users ?? [], currentUser);
 
-    const defaultRecipient = convertCurrentUserToAutomationRecipient(users ?? [], currentUser);
+    const defaultRecipient = externalRecipientOverride
+        ? convertExternalRecipientToAutomationRecipient(externalRecipientOverride)
+        : convertCurrentUserToAutomationRecipient(users ?? [], currentUser);
     const enabledExternalRecipients = useDashboardSelector(selectEnableExternalRecipients);
 
     const firstChannel = notificationChannels[0]?.id;


### PR DESCRIPTION
- when external recipient is provided to dashboard, we filter automations by the recipient
- recipient is pre filled in automation dialogs
- recipients dropdown is empty is such case

JIRA: F1-1316
risk: low

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```

#### Commands for Bear platform working on branch rel/9.9

```
extended-test-legacy --backstop
extended-test-legacy --isolated
extended-test-legacy --record
```
