### PR TITLE
fix: wrong type of dataset date object in chat references

### DIFF
--- a/libs/sdk-ui-gen-ai/api/sdk-ui-gen-ai.api.md
+++ b/libs/sdk-ui-gen-ai/api/sdk-ui-gen-ai.api.md
@@ -194,7 +194,7 @@ export type SearchContents = {
 // @public (undocumented)
 export type TextContentObject = {
     id: string;
-    type: "metric" | "attribute" | "fact" | "dataset";
+    type: "metric" | "attribute" | "fact" | "date";
     title: string;
 };
 

--- a/libs/sdk-ui-gen-ai/src/components/completion/plugins/rehype-references.ts
+++ b/libs/sdk-ui-gen-ai/src/components/completion/plugins/rehype-references.ts
@@ -23,7 +23,7 @@ export function rehypeReferences(references: TextContentObject[]) {
                                     metric: obj.type === "metric",
                                     attribute: obj.type === "attribute",
                                     fact: obj.type === "fact",
-                                    date: obj.type === "dataset",
+                                    date: obj.type === "date",
                                 }),
                                 style: {},
                             },

--- a/libs/sdk-ui-gen-ai/src/components/completion/utils.ts
+++ b/libs/sdk-ui-gen-ai/src/components/completion/utils.ts
@@ -62,7 +62,7 @@ export function getOptions(
     });
 }
 
-const SupportedReferenceTypes = ["fact", "metric", "dataset", "attribute"] as const;
+const SupportedReferenceTypes = ["fact", "metric", "date", "attribute"] as const;
 
 // Utility: Get regex for references
 export function getReferenceRegex(split?: boolean) {
@@ -187,7 +187,7 @@ export function getItems(
                 }),
                 item,
                 apply: (view, completion, from, to) => {
-                    const type = "dataset" as typeof SupportedReferenceTypes[number];
+                    const type = "date" as typeof SupportedReferenceTypes[number];
                     const insert = `{${type}/${item.dataSet.id}}`;
                     onCompletionSelected?.(completion as CompletionItem);
                     view.dispatch({
@@ -261,7 +261,7 @@ export function getCatalogItemType(
         return "metric";
     }
     if (isCatalogDateDataset(item)) {
-        return "dataset";
+        return "date";
     }
     if (isCatalogDateAttribute(item)) {
         return "attribute";

--- a/libs/sdk-ui-gen-ai/src/model.ts
+++ b/libs/sdk-ui-gen-ai/src/model.ts
@@ -12,7 +12,7 @@ import {
  */
 export type TextContentObject = {
     id: string;
-    type: "metric" | "attribute" | "fact" | "dataset";
+    type: "metric" | "attribute" | "fact" | "date";
     title: string;
 };
 


### PR DESCRIPTION
JIRA: GDAI-383
risk: low

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```

#### Commands for Bear platform working on branch rel/9.9

```
extended-test-legacy --backstop
extended-test-legacy --isolated
extended-test-legacy --record
```
