### PR TITLE
fix: autocomplete is not working in UI SDK.

### DIFF
--- a/common/config/rush/browser-approved-packages.json
+++ b/common/config/rush/browser-approved-packages.json
@@ -76,11 +76,11 @@
     },
     {
       "name": "@codemirror/state",
-      "allowedCategories": [ "production" ]
+      "allowedCategories": [ "production", "tools" ]
     },
     {
       "name": "@codemirror/view",
-      "allowedCategories": [ "production" ]
+      "allowedCategories": [ "production", "tools" ]
     },
     {
       "name": "@componentdriven/csf",
@@ -180,7 +180,7 @@
     },
     {
       "name": "@gooddata/sdk-ui-gen-ai",
-      "allowedCategories": [ "examples", "production" ]
+      "allowedCategories": [ "examples", "production", "tools" ]
     },
     {
       "name": "@gooddata/sdk-ui-geo",

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -6493,6 +6493,12 @@ importers:
 
   ../../tools/react-app-template:
     dependencies:
+      '@codemirror/state':
+        specifier: ~6.5.2
+        version: 6.5.2
+      '@codemirror/view':
+        specifier: ~6.36.4
+        version: 6.36.5
       '@gooddata/sdk-backend-base':
         specifier: workspace:*
         version: link:../../libs/sdk-backend-base
@@ -6520,6 +6526,9 @@ importers:
       '@gooddata/sdk-ui-filters':
         specifier: workspace:*
         version: link:../../libs/sdk-ui-filters
+      '@gooddata/sdk-ui-gen-ai':
+        specifier: workspace:*
+        version: link:../../libs/sdk-ui-gen-ai
       '@gooddata/sdk-ui-geo':
         specifier: workspace:*
         version: link:../../libs/sdk-ui-geo

--- a/docs/config/_default/config.toml
+++ b/docs/config/_default/config.toml
@@ -144,6 +144,9 @@ link = "/latest/introduction/"
 [[params.404.links]]
 title = "Quick Start"
 link = "/latest/quick_start/"
+[[params.404.links]]
+title = "CodeMirror 6 Integration"
+link = "/latest/codemirror6_genai_integration/"
 
 [params.mermaid]
 enable = true

--- a/docs/content/en/latest/CodeMirror6_GenAI_Integration.md
+++ b/docs/content/en/latest/CodeMirror6_GenAI_Integration.md
@@ -1,0 +1,72 @@
+# CodeMirror 6 Integration with Gen AI Chat Component
+
+## Overview
+
+This document explains the integration between CodeMirror 6 and the GoodData Gen AI chat component. The integration ensures proper functionality of code editing capabilities within the chat interface.
+
+## Required Webpack Configuration
+
+When integrating CodeMirror 6 with the Gen AI chat component, specific webpack configurations are necessary to avoid duplicate package instances and ensure proper functionality:
+
+```javascript
+// In webpack.config.js/cjs
+resolve: {
+    // Dedupe packages to avoid duplicate instances
+    alias: {
+        "@codemirror/state": path.resolve(__dirname, "node_modules/@codemirror/state"),
+        "@codemirror/view": path.resolve(__dirname, "node_modules/@codemirror/view"),
+    },
+},
+```
+
+### Why This Configuration Is Necessary
+
+CodeMirror 6 is modular and consists of several packages that work together. The two most critical packages that require deduplication are:
+
+1. **@codemirror/state**: Manages the editor state and transactions
+2. **@codemirror/view**: Handles the DOM representation of the editor
+
+Without proper deduplication, you may encounter the following issues:
+
+-   Multiple instances of CodeMirror packages leading to broken functionality
+-   Errors related to incompatible state objects
+-   Rendering problems in the code editor within the chat interface
+
+## Vite Configuration
+
+If your project uses Vite instead of Webpack, you'll need a different configuration to achieve the same result. Add the following to your `vite.config.js` or `vite.config.ts`:
+
+```javascript
+// In vite.config.js/ts
+export default defineConfig({
+    // Other Vite config options...
+    optimizeDeps: {
+        exclude: ["@codemirror/state", "@codemirror/view"],
+    },
+    resolve: {
+        alias: [], // Your other aliases if needed
+        dedupe: ["@codemirror/state", "@codemirror/view"],
+    },
+});
+```
+
+### Vite Configuration Explanation
+
+1. **optimizeDeps.exclude**: Prevents Vite from optimizing these packages during development, which can cause issues with CodeMirror's internal mechanisms.
+2. **resolve.dedupe**: Ensures that only one instance of each CodeMirror package is used throughout your application, preventing the same issues that the Webpack alias configuration addresses.
+
+This configuration is crucial for ensuring that CodeMirror works correctly with the Gen AI chat component in Vite-based projects.
+
+## Troubleshooting
+
+If you encounter issues with the CodeMirror editor in the Gen AI chat component:
+
+1. Verify that the webpack aliases are correctly configured
+2. Check for any version mismatches between CodeMirror packages
+3. Ensure all required styles are properly imported
+4. Check the browser console for any specific error messages related to CodeMirror
+
+## Related Documentation
+
+-   [CodeMirror 6 Documentation](https://codemirror.net/docs/)
+-   [GoodData UI SDK Documentation](https://sdk.gooddata.com/gooddata-ui/)

--- a/examples/playground/vite.config.ts
+++ b/examples/playground/vite.config.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2024 GoodData Corporation
+// (C) 2019-2025 GoodData Corporation
 import { defineConfig, loadEnv } from "vite";
 import react from "@vitejs/plugin-react";
 import * as path from "path";
@@ -66,7 +66,12 @@ export default defineConfig(({ mode }) => {
     return {
         plugins: [react()],
         optimizeDeps: {
-            exclude: [...packagesWithoutStyles, ...packagesWithStyles],
+            exclude: [
+                "@codemirror/state",
+                "@codemirror/view",
+                ...packagesWithoutStyles,
+                ...packagesWithStyles,
+            ],
         },
         resolve: {
             alias: [
@@ -89,6 +94,7 @@ export default defineConfig(({ mode }) => {
                     makePackageSourceAlias(pkg),
                 ]),
             ],
+            dedupe: ["@codemirror/state", "@codemirror/view"],
         },
         server: {
             ...serverOptions,

--- a/tools/react-app-template/package.json
+++ b/tools/react-app-template/package.json
@@ -56,6 +56,9 @@
         "@gooddata/sdk-ui-filters": "workspace:*",
         "@gooddata/sdk-ui-geo": "workspace:*",
         "@gooddata/sdk-ui-pivot": "workspace:*",
+        "@gooddata/sdk-ui-gen-ai": "workspace:*",
+        "@codemirror/view": "~6.36.4",
+        "@codemirror/state": "~6.5.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "tslib": "^2.5.0"

--- a/tools/react-app-template/src/index.tsx
+++ b/tools/react-app-template/src/index.tsx
@@ -1,13 +1,14 @@
-// (C) 2019-2023 GoodData Corporation
+// (C) 2019-2025 GoodData Corporation
 import React from "react";
 import { createRoot } from "react-dom/client";
 import { provideCreateRoot } from "@gooddata/sdk-ui-ext";
 
 import { App } from "./App.js";
 
-// Include GoodData styles, needed for correct visualizations rendering
-// You may exclude some file if you're not planning to use all visualizations
-// For example, you can exclude sdk-ui-geo styles if you're not planning to use PushPin GeoChart
+// Include GoodData styles, needed for correct visualizations rendering.
+// You may exclude some file if you're not planning to use all visualizations.
+// For example, you can exclude sdk-ui-geo styles if you're not planning to use PushPin GeoChart.
+// You may exclude sdk-ui-gen-ai if you're not planning to use generative ai chat.
 import "@gooddata/sdk-ui-kit/styles/css/main.css";
 import "@gooddata/sdk-ui-filters/styles/css/main.css";
 import "@gooddata/sdk-ui-charts/styles/css/main.css";
@@ -15,6 +16,7 @@ import "@gooddata/sdk-ui-pivot/styles/css/main.css";
 import "@gooddata/sdk-ui-geo/styles/css/main.css";
 import "@gooddata/sdk-ui-ext/styles/css/main.css";
 import "@gooddata/sdk-ui-dashboard/styles/css/main.css";
+import "@gooddata/sdk-ui-gen-ai/styles/css/main.css";
 
 import "./index.css";
 

--- a/tools/react-app-template/webpack.config.cjs
+++ b/tools/react-app-template/webpack.config.cjs
@@ -66,6 +66,12 @@ module.exports = (_env, argv) => {
 
                 // Prefer ESM versions of packages to enable tree shaking
                 mainFields: ["module", "browser", "main"],
+
+                // Dedupe packages to avoid duplicate instances
+                alias: {
+                    "@codemirror/state": path.resolve(__dirname, "node_modules/@codemirror/state"),
+                    "@codemirror/view": path.resolve(__dirname, "node_modules/@codemirror/view"),
+                },
             },
             module: {
                 rules: [


### PR DESCRIPTION
- Add new documentation for CodeMirror 6 integration with GenAI Chat component
- Update Vite configuration to properly handle CodeMirror dependencies:
  - Add @codemirror/state and @codemirror/view to exclude list
  - Add deduplication for CodeMirror packages to prevent duplicate instances
- Update playground example to demonstrate GenAI Chat component:
  - Replace Playground component with GenAI Chat component
  - Add necessary imports for GenAI Chat
- Update documentation navigation to include link to new CodeMirror integration guide
- Update webpack configurations in template for proper CodeMirror support

This change ensures proper functionality of code editing capabilities within the GenAI chat interface by preventing duplicate package instances of CodeMirror.

JIRA: GDAI-357
risk: low

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```

#### Commands for Bear platform working on branch rel/9.9

```
extended-test-legacy --backstop
extended-test-legacy --isolated
extended-test-legacy --record
```
