### PR TITLE
feat: objects selected via auto-completion are used deterministically

### DIFF
--- a/libs/sdk-model/api/sdk-model.api.md
+++ b/libs/sdk-model/api/sdk-model.api.md
@@ -3171,6 +3171,9 @@ export function isCatalogAttribute(obj: unknown): obj is ICatalogAttribute;
 // @public
 export function isCatalogAttributeHierarchy(obj: unknown): obj is ICatalogAttributeHierarchy;
 
+// @public
+export function isCatalogDateAttribute(obj: unknown): obj is ICatalogDateAttribute;
+
 // @internal (undocumented)
 export function isCatalogDateAttributeHierarchy(obj: unknown): obj is ICatalogDateAttributeHierarchy;
 

--- a/libs/sdk-model/src/index.ts
+++ b/libs/sdk-model/src/index.ts
@@ -680,6 +680,7 @@ export {
     isCatalogFact,
     isCatalogMeasure,
     isCatalogDateDataset,
+    isCatalogDateAttribute,
     catalogItemMetadataObject,
     getHierarchyRef,
     getHierarchyTitle,

--- a/libs/sdk-model/src/ldm/catalog/dateDataset/index.ts
+++ b/libs/sdk-model/src/ldm/catalog/dateDataset/index.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2020 GoodData Corporation
+// (C) 2019-2025 GoodData Corporation
 import isEmpty from "lodash/isEmpty.js";
 import { ICatalogItemBase } from "../types.js";
 import { IAttributeMetadataObject } from "../../metadata/attribute/index.js";
@@ -26,6 +26,16 @@ export interface ICatalogDateAttribute {
      * Date attribute default display form metadata object
      */
     defaultDisplayForm: IAttributeDisplayFormMetadataObject;
+}
+
+/**
+ * Type guard checking whether object is an instance of ICatalogDateDataset.
+ *
+ * @public
+ */
+export function isCatalogDateAttribute(obj: unknown): obj is ICatalogDateAttribute {
+    const o = obj as ICatalogDateAttribute;
+    return !isEmpty(obj) && Boolean(o.attribute && o.defaultDisplayForm && o.granularity);
 }
 
 /**

--- a/libs/sdk-model/src/ldm/catalog/index.ts
+++ b/libs/sdk-model/src/ldm/catalog/index.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2024 GoodData Corporation
+// (C) 2019-2025 GoodData Corporation
 import { ICatalogAttribute, isCatalogAttribute } from "./attribute/index.js";
 import { ICatalogMeasure, isCatalogMeasure } from "./measure/index.js";
 import { ICatalogFact, isCatalogFact } from "./fact/index.js";
@@ -62,7 +62,7 @@ export { isCatalogMeasure } from "./measure/index.js";
 export type { ICatalogFact } from "./fact/index.js";
 export { isCatalogFact } from "./fact/index.js";
 export type { ICatalogDateDataset, ICatalogDateAttribute } from "./dateDataset/index.js";
-export { isCatalogDateDataset } from "./dateDataset/index.js";
+export { isCatalogDateDataset, isCatalogDateAttribute } from "./dateDataset/index.js";
 export type { ICatalogGroup, IGroupableCatalogItemBase } from "./group/index.js";
 export type {
     ICatalogAttributeHierarchy,

--- a/libs/sdk-ui-gen-ai/src/components/completion/plugins/rehype-references.ts
+++ b/libs/sdk-ui-gen-ai/src/components/completion/plugins/rehype-references.ts
@@ -82,6 +82,7 @@ function iterateReferenceMatch<T>(
 ): T[] {
     const items: T[] = [];
     const regex = getReferenceRegex();
+
     let match = regex.exec(value);
     while (match) {
         const [type, id] = match[1].split("/");

--- a/libs/sdk-ui-gen-ai/src/components/completion/references.ts
+++ b/libs/sdk-ui-gen-ai/src/components/completion/references.ts
@@ -1,11 +1,14 @@
 // (C) 2025 GoodData Corporation
-import { CatalogItem } from "@gooddata/sdk-model";
+import { CatalogItem, ICatalogDateAttribute } from "@gooddata/sdk-model";
 
 import { TextContentObject } from "../../model.js";
 
 import { getCatalogItemId, getCatalogItemTitle, getCatalogItemType } from "./utils.js";
 
-export function collectReferences(text: string, used: CatalogItem[]): TextContentObject[] {
+export function collectReferences(
+    text: string,
+    used: (CatalogItem | ICatalogDateAttribute)[],
+): TextContentObject[] {
     const items: TextContentObject[] = [];
     used.forEach((item) => {
         const id = getCatalogItemId(item);

--- a/libs/sdk-ui-gen-ai/src/components/completion/useCompletion.ts
+++ b/libs/sdk-ui-gen-ai/src/components/completion/useCompletion.ts
@@ -3,7 +3,7 @@ import { useCallback, useRef, useState, MutableRefObject } from "react";
 import { IWorkspaceCatalog } from "@gooddata/sdk-backend-spi";
 import { useBackendStrict, useWorkspaceStrict } from "@gooddata/sdk-ui";
 import { CompletionContext, CompletionResult, CompletionSource } from "@codemirror/autocomplete";
-import { CatalogItem } from "@gooddata/sdk-model";
+import { CatalogItem, ICatalogDateAttribute } from "@gooddata/sdk-model";
 import { useIntl } from "react-intl";
 
 import { CompletionItem, getCatalogItemId, getCompletionItemId, getOptions } from "./utils.js";
@@ -12,7 +12,7 @@ const WORD_REGEX = /\p{L}[\p{L}\p{N}_]*/u;
 
 export interface IUseCompletion {
     onCompletion: CompletionSource;
-    used: MutableRefObject<CatalogItem[]>;
+    used: MutableRefObject<(CatalogItem | ICatalogDateAttribute)[]>;
 }
 
 export function useCompletion(
@@ -21,7 +21,7 @@ export function useCompletion(
     { canManage, canAnalyze }: { canManage?: boolean; canAnalyze?: boolean },
 ): IUseCompletion {
     const [catalogItems, setCatalogItems] = useState<CatalogItem[] | undefined>(items);
-    const usedItems = useRef<CatalogItem[]>(selected ?? []);
+    const usedItems = useRef<(CatalogItem | ICatalogDateAttribute)[]>(selected ?? []);
     const backend = useBackendStrict();
     const workspace = useWorkspaceStrict();
     const intl = useIntl();

--- a/libs/sdk-ui-gen-ai/src/components/completion/utils.ts
+++ b/libs/sdk-ui-gen-ai/src/components/completion/utils.ts
@@ -4,7 +4,9 @@ import { IntlShape } from "react-intl";
 import { Completion } from "@codemirror/autocomplete";
 import {
     CatalogItem,
+    ICatalogDateAttribute,
     isCatalogAttribute,
+    isCatalogDateAttribute,
     isCatalogDateDataset,
     isCatalogFact,
     isCatalogMeasure,
@@ -13,7 +15,7 @@ import {
 import { getInfo } from "./InfoComponent.js";
 
 export interface CompletionItem extends Completion {
-    item: CatalogItem;
+    item: CatalogItem | ICatalogDateAttribute;
 }
 
 // Utility: Get item title
@@ -161,7 +163,7 @@ export function getItems(
                     canManage,
                     canAnalyze,
                 }),
-                item,
+                item: attr,
                 apply: (view, completion, from, to) => {
                     const type = "attribute" as typeof SupportedReferenceTypes[number];
                     const insert = `{${type}/${attr.attribute.id}}`;
@@ -206,7 +208,7 @@ export function getCompletionItemId(data: CompletionItem) {
 }
 
 // Utility: Get catalog item ID
-export function getCatalogItemId(item: CatalogItem) {
+export function getCatalogItemId(item: CatalogItem | ICatalogDateAttribute): string | null {
     if (isCatalogFact(item)) {
         return item.fact.id;
     }
@@ -219,11 +221,14 @@ export function getCatalogItemId(item: CatalogItem) {
     if (isCatalogDateDataset(item)) {
         return item.dataSet.id;
     }
+    if (isCatalogDateAttribute(item)) {
+        return item.attribute.id;
+    }
     return null;
 }
 
 // Utility: Get catalog item ID
-export function getCatalogItemTitle(item: CatalogItem) {
+export function getCatalogItemTitle(item: CatalogItem | ICatalogDateAttribute) {
     if (isCatalogFact(item)) {
         return item.fact.title ?? item.fact.id;
     }
@@ -236,11 +241,16 @@ export function getCatalogItemTitle(item: CatalogItem) {
     if (isCatalogDateDataset(item)) {
         return item.dataSet.title ?? item.dataSet.id;
     }
+    if (isCatalogDateAttribute(item)) {
+        return item.attribute.title ?? item.attribute.id;
+    }
     return "Unknown Item";
 }
 
 // Utility: Get a catalog item type
-export function getCatalogItemType(item: CatalogItem): typeof SupportedReferenceTypes[number] | null {
+export function getCatalogItemType(
+    item: CatalogItem | ICatalogDateAttribute,
+): typeof SupportedReferenceTypes[number] | null {
     if (isCatalogFact(item)) {
         return "fact";
     }
@@ -252,6 +262,9 @@ export function getCatalogItemType(item: CatalogItem): typeof SupportedReference
     }
     if (isCatalogDateDataset(item)) {
         return "dataset";
+    }
+    if (isCatalogDateAttribute(item)) {
+        return "attribute";
     }
     return null;
 }


### PR DESCRIPTION
Objects selected via auto-completion are used deterministically in ad-hoc visualizations

JIRA: GDAI-347
risk: low

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```

#### Commands for Bear platform working on branch rel/9.9

```
extended-test-legacy --backstop
extended-test-legacy --isolated
extended-test-legacy --record
```
