### PR TITLE
fix: distinguish undefined and empty dashboard automation filters

### DIFF
--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/scheduledEmail/initializeAutomationsHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/scheduledEmail/initializeAutomationsHandler.ts
@@ -241,9 +241,11 @@ function extractRelevantFilters(
 
 function extractExportDefinitionFilters(
     content?: IExportDefinitionVisualizationObjectRequestPayload | IExportDefinitionDashboardRequestPayload,
-): FilterContextItem[] {
+): FilterContextItem[] | undefined {
     if (isExportDefinitionDashboardRequestPayload(content)) {
-        return compact(content.content.filters);
+        // The filters in dashboard case may be undefined or an array depending
+        // on whether they should override filter context or use live filter context.
+        return content.content.filters ? compact(content.content.filters) : undefined;
     }
     if (isExportDefinitionVisualizationObjectRequestPayload(content)) {
         return compact(


### PR DESCRIPTION
JIRA: F1-1541
risk: low

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```

#### Commands for Bear platform working on branch rel/9.9

```
extended-test-legacy --backstop
extended-test-legacy --isolated
extended-test-legacy --record
```
