### PR TITLE
feat: view user can se visualisation link

### DIFF
--- a/libs/sdk-ui-gen-ai/src/components/messages/contents/CustomHyperlink.tsx
+++ b/libs/sdk-ui-gen-ai/src/components/messages/contents/CustomHyperlink.tsx
@@ -15,6 +15,7 @@ export type CustomHyperlinkProps = {
 export const CustomHyperlink: React.FC<CustomHyperlinkProps> = ({ href, text }) => {
     const { linkHandler, allowNativeLinks, canManage, canAnalyze } = useConfig();
     const canManageMetrics = canManage || canAnalyze;
+    const canManageVisualisations = canManage || canAnalyze;
 
     const parsedRef = React.useMemo(() => {
         if (!href) {
@@ -71,6 +72,11 @@ export const CustomHyperlink: React.FC<CustomHyperlinkProps> = ({ href, text }) 
     // If the link is for a metric and the user cannot manage metrics,
     // we do not render the link
     if (parsedRef.type === "metric" && !canManageMetrics) {
+        return text;
+    }
+    // If the link is for a visualization and the user cannot manage visualizations,
+    // we do not render the link
+    if (parsedRef.type === "visualization" && !canManageVisualisations) {
         return text;
     }
 


### PR DESCRIPTION
[User Permission] WS.VIEW user can search for Visualization when use the chatbot

risk: low
JIRA: GDAI-411

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```

#### Commands for Bear platform working on branch rel/9.9

```
extended-test-legacy --backstop
extended-test-legacy --isolated
extended-test-legacy --record
```
