### PR TITLE
fix: widget options button and menu position

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/widget/common/configuration/ConfigurationBubble.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/common/configuration/ConfigurationBubble.tsx
@@ -27,6 +27,7 @@ export const defaultAlignPoints: IAlignPoint[] = [
     { align: "tr tl" },
     { align: "br bl" },
     { align: "tl tr" },
+    { align: "bl br" },
     { align: "tr tr" },
     { align: "br br" },
 ];
@@ -40,11 +41,10 @@ export const defaultFluidArrowOffsets: ArrowOffsets = {
 };
 
 export const defaultFlexibleArrowOffsets: ArrowOffsets = {
-    "tr tl": [7, 8],
-    "br bl": [7, -8],
-    "tl tr": [-7, 8],
-    "tr tr": [-76, 8],
-    "br br": [-76, -8],
+    "tr tl": [15, 16],
+    "br bl": [15, -16],
+    "tl tr": [-15, 16],
+    "bl br": [-15, -16],
 };
 
 export const defaultArrowDirections: ArrowDirections = {

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insightMenu/DefaultDashboardInsightMenu/DashboardInsightMenu/DashboardInsightMenuBubble.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insightMenu/DefaultDashboardInsightMenu/DashboardInsightMenu/DashboardInsightMenuBubble.tsx
@@ -1,4 +1,4 @@
-// (C) 2021-2024 GoodData Corporation
+// (C) 2021-2025 GoodData Corporation
 import React from "react";
 import cx from "classnames";
 import { stringUtils } from "@gooddata/util";
@@ -6,11 +6,13 @@ import { IWidget, objRefToString, widgetRef } from "@gooddata/sdk-model";
 import { ArrowDirections, ArrowOffsets, Bubble, IAlignPoint } from "@gooddata/sdk-ui-kit";
 
 import { IGNORED_CONFIGURATION_MENU_CLICK_CLASS } from "../../../../constants/index.js";
+import { useDashboardSelector, selectEnableFlexibleLayout } from "../../../../../model/index.js";
 
 const alignPoints: IAlignPoint[] = [
     { align: "tr tl" },
     { align: "br bl" },
     { align: "tl tr" },
+    { align: "bl br" },
     { align: "tr tr" },
     { align: "br br" },
 ];
@@ -20,9 +22,16 @@ const arrowDirections: ArrowDirections = {
     "br br": "right",
 };
 
-const arrowOffsets: ArrowOffsets = {
+const fluidArrowOffsets: ArrowOffsets = {
     "tr tl": [20, 0],
     "tl tr": [-20, 0],
+};
+
+const flexibleArrowOffsets: ArrowOffsets = {
+    "tr tl": [16, -2],
+    "br bl": [16, 27],
+    "tl tr": [-16, -2],
+    "bl br": [-16, 27],
 };
 
 interface IDashboardInsightMenuBubbleProps {
@@ -35,13 +44,14 @@ interface IDashboardInsightMenuBubbleProps {
 export const DashboardInsightMenuBubble: React.FC<IDashboardInsightMenuBubbleProps> = (props) => {
     const { onClose, isSubmenu, widget, children } = props;
     const widgetRefAsString = objRefToString(widgetRef(widget));
+    const isFlexibleLayoutEnabled = useDashboardSelector(selectEnableFlexibleLayout);
 
     return (
         <Bubble
             alignTo={`.dash-item-action-widget-options-${stringUtils.simplifyText(widgetRefAsString)}`}
             alignPoints={alignPoints}
             arrowDirections={arrowDirections}
-            arrowOffsets={arrowOffsets}
+            arrowOffsets={isFlexibleLayoutEnabled ? flexibleArrowOffsets : fluidArrowOffsets}
             className={cx(
                 "bubble-light",
                 "gd-configuration-bubble",

--- a/libs/sdk-ui-dashboard/src/presentation/widget/richTextMenu/DefaultDashboardRichTextMenu/DashboardRichTextMenu/DashboardRichTextMenuContainer.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/richTextMenu/DefaultDashboardRichTextMenu/DashboardRichTextMenu/DashboardRichTextMenuContainer.tsx
@@ -27,7 +27,11 @@ export const DashboardRichTextMenuContainer: React.FC<IDashboardRichTextMenuCont
                     dataTestId="s-configuration-panel-header-close-button"
                 />
             </div>
-            <ItemsWrapper smallItemsSpacing style={itemsWrapperStyle}>
+            <ItemsWrapper
+                smallItemsSpacing
+                style={itemsWrapperStyle}
+                className="gd-rich-text-insight-configuration-menu-item"
+            >
                 {props.children}
             </ItemsWrapper>
         </div>

--- a/libs/sdk-ui-dashboard/styles/scss/dashboard.scss
+++ b/libs/sdk-ui-dashboard/styles/scss/dashboard.scss
@@ -814,3 +814,13 @@ $dashboard-menu-item-icon-color: var(--gd-palette-complementary-5-from-theme, #b
         right: 20px;
     }
 }
+
+.sdk-edit-mode-on {
+    .gd-grid-layout {
+        .item-headline-outer {
+            // Make title headline narrower so the widget option menu does not overlap the widget title.
+            // Top margin is taken from rule this rule overrides. This change is necessary only in edit mode.
+            margin: 10px 50px 0;
+        }
+    }
+}

--- a/libs/sdk-ui-dashboard/styles/scss/insightConfiguration.scss
+++ b/libs/sdk-ui-dashboard/styles/scss/insightConfiguration.scss
@@ -90,6 +90,7 @@ $delete-hover-status-bg: var(--gd-palette-error-lightest, #fff2f1);
 
             .insight-menu-title-wrapper {
                 flex: 1;
+                overflow: hidden;
             }
 
             p.insight-title {
@@ -110,6 +111,8 @@ $delete-hover-status-bg: var(--gd-palette-error-lightest, #fff2f1);
     }
 
     .configuration-panel-header-close-button[class*="gd-icon-"] {
+        height: 23px; // fix icon height to the same as the text before it
+
         &::before {
             font-size: 14px;
         }

--- a/libs/sdk-ui-dashboard/styles/scss/layout.scss
+++ b/libs/sdk-ui-dashboard/styles/scss/layout.scss
@@ -454,6 +454,12 @@ $gd-dashboards-section-description-color: var(
                 color: kit-variables.$gd-color-state-blank;
             }
         }
+
+        .gd-row-header-view {
+            .description {
+                padding: 4px 5px 15px; // add bottom padding after section description, same as fluid layout
+            }
+        }
     }
 
     .gd-fluid-layout-row-header-container--with-headers {
@@ -493,6 +499,11 @@ $gd-dashboards-section-description-color: var(
     display: flex;
     flex-direction: column;
     position: relative;
+
+    .gd-editable-label {
+        // fix height of the title of widget in edit mode, long title is shortened to parent height
+        max-height: inherit;
+    }
 }
 
 // generate classes for grid span from 1 to 12

--- a/libs/sdk-ui-dashboard/styles/scss/richTextWidget.scss
+++ b/libs/sdk-ui-dashboard/styles/scss/richTextWidget.scss
@@ -102,3 +102,12 @@
     align-items: center;
     gap: 8px;
 }
+
+// can be removed once the menu is rewritten to new UI kit menu component that adds missing padding
+.edit-insight-config {
+    .insight-configuration {
+        .gd-menu-wrapper-small-spacing.gd-menu-wrapper.gd-rich-text-insight-configuration-menu-item {
+            padding-bottom: 8px;
+        }
+    }
+}


### PR DESCRIPTION
- widget option btn does not overlap section description in view mode
- widget option btn does not overlap insight title in edit mode
- widget option button is better aligned in both modes
- widget option menu is aligned to the button in both modes
- rich text widget menu style is aligned with insight widget one

JIRA: LX-780
risk: low

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```

#### Commands for Bear platform working on branch rel/9.9

```
extended-test-legacy --backstop
extended-test-legacy --isolated
extended-test-legacy --record
```
