### PR TITLE
fix(sdk-ui-filters): revert PR #6682

### DIFF
--- a/libs/sdk-ui-filters/src/AttributeFilter/hooks/useAttributeFilterController.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilter/hooks/useAttributeFilterController.ts
@@ -193,7 +193,6 @@ export const useAttributeFilterController = (
             shouldReloadElements,
             setShouldReloadElements,
             displayAsLabel,
-            shouldIncludeLimitingFilters,
             withoutApply,
         },
         supportsKeepingDependentFiltersSelection,
@@ -316,7 +315,6 @@ function useInitOrReload(
         shouldReloadElements: MutableRefObject<boolean>;
         setShouldReloadElements: (value: boolean) => void;
         displayAsLabel: ObjRef;
-        shouldIncludeLimitingFilters: boolean;
         withoutApply: boolean;
     },
     supportsKeepingDependentFiltersSelection: boolean,
@@ -340,7 +338,6 @@ function useInitOrReload(
         shouldReloadElements,
         setShouldReloadElements,
         displayAsLabel,
-        shouldIncludeLimitingFilters,
         withoutApply,
     } = props;
 
@@ -370,7 +367,7 @@ function useInitOrReload(
 
     useEffect(() => {
         const limitingAttributesChanged = !isEqual(
-            shouldIncludeLimitingFilters ? limitingAttributeFilters : [],
+            limitingAttributeFilters,
             handler.getLimitingAttributeFilters(),
         );
 
@@ -486,7 +483,6 @@ function useInitOrReload(
         enableDuplicatedLabelValuesInAttributeFilter,
         enableDashboardFiltersApplyModes,
         shouldReloadElements,
-        shouldIncludeLimitingFilters,
         withoutApply,
         enableDashboardFiltersApplyWithoutLoading,
     ]);


### PR DESCRIPTION
- revert: no filter values when ignore limiting filter
- it introduced a bug with loading dependent filter values

JIRA: LX-1196
risk: low

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```

#### Commands for Bear platform working on branch rel/9.9

```
extended-test-legacy --backstop
extended-test-legacy --isolated
extended-test-legacy --record
```
