### PR TITLE
fix: overflowing insight title of widget in edit mode

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/flexibleLayout/DefaultDashboardLayoutRenderer/useItemWidthValidation.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/flexibleLayout/DefaultDashboardLayoutRenderer/useItemWidthValidation.tsx
@@ -20,7 +20,7 @@ export const useWidthValidation = (
     const isValid = !(parentWidthForScreen && itemWidth > parentWidthForScreen);
 
     return {
-        isValid: !(parentWidthForScreen && itemWidth > parentWidthForScreen),
+        isValid,
         parentWidth: parentWidthForScreen,
         validWidth: isValid ? itemWidth : parentWidthForScreen ?? DASHBOARD_LAYOUT_GRID_COLUMNS_COUNT,
     };

--- a/libs/sdk-ui-dashboard/src/presentation/flexibleLayout/dragAndDrop/draggableWidget/RowEndHotspot.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/flexibleLayout/dragAndDrop/draggableWidget/RowEndHotspot.tsx
@@ -1,7 +1,7 @@
 // (C) 2007-2025 GoodData Corporation
 import { IDashboardWidget } from "@gooddata/sdk-model";
 import cx from "classnames";
-import React from "react";
+import React, { useMemo } from "react";
 
 import { selectIsInEditMode, useDashboardSelector } from "../../../../model/index.js";
 import { IDashboardLayoutItemFacade } from "../../../../_staging/dashboard/flexibleLayout/index.js";
@@ -27,7 +27,13 @@ export const RowEndHotspot = (props: RowEndHotspotProps<unknown>) => {
     const isLastInRow = item.isLastInRow(screen);
     const showEndingHotspot = (item.isLastInSection() || isLastInRow) && isInEditMode;
 
-    if (!showEndingHotspot) {
+    const remainingRowGridWidth = useMemo(
+        () => getRemainingWidthInRow(item, screen, rowIndex),
+        [item, screen, rowIndex],
+    );
+    const isDropZoneVisible = shouldShowRowEndDropZone(remainingRowGridWidth);
+
+    if (!showEndingHotspot || !isDropZoneVisible) {
         return null;
     }
 
@@ -36,9 +42,6 @@ export const RowEndHotspot = (props: RowEndHotspotProps<unknown>) => {
         layoutPath[layoutPath.length - 1].sectionIndex,
         layoutPath[layoutPath.length - 1].itemIndex + 1,
     ); // increment item index manually as end hotspot is rendered as prev type
-
-    const remainingRowGridWidth = getRemainingWidthInRow(item, screen, rowIndex);
-    const isDropZoneVisible = shouldShowRowEndDropZone(remainingRowGridWidth);
 
     return (
         <>
@@ -62,13 +65,11 @@ export const RowEndHotspot = (props: RowEndHotspotProps<unknown>) => {
                     },
                 )}
             >
-                {isDropZoneVisible ? (
-                    <WidgetDropZoneColumn
-                        layoutPath={layoutPathForEndHotspot}
-                        isLastInSection={true}
-                        gridWidthOverride={remainingRowGridWidth}
-                    />
-                ) : null}
+                <WidgetDropZoneColumn
+                    layoutPath={layoutPathForEndHotspot}
+                    isLastInSection={true}
+                    gridWidthOverride={remainingRowGridWidth}
+                />
                 <Hotspot
                     dropZoneType="prev"
                     isEndingHotspot

--- a/libs/sdk-ui-dashboard/styles/scss/dashboardNestedLayoutWidget.scss
+++ b/libs/sdk-ui-dashboard/styles/scss/dashboardNestedLayoutWidget.scss
@@ -47,8 +47,7 @@
 
 .gd-nested-layout-widget-renderer {
     .gd-nested-layout-hotspot.dropzone {
-        width: min(10%, 50px); // 10% of left and right side of the widget, or 50px, whatever is smaller
-        min-width: 24px; // ensure usage in narrow containers, when parent dropzone would cover child one
+        width: 50px;
     }
 }
 

--- a/libs/sdk-ui-dashboard/styles/scss/layout.scss
+++ b/libs/sdk-ui-dashboard/styles/scss/layout.scss
@@ -503,6 +503,7 @@ $gd-dashboards-section-description-color: var(
     .gd-editable-label {
         // fix height of the title of widget in edit mode, long title is shortened to parent height
         max-height: inherit;
+        overflow: hidden;
     }
 }
 


### PR DESCRIPTION
JIRA: LX-780
risk: low

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```

#### Commands for Bear platform working on branch rel/9.9

```
extended-test-legacy --backstop
extended-test-legacy --isolated
extended-test-legacy --record
```
