### PR TITLE
fix: hide last parent dropzone when hover over container drop zone

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/flexibleLayout/dragAndDrop/draggableWidget/EmptyNestedLayoutDropZone.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/flexibleLayout/dragAndDrop/draggableWidget/EmptyNestedLayoutDropZone.tsx
@@ -1,5 +1,5 @@
 // (C) 2022-2025 GoodData Corporation
-import React, { ReactNode } from "react";
+import React, { ReactNode, useEffect } from "react";
 import { FormattedMessage, defineMessages } from "react-intl";
 import cx from "classnames";
 import { Typography } from "@gooddata/sdk-ui-kit";
@@ -7,6 +7,7 @@ import { Typography } from "@gooddata/sdk-ui-kit";
 import { DraggableItemType } from "../../../dragAndDrop/types.js";
 import { useEmptyContentHandlers } from "./useEmptyContentHandlers.js";
 import { useDashboardItemPathAndSize } from "../../../dashboard/components/DashboardItemPathAndSizeContext.js";
+import { useWidgetDragHoverHandlers } from "./useWidgetDragHoverHandlers.js";
 
 const widgetCategoryMapping: Partial<{ [D in DraggableItemType]: string }> = {
     "insight-placeholder": "insight",
@@ -56,6 +57,14 @@ export const EmptyNestedLayoutDropZone: React.FC = () => {
     };
 
     const { itemType, canDrop, isOver, dropRef } = useEmptyContentHandlers(sectionPath);
+    const { handleDragHoverEnd } = useWidgetDragHoverHandlers();
+
+    useEffect(() => {
+        if (isOver) {
+            // hide section end drop zone in case when user drags widget to empty nested layout drag zone
+            handleDragHoverEnd();
+        }
+    }, [isOver, handleDragHoverEnd]);
 
     const widgetCategory = widgetCategoryMapping[itemType];
 

--- a/libs/sdk-ui-dashboard/src/presentation/flexibleLayout/dragAndDrop/draggableWidget/WidgetDropZone.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/flexibleLayout/dragAndDrop/draggableWidget/WidgetDropZone.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import { ILayoutItemPath } from "../../../../types.js";
 
 import { WidgetDropZoneBox } from "./WidgetDropZoneBox.js";
+import { hasParent } from "../../../../_staging/layout/coordinates.js";
 
 export type WidgetDropZoneProps = {
     isLastInSection: boolean;
@@ -11,14 +12,8 @@ export type WidgetDropZoneProps = {
     dropRef: any;
 };
 
-export const WidgetDropZone = (props: WidgetDropZoneProps) => {
-    const { isLastInSection, dropRef, layoutPath } = props;
-
-    const isInContainer = layoutPath.length > 1;
-
-    return (
-        <div className="widget-dropzone" ref={dropRef}>
-            <WidgetDropZoneBox isLast={isLastInSection} isInContainer={isInContainer} />
-        </div>
-    );
-};
+export const WidgetDropZone: React.FC<WidgetDropZoneProps> = ({ isLastInSection, dropRef, layoutPath }) => (
+    <div className="widget-dropzone" ref={dropRef}>
+        <WidgetDropZoneBox isLast={isLastInSection} isInContainer={hasParent(layoutPath)} />
+    </div>
+);


### PR DESCRIPTION
Two drop zones were highlighted at once before the fix.

JIRA: LX-750
risk: low

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```

#### Commands for Bear platform working on branch rel/9.9

```
extended-test-legacy --backstop
extended-test-legacy --isolated
extended-test-legacy --record
```
