### PR TITLE
fix: address missing accessible names for dialog and feedback buttons

### DIFF
--- a/libs/sdk-ui-gen-ai/src/components/GenAIChatOverlay.tsx
+++ b/libs/sdk-ui-gen-ai/src/components/GenAIChatOverlay.tsx
@@ -57,7 +57,12 @@ const GenAIChatOverlayComponent: React.FC<GenAIChatOverlayProps & WrappedCompone
             closeOnMouseDrag={false}
             onClose={onClose}
         >
-            <div className={classNames} role="dialog" aria-modal={isFullscreen}>
+            <div
+                className={classNames}
+                role="dialog"
+                aria-modal={isFullscreen}
+                aria-label={intl.formatMessage({ id: "gd.gen-ai.dialog.label" })}
+            >
                 <div className="gd-gen-ai-chat__window__header">
                     <HeaderIcon
                         Icon={Icon.Undo}

--- a/libs/sdk-ui-gen-ai/src/components/messages/AssistantMessage.tsx
+++ b/libs/sdk-ui-gen-ai/src/components/messages/AssistantMessage.tsx
@@ -2,7 +2,7 @@
 
 import React from "react";
 import cx from "classnames";
-import { Icon } from "@gooddata/sdk-ui-kit";
+import { Button, Icon } from "@gooddata/sdk-ui-kit";
 import { defineMessage, injectIntl, WrappedComponentProps } from "react-intl";
 import { connect } from "react-redux";
 
@@ -57,23 +57,25 @@ const AssistantMessageComponentCore: React.FC<AssistantMessageProps & WrappedCom
                             "gd-gen-ai-chat__messages__feedback--assigned": message.feedback !== "NONE",
                         })}
                     >
-                        <button
+                        <Button
                             className={cx({
                                 "gd-gen-ai-chat__messages__feedback__button": true,
                                 "gd-gen-ai-chat__messages__feedback__button--positive":
                                     message.feedback === "POSITIVE",
                             })}
-                            type="button"
                             onClick={() =>
                                 setUserFeedback({
                                     assistantMessageId: message.localId,
                                     feedback: message.feedback === "POSITIVE" ? "NONE" : "POSITIVE",
                                 })
                             }
+                            accessibilityConfig={{
+                                ariaLabel: intl.formatMessage({ id: "gd.gen-ai.feedback.like" }),
+                            }}
                         >
                             <Icon.ThumbsUp />
-                        </button>
-                        <button
+                        </Button>
+                        <Button
                             className={cx({
                                 "gd-gen-ai-chat__messages__feedback__button": true,
                                 "gd-gen-ai-chat__messages__feedback__button--negative":
@@ -86,9 +88,12 @@ const AssistantMessageComponentCore: React.FC<AssistantMessageProps & WrappedCom
                                     feedback: message.feedback === "NEGATIVE" ? "NONE" : "NEGATIVE",
                                 })
                             }
+                            accessibilityConfig={{
+                                ariaLabel: intl.formatMessage({ id: "gd.gen-ai.feedback.dislike" }),
+                            }}
                         >
                             <Icon.ThumbsDown />
-                        </button>
+                        </Button>
                     </div>
                 ) : null}
             </div>

--- a/libs/sdk-ui-gen-ai/src/localization/bundles/en-US.json
+++ b/libs/sdk-ui-gen-ai/src/localization/bundles/en-US.json
@@ -44,8 +44,23 @@
         "comment": "",
         "limit": 0
     },
+    "gd.gen-ai.feedback.like": {
+        "value": "Mark this message as helpful",
+        "comment": "",
+        "limit": 0
+    },
+    "gd.gen-ai.feedback.dislike": {
+        "value": "Mark this message as not helpful",
+        "comment": "",
+        "limit": 0
+    },
     "gd.gen-ai.disclaimer": {
         "value": "AI assistants can make mistakes. Check before relying on these answers.",
+        "comment": "",
+        "limit": 0
+    },
+    "gd.gen-ai.dialog.label": {
+        "value": "AI assistant chatbot dialog",
         "comment": "",
         "limit": 0
     },

--- a/libs/sdk-ui-gen-ai/styles/scss/messages.scss
+++ b/libs/sdk-ui-gen-ai/styles/scss/messages.scss
@@ -36,7 +36,6 @@
 .gd-gen-ai-chat__messages__feedback {
     display: flex;
     flex-direction: row;
-    gap: 10px;
     visibility: hidden;
     opacity: 0;
     height: 20px;


### PR DESCRIPTION
AI Assistant Accessibility: Address missing accessible names for dialog and feedback buttons

JIRA: GDAI-356
risk: low

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```

#### Commands for Bear platform working on branch rel/9.9

```
extended-test-legacy --backstop
extended-test-legacy --isolated
extended-test-legacy --record
```
