### PR TITLE
test: move sdk checklist to team qa channel

### DIFF
--- a/.github/workflows/checklist-integrated-staging.yaml
+++ b/.github/workflows/checklist-integrated-staging.yaml
@@ -131,7 +131,7 @@ jobs:
         uses: slackapi/slack-github-action@v1.27.1
         if: ${{ !cancelled() && needs.setup-stage.outputs.send_message_to_slack_channel == 'true' }}
         with:
-          channel-id: panther-checklist-testing
+          channel-id: team-qa
           slack-message: "${{ steps.alls-green.outcome == 'success' &&  ':unicorn_face:' || ':robot_panic:' }} `checklist-SDK-${{ github.ref_name }}-branch: ` *${{ steps.alls-green.outcome == 'success' &&  'success' || 'failed' }}*; please check *<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|the logs>*."
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}


### PR DESCRIPTION
Moving sdk checklist that basic checking for sdk release to team-qa channel instead of panther-checklist-testing (where includes info of daily panther release)

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```

#### Commands for Bear platform working on branch rel/9.9

```
extended-test-legacy --backstop
extended-test-legacy --isolated
extended-test-legacy --record
```
