### PR TITLE
fix: ai assistant not read correctly by screen readers

### DIFF
--- a/libs/sdk-ui-kit/api/sdk-ui-kit.api.md
+++ b/libs/sdk-ui-kit/api/sdk-ui-kit.api.md
@@ -5024,6 +5024,8 @@ export interface IUiNavigationBypassProps {
     label: string;
     // (undocumented)
     onItemClick?: (item: IUiNavigationItem) => void;
+    // (undocumented)
+    style?: React_2.CSSProperties;
 }
 
 // @internal (undocumented)

--- a/libs/sdk-ui-kit/src/@ui/@utils/tests/keyboardNavigationTarget.test.tsx
+++ b/libs/sdk-ui-kit/src/@ui/@utils/tests/keyboardNavigationTarget.test.tsx
@@ -1,0 +1,63 @@
+// (C) 2025 GoodData Corporation
+
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { IntlProvider } from "react-intl";
+import { describe, it, expect, vi } from "vitest";
+import { messagesMap, pickCorrectWording } from "@gooddata/sdk-ui";
+import { useKeyboardNavigationTarget } from "../useKeyboardNavigationTarget";
+
+describe("useKeyboardNavigationTarget", () => {
+    const renderHook = () => {
+        const DefaultLocale = "en-US";
+        const onFocus = vi.fn();
+
+        const messages = pickCorrectWording(messagesMap[DefaultLocale], {
+            workspace: "mockWorkspace",
+            enableRenamingMeasureToMetric: true,
+        });
+
+        const Component = () => {
+            const { targetRef } = useKeyboardNavigationTarget({
+                label: "Test label",
+                tabIndex: 1,
+                navigationId: "test-id",
+                onFocus,
+            });
+
+            return <div data-testid="target" ref={targetRef} />;
+        };
+
+        const res = render(
+            <IntlProvider key={DefaultLocale} locale={DefaultLocale} messages={messages}>
+                <Component />
+            </IntlProvider>,
+        );
+
+        return {
+            res,
+            onFocus,
+        };
+    };
+
+    it("render and update target", () => {
+        renderHook();
+
+        expect(screen.getByTestId("target")).toBeInTheDocument();
+        expect(screen.getByTestId("target").outerHTML).toBe(
+            `<div data-testid="target" id="test-id" tabindex="1" role="navigation" aria-label="Test label"></div>`,
+        );
+    });
+
+    it("check focus call", () => {
+        const { onFocus } = renderHook();
+
+        const div = screen.getByTestId("target");
+
+        expect(onFocus).not.toHaveBeenCalled();
+
+        div.focus();
+
+        expect(onFocus).toHaveBeenCalled();
+    });
+});

