### PR TITLE
fix(sdk-ui-filters): no filter values when ignore limiting filter

### DIFF
--- a/libs/sdk-ui-filters/src/AttributeFilter/hooks/useAttributeFilterController.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilter/hooks/useAttributeFilterController.ts
@@ -192,6 +192,7 @@ export const useAttributeFilterController = (
             shouldReloadElements,
             setShouldReloadElements,
             displayAsLabel,
+            shouldIncludeLimitingFilters,
         },
         supportsKeepingDependentFiltersSelection,
         supportsCircularDependencyInFilters,
@@ -312,6 +313,7 @@ function useInitOrReload(
         shouldReloadElements: MutableRefObject<boolean>;
         setShouldReloadElements: (value: boolean) => void;
         displayAsLabel: ObjRef;
+        shouldIncludeLimitingFilters: boolean;
     },
     supportsKeepingDependentFiltersSelection: boolean,
     supportsCircularDependencyInFilters: boolean,
@@ -333,6 +335,7 @@ function useInitOrReload(
         shouldReloadElements,
         setShouldReloadElements,
         displayAsLabel,
+        shouldIncludeLimitingFilters,
     } = props;
 
     useEffect(() => {
@@ -361,7 +364,7 @@ function useInitOrReload(
 
     useEffect(() => {
         const limitingAttributesChanged = !isEqual(
-            limitingAttributeFilters,
+            shouldIncludeLimitingFilters ? limitingAttributeFilters : [],
             handler.getLimitingAttributeFilters(),
         );
 
@@ -475,6 +478,7 @@ function useInitOrReload(
         enableDuplicatedLabelValuesInAttributeFilter,
         enableDashboardFiltersApplyModes,
         shouldReloadElements,
+        shouldIncludeLimitingFilters,
     ]);
 
     const isMountedRef = useRef(false);


### PR DESCRIPTION
- when parent filter has some selection

JIRA: LX-1196
risk: low

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```

#### Commands for Bear platform working on branch rel/9.9

```
extended-test-legacy --backstop
extended-test-legacy --isolated
extended-test-legacy --record
```
