### PR TITLE
fix: bugfixes related to accessibility

### DIFF
--- a/libs/sdk-ui-gen-ai/src/components/EmptyState.tsx
+++ b/libs/sdk-ui-gen-ai/src/components/EmptyState.tsx
@@ -1,6 +1,6 @@
 // (C) 2024-2025 GoodData Corporation
 import React from "react";
-import { Button, Icon, Typography } from "@gooddata/sdk-ui-kit";
+import { Button, Icon } from "@gooddata/sdk-ui-kit";
 import { connect } from "react-redux";
 import { makeAssistantMessage, makeTextContents, makeUserMessage } from "../model.js";
 import { setMessagesAction } from "../store/index.js";
@@ -37,12 +37,13 @@ const EmptyStateComponent: React.FC<EmptyStateDispatchProps & WrappedComponentPr
 }) => {
     return (
         <div className="gd-gen-ai-chat__messages__empty">
-            <Typography tagName="h1" className="gd-gen-ai-chat__messages__empty__h1--accent">
-                <FormattedMessage id="gd.gen-ai.welcome.line-1" />
-            </Typography>
-            <Typography tagName="h1">
+            <h3 className="gd-typography gd-typography--h1">
+                <span className="gd-gen-ai-chat__messages__empty__h1--accent">
+                    <FormattedMessage id="gd.gen-ai.welcome.line-1" />
+                </span>
+                <br />
                 <FormattedMessage id="gd.gen-ai.welcome.line-2" />
-            </Typography>
+            </h3>
             {quickOptions.map((option) => (
                 <Button
                     key={option.title.id}

--- a/libs/sdk-ui-gen-ai/src/components/Messages.tsx
+++ b/libs/sdk-ui-gen-ai/src/components/Messages.tsx
@@ -18,11 +18,16 @@ type MessagesComponentProps = {
 const MessagesComponent: React.FC<MessagesComponentProps> = ({ messages, loading, initializing }) => {
     const { scrollerRef } = useMessageScroller(messages);
     const isLoading = loading === "loading" || loading === "clearing" || initializing;
+    const isEmpty = !messages.length && !isLoading;
 
     return (
         <div className="gd-gen-ai-chat__messages" ref={scrollerRef}>
-            <div className="gd-gen-ai-chat__messages__scroll" role="log" aria-relevant="additions">
-                {!messages.length && !isLoading ? <EmptyState /> : null}
+            <div
+                className="gd-gen-ai-chat__messages__scroll"
+                role="log"
+                aria-relevant={isEmpty || isLoading ? undefined : "additions"}
+            >
+                {isEmpty ? <EmptyState /> : null}
                 {isLoading ? <Skeleton count={3} height="2em" /> : null}
                 {!isLoading
                     ? messages.map((message, index) => {


### PR DESCRIPTION
VoiceOver reads out the 3 buttons in empty screen twice
Multiple H1 in chatbot UI

risk: low
JIRA: GDAI-426, GDAI-425

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```

#### Commands for Bear platform working on branch rel/9.9

```
extended-test-legacy --backstop
extended-test-legacy --isolated
extended-test-legacy --record
```
