### PR TITLE
feat: change nested containers' direction and width when moved

### DIFF
--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/layout/containerWidthSanitization.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/layout/containerWidthSanitization.ts
@@ -27,17 +27,24 @@ const getLayoutDirection = (layout: IDashboardLayout<ExtendedDashboardWidget>) =
 /**
  * Collects layout paths of all child widgets that need width updates when a nested layout is resized.
  * For nested layouts with a "column" direction, it processes children recursively.
- * For other widgets (including nested layouts with "row" direction), it returns their paths directly.
+ * For other widgets (including nested layouts with "row" direction), it returns their paths directly unless
+ * the processAllContainers is true.
+ *
+ * @param layoutItem - The layout item to process
+ * @param layoutItemPath - The path to the provided layout item (this could be a nested layout, and we need to know his preceding path)
+ * @param processAllContainers - If true, process all containers, including those with a "row" direction, otherwise only process containers with a "column" direction
  */
 export function getChildWidgetLayoutPaths(
-    layout: IDashboardLayout<ExtendedDashboardWidget>,
-    parentPath: ILayoutItemPath,
+    layoutItem: IDashboardLayout<ExtendedDashboardWidget>,
+    layoutItemPath: ILayoutItemPath,
+    processAllContainers = false,
 ): ILayoutItemPath[] {
-    return layout.sections.flatMap((section, sectionIndex) =>
+    return layoutItem.sections.flatMap((section, sectionIndex) =>
         section.items.flatMap((item, itemIndex) => {
-            const currentPath: ILayoutItemPath = [...parentPath, { sectionIndex, itemIndex }];
-            return isDashboardLayout(item.widget) && getLayoutDirection(item.widget) === "column"
-                ? [...getChildWidgetLayoutPaths(item.widget, currentPath), currentPath]
+            const currentPath: ILayoutItemPath = [...layoutItemPath, { sectionIndex, itemIndex }];
+            return isDashboardLayout(item.widget) &&
+                (processAllContainers || getLayoutDirection(item.widget) === "column")
+                ? [currentPath, ...getChildWidgetLayoutPaths(item.widget, currentPath, processAllContainers)]
                 : [currentPath];
         }),
     );

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/layout/rowContainerSanitization.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/layout/rowContainerSanitization.ts
@@ -1,0 +1,144 @@
+// (C) 2025 GoodData Corporation
+
+import { AnyAction } from "@reduxjs/toolkit";
+import { isDashboardLayout, IDashboardLayout, ScreenSize, IDashboardLayoutItem } from "@gooddata/sdk-model";
+
+import { ExtendedDashboardWidget } from "../../types/layoutTypes.js";
+import { ILayoutItemPath } from "../../../types.js";
+import {
+    getLayoutConfiguration,
+    getContainerDirectionAtPath,
+} from "../../../_staging/dashboard/flexibleLayout/layoutConfiguration.js";
+import { getParentPath } from "../../../_staging/layout/coordinates.js";
+import { layoutActions } from "../../store/layout/index.js";
+import { IDashboardCommand } from "../../commands/index.js";
+
+import { getChildWidgetLayoutPaths, getUpdatedSizesOnly } from "./containerWidthSanitization.js";
+
+function findNestedRowContainers(
+    container: ExtendedDashboardWidget,
+    containerLayoutPath: ILayoutItemPath,
+): ILayoutItemPath[] {
+    if (!isDashboardLayout(container)) {
+        return [];
+    }
+    return [
+        // include itself if the container has a row direction
+        ...(getLayoutConfiguration(container).direction === "row" ? [containerLayoutPath] : []),
+        // process nested items and look for row containers
+        ...container.sections.flatMap((section, sectionIndex) =>
+            section.items.flatMap((item, itemIndex) => {
+                const currentPath: ILayoutItemPath = [...containerLayoutPath, { sectionIndex, itemIndex }];
+                return item.widget && isDashboardLayout(item.widget)
+                    ? findNestedRowContainers(item.widget, currentPath)
+                    : [];
+            }),
+        ),
+    ];
+}
+
+function mapChildrenWithNewWidth(
+    rootLayout: IDashboardLayout<ExtendedDashboardWidget>,
+    container: ExtendedDashboardWidget | undefined,
+    containerLayoutPath: ILayoutItemPath,
+    newWidth: number,
+    screen: ScreenSize,
+) {
+    if (!isDashboardLayout(container)) {
+        return [];
+    }
+    const children = getChildWidgetLayoutPaths(container, containerLayoutPath, true);
+    const childrenWithNewSize = children.map((itemPath) => ({
+        itemPath,
+        width: newWidth,
+    }));
+    return getUpdatedSizesOnly(rootLayout, childrenWithNewSize, screen);
+}
+
+function shouldChangeNestedContainersDirectionToColumn(
+    rootLayout: IDashboardLayout<ExtendedDashboardWidget>,
+    item: IDashboardLayoutItem<ExtendedDashboardWidget>,
+    targetItemIndex: ILayoutItemPath,
+) {
+    const targetParentPath = getParentPath(targetItemIndex);
+    const targetLayoutDirection = getContainerDirectionAtPath(rootLayout, targetParentPath);
+    return isDashboardLayout(item.widget) && targetLayoutDirection === "column";
+}
+
+function calculateRowContainerSanitization(
+    rootLayout: IDashboardLayout<ExtendedDashboardWidget>,
+    possibleContainer: IDashboardLayoutItem<ExtendedDashboardWidget>,
+    fromItemIndex: ILayoutItemPath,
+    toItemIndex: ILayoutItemPath,
+    screen: ScreenSize,
+) {
+    const changeNestedContainersDirectionToColumn = shouldChangeNestedContainersDirectionToColumn(
+        rootLayout,
+        possibleContainer,
+        toItemIndex,
+    );
+    if (!changeNestedContainersDirectionToColumn) {
+        return {
+            containersForDirectionChange: [],
+            childrenWithNewWidth: [],
+        };
+    }
+
+    const containersForDirectionChange = findNestedRowContainers(possibleContainer.widget!, fromItemIndex);
+    const newWidth = possibleContainer.size.xl.gridWidth;
+    const childrenWithNewWidth = mapChildrenWithNewWidth(
+        rootLayout,
+        possibleContainer.widget,
+        fromItemIndex,
+        newWidth,
+        screen,
+    );
+
+    return {
+        containersForDirectionChange,
+        childrenWithNewWidth,
+    };
+}
+
+/**
+ * Builds actions for row container sanitization when moving items between layouts.
+ *
+ * If a container is being moved, we need to check if it has a row direction, and it is being moved to
+ * a column layout. If yes, we need to change its direction to column. In any case, we need to check all
+ * its children and find all the row containers and change their direction to column. We will also need to
+ * update the width of all the children to match the moved container width.
+ */
+export function buildRowContainerSanitizationActions(
+    cmd: IDashboardCommand,
+    rootLayout: IDashboardLayout<ExtendedDashboardWidget>,
+    possibleContainer: IDashboardLayoutItem<ExtendedDashboardWidget>,
+    fromItemIndex: ILayoutItemPath,
+    toItemIndex: ILayoutItemPath,
+    screen: ScreenSize,
+): AnyAction[] {
+    const { containersForDirectionChange, childrenWithNewWidth } = calculateRowContainerSanitization(
+        rootLayout,
+        possibleContainer,
+        fromItemIndex,
+        toItemIndex,
+        screen,
+    );
+    return [
+        ...containersForDirectionChange.map((itemPath) =>
+            layoutActions.toggleLayoutDirection({
+                layoutPath: itemPath,
+                direction: "column",
+                undo: {
+                    cmd,
+                },
+            }),
+        ),
+        ...(childrenWithNewWidth.length > 0
+            ? [
+                  layoutActions.updateWidthOfMultipleItems({
+                      itemsWithSizes: childrenWithNewWidth,
+                  }),
+              ]
+            : []),
+    ];
+}

--- a/libs/sdk-ui-dashboard/src/presentation/widget/widget/DashboardNestedLayoutWidget/Toolbar.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/widget/DashboardNestedLayoutWidget/Toolbar.tsx
@@ -74,6 +74,7 @@ const ToggleDirectionButton: React.FC<{
                                 }}
                                 ariaAttributes={ariaAttributes}
                                 accessibilityConfig={accessibilityConfig}
+                                size="large"
                             />
                         }
                     />
@@ -123,7 +124,8 @@ const ToggleSectionHeaderButton: React.FC<{
                 anchor={
                     <UiIconButton
                         icon="header"
-                        variant={"tertiary"}
+                        variant="tertiary"
+                        size="large"
                         isActive={areSectionHeadersEnabled}
                         dataTestId="s-nested-layout__button--headers"
                         onClick={onButtonClick}
@@ -156,6 +158,7 @@ const RemoveContainerButton: React.FC<{
                     <UiIconButton
                         icon="trash"
                         variant="tertiary"
+                        size="large"
                         dataTestId="s-nested-layout__button--remove"
                         onClick={onButtonClick}
                         label={tooltipContent}


### PR DESCRIPTION
JIRA: LX-1205
risk: low

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```

#### Commands for Bear platform working on branch rel/9.9

```
extended-test-legacy --backstop
extended-test-legacy --isolated
extended-test-legacy --record
```
