### PR TITLE
fix: dark themes affect the border and query text of chatbot

### DIFF
--- a/libs/sdk-ui-gen-ai/styles/scss/messages.scss
+++ b/libs/sdk-ui-gen-ai/styles/scss/messages.scss
@@ -20,6 +20,11 @@
     display: flex;
     flex-direction: column;
     gap: 15px;
+
+    .react-loading-skeleton {
+        --base-color: #{kit-variables.$is-focused-background};
+        --highlight-color: #{kit-variables.$gd-color-white};
+    }
 }
 
 .gd-gen-ai-chat__messages__message {

--- a/libs/sdk-ui-gen-ai/styles/scss/window.scss
+++ b/libs/sdk-ui-gen-ai/styles/scss/window.scss
@@ -10,14 +10,17 @@
     width: 420px;
     height: calc(100vh - 84px);
     background-color: kit-variables.$gd-color-light;
-    border-width: 1px;
-    border-radius: 3px;
-    box-shadow: 0 1px 20px 0 color-mix(in sRGB, kit-variables.$gd-palette-primary-base 20%, transparent);
     display: flex;
     flex-direction: column;
     margin: 0 1em 1em 0;
     //stylelint-disable-next-line declaration-no-important
+    box-shadow: 0 1px 20px 0 color-mix(in sRGB, kit-variables.$gd-palette-primary-base 20%, transparent) !important;
+    //stylelint-disable-next-line declaration-no-important
     padding: 0 !important;
+    //stylelint-disable-next-line declaration-no-important
+    border-width: 1px !important;
+    //stylelint-disable-next-line declaration-no-important
+    border-radius: 3px !important;
 
     &--fullscreen {
         margin: 0;

--- a/libs/sdk-ui-kit/styles/scss/syntaxHighlightingInput.scss
+++ b/libs/sdk-ui-kit/styles/scss/syntaxHighlightingInput.scss
@@ -13,7 +13,7 @@
         border: 1px solid variables.$gd-input-text-border;
         line-height: normal;
         vertical-align: middle;
-        color: variables.$default-gd-color-text;
+        color: variables.$gd-medium-gray;
         background: variables.$gd-color-white;
         font-size: 14px;
         font-family: monospace;
@@ -28,7 +28,8 @@
         );
 
         @include mixins.placeholder {
-            color: color.adjust(variables.$default-gd-color-link, $alpha: -0.25);
+            color: variables.$gd-color-link;
+            opacity: 0.75;
 
             @include mixins.transition(color, 0.25s, ease-in-out);
         }
@@ -57,6 +58,15 @@
 
         .cm-nonmatchingBracket {
             color: variables.$gd-palette-error-base;
+        }
+
+        .cm-content {
+            caret-color: variables.$gd-medium-gray;
+        }
+
+        .cm-placeholder {
+            color: variables.$gd-color-link;
+            opacity: 0.75;
         }
     }
 }


### PR DESCRIPTION
Custom theme - Dark themes affect the border and query text of AI Chatbot

JIRA: GDAI-384
risk: low

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```

#### Commands for Bear platform working on branch rel/9.9

```
extended-test-legacy --backstop
extended-test-legacy --isolated
extended-test-legacy --record
```
