### PR TITLE
fix(sdk-ui-dashboard): showing reset button when no change

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/filterBar/filterBar/hooks/useResetFiltersButton.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/filterBar/filterBar/hooks/useResetFiltersButton.ts
@@ -33,6 +33,7 @@ import {
     resetFilterContextWorkingSelection,
     selectEnableDashboardFiltersApplyModes,
     selectEnableDateFilterIdentifiers,
+    selectDashboardFiltersApplyMode,
 } from "../../../../model/index.js";
 import { generateDateFilterLocalIdentifier } from "@gooddata/sdk-backend-base";
 
@@ -59,6 +60,7 @@ export const useResetFiltersButton = (): {
     const disableUserFilterReset = useDashboardSelector(selectDisableDashboardUserFilterReset);
     const isWorkingFilterContextChanged = useDashboardSelector(selectIsWorkingFilterContextChanged);
     const enableDashboardFiltersApplyModes = useDashboardSelector(selectEnableDashboardFiltersApplyModes);
+    const dashboardFiltersApplyMode = useDashboardSelector(selectDashboardFiltersApplyMode).mode;
     const enableDateFilterIdentifiers = useDashboardSelector(selectEnableDateFilterIdentifiers);
 
     const dispatch = useDashboardDispatch();
@@ -108,7 +110,7 @@ export const useResetFiltersButton = (): {
                 // If the cross filter add some filters, we should allow the reset
                 ((!disableUserFilterReset && !disableUserFilterResetByConfig) ||
                     newlyAddedFiltersLocalIds.length > 0)) ||
-                !!isWorkingFilterContextChanged)
+                (!!isWorkingFilterContextChanged && dashboardFiltersApplyMode === "ALL_AT_ONCE"))
         );
     }, [
         isEditMode,
@@ -118,6 +120,7 @@ export const useResetFiltersButton = (): {
         disableUserFilterResetByConfig,
         newlyAddedFiltersLocalIds.length,
         isWorkingFilterContextChanged,
+        dashboardFiltersApplyMode,
     ]);
 
     const resetFilters = React.useCallback(() => {


### PR DESCRIPTION
- in individual apply mode when only working filter is changed

JIRA: LX-1061
risk: low

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```

#### Commands for Bear platform working on branch rel/9.9

```
extended-test-legacy --backstop
extended-test-legacy --isolated
extended-test-legacy --record
```
