### PR TITLE
fix: correctly use onChange in automation attribute filter

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/automationFilters/components/AutomationAttributeFilter.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/automationFilters/components/AutomationAttributeFilter.tsx
@@ -1,22 +1,14 @@
 // (C) 2025 GoodData Corporation
 
-import React, { useCallback, useMemo } from "react";
-import {
-    FilterContextItem,
-    IAttributeFilter,
-    IDashboardAttributeFilter,
-    isNegativeAttributeFilter,
-    ObjRef,
-} from "@gooddata/sdk-model";
+import React, { useCallback } from "react";
+import { FilterContextItem, IDashboardAttributeFilter, ObjRef } from "@gooddata/sdk-model";
 import {
     AttributeFilterButton,
     IAttributeFilterButtonProps,
     IAttributeFilterDropdownButtonProps,
 } from "@gooddata/sdk-ui-filters";
 import { Bubble, BubbleHoverTrigger, OverlayPositionType, UiChip, UiSkeleton } from "@gooddata/sdk-ui-kit";
-import noop from "lodash/noop.js";
 import { DefaultDashboardAttributeFilter } from "../../../presentation/filterBar/index.js";
-import { attributeFilterToDashboardAttributeFilter } from "../../../_staging/dashboard/dashboardFilterConverter.js";
 import {
     AutomationAttributeFilterProvider,
     useAutomationAttributeFilterContext,
@@ -38,6 +30,7 @@ export const AutomationAttributeFilter: React.FC<{
 }> = ({ filter, onChange, onDelete, isLocked, displayAsLabel, overlayPositionType }) => {
     const intl = useIntl();
     const deleteAriaLabel = intl.formatMessage({ id: "delete" });
+
     return (
         <AutomationAttributeFilterProvider
             filter={filter}
@@ -46,52 +39,45 @@ export const AutomationAttributeFilter: React.FC<{
             isLocked={isLocked}
             deleteAriaLabel={deleteAriaLabel}
         >
-            <DefaultDashboardAttributeFilter
-                filter={filter}
-                onFilterChanged={noop}
+            <AttributeFilterWrapper
                 displayAsLabel={displayAsLabel}
-                AttributeFilterComponent={AttributeFilter}
                 overlayPositionType={overlayPositionType}
             />
         </AutomationAttributeFilterProvider>
     );
 };
 
-function AttributeFilter(props: IAttributeFilterButtonProps) {
+const AttributeFilterWrapper = ({
+    displayAsLabel,
+    overlayPositionType,
+}: {
+    displayAsLabel?: ObjRef;
+    overlayPositionType?: OverlayPositionType;
+}) => {
     const { onChange, filter } = useAutomationAttributeFilterContext();
 
-    const filterTitle = useMemo(() => {
-        return filter?.attributeFilter.title;
-    }, [filter]);
-
-    const filterLocalIdentifier = useMemo(() => {
-        return filter?.attributeFilter.localIdentifier;
-    }, [filter]);
-
-    const filterSelectionMode = useMemo(() => {
-        return filter?.attributeFilter.selectionMode;
-    }, [filter]);
-
-    const handleOnApply = useCallback(
-        (newFilter: IAttributeFilter) => {
-            onChange?.(
-                attributeFilterToDashboardAttributeFilter(
-                    newFilter,
-                    filterLocalIdentifier,
-                    filterTitle,
-                    undefined,
-                    isNegativeAttributeFilter(newFilter),
-                    filterSelectionMode,
-                ),
-            );
+    const handleFilterChanged = useCallback(
+        (newFilter: IDashboardAttributeFilter) => {
+            onChange(newFilter);
         },
-        [filterLocalIdentifier, filterSelectionMode, filterTitle, onChange],
+        [onChange],
     );
 
     return (
+        <DefaultDashboardAttributeFilter
+            filter={filter}
+            onFilterChanged={handleFilterChanged}
+            displayAsLabel={displayAsLabel}
+            AttributeFilterComponent={AttributeFilter}
+            overlayPositionType={overlayPositionType}
+        />
+    );
+};
+
+function AttributeFilter(props: IAttributeFilterButtonProps) {
+    return (
         <AttributeFilterButton
             {...props}
-            onApply={handleOnApply}
             LoadingComponent={AutomationAttributeFilterLoadingComponent}
             DropdownButtonComponent={AutomationAttributeFilterDropdownButtonComponent}
         />


### PR DESCRIPTION
JIRA: F1-1521
risk: low

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```

#### Commands for Bear platform working on branch rel/9.9

```
extended-test-legacy --backstop
extended-test-legacy --isolated
extended-test-legacy --record
```
