### PR TITLE
fix: automation filters

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/alerting/DefaultAlertingDialog/DefaultAlertingDialogNew.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/alerting/DefaultAlertingDialog/DefaultAlertingDialogNew.tsx
@@ -390,7 +390,7 @@ export function AlertingDialogRenderer({
                             </FormFieldGroup>
                             <ContentDivider className="gd-divider-with-margin" />
                             <FormFieldGroup label={<FormattedMessage id="insightAlert.config.do" />}>
-                                {editedAutomation?.notificationChannel ? (
+                                {notificationChannels.length > 1 && (
                                     <FormField
                                         label={<FormattedMessage id="insightAlert.config.action" />}
                                         htmlFor="alert.destination"
@@ -404,7 +404,7 @@ export function AlertingDialogRenderer({
                                             closeOnParentScroll={CLOSE_ON_PARENT_SCROLL}
                                         />
                                     </FormField>
-                                ) : null}
+                                )}
                                 <FormField
                                     label={<FormattedMessage id="insightAlert.config.trigger" />}
                                     htmlFor="alert.trigger"

--- a/libs/sdk-ui-dashboard/src/presentation/alerting/DefaultAlertingDialog/test/transform.test.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/alerting/DefaultAlertingDialog/test/transform.test.ts
@@ -497,6 +497,7 @@ describe("alert transforms", () => {
                     type: "displayForm",
                     identifier: "region",
                 },
+                showAllValues: false,
             },
         },
         type: "attribute",
@@ -972,6 +973,7 @@ describe("alert transforms", () => {
                                     in: {
                                         values: ["America"],
                                     },
+                                    localIdentifier: undefined,
                                 },
                             },
                         ],

--- a/libs/sdk-ui-dashboard/src/presentation/automationFilters/hooks/test/validateExistingAutomationFilters.test.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/automationFilters/hooks/test/validateExistingAutomationFilters.test.ts
@@ -3,6 +3,7 @@ import { createIntlMock } from "@gooddata/sdk-ui";
 import {
     dashboardFilterLocalIdentifier,
     FilterContextItem,
+    IAttributeFilter,
     IAutomationVisibleFilter,
     idRef,
     IFilterableWidget,
@@ -170,6 +171,17 @@ const changedInsightAttributeFilter = newPositiveAttributeFilter(
     ["changedElement"],
     "insightAttribute",
 );
+
+const sliceAttributeFilter: IAttributeFilter = {
+    positiveAttributeFilter: {
+        displayForm: {
+            localIdentifier: "attribute",
+        },
+        in: {
+            values: ["element"],
+        },
+    },
+};
 
 const [
     nonAllTimeCommonDateFilter,
@@ -1071,6 +1083,22 @@ describe("validateExistingAutomationFilters", () => {
         it("should be valid with empty filters", () => {
             const { isValid, removedFilterIsAppliedInSavedFilters } = validateExistingAutomationFilters({
                 savedAutomationFilters: [],
+                savedAutomationVisibleFilters: [],
+                hiddenFilters: [],
+                lockedFilters: [],
+                ignoredFilters: [],
+                dashboardFilters: [],
+                widget,
+                insight,
+            });
+
+            expect(isValid).toBe(true);
+            expect(removedFilterIsAppliedInSavedFilters).toBe(false);
+        });
+
+        it("should be valid with saved ad-hoc slicing attribute filter that is missing in insight", () => {
+            const { isValid, removedFilterIsAppliedInSavedFilters } = validateExistingAutomationFilters({
+                savedAutomationFilters: [sliceAttributeFilter],
                 savedAutomationVisibleFilters: [],
                 hiddenFilters: [],
                 lockedFilters: [],


### PR DESCRIPTION
- Fix handling of missing notification channel
- Fix automation filters validation to handle ad-hoc slicing attribute filters
- Fix handling of the ad-hoc slicing attribute filters and comparative operators on filters change

JIRA: F1-1455

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```

#### Commands for Bear platform working on branch rel/9.9

```
extended-test-legacy --backstop
extended-test-legacy --isolated
extended-test-legacy --record
```