--- a/libs/sdk-ui-kit/src/@ui/UiNavigationBypass/UiNavigationBypass.tsx
+++ b/libs/sdk-ui-kit/src/@ui/UiNavigationBypass/UiNavigationBypass.tsx
@@ -23,6 +23,7 @@ export interface IUiNavigationItem {
 export interface IUiNavigationBypassProps {
     items: IUiNavigationItem[];
     label: string;
+    style?: React.CSSProperties;
     onItemClick?: (item: IUiNavigationItem) => void;
 }
 
@@ -38,7 +39,12 @@ interface IUiNavigationBypassItem {
 /**
  * @internal
  */
-export const UiNavigationBypass: React.FC<IUiNavigationBypassProps> = ({ label, items, onItemClick }) => {
+export const UiNavigationBypass: React.FC<IUiNavigationBypassProps> = ({
+    label,
+    items,
+    onItemClick,
+    style,
+}) => {
     const [isFocused, setIsFocused] = useState(false);
     const containerRef = useRef<HTMLDivElement>(null);
     const contentRef = useRef<HTMLDivElement>(null);
@@ -109,6 +115,7 @@ export const UiNavigationBypass: React.FC<IUiNavigationBypassProps> = ({ label, 
             <div
                 role="menu"
                 className={b()}
+                style={style}
                 ref={containerRef}
                 onFocus={handleFocus}
                 onBlur={handleBlur}

--- a/libs/sdk-ui-kit/src/@ui/UiNavigationBypass/tests/UiNavigationBypass.test.tsx
+++ b/libs/sdk-ui-kit/src/@ui/UiNavigationBypass/tests/UiNavigationBypass.test.tsx
@@ -1,0 +1,116 @@
+// (C) 2025 GoodData Corporation
+
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { IntlProvider } from "react-intl";
+import { describe, it, expect, vi } from "vitest";
+import { messagesMap, pickCorrectWording } from "@gooddata/sdk-ui";
+import { UiNavigationBypass } from "../UiNavigationBypass";
+
+describe("UiNavigationBypass", () => {
+    const items = [
+        { id: "id-1", name: "Link 1", targetId: "target-1", tabIndex: 1 },
+        { id: "id-2", name: "Link 2", targetId: "target-2", tabIndex: 1 },
+        { id: "id-3", name: "Link 3", targetId: "target-3" },
+    ];
+
+    const renderComponent = () => {
+        const DefaultLocale = "en-US";
+        const onItemClick = vi.fn();
+
+        const messages = pickCorrectWording(messagesMap[DefaultLocale], {
+            workspace: "mockWorkspace",
+            enableRenamingMeasureToMetric: true,
+        });
+
+        const res = render(
+            <IntlProvider key={DefaultLocale} locale={DefaultLocale} messages={messages}>
+                <UiNavigationBypass items={items} label="Label" onItemClick={onItemClick} />
+            </IntlProvider>,
+        );
+
+        return {
+            res,
+            onItemClick,
+        };
+    };
+
+    it("render basic structure", () => {
+        renderComponent();
+
+        expect(screen.getByRole("menu")).toBeInTheDocument();
+
+        const children = screen.getAllByRole("menuitem");
+        expect(children.length).toBe(items.length);
+
+        expect(children[0].tabIndex).toBe(items[0].tabIndex);
+        expect(children[0].textContent).toBe(items[0].name);
+        expect(children[1].tabIndex).toBe(items[1].tabIndex);
+        expect(children[1].textContent).toBe(items[1].name);
+        expect(children[2].tabIndex).toBe(0);
+        expect(children[2].textContent).toBe(items[2].name);
+    });
+
+    it("check focus down move", async () => {
+        renderComponent();
+
+        const children = screen.getAllByRole("menuitem");
+
+        expect(children[0]).not.toHaveFocus();
+
+        children[0].focus();
+
+        expect(children[0]).toHaveFocus();
+        await userEvent.keyboard("{ArrowDown}");
+        expect(children[1]).toHaveFocus();
+        await userEvent.keyboard("{ArrowDown}");
+        expect(children[2]).toHaveFocus();
+        await userEvent.keyboard("{ArrowDown}");
+        expect(children[0]).toHaveFocus();
+    });
+
+    it("check focus up move", async () => {
+        renderComponent();
+
+        const children = screen.getAllByRole("menuitem");
+
+        expect(children[2]).not.toHaveFocus();
+
+        children[2].focus();
+
+        expect(children[2]).toHaveFocus();
+        await userEvent.keyboard("{ArrowUp}");
+        expect(children[1]).toHaveFocus();
+        await userEvent.keyboard("{ArrowUp}");
+        expect(children[0]).toHaveFocus();
+        await userEvent.keyboard("{ArrowUp}");
+        expect(children[2]).toHaveFocus();
+    });
+
+    it("check callback call with Enter", async () => {
+        const { onItemClick } = renderComponent();
+
+        expect(onItemClick).not.toHaveBeenCalled();
+
+        const children = screen.getAllByRole("menuitem");
+        children[1].focus();
+
+        await userEvent.keyboard("{Enter}");
+        expect(onItemClick).toHaveBeenCalledTimes(1);
+        expect(onItemClick).toHaveBeenCalledWith(items[1]);
+    });
+
+    it("check callback call with Space", async () => {
+        const { onItemClick } = renderComponent();
+
+        expect(onItemClick).not.toHaveBeenCalled();
+
+        const children = screen.getAllByRole("menuitem");
+        children[1].focus();
+
+        await userEvent.keyboard(" ");
+        expect(onItemClick).toHaveBeenCalledTimes(1);
+        expect(onItemClick).toHaveBeenCalledWith(items[1]);
+    });
+});

--- a/libs/sdk-ui-tests/stories/visual-regression/ui/UiNavigationBypass.tsx
+++ b/libs/sdk-ui-tests/stories/visual-regression/ui/UiNavigationBypass.tsx
@@ -1,0 +1,73 @@
+// (C) 2020-2025 GoodData Corporation
+import {
+    UiNavigationBypass,
+    IUiNavigationBypassProps,
+    ComponentTable,
+    propCombinationsFor,
+} from "@gooddata/sdk-ui-kit";
+import React from "react";
+import noop from "lodash/noop.js";
+
+import { storiesOf } from "../../_infra/storyRepository.js";
+import { UiStories } from "../../_infra/storyGroups.js";
+import { wrapWithTheme } from "../themeWrapper.js";
+
+const propCombination = propCombinationsFor({
+    label: "Navigation Skip",
+    onItemClick: noop,
+} as IUiNavigationBypassProps);
+
+const allItems = propCombination("items", [
+    [
+        { id: "item1", name: "Item 1", targetId: "target1" },
+        { id: "item2", name: "Item 2", targetId: "target2" },
+        { id: "item3", name: "Item 3", targetId: "target3" },
+    ],
+    [
+        { id: "item1", name: "Item 1", targetId: "target1" },
+        { id: "item2", name: "Item 2", targetId: "target2", tabIndex: -1 },
+        { id: "item3", name: "Item 3", targetId: "target3", tabIndex: -1 },
+    ],
+]);
+
+const WrapperComponent: React.FC<IUiNavigationBypassProps> = (props) => {
+    return (
+        <>
+            <h3>Focus &quot;Start&quot; by mouse and use Tab to navigate</h3>
+            <div
+                style={{
+                    display: "flex",
+                    flexDirection: "row",
+                    alignItems: "center",
+                    minWidth: "80%",
+                    justifyContent: "space-between",
+                }}
+            >
+                <button>Start</button>
+                <UiNavigationBypass
+                    {...props}
+                    style={{
+                        flex: "1 1 auto",
+                    }}
+                />
+                <button>End</button>
+            </div>
+        </>
+    );
+};
+
+const UiNavigationBypassTest: React.FC<{ showCode?: boolean }> = ({ showCode }) => (
+    <div className="screenshot-target">
+        <ComponentTable
+            rowsBy={[allItems]}
+            Component={WrapperComponent}
+            codeSnippet={showCode ? "UiNavigationBypass" : undefined}
+            align="center"
+        />
+    </div>
+);
+
+storiesOf(`${UiStories}/UiNavigationBypass`)
+    .add("full-featured navigation skip", () => <UiNavigationBypassTest />)
+    .add("themed", () => wrapWithTheme(<UiNavigationBypassTest />))
+    .add("interface", () => <UiNavigationBypassTest showCode />);


### PR DESCRIPTION
Add a skip link to skip the chatbot history

risk: low
JIRA: GDAI-376

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```

#### Commands for Bear platform working on branch rel/9.9

```
extended-test-legacy --backstop
extended-test-legacy --isolated
extended-test-legacy --record
```
