### PR TITLE
fix: change hiding of loading animation in export mode

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/ViewModeDashboardInsight/Insight/DashboardInsight.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/ViewModeDashboardInsight/Insight/DashboardInsight.tsx
@@ -40,6 +40,7 @@ import {
     selectEnableExecutionCancelling,
     selectExecutionTimestamp,
     selectEnableSnapshotExportAccessibility,
+    selectIsInExportMode,
 } from "../../../../../model/index.js";
 import { useResolveDashboardInsightProperties } from "../useResolveDashboardInsightProperties.js";
 import { useMinimalSizeValidation, useVisualizationExportData } from "../../../../export/index.js";
@@ -273,6 +274,11 @@ export const DashboardInsight = (props: IDashboardInsightProps): JSX.Element => 
         loading,
     );
 
+    const isExportSlidesMode = useDashboardSelector(selectIsInExportMode);
+    const loadingClassNames = cx("insight-view-loader", {
+        isInvisible: isExportSlidesMode && !loading,
+    });
+
     const renderComponent = () => {
         if (effectiveError) {
             return (
@@ -286,8 +292,8 @@ export const DashboardInsight = (props: IDashboardInsightProps): JSX.Element => 
         } else {
             return (
                 <>
-                    {loading ? (
-                        <div className="insight-view-loader">
+                    {loading || isExportSlidesMode ? (
+                        <div className={loadingClassNames}>
                             <LoadingComponent />
                         </div>
                     ) : null}

--- a/libs/sdk-ui-dashboard/styles/scss/dashboard.scss
+++ b/libs/sdk-ui-dashboard/styles/scss/dashboard.scss
@@ -771,6 +771,9 @@ $dashboard-menu-item-icon-color: var(--gd-palette-complementary-5-from-theme, #b
     left: 0;
     bottom: 0;
     right: 0;
+    &.isInvisible {
+        visibility: hidden;
+    }
 }
 
 .bubble.options-menu-bubble {


### PR DESCRIPTION
Issue is caused by re-render of charts during switching between loading animation and chart itself. Size of chart is changing rapidly between its min-height and size derived from height of whole slide. Sometimes this size change ends even in infinite loop.

I did not found root cause of this re-render - react-measure measures its container repeatedly with these two different heights. May be related to https://github.com/souporserious/react-measure/issues/150. This is triggered in moment when Loading animation should be hidden and visualization content shown.

So I decided to hide Loading animation in export mode not be not rendering it but just hiding it.

JIRA: LX-1165
risk: low

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```

#### Commands for Bear platform working on branch rel/9.9

```
extended-test-legacy --backstop
extended-test-legacy --isolated
extended-test-legacy --record
```
