### PR TITLE
fix: do not reinit attribute filter when without apply mode is on

### DIFF
--- a/libs/sdk-backend-tiger/src/backend/features/feature.ts
+++ b/libs/sdk-backend-tiger/src/backend/features/feature.ts
@@ -800,6 +800,13 @@ export function mapFeatures(features: FeaturesMap): Partial<ITigerFeatureFlags> 
             "BOOLEAN",
             FeatureFlagsValues.enableDestinationTestRecipient,
         ),
+        ...loadFeature(
+            features,
+            TigerFeaturesNames.EnableDashboardFiltersApplyWithoutLoading,
+            "enableDashboardFiltersApplyWithoutLoading",
+            "BOOLEAN",
+            FeatureFlagsValues.enableDashboardFiltersApplyWithoutLoading,
+        ),
     };
 }
 

--- a/libs/sdk-backend-tiger/src/backend/uiFeatures.ts
+++ b/libs/sdk-backend-tiger/src/backend/uiFeatures.ts
@@ -153,6 +153,7 @@ export enum TigerFeaturesNames {
     EnableNotificationChannelIdentifiers = "enableNotificationChannelIdentifiers",
     EnableDashboardShareDialogLink = "enableDashboardShareDialogLink",
     EnableDestinationTestRecipient = "enableDestinationTestRecipient",
+    EnableDashboardFiltersApplyWithoutLoading = "enableDashboardFiltersApplyWithoutLoading",
 }
 
 export type ITigerFeatureFlags = {
@@ -268,6 +269,7 @@ export type ITigerFeatureFlags = {
     enableNotificationChannelIdentifiers: typeof FeatureFlagsValues["enableNotificationChannelIdentifiers"][number];
     enableDashboardShareDialogLink: typeof FeatureFlagsValues["enableDashboardShareDialogLink"][number];
     enableDestinationTestRecipient: typeof FeatureFlagsValues["enableDestinationTestRecipient"][number];
+    enableDashboardFiltersApplyWithoutLoading: typeof FeatureFlagsValues["enableDashboardFiltersApplyWithoutLoading"][number];
 };
 
 export const DefaultFeatureFlags: ITigerFeatureFlags = {
@@ -383,6 +385,7 @@ export const DefaultFeatureFlags: ITigerFeatureFlags = {
     enableNotificationChannelIdentifiers: false,
     enableDashboardShareDialogLink: false,
     enableDestinationTestRecipient: false,
+    enableDashboardFiltersApplyWithoutLoading: false,
 };
 
 export const FeatureFlagsValues = {
@@ -502,4 +505,5 @@ export const FeatureFlagsValues = {
     enableNotificationChannelIdentifiers: [true, false] as const,
     enableDashboardShareDialogLink: [true, false] as const,
     enableDestinationTestRecipient: [true, false] as const,
+    enableDashboardFiltersApplyWithoutLoading: [true, false] as const,
 };

--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -8836,6 +8836,9 @@ export const selectEnableDashboardDescriptionDynamicHeight: DashboardSelector<bo
 export const selectEnableDashboardFiltersApplyModes: DashboardSelector<boolean>;
 
 // @internal
+export const selectEnableDashboardFiltersApplyWithoutLoading: DashboardSelector<boolean>;
+
+// @internal
 export const selectEnableDashboardShareDialogLink: DashboardSelector<boolean>;
 
 // @internal

--- a/libs/sdk-ui-dashboard/src/model/store/config/configSelectors.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/config/configSelectors.ts
@@ -1096,3 +1096,15 @@ export const selectEnableDashboardShareDialogLink: DashboardSelector<boolean> = 
         return Boolean(state.settings?.enableDashboardShareDialogLink) ?? false;
     },
 );
+
+/**
+ * Selector for the dashboard filters apply without loading feature flag
+ *
+ * @internal
+ */
+export const selectEnableDashboardFiltersApplyWithoutLoading: DashboardSelector<boolean> = createSelector(
+    selectConfig,
+    (state) => {
+        return Boolean(state.settings?.enableDashboardFiltersApplyWithoutLoading) ?? false;
+    },
+);

--- a/libs/sdk-ui-dashboard/src/model/store/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/index.ts
@@ -121,6 +121,7 @@ export {
     selectEnableExportToDocumentStorage,
     selectExternalRecipient,
     selectEnableDashboardShareDialogLink,
+    selectEnableDashboardFiltersApplyWithoutLoading,
 } from "./config/configSelectors.js";
 export type { EntitlementsState } from "./entitlements/entitlementsState.js";
 export {

--- a/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/DefaultDashboardAttributeFilter.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/DefaultDashboardAttributeFilter.tsx
@@ -42,6 +42,7 @@ import {
     selectDashboardFiltersApplyMode,
     selectEnableDashboardFiltersApplyModes,
     selectEnableAttributeFilterVirtualisedList,
+    selectEnableDashboardFiltersApplyWithoutLoading,
 } from "../../../model/index.js";
 import { useAttributes } from "../../../_staging/sharedHooks/useAttributes.js";
 import { getVisibilityIcon } from "../utils.js";
@@ -121,6 +122,9 @@ const DefaultDashboardAttributeFilterInner = (props: IDashboardAttributeFilterPr
     );
     const filtersApplyMode = useDashboardSelector(selectDashboardFiltersApplyMode);
     const enableDashboardFiltersApplyModes = useDashboardSelector(selectEnableDashboardFiltersApplyModes);
+    const enableDashboardFiltersApplyWithoutLoading = useDashboardSelector(
+        selectEnableDashboardFiltersApplyWithoutLoading,
+    );
     const enableAttributeFilterVirtualisedList = useDashboardSelector(
         selectEnableAttributeFilterVirtualisedList,
     );
@@ -506,6 +510,7 @@ const DefaultDashboardAttributeFilterInner = (props: IDashboardAttributeFilterPr
                 enableAttributeFilterVirtualised={enableAttributeFilterVirtualisedList}
                 withoutApply={filtersApplyMode.mode === "ALL_AT_ONCE" && enableDashboardFiltersApplyModes}
                 enableDashboardFiltersApplyModes={enableDashboardFiltersApplyModes}
+                enableDashboardFiltersApplyWithoutLoading={enableDashboardFiltersApplyWithoutLoading}
             />
         </AttributeFilterParentFilteringProvider>
     );

--- a/libs/sdk-ui-filters/api/sdk-ui-filters.api.md
+++ b/libs/sdk-ui-filters/api/sdk-ui-filters.api.md
@@ -410,6 +410,8 @@ export interface IAttributeFilterCoreProps {
     displayAsLabel?: ObjRef;
     enableAttributeFilterVirtualised?: boolean;
     enableDashboardFiltersApplyModes?: boolean;
+    // @alpha
+    enableDashboardFiltersApplyWithoutLoading?: boolean;
     enableDuplicatedLabelValuesInAttributeFilter?: boolean;
     enableImmediateAttributeFilterDisplayAsLabelMigration?: boolean;
     filter?: IAttributeFilter;

--- a/libs/sdk-ui-filters/src/AttributeFilter/AttributeFilterProviders.tsx
+++ b/libs/sdk-ui-filters/src/AttributeFilter/AttributeFilterProviders.tsx
@@ -53,6 +53,7 @@ export const AttributeFilterProviders: React.FC<IAttributeFilterBaseProps & { ch
         enableDuplicatedLabelValuesInAttributeFilter = true,
         enableAttributeFilterVirtualised,
         enableImmediateAttributeFilterDisplayAsLabelMigration = false,
+        enableDashboardFiltersApplyWithoutLoading = false,
     } = props;
 
     const DefaultComponents = getAttributeFilterDefaultComponents(props);
@@ -119,6 +120,7 @@ export const AttributeFilterProviders: React.FC<IAttributeFilterBaseProps & { ch
                     withoutApply={props.withoutApply}
                     enableDashboardFiltersApplyModes={props.enableDashboardFiltersApplyModes}
                     overlayPositionType={props.overlayPositionType}
+                    enableDashboardFiltersApplyWithoutLoading={enableDashboardFiltersApplyWithoutLoading}
                 >
                     {children}
                 </AttributeFilterContextProvider>

--- a/libs/sdk-ui-filters/src/AttributeFilter/hooks/useAttributeFilterController.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilter/hooks/useAttributeFilterController.ts
@@ -105,6 +105,7 @@ export const useAttributeFilterController = (
         enableDashboardFiltersApplyModes = false,
         enableAttributeFilterVirtualised = false,
         withoutApply = false,
+        enableDashboardFiltersApplyWithoutLoading = false,
     } = props;
 
     const backend = useBackendStrict(backendInput, "AttributeFilter");
@@ -193,11 +194,13 @@ export const useAttributeFilterController = (
             setShouldReloadElements,
             displayAsLabel,
             shouldIncludeLimitingFilters,
+            withoutApply,
         },
         supportsKeepingDependentFiltersSelection,
         supportsCircularDependencyInFilters,
         enableDuplicatedLabelValuesInAttributeFilter,
         enableDashboardFiltersApplyModes,
+        enableDashboardFiltersApplyWithoutLoading,
     );
     const callbacks = useCallbacks(
         handler,
@@ -314,11 +317,13 @@ function useInitOrReload(
         setShouldReloadElements: (value: boolean) => void;
         displayAsLabel: ObjRef;
         shouldIncludeLimitingFilters: boolean;
+        withoutApply: boolean;
     },
     supportsKeepingDependentFiltersSelection: boolean,
     supportsCircularDependencyInFilters: boolean,
     enableDuplicatedLabelValuesInAttributeFilter: boolean,
     enableDashboardFiltersApplyModes: boolean,
+    enableDashboardFiltersApplyWithoutLoading: boolean,
 ) {
     const {
         filter,
@@ -336,6 +341,7 @@ function useInitOrReload(
         setShouldReloadElements,
         displayAsLabel,
         shouldIncludeLimitingFilters,
+        withoutApply,
     } = props;
 
     useEffect(() => {
@@ -437,6 +443,7 @@ function useInitOrReload(
             limitingValidationItems,
             limitingValidationItemsChanged,
             displayAsLabel,
+            withoutApply,
         };
 
         const change = resetOnParentFilterChange
@@ -447,6 +454,7 @@ function useInitOrReload(
                   supportsKeepingDependentFiltersSelection,
                   enableDuplicatedLabelValuesInAttributeFilter,
                   enableDashboardFiltersApplyModes,
+                  enableDashboardFiltersApplyWithoutLoading,
               );
         refreshByType(
             handler,
@@ -479,6 +487,8 @@ function useInitOrReload(
         enableDashboardFiltersApplyModes,
         shouldReloadElements,
         shouldIncludeLimitingFilters,
+        withoutApply,
+        enableDashboardFiltersApplyWithoutLoading,
     ]);
 
     const isMountedRef = useRef(false);
@@ -547,6 +557,7 @@ type UpdateFilterProps = {
     setShouldReloadElements: (value: boolean) => void;
     limitingValidationItems: ObjRef[];
     limitingValidationItemsChanged: boolean;
+    withoutApply: boolean;
 };
 
 type UpdateFilterType = "init-parent" | "init-self" | undefined;
@@ -565,10 +576,12 @@ function updateNonResettingFilter(
         limitingValidationItemsChanged,
         limitingValidationItems,
         displayAsLabel,
+        withoutApply,
     }: UpdateFilterProps,
     supportsKeepingDependentFiltersSelection: boolean,
     enableDuplicatedLabelValuesInAttributeFilter: boolean,
     enableDashboardFiltersApplyModes: boolean,
+    enableDashboardFiltersApplyWithoutLoading: boolean,
 ): UpdateFilterType {
     if (
         limitingAttributesChanged ||
@@ -626,6 +639,13 @@ function updateNonResettingFilter(
             setShouldReloadElements(true);
             return "init-parent";
         }
+
+        // If the filter changes are commited without apply, we want to avoid loading based on FF.
+        // This is experimental and will be removed after the feature is fully tested and released.
+        if (enableDashboardFiltersApplyWithoutLoading && enableDashboardFiltersApplyModes && withoutApply) {
+            return undefined;
+        }
+
         return "init-self";
     }
 

--- a/libs/sdk-ui-filters/src/AttributeFilter/types.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilter/types.ts
@@ -315,6 +315,17 @@ export interface IAttributeFilterCoreProps {
      * Specifies the overlay position type for the attribute filter dropdown.
      */
     overlayPositionType?: OverlayPositionType;
+
+    /**
+     * Enables the new apply all filters at once mode without loading on every change
+     *
+     * @remarks
+     * This is a temporary flag to enable the new apply all filters at once mode without loading on every change.
+     * It will be removed after the feature is fully tested and released.
+     *
+     * @alpha
+     */
+    enableDashboardFiltersApplyWithoutLoading?: boolean;
 }
 
 /**


### PR DESCRIPTION
JIRA: F1-1521
risk: low

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```

#### Commands for Bear platform working on branch rel/9.9

```
extended-test-legacy --backstop
extended-test-legacy --isolated
extended-test-legacy --record
```
