### PR TITLE
fix: improve zooming in charts with forced data label visibility

### DIFF
--- a/libs/sdk-ui-charts/src/highcharts/adapter/plugins/autohideLabels/autohideLabelsOverlappingItsShape.ts
+++ b/libs/sdk-ui-charts/src/highcharts/adapter/plugins/autohideLabels/autohideLabelsOverlappingItsShape.ts
@@ -22,13 +22,13 @@ function autohideLabelsOverlappingItsShape(
     const visibleSeries = getVisibleSeries(chart);
     const visiblePoints = getDataPoints(visibleSeries);
 
-    const axesWithCategories = getAxesWithCategoriesFromSpaceFillingChart(chart);
+    const zoomableAxes = getAxesWithCategoriesFromSpaceFillingChart(chart);
 
     visiblePoints.forEach((point: any) => {
         if (point) {
             // bubble chart has two axes but none of them has categories and is affected by zooming
             const isPointVisible =
-                axesWithCategories.length <= 0 || isPointVisibleInAxesRanges(point, axesWithCategories);
+                zoomableAxes.length <= 0 || isPointVisibleInAxesRanges(point, zoomableAxes);
             if (
                 isLabelOverlappingItsShape(point) ||
                 intersectsParentLabel(point, visiblePoints) ||

--- a/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartCreators/dataLabelsHelpers.ts
+++ b/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartCreators/dataLabelsHelpers.ts
@@ -122,15 +122,15 @@ export interface IInsideResult {
 }
 
 export function showDataLabelInAxisRange(
-    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-    point: any,
+    point: Highcharts.Point,
     value: number,
     axisRangeForAxes: IAxisRangeForAxes,
+    isVisibleInZoomedAxis: boolean,
 ): void {
-    const isSecondAxis = point?.series?.yAxis?.opposite ?? false;
+    const isSecondAxis = point?.series?.yAxis?.options?.opposite ?? false;
     const axisRange: IAxisRange = axisRangeForAxes[isSecondAxis ? "second" : "first"];
     const isInsideAxisRange = pointInRange(value, axisRange);
-    if (!isInsideAxisRange) {
+    if (!isInsideAxisRange || !isVisibleInZoomedAxis) {
         hideDataLabel(point);
     } else {
         showDataLabel(point);
@@ -138,14 +138,18 @@ export function showDataLabelInAxisRange(
 }
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-export function showStackLabelInAxisRange(point: any, axisRangeForAxes: IAxisRangeForAxes): void {
-    const isSecondAxis = point.series?.yAxis?.opposite ?? false;
+export function showStackLabelInAxisRange(
+    point: Highcharts.Point,
+    axisRangeForAxes: IAxisRangeForAxes,
+    isVisibleInZoomedAxis: boolean,
+): void {
+    const isSecondAxis = point.series?.yAxis?.options?.opposite ?? false;
     const axisRange: IAxisRange = axisRangeForAxes[isSecondAxis ? "second" : "first"];
-    const end = point.stackY || point.total;
+    const end = (point as any).stackY || point.total;
     const start = end - point.y;
     const isWholeUnderMin: boolean = start <= axisRange.minAxisValue && end <= axisRange.minAxisValue;
     const isWholeAboveMax: boolean = start >= axisRange.maxAxisValue && end >= axisRange.maxAxisValue;
-    if (isWholeUnderMin || isWholeAboveMax) {
+    if (isWholeUnderMin || isWholeAboveMax || !isVisibleInZoomedAxis) {
         hideDataLabel(point);
     }
 }

--- a/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartCreators/helpers.ts
+++ b/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartCreators/helpers.ts
@@ -463,8 +463,12 @@ export function getPointsVisibleInAxisRange(
     if (!axis) {
         return points;
     }
+    return points.filter((point) => isPointVisibleInAxisRange(point, axis));
+}
+
+export function isPointVisibleInAxisRange(point: Highcharts.Point, axis: Highcharts.Axis): boolean {
     const { min, max } = axis.getExtremes();
-    return points.filter((point) => point.x >= min && point.x <= Math.round(max));
+    return point.x >= min && point.x <= Math.round(max);
 }
 
 export function getPointsVisibleInAxesRanges(

--- a/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartCreators/test/dataLabelsHelpers.test.ts
+++ b/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartCreators/test/dataLabelsHelpers.test.ts
@@ -1,4 +1,4 @@
-// (C) 2007-2021 GoodData Corporation
+// (C) 2007-2025 GoodData Corporation
 import set from "lodash/set.js";
 import {
     getDataLabelAttributes,
@@ -206,26 +206,26 @@ describe("dataLabelsHelpers", () => {
 
         it("should show data label in second axis", () => {
             point.y = 15;
-            point = set(point, "series.yAxis.opposite", true);
-            showDataLabelInAxisRange(point, point.y, axisRangeForAxes);
+            point = set(point, "series.yAxis.options.opposite", true);
+            showDataLabelInAxisRange(point, point.y, axisRangeForAxes, true);
             expect(point.dataLabel.hide).not.toHaveBeenCalled();
         });
 
         it("should hide data label in second axis", () => {
             point.y = 30;
-            point = set(point, "series.yAxis.opposite", true);
-            showDataLabelInAxisRange(point, point.y, axisRangeForAxes);
+            point = set(point, "series.yAxis.options.opposite", true);
+            showDataLabelInAxisRange(point, point.y, axisRangeForAxes, true);
             expect(point.dataLabel.hide).toHaveBeenCalled();
         });
 
         it("should keep shown data label when inside axis range", () => {
-            showDataLabelInAxisRange(point, point.y, axisRangeForAxes);
+            showDataLabelInAxisRange(point, point.y, axisRangeForAxes, true);
             expect(point.dataLabel.hide).not.toHaveBeenCalled();
         });
 
         it("should hide data label when outside axis range", () => {
             point.y = 20;
-            showDataLabelInAxisRange(point, point.y, axisRangeForAxes);
+            showDataLabelInAxisRange(point, point.y, axisRangeForAxes, true);
             expect(point.dataLabel.hide).toHaveBeenCalled();
         });
     });
@@ -267,42 +267,47 @@ describe("dataLabelsHelpers", () => {
         });
 
         it("should keep shown data label when inside axis range", () => {
-            showStackLabelInAxisRange(point, axisRangeForAxes);
+            showStackLabelInAxisRange(point, axisRangeForAxes, true);
             expect(point.dataLabel.hide).not.toHaveBeenCalled();
         });
 
         it("should hide data label when outside axis range", () => {
             point.y = 10;
             point.stackY = 20;
-            showStackLabelInAxisRange(point, axisRangeForAxes);
+            showStackLabelInAxisRange(point, axisRangeForAxes, true);
             expect(point.dataLabel.hide).toHaveBeenCalled();
         });
 
         it("should show data label in second axis", () => {
             point.y = 15;
             point.stackY = 15;
-            point = set(point, "series.yAxis.opposite", true);
-            showStackLabelInAxisRange(point, axisRangeForAxes);
+            point = set(point, "series.yAxis.options.opposite", true);
+            showStackLabelInAxisRange(point, axisRangeForAxes, true);
             expect(point.dataLabel.hide).not.toHaveBeenCalled();
         });
 
         it("should hide data label in second axis outside range", () => {
             point.y = 30;
-            point = set(point, "series.yAxis.opposite", true);
-            showStackLabelInAxisRange(point, axisRangeForAxes);
+            point = set(point, "series.yAxis.options.opposite", true);
+            showStackLabelInAxisRange(point, axisRangeForAxes, true);
             expect(point.dataLabel.hide).toHaveBeenCalled();
         });
 
         it("should show last data label without stackY", () => {
             delete point.stackY;
             point.total = 10;
-            showStackLabelInAxisRange(point, axisRangeForAxes);
+            showStackLabelInAxisRange(point, axisRangeForAxes, true);
             expect(point.dataLabel.hide).not.toHaveBeenCalled();
         });
 
         it("should hide last data label without stackY", () => {
             delete point.stackY;
-            showStackLabelInAxisRange(point, axisRangeForAxes);
+            showStackLabelInAxisRange(point, axisRangeForAxes, true);
+            expect(point.dataLabel.hide).toHaveBeenCalled();
+        });
+
+        it("should hide data label when outside of zoomed axis range", () => {
+            showStackLabelInAxisRange(point, axisRangeForAxes, false);
             expect(point.dataLabel.hide).toHaveBeenCalled();
         });
     });


### PR DESCRIPTION
+ added types on some places

JIRA: LX-725
risk: low

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```

#### Commands for Bear platform working on branch rel/9.9

```
extended-test-legacy --backstop
extended-test-legacy --isolated
extended-test-legacy --record
```
