### PR TITLE
chore: regenerate api client

### DIFF
--- a/libs/api-client-tiger/api/api-client-tiger.api.md
+++ b/libs/api-client-tiger/api/api-client-tiger.api.md
@@ -1546,10 +1546,10 @@ export interface AfmRelativeDateFilter {
 export interface AfmRelativeDateFilterRelativeDateFilter {
     applyOnResult?: boolean;
     dataset: AfmModelObjectIdentifierDataset;
-    from: number;
+    from?: number | null;
     granularity: AfmRelativeDateFilterRelativeDateFilterGranularityEnum;
     localIdentifier?: string;
-    to: number;
+    to?: number | null;
 }
 
 // @public (undocumented)
@@ -3523,10 +3523,10 @@ export interface AutomationRelativeDateFilter {
 export interface AutomationRelativeDateFilterRelativeDateFilter {
     applyOnResult?: boolean;
     dataset: AutomationAfmObjectIdentifierDataset;
-    from: number;
+    from?: number | null;
     granularity: AutomationRelativeDateFilterRelativeDateFilterGranularityEnum;
     localIdentifier?: string;
-    to: number;
+    to?: number | null;
 }
 
 // @public (undocumented)
@@ -10596,10 +10596,10 @@ export interface ExportRelativeDateFilter {
 export interface ExportRelativeDateFilterRelativeDateFilter {
     applyOnResult?: boolean;
     dataset: ExportAfmObjectIdentifierDataset;
-    from: number;
+    from?: number | null;
     granularity: ExportRelativeDateFilterRelativeDateFilterGranularityEnum;
     localIdentifier?: string;
-    to: number;
+    to?: number | null;
 }
 
 // @public (undocumented)
@@ -11941,7 +11941,12 @@ export interface JsonApiAnalyticalDashboardOutList {
     data: Array<JsonApiAnalyticalDashboardOutWithLinks>;
     included?: Array<JsonApiAnalyticalDashboardOutIncludes>;
     links?: ListLinks;
-    meta?: JsonApiApiTokenOutListMeta;
+    meta?: JsonApiAnalyticalDashboardOutListMeta;
+}
+
+// @public
+export interface JsonApiAnalyticalDashboardOutListMeta {
+    page?: PageMetadata;
 }
 
 // @public
@@ -12118,12 +12123,7 @@ export interface JsonApiApiTokenOutDocument {
 export interface JsonApiApiTokenOutList {
     data: Array<JsonApiApiTokenOutWithLinks>;
     links?: ListLinks;
-    meta?: JsonApiApiTokenOutListMeta;
-}
-
-// @public
-export interface JsonApiApiTokenOutListMeta {
-    page?: PageMetadata;
+    meta?: JsonApiAnalyticalDashboardOutListMeta;
 }
 
 // @public (undocumented)
@@ -12219,7 +12219,7 @@ export interface JsonApiAttributeHierarchyOutList {
     data: Array<JsonApiAttributeHierarchyOutWithLinks>;
     included?: Array<JsonApiAttributeHierarchyOutIncludes>;
     links?: ListLinks;
-    meta?: JsonApiApiTokenOutListMeta;
+    meta?: JsonApiAnalyticalDashboardOutListMeta;
 }
 
 // @public
@@ -12380,7 +12380,7 @@ export interface JsonApiAttributeOutList {
     data: Array<JsonApiAttributeOutWithLinks>;
     included?: Array<JsonApiAttributeOutIncludes>;
     links?: ListLinks;
-    meta?: JsonApiApiTokenOutListMeta;
+    meta?: JsonApiAnalyticalDashboardOutListMeta;
 }
 
 // @public
@@ -12525,7 +12525,7 @@ export interface JsonApiAutomationOutList {
     data: Array<JsonApiAutomationOutWithLinks>;
     included?: Array<JsonApiAutomationOutIncludes>;
     links?: ListLinks;
-    meta?: JsonApiApiTokenOutListMeta;
+    meta?: JsonApiAnalyticalDashboardOutListMeta;
 }
 
 // @public
@@ -12753,7 +12753,7 @@ export interface JsonApiColorPaletteOutDocument {
 export interface JsonApiColorPaletteOutList {
     data: Array<JsonApiColorPaletteOutWithLinks>;
     links?: ListLinks;
-    meta?: JsonApiApiTokenOutListMeta;
+    meta?: JsonApiAnalyticalDashboardOutListMeta;
 }
 
 // @public (undocumented)
@@ -12808,7 +12808,7 @@ export type JsonApiColorPalettePatchTypeEnum = typeof JsonApiColorPalettePatchTy
 
 // @public
 export interface JsonApiCookieSecurityConfigurationIn {
-    attributes?: JsonApiCookieSecurityConfigurationOutAttributes;
+    attributes?: JsonApiCookieSecurityConfigurationPatchAttributes;
     id: string;
     type: JsonApiCookieSecurityConfigurationInTypeEnum;
 }
@@ -12828,15 +12828,9 @@ export type JsonApiCookieSecurityConfigurationInTypeEnum = typeof JsonApiCookieS
 
 // @public
 export interface JsonApiCookieSecurityConfigurationOut {
-    attributes?: JsonApiCookieSecurityConfigurationOutAttributes;
+    attributes?: JsonApiCookieSecurityConfigurationPatchAttributes;
     id: string;
     type: JsonApiCookieSecurityConfigurationOutTypeEnum;
-}
-
-// @public
-export interface JsonApiCookieSecurityConfigurationOutAttributes {
-    lastRotation?: string;
-    rotationInterval?: string;
 }
 
 // @public
@@ -12855,9 +12849,15 @@ export type JsonApiCookieSecurityConfigurationOutTypeEnum = typeof JsonApiCookie
 
 // @public
 export interface JsonApiCookieSecurityConfigurationPatch {
-    attributes?: JsonApiCookieSecurityConfigurationOutAttributes;
+    attributes?: JsonApiCookieSecurityConfigurationPatchAttributes;
     id: string;
     type: JsonApiCookieSecurityConfigurationPatchTypeEnum;
+}
+
+// @public
+export interface JsonApiCookieSecurityConfigurationPatchAttributes {
+    lastRotation?: string;
+    rotationInterval?: string;
 }
 
 // @public
@@ -12915,7 +12915,7 @@ export interface JsonApiCspDirectiveOutDocument {
 export interface JsonApiCspDirectiveOutList {
     data: Array<JsonApiCspDirectiveOutWithLinks>;
     links?: ListLinks;
-    meta?: JsonApiApiTokenOutListMeta;
+    meta?: JsonApiAnalyticalDashboardOutListMeta;
 }
 
 // @public (undocumented)
@@ -13011,7 +13011,7 @@ export interface JsonApiCustomApplicationSettingOutDocument {
 export interface JsonApiCustomApplicationSettingOutList {
     data: Array<JsonApiCustomApplicationSettingOutWithLinks>;
     links?: ListLinks;
-    meta?: JsonApiApiTokenOutListMeta;
+    meta?: JsonApiAnalyticalDashboardOutListMeta;
 }
 
 // @public (undocumented)
@@ -13151,7 +13151,7 @@ export interface JsonApiDashboardPluginOutList {
     data: Array<JsonApiDashboardPluginOutWithLinks>;
     included?: Array<JsonApiUserIdentifierOutWithLinks>;
     links?: ListLinks;
-    meta?: JsonApiApiTokenOutListMeta;
+    meta?: JsonApiAnalyticalDashboardOutListMeta;
 }
 
 // @public
@@ -13384,7 +13384,7 @@ export interface JsonApiDatasetOutList {
     data: Array<JsonApiDatasetOutWithLinks>;
     included?: Array<JsonApiDatasetOutIncludes>;
     links?: ListLinks;
-    meta?: JsonApiApiTokenOutListMeta;
+    meta?: JsonApiAnalyticalDashboardOutListMeta;
 }
 
 // @public
@@ -13433,7 +13433,7 @@ export type JsonApiDatasetToOneLinkage = JsonApiDatasetLinkage;
 export interface JsonApiDataSourceIdentifierOut {
     attributes: JsonApiDataSourceIdentifierOutAttributes;
     id: string;
-    meta?: JsonApiDataSourceIdentifierOutMeta;
+    meta?: JsonApiDataSourceOutMeta;
     type: JsonApiDataSourceIdentifierOutTypeEnum;
 }
 
@@ -13486,22 +13486,8 @@ export interface JsonApiDataSourceIdentifierOutDocument {
 export interface JsonApiDataSourceIdentifierOutList {
     data: Array<JsonApiDataSourceIdentifierOutWithLinks>;
     links?: ListLinks;
-    meta?: JsonApiApiTokenOutListMeta;
+    meta?: JsonApiAnalyticalDashboardOutListMeta;
 }
-
-// @public
-export interface JsonApiDataSourceIdentifierOutMeta {
-    permissions?: Array<JsonApiDataSourceIdentifierOutMetaPermissionsEnum>;
-}
-
-// @public (undocumented)
-export const JsonApiDataSourceIdentifierOutMetaPermissionsEnum: {
-    readonly MANAGE: "MANAGE";
-    readonly USE: "USE";
-};
-
-// @public (undocumented)
-export type JsonApiDataSourceIdentifierOutMetaPermissionsEnum = typeof JsonApiDataSourceIdentifierOutMetaPermissionsEnum[keyof typeof JsonApiDataSourceIdentifierOutMetaPermissionsEnum];
 
 // @public (undocumented)
 export const JsonApiDataSourceIdentifierOutTypeEnum: {
@@ -13516,7 +13502,7 @@ export interface JsonApiDataSourceIdentifierOutWithLinks {
     attributes: JsonApiDataSourceIdentifierOutAttributes;
     id: string;
     links?: ObjectLinks;
-    meta?: JsonApiDataSourceIdentifierOutMeta;
+    meta?: JsonApiDataSourceOutMeta;
     type: JsonApiDataSourceIdentifierOutWithLinksTypeEnum;
 }
 
@@ -13541,7 +13527,7 @@ export interface JsonApiDataSourceInAttributes {
     clientId?: string | null;
     clientSecret?: string | null;
     name: string;
-    parameters?: Array<JsonApiDataSourceOutAttributesParameters> | null;
+    parameters?: Array<JsonApiDataSourcePatchAttributesParameters> | null;
     password?: string | null;
     privateKey?: string | null;
     privateKeyPassphrase?: string | null;
@@ -13610,7 +13596,7 @@ export type JsonApiDataSourceInTypeEnum = typeof JsonApiDataSourceInTypeEnum[key
 export interface JsonApiDataSourceOut {
     attributes: JsonApiDataSourceOutAttributes;
     id: string;
-    meta?: JsonApiDataSourceIdentifierOutMeta;
+    meta?: JsonApiDataSourceOutMeta;
     type: JsonApiDataSourceOutTypeEnum;
 }
 
@@ -13619,9 +13605,9 @@ export interface JsonApiDataSourceOutAttributes {
     authenticationType?: JsonApiDataSourceOutAttributesAuthenticationTypeEnum;
     cacheStrategy?: JsonApiDataSourceOutAttributesCacheStrategyEnum;
     clientId?: string | null;
-    decodedParameters?: Array<JsonApiDataSourceOutAttributesParameters> | null;
+    decodedParameters?: Array<JsonApiDataSourcePatchAttributesParameters> | null;
     name: string;
-    parameters?: Array<JsonApiDataSourceOutAttributesParameters> | null;
+    parameters?: Array<JsonApiDataSourcePatchAttributesParameters> | null;
     schema: string;
     type: JsonApiDataSourceOutAttributesTypeEnum;
     url?: string | null;
@@ -13648,12 +13634,6 @@ export const JsonApiDataSourceOutAttributesCacheStrategyEnum: {
 
 // @public (undocumented)
 export type JsonApiDataSourceOutAttributesCacheStrategyEnum = typeof JsonApiDataSourceOutAttributesCacheStrategyEnum[keyof typeof JsonApiDataSourceOutAttributesCacheStrategyEnum];
-
-// @public
-export interface JsonApiDataSourceOutAttributesParameters {
-    name: string;
-    value: string;
-}
 
 // @public (undocumented)
 export const JsonApiDataSourceOutAttributesTypeEnum: {
@@ -13697,8 +13677,22 @@ export interface JsonApiDataSourceOutDocument {
 export interface JsonApiDataSourceOutList {
     data: Array<JsonApiDataSourceOutWithLinks>;
     links?: ListLinks;
-    meta?: JsonApiApiTokenOutListMeta;
+    meta?: JsonApiAnalyticalDashboardOutListMeta;
 }
+
+// @public
+export interface JsonApiDataSourceOutMeta {
+    permissions?: Array<JsonApiDataSourceOutMetaPermissionsEnum>;
+}
+
+// @public (undocumented)
+export const JsonApiDataSourceOutMetaPermissionsEnum: {
+    readonly MANAGE: "MANAGE";
+    readonly USE: "USE";
+};
+
+// @public (undocumented)
+export type JsonApiDataSourceOutMetaPermissionsEnum = typeof JsonApiDataSourceOutMetaPermissionsEnum[keyof typeof JsonApiDataSourceOutMetaPermissionsEnum];
 
 // @public (undocumented)
 export const JsonApiDataSourceOutTypeEnum: {
@@ -13713,7 +13707,7 @@ export interface JsonApiDataSourceOutWithLinks {
     attributes: JsonApiDataSourceOutAttributes;
     id: string;
     links?: ObjectLinks;
-    meta?: JsonApiDataSourceIdentifierOutMeta;
+    meta?: JsonApiDataSourceOutMeta;
     type: JsonApiDataSourceOutWithLinksTypeEnum;
 }
 
@@ -13738,7 +13732,7 @@ export interface JsonApiDataSourcePatchAttributes {
     clientId?: string | null;
     clientSecret?: string | null;
     name?: string;
-    parameters?: Array<JsonApiDataSourceOutAttributesParameters> | null;
+    parameters?: Array<JsonApiDataSourcePatchAttributesParameters> | null;
     password?: string | null;
     privateKey?: string | null;
     privateKeyPassphrase?: string | null;
@@ -13757,6 +13751,12 @@ export const JsonApiDataSourcePatchAttributesCacheStrategyEnum: {
 
 // @public (undocumented)
 export type JsonApiDataSourcePatchAttributesCacheStrategyEnum = typeof JsonApiDataSourcePatchAttributesCacheStrategyEnum[keyof typeof JsonApiDataSourcePatchAttributesCacheStrategyEnum];
+
+// @public
+export interface JsonApiDataSourcePatchAttributesParameters {
+    name: string;
+    value: string;
+}
 
 // @public (undocumented)
 export const JsonApiDataSourcePatchAttributesTypeEnum: {
@@ -13826,7 +13826,7 @@ export interface JsonApiEntitlementOutDocument {
 export interface JsonApiEntitlementOutList {
     data: Array<JsonApiEntitlementOutWithLinks>;
     links?: ListLinks;
-    meta?: JsonApiApiTokenOutListMeta;
+    meta?: JsonApiAnalyticalDashboardOutListMeta;
 }
 
 // @public (undocumented)
@@ -13923,7 +13923,7 @@ export interface JsonApiExportDefinitionOutList {
     data: Array<JsonApiExportDefinitionOutWithLinks>;
     included?: Array<JsonApiExportDefinitionOutIncludes>;
     links?: ListLinks;
-    meta?: JsonApiApiTokenOutListMeta;
+    meta?: JsonApiAnalyticalDashboardOutListMeta;
 }
 
 // @public
@@ -14057,43 +14057,10 @@ export interface JsonApiExportTemplateOut {
 
 // @public
 export interface JsonApiExportTemplateOutAttributes {
-    dashboardSlidesTemplate?: JsonApiExportTemplateOutAttributesDashboardSlidesTemplate | null;
+    dashboardSlidesTemplate?: JsonApiExportTemplatePatchAttributesDashboardSlidesTemplate | null;
     name: string;
-    widgetSlidesTemplate?: JsonApiExportTemplateOutAttributesWidgetSlidesTemplate | null;
+    widgetSlidesTemplate?: JsonApiExportTemplatePatchAttributesWidgetSlidesTemplate | null;
 }
-
-// @public
-export interface JsonApiExportTemplateOutAttributesDashboardSlidesTemplate {
-    appliedOn: Array<JsonApiExportTemplateOutAttributesDashboardSlidesTemplateAppliedOnEnum>;
-    contentSlide?: ContentSlideTemplate | null;
-    coverSlide?: CoverSlideTemplate | null;
-    introSlide?: IntroSlideTemplate | null;
-    sectionSlide?: SectionSlideTemplate | null;
-}
-
-// @public (undocumented)
-export const JsonApiExportTemplateOutAttributesDashboardSlidesTemplateAppliedOnEnum: {
-    readonly PDF: "PDF";
-    readonly PPTX: "PPTX";
-};
-
-// @public (undocumented)
-export type JsonApiExportTemplateOutAttributesDashboardSlidesTemplateAppliedOnEnum = typeof JsonApiExportTemplateOutAttributesDashboardSlidesTemplateAppliedOnEnum[keyof typeof JsonApiExportTemplateOutAttributesDashboardSlidesTemplateAppliedOnEnum];
-
-// @public
-export interface JsonApiExportTemplateOutAttributesWidgetSlidesTemplate {
-    appliedOn: Array<JsonApiExportTemplateOutAttributesWidgetSlidesTemplateAppliedOnEnum>;
-    contentSlide?: ContentSlideTemplate | null;
-}
-
-// @public (undocumented)
-export const JsonApiExportTemplateOutAttributesWidgetSlidesTemplateAppliedOnEnum: {
-    readonly PDF: "PDF";
-    readonly PPTX: "PPTX";
-};
-
-// @public (undocumented)
-export type JsonApiExportTemplateOutAttributesWidgetSlidesTemplateAppliedOnEnum = typeof JsonApiExportTemplateOutAttributesWidgetSlidesTemplateAppliedOnEnum[keyof typeof JsonApiExportTemplateOutAttributesWidgetSlidesTemplateAppliedOnEnum];
 
 // @public
 export interface JsonApiExportTemplateOutDocument {
@@ -14105,7 +14072,7 @@ export interface JsonApiExportTemplateOutDocument {
 export interface JsonApiExportTemplateOutList {
     data: Array<JsonApiExportTemplateOutWithLinks>;
     links?: ListLinks;
-    meta?: JsonApiApiTokenOutListMeta;
+    meta?: JsonApiAnalyticalDashboardOutListMeta;
 }
 
 // @public (undocumented)
@@ -14141,10 +14108,43 @@ export interface JsonApiExportTemplatePatch {
 
 // @public
 export interface JsonApiExportTemplatePatchAttributes {
-    dashboardSlidesTemplate?: JsonApiExportTemplateOutAttributesDashboardSlidesTemplate | null;
+    dashboardSlidesTemplate?: JsonApiExportTemplatePatchAttributesDashboardSlidesTemplate | null;
     name?: string;
-    widgetSlidesTemplate?: JsonApiExportTemplateOutAttributesWidgetSlidesTemplate | null;
+    widgetSlidesTemplate?: JsonApiExportTemplatePatchAttributesWidgetSlidesTemplate | null;
 }
+
+// @public
+export interface JsonApiExportTemplatePatchAttributesDashboardSlidesTemplate {
+    appliedOn: Array<JsonApiExportTemplatePatchAttributesDashboardSlidesTemplateAppliedOnEnum>;
+    contentSlide?: ContentSlideTemplate | null;
+    coverSlide?: CoverSlideTemplate | null;
+    introSlide?: IntroSlideTemplate | null;
+    sectionSlide?: SectionSlideTemplate | null;
+}
+
+// @public (undocumented)
+export const JsonApiExportTemplatePatchAttributesDashboardSlidesTemplateAppliedOnEnum: {
+    readonly PDF: "PDF";
+    readonly PPTX: "PPTX";
+};
+
+// @public (undocumented)
+export type JsonApiExportTemplatePatchAttributesDashboardSlidesTemplateAppliedOnEnum = typeof JsonApiExportTemplatePatchAttributesDashboardSlidesTemplateAppliedOnEnum[keyof typeof JsonApiExportTemplatePatchAttributesDashboardSlidesTemplateAppliedOnEnum];
+
+// @public
+export interface JsonApiExportTemplatePatchAttributesWidgetSlidesTemplate {
+    appliedOn: Array<JsonApiExportTemplatePatchAttributesWidgetSlidesTemplateAppliedOnEnum>;
+    contentSlide?: ContentSlideTemplate | null;
+}
+
+// @public (undocumented)
+export const JsonApiExportTemplatePatchAttributesWidgetSlidesTemplateAppliedOnEnum: {
+    readonly PDF: "PDF";
+    readonly PPTX: "PPTX";
+};
+
+// @public (undocumented)
+export type JsonApiExportTemplatePatchAttributesWidgetSlidesTemplateAppliedOnEnum = typeof JsonApiExportTemplatePatchAttributesWidgetSlidesTemplateAppliedOnEnum[keyof typeof JsonApiExportTemplatePatchAttributesWidgetSlidesTemplateAppliedOnEnum];
 
 // @public
 export interface JsonApiExportTemplatePatchDocument {
@@ -14252,7 +14252,7 @@ export interface JsonApiFactOutList {
     data: Array<JsonApiFactOutWithLinks>;
     included?: Array<JsonApiFactOutIncludes>;
     links?: ListLinks;
-    meta?: JsonApiApiTokenOutListMeta;
+    meta?: JsonApiAnalyticalDashboardOutListMeta;
 }
 
 // @public
@@ -14362,7 +14362,7 @@ export interface JsonApiFilterContextOutList {
     data: Array<JsonApiFilterContextOutWithLinks>;
     included?: Array<JsonApiFilterContextOutIncludes>;
     links?: ListLinks;
-    meta?: JsonApiApiTokenOutListMeta;
+    meta?: JsonApiAnalyticalDashboardOutListMeta;
 }
 
 // @public
@@ -14492,7 +14492,7 @@ export interface JsonApiFilterViewOutList {
     data: Array<JsonApiFilterViewOutWithLinks>;
     included?: Array<JsonApiFilterViewOutIncludes>;
     links?: ListLinks;
-    meta?: JsonApiApiTokenOutListMeta;
+    meta?: JsonApiAnalyticalDashboardOutListMeta;
 }
 
 // @public (undocumented)
@@ -14546,7 +14546,12 @@ export interface JsonApiFilterViewPatchDocument {
 // @public
 export interface JsonApiFilterViewPatchRelationships {
     analyticalDashboard?: JsonApiAutomationPatchRelationshipsAnalyticalDashboard;
-    user?: JsonApiOrganizationOutRelationshipsBootstrapUser;
+    user?: JsonApiFilterViewPatchRelationshipsUser;
+}
+
+// @public
+export interface JsonApiFilterViewPatchRelationshipsUser {
+    data: JsonApiUserToOneLinkage | null;
 }
 
 // @public (undocumented)
@@ -14641,7 +14646,7 @@ export interface JsonApiIdentityProviderOutDocument {
 export interface JsonApiIdentityProviderOutList {
     data: Array<JsonApiIdentityProviderOutWithLinks>;
     links?: ListLinks;
-    meta?: JsonApiApiTokenOutListMeta;
+    meta?: JsonApiAnalyticalDashboardOutListMeta;
 }
 
 // @public (undocumented)
@@ -14722,7 +14727,7 @@ export type JsonApiIdentityProviderToOneLinkage = JsonApiIdentityProviderLinkage
 
 // @public
 export interface JsonApiJwkIn {
-    attributes?: JsonApiJwkOutAttributes;
+    attributes?: JsonApiJwkPatchAttributes;
     id: string;
     type: JsonApiJwkInTypeEnum;
 }
@@ -14742,14 +14747,9 @@ export type JsonApiJwkInTypeEnum = typeof JsonApiJwkInTypeEnum[keyof typeof Json
 
 // @public
 export interface JsonApiJwkOut {
-    attributes?: JsonApiJwkOutAttributes;
+    attributes?: JsonApiJwkPatchAttributes;
     id: string;
     type: JsonApiJwkOutTypeEnum;
-}
-
-// @public
-export interface JsonApiJwkOutAttributes {
-    content?: RsaSpecification;
 }
 
 // @public
@@ -14762,7 +14762,7 @@ export interface JsonApiJwkOutDocument {
 export interface JsonApiJwkOutList {
     data: Array<JsonApiJwkOutWithLinks>;
     links?: ListLinks;
-    meta?: JsonApiApiTokenOutListMeta;
+    meta?: JsonApiAnalyticalDashboardOutListMeta;
 }
 
 // @public (undocumented)
@@ -14775,7 +14775,7 @@ export type JsonApiJwkOutTypeEnum = typeof JsonApiJwkOutTypeEnum[keyof typeof Js
 
 // @public
 export interface JsonApiJwkOutWithLinks {
-    attributes?: JsonApiJwkOutAttributes;
+    attributes?: JsonApiJwkPatchAttributes;
     id: string;
     links?: ObjectLinks;
     type: JsonApiJwkOutWithLinksTypeEnum;
@@ -14791,9 +14791,14 @@ export type JsonApiJwkOutWithLinksTypeEnum = typeof JsonApiJwkOutWithLinksTypeEn
 
 // @public
 export interface JsonApiJwkPatch {
-    attributes?: JsonApiJwkOutAttributes;
+    attributes?: JsonApiJwkPatchAttributes;
     id: string;
     type: JsonApiJwkPatchTypeEnum;
+}
+
+// @public
+export interface JsonApiJwkPatchAttributes {
+    content?: RsaSpecification;
 }
 
 // @public
@@ -14883,7 +14888,7 @@ export interface JsonApiLabelOutList {
     data: Array<JsonApiLabelOutWithLinks>;
     included?: Array<JsonApiAttributeOutWithLinks>;
     links?: ListLinks;
-    meta?: JsonApiApiTokenOutListMeta;
+    meta?: JsonApiAnalyticalDashboardOutListMeta;
 }
 
 // @public
@@ -14999,7 +15004,7 @@ export interface JsonApiLlmEndpointOutDocument {
 export interface JsonApiLlmEndpointOutList {
     data: Array<JsonApiLlmEndpointOutWithLinks>;
     links?: ListLinks;
-    meta?: JsonApiApiTokenOutListMeta;
+    meta?: JsonApiAnalyticalDashboardOutListMeta;
 }
 
 // @public (undocumented)
@@ -15067,9 +15072,18 @@ export type JsonApiLlmEndpointPatchTypeEnum = typeof JsonApiLlmEndpointPatchType
 
 // @public
 export interface JsonApiMetricIn {
-    attributes: JsonApiMetricPostOptionalIdAttributes;
+    attributes: JsonApiMetricInAttributes;
     id: string;
     type: JsonApiMetricInTypeEnum;
+}
+
+// @public
+export interface JsonApiMetricInAttributes {
+    areRelationsValid?: boolean;
+    content: JsonApiMetricOutAttributesContent;
+    description?: string;
+    tags?: Array<string>;
+    title?: string;
 }
 
 // @public
@@ -15140,7 +15154,7 @@ export interface JsonApiMetricOutList {
     data: Array<JsonApiMetricOutWithLinks>;
     included?: Array<JsonApiMetricOutIncludes>;
     links?: ListLinks;
-    meta?: JsonApiApiTokenOutListMeta;
+    meta?: JsonApiAnalyticalDashboardOutListMeta;
 }
 
 // @public (undocumented)
@@ -15200,18 +15214,9 @@ export type JsonApiMetricPatchTypeEnum = typeof JsonApiMetricPatchTypeEnum[keyof
 
 // @public
 export interface JsonApiMetricPostOptionalId {
-    attributes: JsonApiMetricPostOptionalIdAttributes;
+    attributes: JsonApiMetricInAttributes;
     id?: string;
     type: JsonApiMetricPostOptionalIdTypeEnum;
-}
-
-// @public
-export interface JsonApiMetricPostOptionalIdAttributes {
-    areRelationsValid?: boolean;
-    content: JsonApiMetricOutAttributesContent;
-    description?: string;
-    tags?: Array<string>;
-    title?: string;
 }
 
 // @public
@@ -15273,7 +15278,7 @@ export interface JsonApiNotificationChannelIdentifierOutDocument {
 export interface JsonApiNotificationChannelIdentifierOutList {
     data: Array<JsonApiNotificationChannelIdentifierOutWithLinks>;
     links?: ListLinks;
-    meta?: JsonApiApiTokenOutListMeta;
+    meta?: JsonApiAnalyticalDashboardOutListMeta;
 }
 
 // @public (undocumented)
@@ -15404,7 +15409,7 @@ export interface JsonApiNotificationChannelOutDocument {
 export interface JsonApiNotificationChannelOutList {
     data: Array<JsonApiNotificationChannelOutWithLinks>;
     links?: ListLinks;
-    meta?: JsonApiApiTokenOutListMeta;
+    meta?: JsonApiAnalyticalDashboardOutListMeta;
 }
 
 // @public (undocumented)
@@ -15605,24 +15610,9 @@ export type JsonApiOrganizationOutMetaPermissionsEnum = typeof JsonApiOrganizati
 
 // @public
 export interface JsonApiOrganizationOutRelationships {
-    bootstrapUser?: JsonApiOrganizationOutRelationshipsBootstrapUser;
-    bootstrapUserGroup?: JsonApiOrganizationOutRelationshipsBootstrapUserGroup;
-    identityProvider?: JsonApiOrganizationOutRelationshipsIdentityProvider;
-}
-
-// @public
-export interface JsonApiOrganizationOutRelationshipsBootstrapUser {
-    data: JsonApiUserToOneLinkage | null;
-}
-
-// @public
-export interface JsonApiOrganizationOutRelationshipsBootstrapUserGroup {
-    data: JsonApiUserGroupToOneLinkage | null;
-}
-
-// @public
-export interface JsonApiOrganizationOutRelationshipsIdentityProvider {
-    data: JsonApiIdentityProviderToOneLinkage | null;
+    bootstrapUser?: JsonApiFilterViewPatchRelationshipsUser;
+    bootstrapUserGroup?: JsonApiUserDataFilterPatchRelationshipsUserGroup;
+    identityProvider?: JsonApiOrganizationPatchRelationshipsIdentityProvider;
 }
 
 // @public (undocumented)
@@ -15667,7 +15657,12 @@ export interface JsonApiOrganizationPatchDocument {
 
 // @public
 export interface JsonApiOrganizationPatchRelationships {
-    identityProvider?: JsonApiOrganizationOutRelationshipsIdentityProvider;
+    identityProvider?: JsonApiOrganizationPatchRelationshipsIdentityProvider;
+}
+
+// @public
+export interface JsonApiOrganizationPatchRelationshipsIdentityProvider {
+    data: JsonApiIdentityProviderToOneLinkage | null;
 }
 
 // @public (undocumented)
@@ -15680,7 +15675,7 @@ export type JsonApiOrganizationPatchTypeEnum = typeof JsonApiOrganizationPatchTy
 
 // @public
 export interface JsonApiOrganizationSettingIn {
-    attributes?: JsonApiUserSettingInAttributes;
+    attributes?: JsonApiWorkspaceSettingPatchAttributes;
     id: string;
     type: JsonApiOrganizationSettingInTypeEnum;
 }
@@ -15700,7 +15695,7 @@ export type JsonApiOrganizationSettingInTypeEnum = typeof JsonApiOrganizationSet
 
 // @public
 export interface JsonApiOrganizationSettingOut {
-    attributes?: JsonApiUserSettingInAttributes;
+    attributes?: JsonApiWorkspaceSettingPatchAttributes;
     id: string;
     type: JsonApiOrganizationSettingOutTypeEnum;
 }
@@ -15715,7 +15710,7 @@ export interface JsonApiOrganizationSettingOutDocument {
 export interface JsonApiOrganizationSettingOutList {
     data: Array<JsonApiOrganizationSettingOutWithLinks>;
     links?: ListLinks;
-    meta?: JsonApiApiTokenOutListMeta;
+    meta?: JsonApiAnalyticalDashboardOutListMeta;
 }
 
 // @public (undocumented)
@@ -15728,7 +15723,7 @@ export type JsonApiOrganizationSettingOutTypeEnum = typeof JsonApiOrganizationSe
 
 // @public
 export interface JsonApiOrganizationSettingOutWithLinks {
-    attributes?: JsonApiUserSettingInAttributes;
+    attributes?: JsonApiWorkspaceSettingPatchAttributes;
     id: string;
     links?: ObjectLinks;
     type: JsonApiOrganizationSettingOutWithLinksTypeEnum;
@@ -15744,7 +15739,7 @@ export type JsonApiOrganizationSettingOutWithLinksTypeEnum = typeof JsonApiOrgan
 
 // @public
 export interface JsonApiOrganizationSettingPatch {
-    attributes?: JsonApiUserSettingInAttributes;
+    attributes?: JsonApiWorkspaceSettingPatchAttributes;
     id: string;
     type: JsonApiOrganizationSettingPatchTypeEnum;
 }
@@ -15799,7 +15794,7 @@ export interface JsonApiThemeOutDocument {
 export interface JsonApiThemeOutList {
     data: Array<JsonApiThemeOutWithLinks>;
     links?: ListLinks;
-    meta?: JsonApiApiTokenOutListMeta;
+    meta?: JsonApiAnalyticalDashboardOutListMeta;
 }
 
 // @public (undocumented)
@@ -15900,7 +15895,7 @@ export interface JsonApiUserDataFilterOutList {
     data: Array<JsonApiUserDataFilterOutWithLinks>;
     included?: Array<JsonApiUserDataFilterOutIncludes>;
     links?: ListLinks;
-    meta?: JsonApiApiTokenOutListMeta;
+    meta?: JsonApiAnalyticalDashboardOutListMeta;
 }
 
 // @public
@@ -15910,8 +15905,8 @@ export interface JsonApiUserDataFilterOutRelationships {
     facts?: JsonApiVisualizationObjectOutRelationshipsFacts;
     labels?: JsonApiVisualizationObjectOutRelationshipsLabels;
     metrics?: JsonApiVisualizationObjectOutRelationshipsMetrics;
-    user?: JsonApiOrganizationOutRelationshipsBootstrapUser;
-    userGroup?: JsonApiOrganizationOutRelationshipsBootstrapUserGroup;
+    user?: JsonApiFilterViewPatchRelationshipsUser;
+    userGroup?: JsonApiUserDataFilterPatchRelationshipsUserGroup;
 }
 
 // @public (undocumented)
@@ -15964,8 +15959,13 @@ export interface JsonApiUserDataFilterPatchDocument {
 
 // @public
 export interface JsonApiUserDataFilterPatchRelationships {
-    user?: JsonApiOrganizationOutRelationshipsBootstrapUser;
-    userGroup?: JsonApiOrganizationOutRelationshipsBootstrapUserGroup;
+    user?: JsonApiFilterViewPatchRelationshipsUser;
+    userGroup?: JsonApiUserDataFilterPatchRelationshipsUserGroup;
+}
+
+// @public
+export interface JsonApiUserDataFilterPatchRelationshipsUserGroup {
+    data: JsonApiUserGroupToOneLinkage | null;
 }
 
 // @public (undocumented)
@@ -16057,7 +16057,7 @@ export interface JsonApiUserGroupOutList {
     data: Array<JsonApiUserGroupOutWithLinks>;
     included?: Array<JsonApiUserGroupOutWithLinks>;
     links?: ListLinks;
-    meta?: JsonApiApiTokenOutListMeta;
+    meta?: JsonApiAnalyticalDashboardOutListMeta;
 }
 
 // @public
@@ -16152,7 +16152,7 @@ export interface JsonApiUserIdentifierOutDocument {
 export interface JsonApiUserIdentifierOutList {
     data: Array<JsonApiUserIdentifierOutWithLinks>;
     links?: ListLinks;
-    meta?: JsonApiApiTokenOutListMeta;
+    meta?: JsonApiAnalyticalDashboardOutListMeta;
 }
 
 // @public (undocumented)
@@ -16245,7 +16245,7 @@ export interface JsonApiUserOutList {
     data: Array<JsonApiUserOutWithLinks>;
     included?: Array<JsonApiUserGroupOutWithLinks>;
     links?: ListLinks;
-    meta?: JsonApiApiTokenOutListMeta;
+    meta?: JsonApiAnalyticalDashboardOutListMeta;
 }
 
 // @public
@@ -16306,48 +16306,10 @@ export type JsonApiUserPatchTypeEnum = typeof JsonApiUserPatchTypeEnum[keyof typ
 
 // @public
 export interface JsonApiUserSettingIn {
-    attributes?: JsonApiUserSettingInAttributes;
+    attributes?: JsonApiWorkspaceSettingPatchAttributes;
     id: string;
     type: JsonApiUserSettingInTypeEnum;
 }
-
-// @public
-export interface JsonApiUserSettingInAttributes {
-    content?: object;
-    type?: JsonApiUserSettingInAttributesTypeEnum;
-}
-
-// @public (undocumented)
-export const JsonApiUserSettingInAttributesTypeEnum: {
-    readonly TIMEZONE: "TIMEZONE";
-    readonly ACTIVE_THEME: "ACTIVE_THEME";
-    readonly ACTIVE_COLOR_PALETTE: "ACTIVE_COLOR_PALETTE";
-    readonly ACTIVE_LLM_ENDPOINT: "ACTIVE_LLM_ENDPOINT";
-    readonly WHITE_LABELING: "WHITE_LABELING";
-    readonly LOCALE: "LOCALE";
-    readonly METADATA_LOCALE: "METADATA_LOCALE";
-    readonly FORMAT_LOCALE: "FORMAT_LOCALE";
-    readonly MAPBOX_TOKEN: "MAPBOX_TOKEN";
-    readonly WEEK_START: "WEEK_START";
-    readonly SHOW_HIDDEN_CATALOG_ITEMS: "SHOW_HIDDEN_CATALOG_ITEMS";
-    readonly OPERATOR_OVERRIDES: "OPERATOR_OVERRIDES";
-    readonly TIMEZONE_VALIDATION_ENABLED: "TIMEZONE_VALIDATION_ENABLED";
-    readonly OPENAI_CONFIG: "OPENAI_CONFIG";
-    readonly ENABLE_FILE_ANALYTICS: "ENABLE_FILE_ANALYTICS";
-    readonly ALERT: "ALERT";
-    readonly SEPARATORS: "SEPARATORS";
-    readonly DATE_FILTER_CONFIG: "DATE_FILTER_CONFIG";
-    readonly JIT_PROVISIONING: "JIT_PROVISIONING";
-    readonly JWT_JIT_PROVISIONING: "JWT_JIT_PROVISIONING";
-    readonly DASHBOARD_FILTERS_APPLY_MODE: "DASHBOARD_FILTERS_APPLY_MODE";
-    readonly ENABLE_SLIDES_EXPORT: "ENABLE_SLIDES_EXPORT";
-    readonly AI_RATE_LIMIT: "AI_RATE_LIMIT";
-    readonly ATTACHMENT_SIZE_LIMIT: "ATTACHMENT_SIZE_LIMIT";
-    readonly ATTACHMENT_LINK_TTL: "ATTACHMENT_LINK_TTL";
-};
-
-// @public (undocumented)
-export type JsonApiUserSettingInAttributesTypeEnum = typeof JsonApiUserSettingInAttributesTypeEnum[keyof typeof JsonApiUserSettingInAttributesTypeEnum];
 
 // @public
 export interface JsonApiUserSettingInDocument {
@@ -16364,7 +16326,7 @@ export type JsonApiUserSettingInTypeEnum = typeof JsonApiUserSettingInTypeEnum[k
 
 // @public
 export interface JsonApiUserSettingOut {
-    attributes?: JsonApiUserSettingInAttributes;
+    attributes?: JsonApiWorkspaceSettingPatchAttributes;
     id: string;
     type: JsonApiUserSettingOutTypeEnum;
 }
@@ -16379,7 +16341,7 @@ export interface JsonApiUserSettingOutDocument {
 export interface JsonApiUserSettingOutList {
     data: Array<JsonApiUserSettingOutWithLinks>;
     links?: ListLinks;
-    meta?: JsonApiApiTokenOutListMeta;
+    meta?: JsonApiAnalyticalDashboardOutListMeta;
 }
 
 // @public (undocumented)
@@ -16392,7 +16354,7 @@ export type JsonApiUserSettingOutTypeEnum = typeof JsonApiUserSettingOutTypeEnum
 
 // @public
 export interface JsonApiUserSettingOutWithLinks {
-    attributes?: JsonApiUserSettingInAttributes;
+    attributes?: JsonApiWorkspaceSettingPatchAttributes;
     id: string;
     links?: ObjectLinks;
     type: JsonApiUserSettingOutWithLinksTypeEnum;
@@ -16475,7 +16437,7 @@ export interface JsonApiVisualizationObjectOutList {
     data: Array<JsonApiVisualizationObjectOutWithLinks>;
     included?: Array<JsonApiMetricOutIncludes>;
     links?: ListLinks;
-    meta?: JsonApiApiTokenOutListMeta;
+    meta?: JsonApiAnalyticalDashboardOutListMeta;
 }
 
 // @public
@@ -16671,7 +16633,7 @@ export interface JsonApiWorkspaceDataFilterOutList {
     data: Array<JsonApiWorkspaceDataFilterOutWithLinks>;
     included?: Array<JsonApiWorkspaceDataFilterSettingOutWithLinks>;
     links?: ListLinks;
-    meta?: JsonApiApiTokenOutListMeta;
+    meta?: JsonApiAnalyticalDashboardOutListMeta;
 }
 
 // @public
@@ -16787,7 +16749,7 @@ export interface JsonApiWorkspaceDataFilterSettingOutList {
     data: Array<JsonApiWorkspaceDataFilterSettingOutWithLinks>;
     included?: Array<JsonApiWorkspaceDataFilterOutWithLinks>;
     links?: ListLinks;
-    meta?: JsonApiApiTokenOutListMeta;
+    meta?: JsonApiAnalyticalDashboardOutListMeta;
 }
 
 // @public (undocumented)
@@ -16859,9 +16821,9 @@ export type JsonApiWorkspaceDataFilterToOneLinkage = JsonApiWorkspaceDataFilterL
 
 // @public
 export interface JsonApiWorkspaceIn {
-    attributes?: JsonApiWorkspaceOutAttributes;
+    attributes?: JsonApiWorkspacePatchAttributes;
     id: string;
-    relationships?: JsonApiWorkspaceOutRelationships;
+    relationships?: JsonApiWorkspacePatchRelationships;
     type: JsonApiWorkspaceInTypeEnum;
 }
 
@@ -16894,29 +16856,11 @@ export type JsonApiWorkspaceLinkageTypeEnum = typeof JsonApiWorkspaceLinkageType
 
 // @public
 export interface JsonApiWorkspaceOut {
-    attributes?: JsonApiWorkspaceOutAttributes;
+    attributes?: JsonApiWorkspacePatchAttributes;
     id: string;
     meta?: JsonApiWorkspaceOutMeta;
-    relationships?: JsonApiWorkspaceOutRelationships;
+    relationships?: JsonApiWorkspacePatchRelationships;
     type: JsonApiWorkspaceOutTypeEnum;
-}
-
-// @public
-export interface JsonApiWorkspaceOutAttributes {
-    cacheExtraLimit?: number;
-    dataSource?: JsonApiWorkspaceOutAttributesDataSource;
-    description?: string | null;
-    // @deprecated
-    earlyAccess?: string | null;
-    earlyAccessValues?: Array<string> | null;
-    name?: string | null;
-    prefix?: string | null;
-}
-
-// @public
-export interface JsonApiWorkspaceOutAttributesDataSource {
-    id: string;
-    schemaPath?: Array<string>;
 }
 
 // @public
@@ -16931,7 +16875,7 @@ export interface JsonApiWorkspaceOutList {
     data: Array<JsonApiWorkspaceOutWithLinks>;
     included?: Array<JsonApiWorkspaceOutWithLinks>;
     links?: ListLinks;
-    meta?: JsonApiApiTokenOutListMeta;
+    meta?: JsonApiAnalyticalDashboardOutListMeta;
 }
 
 // @public
@@ -16975,16 +16919,6 @@ export const JsonApiWorkspaceOutMetaPermissionsEnum: {
 // @public (undocumented)
 export type JsonApiWorkspaceOutMetaPermissionsEnum = typeof JsonApiWorkspaceOutMetaPermissionsEnum[keyof typeof JsonApiWorkspaceOutMetaPermissionsEnum];
 
-// @public
-export interface JsonApiWorkspaceOutRelationships {
-    parent?: JsonApiWorkspaceOutRelationshipsParent;
-}
-
-// @public
-export interface JsonApiWorkspaceOutRelationshipsParent {
-    data: JsonApiWorkspaceToOneLinkage | null;
-}
-
 // @public (undocumented)
 export const JsonApiWorkspaceOutTypeEnum: {
     readonly WORKSPACE: "workspace";
@@ -16995,11 +16929,11 @@ export type JsonApiWorkspaceOutTypeEnum = typeof JsonApiWorkspaceOutTypeEnum[key
 
 // @public
 export interface JsonApiWorkspaceOutWithLinks {
-    attributes?: JsonApiWorkspaceOutAttributes;
+    attributes?: JsonApiWorkspacePatchAttributes;
     id: string;
     links?: ObjectLinks;
     meta?: JsonApiWorkspaceOutMeta;
-    relationships?: JsonApiWorkspaceOutRelationships;
+    relationships?: JsonApiWorkspacePatchRelationships;
     type: JsonApiWorkspaceOutWithLinksTypeEnum;
 }
 
@@ -17013,15 +16947,43 @@ export type JsonApiWorkspaceOutWithLinksTypeEnum = typeof JsonApiWorkspaceOutWit
 
 // @public
 export interface JsonApiWorkspacePatch {
-    attributes?: JsonApiWorkspaceOutAttributes;
+    attributes?: JsonApiWorkspacePatchAttributes;
     id: string;
-    relationships?: JsonApiWorkspaceOutRelationships;
+    relationships?: JsonApiWorkspacePatchRelationships;
     type: JsonApiWorkspacePatchTypeEnum;
+}
+
+// @public
+export interface JsonApiWorkspacePatchAttributes {
+    cacheExtraLimit?: number;
+    dataSource?: JsonApiWorkspacePatchAttributesDataSource;
+    description?: string | null;
+    // @deprecated
+    earlyAccess?: string | null;
+    earlyAccessValues?: Array<string> | null;
+    name?: string | null;
+    prefix?: string | null;
+}
+
+// @public
+export interface JsonApiWorkspacePatchAttributesDataSource {
+    id: string;
+    schemaPath?: Array<string>;
 }
 
 // @public
 export interface JsonApiWorkspacePatchDocument {
     data: JsonApiWorkspacePatch;
+}
+
+// @public
+export interface JsonApiWorkspacePatchRelationships {
+    parent?: JsonApiWorkspacePatchRelationshipsParent;
+}
+
+// @public
+export interface JsonApiWorkspacePatchRelationshipsParent {
+    data: JsonApiWorkspaceToOneLinkage | null;
 }
 
 // @public (undocumented)
@@ -17034,7 +16996,7 @@ export type JsonApiWorkspacePatchTypeEnum = typeof JsonApiWorkspacePatchTypeEnum
 
 // @public
 export interface JsonApiWorkspaceSettingIn {
-    attributes?: JsonApiUserSettingInAttributes;
+    attributes?: JsonApiWorkspaceSettingPatchAttributes;
     id: string;
     type: JsonApiWorkspaceSettingInTypeEnum;
 }
@@ -17054,7 +17016,7 @@ export type JsonApiWorkspaceSettingInTypeEnum = typeof JsonApiWorkspaceSettingIn
 
 // @public
 export interface JsonApiWorkspaceSettingOut {
-    attributes?: JsonApiUserSettingInAttributes;
+    attributes?: JsonApiWorkspaceSettingPatchAttributes;
     id: string;
     meta?: JsonApiVisualizationObjectOutMeta;
     type: JsonApiWorkspaceSettingOutTypeEnum;
@@ -17070,7 +17032,7 @@ export interface JsonApiWorkspaceSettingOutDocument {
 export interface JsonApiWorkspaceSettingOutList {
     data: Array<JsonApiWorkspaceSettingOutWithLinks>;
     links?: ListLinks;
-    meta?: JsonApiApiTokenOutListMeta;
+    meta?: JsonApiAnalyticalDashboardOutListMeta;
 }
 
 // @public (undocumented)
@@ -17083,7 +17045,7 @@ export type JsonApiWorkspaceSettingOutTypeEnum = typeof JsonApiWorkspaceSettingO
 
 // @public
 export interface JsonApiWorkspaceSettingOutWithLinks {
-    attributes?: JsonApiUserSettingInAttributes;
+    attributes?: JsonApiWorkspaceSettingPatchAttributes;
     id: string;
     links?: ObjectLinks;
     meta?: JsonApiVisualizationObjectOutMeta;
@@ -17100,10 +17062,48 @@ export type JsonApiWorkspaceSettingOutWithLinksTypeEnum = typeof JsonApiWorkspac
 
 // @public
 export interface JsonApiWorkspaceSettingPatch {
-    attributes?: JsonApiUserSettingInAttributes;
+    attributes?: JsonApiWorkspaceSettingPatchAttributes;
     id: string;
     type: JsonApiWorkspaceSettingPatchTypeEnum;
 }
+
+// @public
+export interface JsonApiWorkspaceSettingPatchAttributes {
+    content?: object;
+    type?: JsonApiWorkspaceSettingPatchAttributesTypeEnum;
+}
+
+// @public (undocumented)
+export const JsonApiWorkspaceSettingPatchAttributesTypeEnum: {
+    readonly TIMEZONE: "TIMEZONE";
+    readonly ACTIVE_THEME: "ACTIVE_THEME";
+    readonly ACTIVE_COLOR_PALETTE: "ACTIVE_COLOR_PALETTE";
+    readonly ACTIVE_LLM_ENDPOINT: "ACTIVE_LLM_ENDPOINT";
+    readonly WHITE_LABELING: "WHITE_LABELING";
+    readonly LOCALE: "LOCALE";
+    readonly METADATA_LOCALE: "METADATA_LOCALE";
+    readonly FORMAT_LOCALE: "FORMAT_LOCALE";
+    readonly MAPBOX_TOKEN: "MAPBOX_TOKEN";
+    readonly WEEK_START: "WEEK_START";
+    readonly SHOW_HIDDEN_CATALOG_ITEMS: "SHOW_HIDDEN_CATALOG_ITEMS";
+    readonly OPERATOR_OVERRIDES: "OPERATOR_OVERRIDES";
+    readonly TIMEZONE_VALIDATION_ENABLED: "TIMEZONE_VALIDATION_ENABLED";
+    readonly OPENAI_CONFIG: "OPENAI_CONFIG";
+    readonly ENABLE_FILE_ANALYTICS: "ENABLE_FILE_ANALYTICS";
+    readonly ALERT: "ALERT";
+    readonly SEPARATORS: "SEPARATORS";
+    readonly DATE_FILTER_CONFIG: "DATE_FILTER_CONFIG";
+    readonly JIT_PROVISIONING: "JIT_PROVISIONING";
+    readonly JWT_JIT_PROVISIONING: "JWT_JIT_PROVISIONING";
+    readonly DASHBOARD_FILTERS_APPLY_MODE: "DASHBOARD_FILTERS_APPLY_MODE";
+    readonly ENABLE_SLIDES_EXPORT: "ENABLE_SLIDES_EXPORT";
+    readonly AI_RATE_LIMIT: "AI_RATE_LIMIT";
+    readonly ATTACHMENT_SIZE_LIMIT: "ATTACHMENT_SIZE_LIMIT";
+    readonly ATTACHMENT_LINK_TTL: "ATTACHMENT_LINK_TTL";
+};
+
+// @public (undocumented)
+export type JsonApiWorkspaceSettingPatchAttributesTypeEnum = typeof JsonApiWorkspaceSettingPatchAttributesTypeEnum[keyof typeof JsonApiWorkspaceSettingPatchAttributesTypeEnum];
 
 // @public
 export interface JsonApiWorkspaceSettingPatchDocument {
@@ -17120,7 +17120,7 @@ export type JsonApiWorkspaceSettingPatchTypeEnum = typeof JsonApiWorkspaceSettin
 
 // @public
 export interface JsonApiWorkspaceSettingPostOptionalId {
-    attributes?: JsonApiUserSettingInAttributes;
+    attributes?: JsonApiWorkspaceSettingPatchAttributes;
     id?: string;
     type: JsonApiWorkspaceSettingPostOptionalIdTypeEnum;
 }
@@ -20798,10 +20798,10 @@ export interface RelativeDateFilter {
 export interface RelativeDateFilterRelativeDateFilter {
     applyOnResult?: boolean;
     dataset: AfmObjectIdentifierDataset;
-    from: number;
+    from?: number | null;
     granularity: RelativeDateFilterRelativeDateFilterGranularityEnum;
     localIdentifier?: string;
-    to: number;
+    to?: number | null;
 }
 
 // @public (undocumented)

--- a/libs/api-client-tiger/src/generated/afm-rest-api/api.ts
+++ b/libs/api-client-tiger/src/generated/afm-rest-api/api.ts
@@ -2925,7 +2925,7 @@ export type RankingFilterRankingFilterOperatorEnum =
     typeof RankingFilterRankingFilterOperatorEnum[keyof typeof RankingFilterRankingFilterOperatorEnum];
 
 /**
- * A date filter specifying a time interval that is relative to the current date. For example, last week, next month, and so on. Field dataset is representing qualifier of date dimension.
+ * A date filter specifying a time interval that is relative to the current date. For example, last week, next month, and so on. Field dataset is representing qualifier of date dimension. The \'from\' and \'to\' properties mark the boundaries of the interval. If \'from\' is omitted, all values earlier than \'to\' are included. If \'to\' is omitted, all values later than \'from\' are included. It is not allowed to omit both.
  * @export
  * @interface RelativeDateFilter
  */
@@ -2950,17 +2950,17 @@ export interface RelativeDateFilterRelativeDateFilter {
      */
     granularity: RelativeDateFilterRelativeDateFilterGranularityEnum;
     /**
-     * Start of the filtering interval. Specified by number of periods (with respect to given granularity). Typically negative (historical time interval like -2 for \'2 days/weeks, ... ago\').
+     * Start of the filtering interval. Specified by number of periods (with respect to given granularity). Typically negative (historical time interval like -2 for \'2 days/weeks, ... ago\'). If null, then start of the range is unbounded.
      * @type {number}
      * @memberof RelativeDateFilterRelativeDateFilter
      */
-    from: number;
+    from?: number | null;
     /**
-     * End of the filtering interval. Specified by number of periods (with respect to given granularity). Value \'O\' is representing current time-interval (current day, week, ...).
+     * End of the filtering interval. Specified by number of periods (with respect to given granularity). Value \'O\' is representing current time-interval (current day, week, ...). If null, then end of the range is unbounded.
      * @type {number}
      * @memberof RelativeDateFilterRelativeDateFilter
      */
-    to: number;
+    to?: number | null;
     /**
      *
      * @type {string}

--- a/libs/api-client-tiger/src/generated/afm-rest-api/openapi-spec.json
+++ b/libs/api-client-tiger/src/generated/afm-rest-api/openapi-spec.json
@@ -1769,7 +1769,7 @@
                 "type": "object",
                 "properties": {
                     "relativeDateFilter": {
-                        "required": ["from", "granularity", "to", "dataset"],
+                        "required": ["granularity", "dataset"],
                         "type": "object",
                         "properties": {
                             "granularity": {
@@ -1796,14 +1796,16 @@
                             },
                             "from": {
                                 "type": "integer",
-                                "description": "Start of the filtering interval. Specified by number of periods (with respect to given granularity). Typically negative (historical time interval like -2 for '2 days/weeks, ... ago').",
+                                "description": "Start of the filtering interval. Specified by number of periods (with respect to given granularity). Typically negative (historical time interval like -2 for '2 days/weeks, ... ago'). If null, then start of the range is unbounded.",
                                 "format": "int32",
+                                "nullable": true,
                                 "example": -6
                             },
                             "to": {
                                 "type": "integer",
-                                "description": "End of the filtering interval. Specified by number of periods (with respect to given granularity). Value 'O' is representing current time-interval (current day, week, ...).",
+                                "description": "End of the filtering interval. Specified by number of periods (with respect to given granularity). Value 'O' is representing current time-interval (current day, week, ...). If null, then end of the range is unbounded.",
                                 "format": "int32",
+                                "nullable": true,
                                 "example": 0
                             },
                             "localIdentifier": {
@@ -1818,7 +1820,7 @@
                         }
                     }
                 },
-                "description": "A date filter specifying a time interval that is relative to the current date. For example, last week, next month, and so on. Field dataset is representing qualifier of date dimension."
+                "description": "A date filter specifying a time interval that is relative to the current date. For example, last week, next month, and so on. Field dataset is representing qualifier of date dimension. The 'from' and 'to' properties mark the boundaries of the interval. If 'from' is omitted, all values earlier than 'to' are included. If 'to' is omitted, all values later than 'from' are included. It is not allowed to omit both."
             },
             "SimpleMeasureDefinition": {
                 "required": ["measure"],

--- a/libs/api-client-tiger/src/generated/automation-json-api/api.ts
+++ b/libs/api-client-tiger/src/generated/automation-json-api/api.ts
@@ -2672,7 +2672,7 @@ export type AutomationRelativeOperatorEnum =
     typeof AutomationRelativeOperatorEnum[keyof typeof AutomationRelativeOperatorEnum];
 
 /**
- * A date filter specifying a time interval that is relative to the current date. For example, last week, next month, and so on. Field dataset is representing qualifier of date dimension.
+ * A date filter specifying a time interval that is relative to the current date. For example, last week, next month, and so on. Field dataset is representing qualifier of date dimension. The \'from\' and \'to\' properties mark the boundaries of the interval. If \'from\' is omitted, all values earlier than \'to\' are included. If \'to\' is omitted, all values later than \'from\' are included. It is not allowed to omit both.
  * @export
  * @interface AutomationRelativeDateFilter
  */
@@ -2697,17 +2697,17 @@ export interface AutomationRelativeDateFilterRelativeDateFilter {
      */
     granularity: AutomationRelativeDateFilterRelativeDateFilterGranularityEnum;
     /**
-     * Start of the filtering interval. Specified by number of periods (with respect to given granularity). Typically negative (historical time interval like -2 for \'2 days/weeks, ... ago\').
+     * Start of the filtering interval. Specified by number of periods (with respect to given granularity). Typically negative (historical time interval like -2 for \'2 days/weeks, ... ago\'). If null, then start of the range is unbounded.
      * @type {number}
      * @memberof AutomationRelativeDateFilterRelativeDateFilter
      */
-    from: number;
+    from?: number | null;
     /**
-     * End of the filtering interval. Specified by number of periods (with respect to given granularity). Value \'O\' is representing current time-interval (current day, week, ...).
+     * End of the filtering interval. Specified by number of periods (with respect to given granularity). Value \'O\' is representing current time-interval (current day, week, ...). If null, then end of the range is unbounded.
      * @type {number}
      * @memberof AutomationRelativeDateFilterRelativeDateFilter
      */
-    to: number;
+    to?: number | null;
     /**
      *
      * @type {string}

--- a/libs/api-client-tiger/src/generated/automation-json-api/openapi-spec.json
+++ b/libs/api-client-tiger/src/generated/automation-json-api/openapi-spec.json
@@ -2061,7 +2061,7 @@
                 "type": "object",
                 "properties": {
                     "relativeDateFilter": {
-                        "required": ["from", "granularity", "to", "dataset"],
+                        "required": ["granularity", "dataset"],
                         "type": "object",
                         "properties": {
                             "granularity": {
@@ -2088,14 +2088,16 @@
                             },
                             "from": {
                                 "type": "integer",
-                                "description": "Start of the filtering interval. Specified by number of periods (with respect to given granularity). Typically negative (historical time interval like -2 for '2 days/weeks, ... ago').",
+                                "description": "Start of the filtering interval. Specified by number of periods (with respect to given granularity). Typically negative (historical time interval like -2 for '2 days/weeks, ... ago'). If null, then start of the range is unbounded.",
                                 "format": "int32",
+                                "nullable": true,
                                 "example": -6
                             },
                             "to": {
                                 "type": "integer",
-                                "description": "End of the filtering interval. Specified by number of periods (with respect to given granularity). Value 'O' is representing current time-interval (current day, week, ...).",
+                                "description": "End of the filtering interval. Specified by number of periods (with respect to given granularity). Value 'O' is representing current time-interval (current day, week, ...). If null, then end of the range is unbounded.",
                                 "format": "int32",
+                                "nullable": true,
                                 "example": 0
                             },
                             "localIdentifier": {
@@ -2110,7 +2112,7 @@
                         }
                     }
                 },
-                "description": "A date filter specifying a time interval that is relative to the current date. For example, last week, next month, and so on. Field dataset is representing qualifier of date dimension."
+                "description": "A date filter specifying a time interval that is relative to the current date. For example, last week, next month, and so on. Field dataset is representing qualifier of date dimension. The 'from' and 'to' properties mark the boundaries of the interval. If 'from' is omitted, all values earlier than 'to' are included. If 'to' is omitted, all values later than 'from' are included. It is not allowed to omit both."
             },
             "RelativeWrapper": {
                 "required": ["relative"],

--- a/libs/api-client-tiger/src/generated/export-json-api/api.ts
+++ b/libs/api-client-tiger/src/generated/export-json-api/api.ts
@@ -1698,7 +1698,7 @@ export type ExportRawExportRequestFormatEnum =
     typeof ExportRawExportRequestFormatEnum[keyof typeof ExportRawExportRequestFormatEnum];
 
 /**
- * A date filter specifying a time interval that is relative to the current date. For example, last week, next month, and so on. Field dataset is representing qualifier of date dimension.
+ * A date filter specifying a time interval that is relative to the current date. For example, last week, next month, and so on. Field dataset is representing qualifier of date dimension. The \'from\' and \'to\' properties mark the boundaries of the interval. If \'from\' is omitted, all values earlier than \'to\' are included. If \'to\' is omitted, all values later than \'from\' are included. It is not allowed to omit both.
  * @export
  * @interface ExportRelativeDateFilter
  */
@@ -1723,17 +1723,17 @@ export interface ExportRelativeDateFilterRelativeDateFilter {
      */
     granularity: ExportRelativeDateFilterRelativeDateFilterGranularityEnum;
     /**
-     * Start of the filtering interval. Specified by number of periods (with respect to given granularity). Typically negative (historical time interval like -2 for \'2 days/weeks, ... ago\').
+     * Start of the filtering interval. Specified by number of periods (with respect to given granularity). Typically negative (historical time interval like -2 for \'2 days/weeks, ... ago\'). If null, then start of the range is unbounded.
      * @type {number}
      * @memberof ExportRelativeDateFilterRelativeDateFilter
      */
-    from: number;
+    from?: number | null;
     /**
-     * End of the filtering interval. Specified by number of periods (with respect to given granularity). Value \'O\' is representing current time-interval (current day, week, ...).
+     * End of the filtering interval. Specified by number of periods (with respect to given granularity). Value \'O\' is representing current time-interval (current day, week, ...). If null, then end of the range is unbounded.
      * @type {number}
      * @memberof ExportRelativeDateFilterRelativeDateFilter
      */
-    to: number;
+    to?: number | null;
     /**
      *
      * @type {string}

--- a/libs/api-client-tiger/src/generated/export-json-api/openapi-spec.json
+++ b/libs/api-client-tiger/src/generated/export-json-api/openapi-spec.json
@@ -1943,7 +1943,7 @@
                 "type": "object",
                 "properties": {
                     "relativeDateFilter": {
-                        "required": ["from", "granularity", "to", "dataset"],
+                        "required": ["granularity", "dataset"],
                         "type": "object",
                         "properties": {
                             "granularity": {
@@ -1970,14 +1970,16 @@
                             },
                             "from": {
                                 "type": "integer",
-                                "description": "Start of the filtering interval. Specified by number of periods (with respect to given granularity). Typically negative (historical time interval like -2 for '2 days/weeks, ... ago').",
+                                "description": "Start of the filtering interval. Specified by number of periods (with respect to given granularity). Typically negative (historical time interval like -2 for '2 days/weeks, ... ago'). If null, then start of the range is unbounded.",
                                 "format": "int32",
+                                "nullable": true,
                                 "example": -6
                             },
                             "to": {
                                 "type": "integer",
-                                "description": "End of the filtering interval. Specified by number of periods (with respect to given granularity). Value 'O' is representing current time-interval (current day, week, ...).",
+                                "description": "End of the filtering interval. Specified by number of periods (with respect to given granularity). Value 'O' is representing current time-interval (current day, week, ...). If null, then end of the range is unbounded.",
                                 "format": "int32",
+                                "nullable": true,
                                 "example": 0
                             },
                             "localIdentifier": {
@@ -1992,7 +1994,7 @@
                         }
                     }
                 },
-                "description": "A date filter specifying a time interval that is relative to the current date. For example, last week, next month, and so on. Field dataset is representing qualifier of date dimension."
+                "description": "A date filter specifying a time interval that is relative to the current date. For example, last week, next month, and so on. Field dataset is representing qualifier of date dimension. The 'from' and 'to' properties mark the boundaries of the interval. If 'from' is omitted, all values earlier than 'to' are included. If 'to' is omitted, all values later than 'from' are included. It is not allowed to omit both."
             },
             "SimpleMeasureDefinition": {
                 "required": ["measure"],

--- a/libs/api-client-tiger/src/generated/metadata-json-api/openapi-spec.json
+++ b/libs/api-client-tiger/src/generated/metadata-json-api/openapi-spec.json
@@ -15142,2240 +15142,6 @@
                     }
                 }
             },
-            "JsonApiApiTokenInDocument": {
-                "required": ["data"],
-                "type": "object",
-                "properties": {
-                    "data": {
-                        "$ref": "#/components/schemas/JsonApiApiTokenIn"
-                    }
-                }
-            },
-            "JsonApiApiTokenIn": {
-                "required": ["id", "type"],
-                "type": "object",
-                "properties": {
-                    "type": {
-                        "type": "string",
-                        "description": "Object type",
-                        "example": "apiToken",
-                        "enum": ["apiToken"]
-                    },
-                    "id": {
-                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
-                        "type": "string",
-                        "description": "API identifier of an object",
-                        "example": "id1"
-                    }
-                },
-                "description": "JSON:API representation of apiToken entity."
-            },
-            "JsonApiApiTokenOutDocument": {
-                "required": ["data"],
-                "type": "object",
-                "properties": {
-                    "data": {
-                        "$ref": "#/components/schemas/JsonApiApiTokenOut"
-                    },
-                    "links": {
-                        "$ref": "#/components/schemas/ObjectLinks"
-                    }
-                }
-            },
-            "JsonApiApiTokenOut": {
-                "required": ["id", "type"],
-                "type": "object",
-                "properties": {
-                    "type": {
-                        "type": "string",
-                        "description": "Object type",
-                        "example": "apiToken",
-                        "enum": ["apiToken"]
-                    },
-                    "id": {
-                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
-                        "type": "string",
-                        "description": "API identifier of an object",
-                        "example": "id1"
-                    },
-                    "attributes": {
-                        "type": "object",
-                        "properties": {
-                            "bearerToken": {
-                                "type": "string",
-                                "description": "The value of the Bearer token. It is only returned when the API token is created."
-                            }
-                        }
-                    }
-                },
-                "description": "JSON:API representation of apiToken entity."
-            },
-            "JsonApiUserSettingInDocument": {
-                "required": ["data"],
-                "type": "object",
-                "properties": {
-                    "data": {
-                        "$ref": "#/components/schemas/JsonApiUserSettingIn"
-                    }
-                }
-            },
-            "JsonApiUserSettingIn": {
-                "required": ["id", "type"],
-                "type": "object",
-                "properties": {
-                    "type": {
-                        "type": "string",
-                        "description": "Object type",
-                        "example": "userSetting",
-                        "enum": ["userSetting"]
-                    },
-                    "id": {
-                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
-                        "type": "string",
-                        "description": "API identifier of an object",
-                        "example": "id1"
-                    },
-                    "attributes": {
-                        "type": "object",
-                        "properties": {
-                            "content": {
-                                "type": "object",
-                                "description": "Free-form JSON content. Maximum supported length is 15000 characters.",
-                                "example": {}
-                            },
-                            "type": {
-                                "type": "string",
-                                "enum": [
-                                    "TIMEZONE",
-                                    "ACTIVE_THEME",
-                                    "ACTIVE_COLOR_PALETTE",
-                                    "ACTIVE_LLM_ENDPOINT",
-                                    "WHITE_LABELING",
-                                    "LOCALE",
-                                    "METADATA_LOCALE",
-                                    "FORMAT_LOCALE",
-                                    "MAPBOX_TOKEN",
-                                    "WEEK_START",
-                                    "SHOW_HIDDEN_CATALOG_ITEMS",
-                                    "OPERATOR_OVERRIDES",
-                                    "TIMEZONE_VALIDATION_ENABLED",
-                                    "OPENAI_CONFIG",
-                                    "ENABLE_FILE_ANALYTICS",
-                                    "ALERT",
-                                    "SEPARATORS",
-                                    "DATE_FILTER_CONFIG",
-                                    "JIT_PROVISIONING",
-                                    "JWT_JIT_PROVISIONING",
-                                    "DASHBOARD_FILTERS_APPLY_MODE",
-                                    "ENABLE_SLIDES_EXPORT",
-                                    "AI_RATE_LIMIT",
-                                    "ATTACHMENT_SIZE_LIMIT",
-                                    "ATTACHMENT_LINK_TTL"
-                                ]
-                            }
-                        }
-                    }
-                },
-                "description": "JSON:API representation of userSetting entity."
-            },
-            "JsonApiUserSettingOutDocument": {
-                "required": ["data"],
-                "type": "object",
-                "properties": {
-                    "data": {
-                        "$ref": "#/components/schemas/JsonApiUserSettingOut"
-                    },
-                    "links": {
-                        "$ref": "#/components/schemas/ObjectLinks"
-                    }
-                }
-            },
-            "JsonApiUserSettingOut": {
-                "required": ["id", "type"],
-                "type": "object",
-                "properties": {
-                    "type": {
-                        "type": "string",
-                        "description": "Object type",
-                        "example": "userSetting",
-                        "enum": ["userSetting"]
-                    },
-                    "id": {
-                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
-                        "type": "string",
-                        "description": "API identifier of an object",
-                        "example": "id1"
-                    },
-                    "attributes": {
-                        "type": "object",
-                        "properties": {
-                            "content": {
-                                "type": "object",
-                                "description": "Free-form JSON content. Maximum supported length is 15000 characters.",
-                                "example": {}
-                            },
-                            "type": {
-                                "type": "string",
-                                "enum": [
-                                    "TIMEZONE",
-                                    "ACTIVE_THEME",
-                                    "ACTIVE_COLOR_PALETTE",
-                                    "ACTIVE_LLM_ENDPOINT",
-                                    "WHITE_LABELING",
-                                    "LOCALE",
-                                    "METADATA_LOCALE",
-                                    "FORMAT_LOCALE",
-                                    "MAPBOX_TOKEN",
-                                    "WEEK_START",
-                                    "SHOW_HIDDEN_CATALOG_ITEMS",
-                                    "OPERATOR_OVERRIDES",
-                                    "TIMEZONE_VALIDATION_ENABLED",
-                                    "OPENAI_CONFIG",
-                                    "ENABLE_FILE_ANALYTICS",
-                                    "ALERT",
-                                    "SEPARATORS",
-                                    "DATE_FILTER_CONFIG",
-                                    "JIT_PROVISIONING",
-                                    "JWT_JIT_PROVISIONING",
-                                    "DASHBOARD_FILTERS_APPLY_MODE",
-                                    "ENABLE_SLIDES_EXPORT",
-                                    "AI_RATE_LIMIT",
-                                    "ATTACHMENT_SIZE_LIMIT",
-                                    "ATTACHMENT_LINK_TTL"
-                                ]
-                            }
-                        }
-                    }
-                },
-                "description": "JSON:API representation of userSetting entity."
-            },
-            "JsonApiApiTokenOutWithLinks": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/JsonApiApiTokenOut"
-                    },
-                    {
-                        "$ref": "#/components/schemas/ObjectLinksContainer"
-                    }
-                ]
-            },
-            "JsonApiApiTokenOutList": {
-                "required": ["data"],
-                "type": "object",
-                "properties": {
-                    "data": {
-                        "uniqueItems": true,
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/JsonApiApiTokenOutWithLinks"
-                        }
-                    },
-                    "links": {
-                        "$ref": "#/components/schemas/ListLinks"
-                    },
-                    "meta": {
-                        "type": "object",
-                        "properties": {
-                            "page": {
-                                "$ref": "#/components/schemas/PageMetadata"
-                            }
-                        }
-                    }
-                },
-                "description": "A JSON:API document with a list of resources"
-            },
-            "JsonApiUserSettingOutWithLinks": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/JsonApiUserSettingOut"
-                    },
-                    {
-                        "$ref": "#/components/schemas/ObjectLinksContainer"
-                    }
-                ]
-            },
-            "JsonApiUserSettingOutList": {
-                "required": ["data"],
-                "type": "object",
-                "properties": {
-                    "data": {
-                        "uniqueItems": true,
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/JsonApiUserSettingOutWithLinks"
-                        }
-                    },
-                    "links": {
-                        "$ref": "#/components/schemas/ListLinks"
-                    },
-                    "meta": {
-                        "type": "object",
-                        "properties": {
-                            "page": {
-                                "$ref": "#/components/schemas/PageMetadata"
-                            }
-                        }
-                    }
-                },
-                "description": "A JSON:API document with a list of resources"
-            },
-            "JsonApiCookieSecurityConfigurationOutDocument": {
-                "required": ["data"],
-                "type": "object",
-                "properties": {
-                    "data": {
-                        "$ref": "#/components/schemas/JsonApiCookieSecurityConfigurationOut"
-                    },
-                    "links": {
-                        "$ref": "#/components/schemas/ObjectLinks"
-                    }
-                }
-            },
-            "JsonApiCookieSecurityConfigurationOut": {
-                "required": ["id", "type"],
-                "type": "object",
-                "properties": {
-                    "type": {
-                        "type": "string",
-                        "description": "Object type",
-                        "example": "cookieSecurityConfiguration",
-                        "enum": ["cookieSecurityConfiguration"]
-                    },
-                    "id": {
-                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
-                        "type": "string",
-                        "description": "API identifier of an object",
-                        "example": "id1"
-                    },
-                    "attributes": {
-                        "type": "object",
-                        "properties": {
-                            "lastRotation": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "rotationInterval": {
-                                "type": "string",
-                                "description": "Length of interval between automatic rotations expressed in format of ISO 8601 duration",
-                                "example": "P30D"
-                            }
-                        }
-                    }
-                },
-                "description": "JSON:API representation of cookieSecurityConfiguration entity."
-            },
-            "JsonApiUserOut": {
-                "required": ["id", "type"],
-                "type": "object",
-                "properties": {
-                    "type": {
-                        "type": "string",
-                        "description": "Object type",
-                        "example": "user",
-                        "enum": ["user"]
-                    },
-                    "id": {
-                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
-                        "type": "string",
-                        "description": "API identifier of an object",
-                        "example": "id1"
-                    },
-                    "attributes": {
-                        "type": "object",
-                        "properties": {
-                            "authenticationId": {
-                                "maxLength": 255,
-                                "type": "string"
-                            },
-                            "firstname": {
-                                "maxLength": 255,
-                                "type": "string"
-                            },
-                            "lastname": {
-                                "maxLength": 255,
-                                "type": "string"
-                            },
-                            "email": {
-                                "maxLength": 255,
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "relationships": {
-                        "type": "object",
-                        "properties": {
-                            "userGroups": {
-                                "required": ["data"],
-                                "type": "object",
-                                "properties": {
-                                    "data": {
-                                        "$ref": "#/components/schemas/JsonApiUserGroupToManyLinkage"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "JSON:API representation of user entity."
-            },
-            "JsonApiUserGroupLinkage": {
-                "required": ["id", "type"],
-                "type": "object",
-                "properties": {
-                    "id": {
-                        "type": "string"
-                    },
-                    "type": {
-                        "type": "string",
-                        "enum": ["userGroup"]
-                    }
-                },
-                "description": "The \\\"type\\\" and \\\"id\\\" to non-empty members."
-            },
-            "JsonApiUserGroupToManyLinkage": {
-                "type": "array",
-                "description": "References to other resource objects in a to-many (\\\"relationship\\\"). Relationships can be specified by including a member in a resource's links object.",
-                "items": {
-                    "$ref": "#/components/schemas/JsonApiUserGroupLinkage"
-                }
-            },
-            "JsonApiUserOutWithLinks": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/JsonApiUserOut"
-                    },
-                    {
-                        "$ref": "#/components/schemas/ObjectLinksContainer"
-                    }
-                ]
-            },
-            "JsonApiUserGroupOut": {
-                "required": ["id", "type"],
-                "type": "object",
-                "properties": {
-                    "type": {
-                        "type": "string",
-                        "description": "Object type",
-                        "example": "userGroup",
-                        "enum": ["userGroup"]
-                    },
-                    "id": {
-                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
-                        "type": "string",
-                        "description": "API identifier of an object",
-                        "example": "id1"
-                    },
-                    "attributes": {
-                        "type": "object",
-                        "properties": {
-                            "name": {
-                                "maxLength": 255,
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "relationships": {
-                        "type": "object",
-                        "properties": {
-                            "parents": {
-                                "required": ["data"],
-                                "type": "object",
-                                "properties": {
-                                    "data": {
-                                        "$ref": "#/components/schemas/JsonApiUserGroupToManyLinkage"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "JSON:API representation of userGroup entity."
-            },
-            "JsonApiUserGroupOutWithLinks": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/JsonApiUserGroupOut"
-                    },
-                    {
-                        "$ref": "#/components/schemas/ObjectLinksContainer"
-                    }
-                ]
-            },
-            "JsonApiIdentityProviderOut": {
-                "required": ["id", "type"],
-                "type": "object",
-                "properties": {
-                    "type": {
-                        "type": "string",
-                        "description": "Object type",
-                        "example": "identityProvider",
-                        "enum": ["identityProvider"]
-                    },
-                    "id": {
-                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
-                        "type": "string",
-                        "description": "API identifier of an object",
-                        "example": "id1"
-                    },
-                    "attributes": {
-                        "type": "object",
-                        "properties": {
-                            "identifiers": {
-                                "type": "array",
-                                "description": "List of identifiers for this IdP, where an identifier is a domain name. Users with email addresses belonging to these domains will be authenticated by this IdP.",
-                                "example": ["gooddata.com"],
-                                "items": {
-                                    "type": "string"
-                                }
-                            },
-                            "customClaimMapping": {
-                                "maxLength": 10000,
-                                "type": "object",
-                                "additionalProperties": {
-                                    "type": "string"
-                                },
-                                "description": "Map of custom claim overrides. To be used when your Idp does not provide default claims (sub, email, name, given_name, family_name). Define the key pair for the claim you wish to override, where the key is the default name of the attribute and the value is your custom name for the given attribute."
-                            },
-                            "oauthClientId": {
-                                "maxLength": 255,
-                                "type": "string",
-                                "description": "The OAuth client id of your OIDC provider. This field is mandatory for OIDC IdP."
-                            },
-                            "oauthIssuerLocation": {
-                                "maxLength": 255,
-                                "type": "string",
-                                "description": "The location of your OIDC provider. This field is mandatory for OIDC IdP."
-                            },
-                            "oauthIssuerId": {
-                                "maxLength": 255,
-                                "type": "string",
-                                "description": "Any string identifying the OIDC provider. This value is used as suffix for OAuth2 callback (redirect) URL. If not defined, the standard callback URL is used. This value is valid only for external OIDC providers, not for the internal DEX provider.",
-                                "example": "myOidcProvider"
-                            },
-                            "oauthSubjectIdClaim": {
-                                "maxLength": 255,
-                                "type": "string",
-                                "description": "Any string identifying the claim in ID token, that should be used for user identification. The default value is 'sub'.",
-                                "example": "oid"
-                            },
-                            "oauthCustomAuthAttributes": {
-                                "maxLength": 10000,
-                                "type": "object",
-                                "additionalProperties": {
-                                    "type": "string"
-                                },
-                                "description": "Map of additional authentication attributes that should be added to the OAuth2 authentication requests, where the key is the name of the attribute and the value is the value of the attribute."
-                            },
-                            "oauthCustomScopes": {
-                                "type": "array",
-                                "description": "List of additional OAuth scopes which may be required by other providers (e.g. Snowflake)",
-                                "nullable": true,
-                                "items": {
-                                    "maxLength": 255,
-                                    "type": "string"
-                                }
-                            },
-                            "idpType": {
-                                "type": "string",
-                                "description": "Type of IdP for management purposes. MANAGED_IDP represents a GoodData managed IdP used in single OIDC setup, which is protected from altering/deletion. FIM_IDP represents a GoodData managed IdP used in federated identity management setup, which is protected from altering/deletion. CUSTOM_IDP represents customer's own IdP, protected from deletion if currently used by org for authentication, deletable otherwise.",
-                                "enum": ["MANAGED_IDP", "FIM_IDP", "CUSTOM_IDP"]
-                            }
-                        }
-                    }
-                },
-                "description": "JSON:API representation of identityProvider entity."
-            },
-            "JsonApiIdentityProviderOutWithLinks": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/JsonApiIdentityProviderOut"
-                    },
-                    {
-                        "$ref": "#/components/schemas/ObjectLinksContainer"
-                    }
-                ]
-            },
-            "JsonApiOrganizationOutIncludes": {
-                "oneOf": [
-                    {
-                        "$ref": "#/components/schemas/JsonApiUserOutWithLinks"
-                    },
-                    {
-                        "$ref": "#/components/schemas/JsonApiUserGroupOutWithLinks"
-                    },
-                    {
-                        "$ref": "#/components/schemas/JsonApiIdentityProviderOutWithLinks"
-                    }
-                ]
-            },
-            "JsonApiOrganizationOutDocument": {
-                "required": ["data"],
-                "type": "object",
-                "properties": {
-                    "data": {
-                        "$ref": "#/components/schemas/JsonApiOrganizationOut"
-                    },
-                    "links": {
-                        "$ref": "#/components/schemas/ObjectLinks"
-                    },
-                    "included": {
-                        "uniqueItems": true,
-                        "type": "array",
-                        "description": "Included resources",
-                        "items": {
-                            "$ref": "#/components/schemas/JsonApiOrganizationOutIncludes"
-                        }
-                    }
-                }
-            },
-            "JsonApiOrganizationOut": {
-                "required": ["id", "type"],
-                "type": "object",
-                "properties": {
-                    "type": {
-                        "type": "string",
-                        "description": "Object type",
-                        "example": "organization",
-                        "enum": ["organization"]
-                    },
-                    "id": {
-                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
-                        "type": "string",
-                        "description": "API identifier of an object",
-                        "example": "id1"
-                    },
-                    "meta": {
-                        "type": "object",
-                        "properties": {
-                            "permissions": {
-                                "type": "array",
-                                "description": "List of valid permissions for a logged-in user.",
-                                "items": {
-                                    "type": "string",
-                                    "enum": ["MANAGE", "SELF_CREATE_TOKEN"]
-                                }
-                            }
-                        }
-                    },
-                    "attributes": {
-                        "type": "object",
-                        "properties": {
-                            "name": {
-                                "maxLength": 255,
-                                "type": "string",
-                                "nullable": true
-                            },
-                            "hostname": {
-                                "maxLength": 255,
-                                "type": "string"
-                            },
-                            "allowedOrigins": {
-                                "type": "array",
-                                "items": {
-                                    "type": "string"
-                                }
-                            },
-                            "oauthIssuerLocation": {
-                                "maxLength": 255,
-                                "type": "string"
-                            },
-                            "oauthClientId": {
-                                "maxLength": 255,
-                                "type": "string"
-                            },
-                            "earlyAccess": {
-                                "maxLength": 255,
-                                "type": "string",
-                                "description": "The early access feature identifier. It is used to enable experimental features. Deprecated in favor of earlyAccessValues.",
-                                "nullable": true,
-                                "deprecated": true
-                            },
-                            "earlyAccessValues": {
-                                "type": "array",
-                                "description": "The early access feature identifiers. They are used to enable experimental features.",
-                                "nullable": true,
-                                "items": {
-                                    "maxLength": 255,
-                                    "type": "string"
-                                }
-                            },
-                            "oauthIssuerId": {
-                                "maxLength": 255,
-                                "type": "string",
-                                "description": "Any string identifying the OIDC provider. This value is used as suffix for OAuth2 callback (redirect) URL. If not defined, the standard callback URL is used. This value is valid only for external OIDC providers, not for the internal DEX provider.",
-                                "example": "myOidcProvider"
-                            },
-                            "cacheSettings": {
-                                "type": "object",
-                                "properties": {
-                                    "extraCacheBudget": {
-                                        "type": "integer",
-                                        "format": "int64"
-                                    },
-                                    "cacheStrategy": {
-                                        "maxLength": 255,
-                                        "type": "string",
-                                        "enum": ["DURABLE", "EPHEMERAL"]
-                                    }
-                                }
-                            },
-                            "oauthSubjectIdClaim": {
-                                "maxLength": 255,
-                                "type": "string",
-                                "description": "Any string identifying the claim in ID token, that should be used for user identification. The default value is 'sub'.",
-                                "example": "oid"
-                            },
-                            "oauthCustomAuthAttributes": {
-                                "maxLength": 10000,
-                                "type": "object",
-                                "additionalProperties": {
-                                    "type": "string"
-                                },
-                                "description": "Map of additional authentication attributes that should be added to the OAuth2 authentication requests, where the key is the name of the attribute and the value is the value of the attribute."
-                            },
-                            "oauthCustomScopes": {
-                                "type": "array",
-                                "description": "List of additional OAuth scopes which may be required by other providers (e.g. Snowflake)",
-                                "nullable": true,
-                                "items": {
-                                    "maxLength": 255,
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    },
-                    "relationships": {
-                        "type": "object",
-                        "properties": {
-                            "bootstrapUser": {
-                                "required": ["data"],
-                                "type": "object",
-                                "properties": {
-                                    "data": {
-                                        "$ref": "#/components/schemas/JsonApiUserToOneLinkage"
-                                    }
-                                }
-                            },
-                            "bootstrapUserGroup": {
-                                "required": ["data"],
-                                "type": "object",
-                                "properties": {
-                                    "data": {
-                                        "$ref": "#/components/schemas/JsonApiUserGroupToOneLinkage"
-                                    }
-                                }
-                            },
-                            "identityProvider": {
-                                "required": ["data"],
-                                "type": "object",
-                                "properties": {
-                                    "data": {
-                                        "$ref": "#/components/schemas/JsonApiIdentityProviderToOneLinkage"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "JSON:API representation of organization entity."
-            },
-            "JsonApiIdentityProviderLinkage": {
-                "required": ["id", "type"],
-                "type": "object",
-                "properties": {
-                    "id": {
-                        "type": "string"
-                    },
-                    "type": {
-                        "type": "string",
-                        "enum": ["identityProvider"]
-                    }
-                },
-                "description": "The \\\"type\\\" and \\\"id\\\" to non-empty members."
-            },
-            "JsonApiIdentityProviderToOneLinkage": {
-                "description": "References to other resource objects in a to-one (\\\"relationship\\\"). Relationships can be specified by including a member in a resource's links object.",
-                "nullable": true,
-                "oneOf": [
-                    {
-                        "$ref": "#/components/schemas/JsonApiIdentityProviderLinkage"
-                    }
-                ]
-            },
-            "JsonApiUserGroupToOneLinkage": {
-                "description": "References to other resource objects in a to-one (\\\"relationship\\\"). Relationships can be specified by including a member in a resource's links object.",
-                "nullable": true,
-                "oneOf": [
-                    {
-                        "$ref": "#/components/schemas/JsonApiUserGroupLinkage"
-                    }
-                ]
-            },
-            "JsonApiUserLinkage": {
-                "required": ["id", "type"],
-                "type": "object",
-                "properties": {
-                    "id": {
-                        "type": "string"
-                    },
-                    "type": {
-                        "type": "string",
-                        "enum": ["user"]
-                    }
-                },
-                "description": "The \\\"type\\\" and \\\"id\\\" to non-empty members."
-            },
-            "JsonApiUserToOneLinkage": {
-                "description": "References to other resource objects in a to-one (\\\"relationship\\\"). Relationships can be specified by including a member in a resource's links object.",
-                "nullable": true,
-                "oneOf": [
-                    {
-                        "$ref": "#/components/schemas/JsonApiUserLinkage"
-                    }
-                ]
-            },
-            "JsonApiColorPaletteOutDocument": {
-                "required": ["data"],
-                "type": "object",
-                "properties": {
-                    "data": {
-                        "$ref": "#/components/schemas/JsonApiColorPaletteOut"
-                    },
-                    "links": {
-                        "$ref": "#/components/schemas/ObjectLinks"
-                    }
-                }
-            },
-            "JsonApiColorPaletteOut": {
-                "required": ["attributes", "id", "type"],
-                "type": "object",
-                "properties": {
-                    "type": {
-                        "type": "string",
-                        "description": "Object type",
-                        "example": "colorPalette",
-                        "enum": ["colorPalette"]
-                    },
-                    "id": {
-                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
-                        "type": "string",
-                        "description": "API identifier of an object",
-                        "example": "id1"
-                    },
-                    "attributes": {
-                        "required": ["content", "name"],
-                        "type": "object",
-                        "properties": {
-                            "name": {
-                                "maxLength": 255,
-                                "type": "string"
-                            },
-                            "content": {
-                                "type": "object",
-                                "description": "Free-form JSON content. Maximum supported length is 15000 characters.",
-                                "example": {}
-                            }
-                        }
-                    }
-                },
-                "description": "JSON:API representation of colorPalette entity."
-            },
-            "JsonApiCspDirectiveOutDocument": {
-                "required": ["data"],
-                "type": "object",
-                "properties": {
-                    "data": {
-                        "$ref": "#/components/schemas/JsonApiCspDirectiveOut"
-                    },
-                    "links": {
-                        "$ref": "#/components/schemas/ObjectLinks"
-                    }
-                }
-            },
-            "JsonApiCspDirectiveOut": {
-                "required": ["attributes", "id", "type"],
-                "type": "object",
-                "properties": {
-                    "type": {
-                        "type": "string",
-                        "description": "Object type",
-                        "example": "cspDirective",
-                        "enum": ["cspDirective"]
-                    },
-                    "id": {
-                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
-                        "type": "string",
-                        "description": "API identifier of an object",
-                        "example": "id1"
-                    },
-                    "attributes": {
-                        "required": ["sources"],
-                        "type": "object",
-                        "properties": {
-                            "sources": {
-                                "type": "array",
-                                "items": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "JSON:API representation of cspDirective entity."
-            },
-            "JsonApiDataSourceIdentifierOutDocument": {
-                "required": ["data"],
-                "type": "object",
-                "properties": {
-                    "data": {
-                        "$ref": "#/components/schemas/JsonApiDataSourceIdentifierOut"
-                    },
-                    "links": {
-                        "$ref": "#/components/schemas/ObjectLinks"
-                    }
-                }
-            },
-            "JsonApiDataSourceIdentifierOut": {
-                "required": ["attributes", "id", "type"],
-                "type": "object",
-                "properties": {
-                    "type": {
-                        "type": "string",
-                        "description": "Object type",
-                        "example": "dataSourceIdentifier",
-                        "enum": ["dataSourceIdentifier"]
-                    },
-                    "id": {
-                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
-                        "type": "string",
-                        "description": "API identifier of an object",
-                        "example": "id1"
-                    },
-                    "meta": {
-                        "type": "object",
-                        "properties": {
-                            "permissions": {
-                                "type": "array",
-                                "description": "List of valid permissions for a logged-in user.",
-                                "items": {
-                                    "type": "string",
-                                    "enum": ["MANAGE", "USE"]
-                                }
-                            }
-                        }
-                    },
-                    "attributes": {
-                        "required": ["name", "schema", "type"],
-                        "type": "object",
-                        "properties": {
-                            "name": {
-                                "maxLength": 255,
-                                "type": "string"
-                            },
-                            "schema": {
-                                "maxLength": 255,
-                                "type": "string"
-                            },
-                            "type": {
-                                "type": "string",
-                                "enum": [
-                                    "POSTGRESQL",
-                                    "REDSHIFT",
-                                    "VERTICA",
-                                    "SNOWFLAKE",
-                                    "ADS",
-                                    "BIGQUERY",
-                                    "MSSQL",
-                                    "PRESTO",
-                                    "DREMIO",
-                                    "DRILL",
-                                    "GREENPLUM",
-                                    "AZURESQL",
-                                    "SYNAPSESQL",
-                                    "DATABRICKS",
-                                    "GDSTORAGE",
-                                    "CLICKHOUSE",
-                                    "MYSQL",
-                                    "MARIADB",
-                                    "ORACLE",
-                                    "PINOT",
-                                    "SINGLESTORE",
-                                    "MOTHERDUCK",
-                                    "FLEXCONNECT",
-                                    "STARROCKS",
-                                    "ATHENA"
-                                ]
-                            }
-                        }
-                    }
-                },
-                "description": "JSON:API representation of dataSourceIdentifier entity."
-            },
-            "JsonApiDataSourceOutDocument": {
-                "required": ["data"],
-                "type": "object",
-                "properties": {
-                    "data": {
-                        "$ref": "#/components/schemas/JsonApiDataSourceOut"
-                    },
-                    "links": {
-                        "$ref": "#/components/schemas/ObjectLinks"
-                    }
-                }
-            },
-            "JsonApiDataSourceOut": {
-                "required": ["attributes", "id", "type"],
-                "type": "object",
-                "properties": {
-                    "type": {
-                        "type": "string",
-                        "description": "Object type",
-                        "example": "dataSource",
-                        "enum": ["dataSource"]
-                    },
-                    "id": {
-                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
-                        "type": "string",
-                        "description": "API identifier of an object",
-                        "example": "id1"
-                    },
-                    "meta": {
-                        "type": "object",
-                        "properties": {
-                            "permissions": {
-                                "type": "array",
-                                "description": "List of valid permissions for a logged-in user.",
-                                "items": {
-                                    "type": "string",
-                                    "enum": ["MANAGE", "USE"]
-                                }
-                            }
-                        }
-                    },
-                    "attributes": {
-                        "required": ["name", "schema", "type"],
-                        "type": "object",
-                        "properties": {
-                            "name": {
-                                "maxLength": 255,
-                                "type": "string",
-                                "description": "User-facing name of the data source."
-                            },
-                            "type": {
-                                "type": "string",
-                                "description": "Type of the database providing the data for the data source.",
-                                "enum": [
-                                    "POSTGRESQL",
-                                    "REDSHIFT",
-                                    "VERTICA",
-                                    "SNOWFLAKE",
-                                    "ADS",
-                                    "BIGQUERY",
-                                    "MSSQL",
-                                    "PRESTO",
-                                    "DREMIO",
-                                    "DRILL",
-                                    "GREENPLUM",
-                                    "AZURESQL",
-                                    "SYNAPSESQL",
-                                    "DATABRICKS",
-                                    "GDSTORAGE",
-                                    "CLICKHOUSE",
-                                    "MYSQL",
-                                    "MARIADB",
-                                    "ORACLE",
-                                    "PINOT",
-                                    "SINGLESTORE",
-                                    "MOTHERDUCK",
-                                    "FLEXCONNECT",
-                                    "STARROCKS",
-                                    "ATHENA"
-                                ]
-                            },
-                            "url": {
-                                "maxLength": 255,
-                                "type": "string",
-                                "description": "The URL of the database providing the data for the data source.",
-                                "nullable": true
-                            },
-                            "schema": {
-                                "maxLength": 255,
-                                "type": "string",
-                                "description": "The schema to use as the root of the data for the data source."
-                            },
-                            "username": {
-                                "maxLength": 255,
-                                "type": "string",
-                                "description": "The username to use to connect to the database providing the data for the data source.",
-                                "nullable": true
-                            },
-                            "clientId": {
-                                "maxLength": 255,
-                                "type": "string",
-                                "description": "The client id to use to connect to the database providing the data for the data source (for example a Databricks Service Account).",
-                                "nullable": true
-                            },
-                            "parameters": {
-                                "type": "array",
-                                "description": "Additional parameters to be used when connecting to the database providing the data for the data source.",
-                                "nullable": true,
-                                "items": {
-                                    "required": ["name", "value"],
-                                    "type": "object",
-                                    "properties": {
-                                        "name": {
-                                            "type": "string"
-                                        },
-                                        "value": {
-                                            "type": "string"
-                                        }
-                                    }
-                                }
-                            },
-                            "decodedParameters": {
-                                "type": "array",
-                                "description": "Decoded parameters to be used when connecting to the database providing the data for the data source.",
-                                "nullable": true,
-                                "items": {
-                                    "required": ["name", "value"],
-                                    "type": "object",
-                                    "properties": {
-                                        "name": {
-                                            "type": "string"
-                                        },
-                                        "value": {
-                                            "type": "string"
-                                        }
-                                    }
-                                }
-                            },
-                            "cacheStrategy": {
-                                "type": "string",
-                                "description": "Determines how the results coming from a particular datasource should be cached.",
-                                "nullable": true,
-                                "enum": ["ALWAYS", "NEVER"]
-                            },
-                            "authenticationType": {
-                                "type": "string",
-                                "description": "Type of authentication used to connect to the database.",
-                                "nullable": true,
-                                "enum": [
-                                    "USERNAME_PASSWORD",
-                                    "TOKEN",
-                                    "KEY_PAIR",
-                                    "CLIENT_SECRET",
-                                    "ACCESS_TOKEN"
-                                ]
-                            }
-                        }
-                    }
-                },
-                "description": "JSON:API representation of dataSource entity."
-            },
-            "JsonApiEntitlementOutDocument": {
-                "required": ["data"],
-                "type": "object",
-                "properties": {
-                    "data": {
-                        "$ref": "#/components/schemas/JsonApiEntitlementOut"
-                    },
-                    "links": {
-                        "$ref": "#/components/schemas/ObjectLinks"
-                    }
-                }
-            },
-            "JsonApiEntitlementOut": {
-                "required": ["id", "type"],
-                "type": "object",
-                "properties": {
-                    "type": {
-                        "type": "string",
-                        "description": "Object type",
-                        "example": "entitlement",
-                        "enum": ["entitlement"]
-                    },
-                    "id": {
-                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
-                        "type": "string",
-                        "description": "API identifier of an object",
-                        "example": "id1"
-                    },
-                    "attributes": {
-                        "type": "object",
-                        "properties": {
-                            "value": {
-                                "maxLength": 255,
-                                "type": "string"
-                            },
-                            "expiry": {
-                                "type": "string",
-                                "format": "date"
-                            }
-                        }
-                    }
-                },
-                "description": "JSON:API representation of entitlement entity."
-            },
-            "JsonApiExportTemplateOutDocument": {
-                "required": ["data"],
-                "type": "object",
-                "properties": {
-                    "data": {
-                        "$ref": "#/components/schemas/JsonApiExportTemplateOut"
-                    },
-                    "links": {
-                        "$ref": "#/components/schemas/ObjectLinks"
-                    }
-                }
-            },
-            "JsonApiExportTemplateOut": {
-                "required": ["attributes", "id", "type"],
-                "type": "object",
-                "properties": {
-                    "type": {
-                        "type": "string",
-                        "description": "Object type",
-                        "example": "exportTemplate",
-                        "enum": ["exportTemplate"]
-                    },
-                    "id": {
-                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
-                        "type": "string",
-                        "description": "API identifier of an object",
-                        "example": "id1"
-                    },
-                    "attributes": {
-                        "required": ["name"],
-                        "type": "object",
-                        "properties": {
-                            "name": {
-                                "maxLength": 255,
-                                "type": "string",
-                                "description": "User-facing name of the Slides template."
-                            },
-                            "dashboardSlidesTemplate": {
-                                "required": ["appliedOn"],
-                                "type": "object",
-                                "properties": {
-                                    "appliedOn": {
-                                        "minItems": 1,
-                                        "type": "array",
-                                        "description": "Export types this template applies to.",
-                                        "example": ["PDF", "PPTX"],
-                                        "items": {
-                                            "type": "string",
-                                            "enum": ["PDF", "PPTX"]
-                                        }
-                                    },
-                                    "coverSlide": {
-                                        "$ref": "#/components/schemas/CoverSlideTemplate"
-                                    },
-                                    "introSlide": {
-                                        "$ref": "#/components/schemas/IntroSlideTemplate"
-                                    },
-                                    "sectionSlide": {
-                                        "$ref": "#/components/schemas/SectionSlideTemplate"
-                                    },
-                                    "contentSlide": {
-                                        "$ref": "#/components/schemas/ContentSlideTemplate"
-                                    }
-                                },
-                                "description": "Template for dashboard slides export.\nAvailable variables: {{currentPageNumber}}, {{dashboardDateFilters}}, {{dashboardDescription}}, {{dashboardFilters}}, {{dashboardId}}, {{dashboardName}}, {{dashboardTags}}, {{dashboardUrl}}, {{exportedAt}}, {{exportedBy}}, {{logo}}, {{totalPages}}, {{workspaceId}}, {{workspaceName}}",
-                                "nullable": true
-                            },
-                            "widgetSlidesTemplate": {
-                                "required": ["appliedOn"],
-                                "type": "object",
-                                "properties": {
-                                    "appliedOn": {
-                                        "minItems": 1,
-                                        "type": "array",
-                                        "description": "Export types this template applies to.",
-                                        "example": ["PDF", "PPTX"],
-                                        "items": {
-                                            "type": "string",
-                                            "enum": ["PDF", "PPTX"]
-                                        }
-                                    },
-                                    "contentSlide": {
-                                        "$ref": "#/components/schemas/ContentSlideTemplate"
-                                    }
-                                },
-                                "description": "Template for widget slides export.\nAvailable variables: {{currentPageNumber}}, {{dashboardDateFilters}}, {{dashboardDescription}}, {{dashboardFilters}}, {{dashboardId}}, {{dashboardName}}, {{dashboardTags}}, {{dashboardUrl}}, {{exportedAt}}, {{exportedBy}}, {{logo}}, {{totalPages}}, {{workspaceId}}, {{workspaceName}}",
-                                "nullable": true
-                            }
-                        }
-                    }
-                },
-                "description": "JSON:API representation of exportTemplate entity."
-            },
-            "ContentSlideTemplate": {
-                "type": "object",
-                "properties": {
-                    "header": {
-                        "$ref": "#/components/schemas/RunningSection"
-                    },
-                    "footer": {
-                        "$ref": "#/components/schemas/RunningSection"
-                    },
-                    "descriptionField": {
-                        "type": "string",
-                        "nullable": true,
-                        "example": "{{dashboardFilters}}"
-                    }
-                },
-                "description": "Settings for content slide.",
-                "nullable": true
-            },
-            "CoverSlideTemplate": {
-                "type": "object",
-                "properties": {
-                    "header": {
-                        "$ref": "#/components/schemas/RunningSection"
-                    },
-                    "footer": {
-                        "$ref": "#/components/schemas/RunningSection"
-                    },
-                    "descriptionField": {
-                        "type": "string",
-                        "nullable": true,
-                        "example": "Exported at: {{exportedAt}}"
-                    },
-                    "backgroundImage": {
-                        "type": "boolean",
-                        "description": "Show background image on the slide.",
-                        "default": true
-                    }
-                },
-                "description": "Settings for cover slide.",
-                "nullable": true
-            },
-            "IntroSlideTemplate": {
-                "type": "object",
-                "properties": {
-                    "header": {
-                        "$ref": "#/components/schemas/RunningSection"
-                    },
-                    "footer": {
-                        "$ref": "#/components/schemas/RunningSection"
-                    },
-                    "titleField": {
-                        "type": "string",
-                        "nullable": true,
-                        "example": "Introduction"
-                    },
-                    "descriptionField": {
-                        "type": "string",
-                        "nullable": true,
-                        "example": "About:\n{{dashboardDescription}}\n\n{{dashboardFilters}}"
-                    },
-                    "backgroundImage": {
-                        "type": "boolean",
-                        "description": "Show background image on the slide.",
-                        "default": true
-                    }
-                },
-                "description": "Settings for intro slide.",
-                "nullable": true
-            },
-            "RunningSection": {
-                "type": "object",
-                "properties": {
-                    "left": {
-                        "type": "string",
-                        "description": "Either {{logo}} variable or custom text with combination of other variables.",
-                        "nullable": true
-                    },
-                    "right": {
-                        "type": "string",
-                        "description": "Either {{logo}} variable or custom text with combination of other variables.",
-                        "nullable": true
-                    }
-                },
-                "description": "Footer section of the slide",
-                "nullable": true
-            },
-            "SectionSlideTemplate": {
-                "type": "object",
-                "properties": {
-                    "header": {
-                        "$ref": "#/components/schemas/RunningSection"
-                    },
-                    "footer": {
-                        "$ref": "#/components/schemas/RunningSection"
-                    },
-                    "backgroundImage": {
-                        "type": "boolean",
-                        "description": "Show background image on the slide.",
-                        "default": true
-                    }
-                },
-                "description": "Settings for section slide.",
-                "nullable": true
-            },
-            "JsonApiIdentityProviderOutDocument": {
-                "required": ["data"],
-                "type": "object",
-                "properties": {
-                    "data": {
-                        "$ref": "#/components/schemas/JsonApiIdentityProviderOut"
-                    },
-                    "links": {
-                        "$ref": "#/components/schemas/ObjectLinks"
-                    }
-                }
-            },
-            "JsonApiJwkOutDocument": {
-                "required": ["data"],
-                "type": "object",
-                "properties": {
-                    "data": {
-                        "$ref": "#/components/schemas/JsonApiJwkOut"
-                    },
-                    "links": {
-                        "$ref": "#/components/schemas/ObjectLinks"
-                    }
-                }
-            },
-            "JsonApiJwkOut": {
-                "required": ["id", "type"],
-                "type": "object",
-                "properties": {
-                    "type": {
-                        "type": "string",
-                        "description": "Object type",
-                        "example": "jwk",
-                        "enum": ["jwk"]
-                    },
-                    "id": {
-                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
-                        "type": "string",
-                        "description": "API identifier of an object",
-                        "example": "id1"
-                    },
-                    "attributes": {
-                        "type": "object",
-                        "properties": {
-                            "content": {
-                                "type": "object",
-                                "description": "Specification of the cryptographic key",
-                                "example": {
-                                    "kyt": "RSA",
-                                    "alg": "RS256",
-                                    "use": "sig"
-                                },
-                                "oneOf": [
-                                    {
-                                        "$ref": "#/components/schemas/RsaSpecification"
-                                    }
-                                ]
-                            }
-                        }
-                    }
-                },
-                "description": "JSON:API representation of jwk entity."
-            },
-            "RsaSpecification": {
-                "required": ["alg", "e", "kid", "kty", "n", "use"],
-                "type": "object",
-                "properties": {
-                    "kty": {
-                        "type": "string",
-                        "enum": ["RSA"]
-                    },
-                    "alg": {
-                        "type": "string",
-                        "enum": ["RS256", "RS384", "RS512"]
-                    },
-                    "use": {
-                        "type": "string",
-                        "enum": ["sig"]
-                    },
-                    "x5c": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "n": {
-                        "type": "string"
-                    },
-                    "e": {
-                        "type": "string"
-                    },
-                    "kid": {
-                        "maxLength": 255,
-                        "minLength": 0,
-                        "pattern": "^[^.]",
-                        "type": "string"
-                    },
-                    "x5t": {
-                        "type": "string"
-                    }
-                }
-            },
-            "JsonApiLlmEndpointOutDocument": {
-                "required": ["data"],
-                "type": "object",
-                "properties": {
-                    "data": {
-                        "$ref": "#/components/schemas/JsonApiLlmEndpointOut"
-                    },
-                    "links": {
-                        "$ref": "#/components/schemas/ObjectLinks"
-                    }
-                }
-            },
-            "JsonApiLlmEndpointOut": {
-                "required": ["attributes", "id", "type"],
-                "type": "object",
-                "properties": {
-                    "type": {
-                        "type": "string",
-                        "description": "Object type",
-                        "example": "llmEndpoint",
-                        "enum": ["llmEndpoint"]
-                    },
-                    "id": {
-                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
-                        "type": "string",
-                        "description": "API identifier of an object",
-                        "example": "id1"
-                    },
-                    "attributes": {
-                        "required": ["title"],
-                        "type": "object",
-                        "properties": {
-                            "title": {
-                                "maxLength": 255,
-                                "type": "string",
-                                "description": "User-facing title of the LLM Provider."
-                            },
-                            "provider": {
-                                "type": "string",
-                                "description": "LLM Provider.",
-                                "enum": ["OPENAI", "AZURE_OPENAI"]
-                            },
-                            "baseUrl": {
-                                "maxLength": 255,
-                                "type": "string",
-                                "description": "Custom LLM endpoint.",
-                                "nullable": true
-                            },
-                            "llmOrganization": {
-                                "maxLength": 255,
-                                "type": "string",
-                                "description": "Organization in LLM provider.",
-                                "nullable": true
-                            },
-                            "llmModel": {
-                                "maxLength": 255,
-                                "type": "string",
-                                "description": "LLM Model. We provide a default model for each provider, but you can override it here."
-                            }
-                        }
-                    }
-                },
-                "description": "JSON:API representation of llmEndpoint entity."
-            },
-            "JsonApiNotificationChannelIdentifierOutDocument": {
-                "required": ["data"],
-                "type": "object",
-                "properties": {
-                    "data": {
-                        "$ref": "#/components/schemas/JsonApiNotificationChannelIdentifierOut"
-                    },
-                    "links": {
-                        "$ref": "#/components/schemas/ObjectLinks"
-                    }
-                }
-            },
-            "JsonApiNotificationChannelIdentifierOut": {
-                "required": ["id", "type"],
-                "type": "object",
-                "properties": {
-                    "type": {
-                        "type": "string",
-                        "description": "Object type",
-                        "example": "notificationChannelIdentifier",
-                        "enum": ["notificationChannelIdentifier"]
-                    },
-                    "id": {
-                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
-                        "type": "string",
-                        "description": "API identifier of an object",
-                        "example": "id1"
-                    },
-                    "attributes": {
-                        "type": "object",
-                        "properties": {
-                            "name": {
-                                "maxLength": 255,
-                                "type": "string",
-                                "nullable": true
-                            },
-                            "description": {
-                                "maxLength": 10000,
-                                "type": "string",
-                                "nullable": true
-                            },
-                            "destinationType": {
-                                "type": "string",
-                                "enum": ["WEBHOOK", "SMTP", "DEFAULT_SMTP", "IN_PLATFORM"]
-                            },
-                            "allowedRecipients": {
-                                "type": "string",
-                                "description": "Allowed recipients of notifications from this channel.\nCREATOR - only the creator\nINTERNAL - all users within the organization\nEXTERNAL - all recipients including those outside the organization\n",
-                                "enum": ["CREATOR", "INTERNAL", "EXTERNAL"]
-                            }
-                        }
-                    }
-                },
-                "description": "JSON:API representation of notificationChannelIdentifier entity."
-            },
-            "JsonApiNotificationChannelOutDocument": {
-                "required": ["data"],
-                "type": "object",
-                "properties": {
-                    "data": {
-                        "$ref": "#/components/schemas/JsonApiNotificationChannelOut"
-                    },
-                    "links": {
-                        "$ref": "#/components/schemas/ObjectLinks"
-                    }
-                }
-            },
-            "JsonApiNotificationChannelOut": {
-                "required": ["id", "type"],
-                "type": "object",
-                "properties": {
-                    "type": {
-                        "type": "string",
-                        "description": "Object type",
-                        "example": "notificationChannel",
-                        "enum": ["notificationChannel"]
-                    },
-                    "id": {
-                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
-                        "type": "string",
-                        "description": "API identifier of an object",
-                        "example": "id1"
-                    },
-                    "attributes": {
-                        "type": "object",
-                        "properties": {
-                            "name": {
-                                "maxLength": 255,
-                                "type": "string",
-                                "nullable": true
-                            },
-                            "description": {
-                                "maxLength": 10000,
-                                "type": "string",
-                                "nullable": true
-                            },
-                            "destination": {
-                                "description": "The destination where the notifications are to be sent.",
-                                "oneOf": [
-                                    {
-                                        "$ref": "#/components/schemas/DefaultSmtp"
-                                    },
-                                    {
-                                        "$ref": "#/components/schemas/InPlatform"
-                                    },
-                                    {
-                                        "$ref": "#/components/schemas/Smtp"
-                                    },
-                                    {
-                                        "$ref": "#/components/schemas/Webhook"
-                                    }
-                                ]
-                            },
-                            "destinationType": {
-                                "type": "string",
-                                "nullable": true,
-                                "enum": ["WEBHOOK", "SMTP", "DEFAULT_SMTP", "IN_PLATFORM"]
-                            },
-                            "customDashboardUrl": {
-                                "maxLength": 255,
-                                "type": "string",
-                                "description": "Custom dashboard url that is going to be used in the notification. If not specified it is going to be deduced based on the context. Allowed placeholders are:\n{workspaceId}\n{dashboardId}\n{automationId}\n{asOfDate}\n"
-                            },
-                            "dashboardLinkVisibility": {
-                                "type": "string",
-                                "description": "Dashboard link visibility in notifications.\nHIDDEN - the link will not be included\nINTERNAL_ONLY - only internal users will see the link\nALL - all users will see the link\n",
-                                "enum": ["HIDDEN", "INTERNAL_ONLY", "ALL"]
-                            },
-                            "notificationSource": {
-                                "maxLength": 10000,
-                                "type": "string",
-                                "description": "Human-readable description of the source of the notification. If specified, this propertywill be included in the notifications to this channel.Allowed placeholders are:\n{{workspaceId}}\n{{workspaceName}}\n{{workspaceDescription}}\n{{dashboardId}}\n{{dashboardName}}\n{{dashboardDescription}}\n"
-                            },
-                            "allowedRecipients": {
-                                "type": "string",
-                                "description": "Allowed recipients of notifications from this channel.\nCREATOR - only the creator\nINTERNAL - all users within the organization\nEXTERNAL - all recipients including those outside the organization\n",
-                                "enum": ["CREATOR", "INTERNAL", "EXTERNAL"]
-                            },
-                            "inPlatformNotification": {
-                                "type": "string",
-                                "description": "In-platform notifications configuration. No effect if the destination type is IN_PLATFORM.\nDISABLED - in-platform notifications are not sent\nENABLED - in-platform notifications are sent in addition to the regular notifications\n",
-                                "enum": ["DISABLED", "ENABLED"]
-                            }
-                        }
-                    }
-                },
-                "description": "JSON:API representation of notificationChannel entity."
-            },
-            "DefaultSmtp": {
-                "required": ["type"],
-                "type": "object",
-                "description": "Default SMTP destination for notifications.",
-                "allOf": [
-                    {
-                        "type": "object",
-                        "properties": {
-                            "fromEmail": {
-                                "type": "string",
-                                "description": "E-mail address to send notifications from. Currently this does not have any effect. E-mail 'no-reply@gooddata.com' is used instead.",
-                                "format": "email",
-                                "default": "no-reply@gooddata.com"
-                            },
-                            "fromEmailName": {
-                                "type": "string",
-                                "description": "An optional e-mail name to send notifications from. Currently this does not have any effect. E-mail from name 'GoodData' is used instead.",
-                                "default": "GoodData"
-                            },
-                            "type": {
-                                "type": "string",
-                                "description": "The destination type.",
-                                "enum": ["DEFAULT_SMTP"]
-                            }
-                        }
-                    }
-                ]
-            },
-            "InPlatform": {
-                "required": ["type"],
-                "type": "object",
-                "description": "In-platform destination for notifications.",
-                "allOf": [
-                    {
-                        "type": "object",
-                        "properties": {
-                            "type": {
-                                "type": "string",
-                                "description": "The destination type.",
-                                "enum": ["IN_PLATFORM"]
-                            }
-                        }
-                    }
-                ]
-            },
-            "Smtp": {
-                "required": ["type"],
-                "type": "object",
-                "description": "Custom SMTP destination for notifications. The properties host, port, username, and password are required on create and update",
-                "allOf": [
-                    {
-                        "type": "object",
-                        "properties": {
-                            "fromEmail": {
-                                "type": "string",
-                                "description": "E-mail address to send notifications from.",
-                                "format": "email",
-                                "default": "no-reply@gooddata.com"
-                            },
-                            "fromEmailName": {
-                                "type": "string",
-                                "description": "An optional e-mail name to send notifications from.",
-                                "default": "GoodData"
-                            },
-                            "host": {
-                                "type": "string",
-                                "description": "The SMTP server address."
-                            },
-                            "port": {
-                                "type": "integer",
-                                "description": "The SMTP server port.",
-                                "format": "int32",
-                                "enum": [25, 465, 587, 2525]
-                            },
-                            "username": {
-                                "type": "string",
-                                "description": "The SMTP server username."
-                            },
-                            "password": {
-                                "type": "string",
-                                "description": "The SMTP server password.",
-                                "writeOnly": true
-                            },
-                            "type": {
-                                "type": "string",
-                                "description": "The destination type.",
-                                "enum": ["SMTP"]
-                            }
-                        }
-                    }
-                ]
-            },
-            "Webhook": {
-                "required": ["type"],
-                "type": "object",
-                "description": "Webhook destination for notifications. The property url is required on create and update.",
-                "allOf": [
-                    {
-                        "type": "object",
-                        "properties": {
-                            "url": {
-                                "maxLength": 255,
-                                "pattern": "https?\\://.*",
-                                "type": "string",
-                                "description": "The webhook URL.",
-                                "example": "https://webhook.site/something"
-                            },
-                            "token": {
-                                "maxLength": 10000,
-                                "type": "string",
-                                "description": "Bearer token for the webhook.",
-                                "nullable": true,
-                                "writeOnly": true,
-                                "example": "secret"
-                            },
-                            "hasToken": {
-                                "maxLength": 10000,
-                                "type": "boolean",
-                                "description": "Flag indicating if webhook has a token.",
-                                "nullable": true,
-                                "readOnly": true
-                            },
-                            "type": {
-                                "type": "string",
-                                "description": "The destination type.",
-                                "enum": ["WEBHOOK"]
-                            }
-                        }
-                    }
-                ]
-            },
-            "JsonApiOrganizationSettingOutDocument": {
-                "required": ["data"],
-                "type": "object",
-                "properties": {
-                    "data": {
-                        "$ref": "#/components/schemas/JsonApiOrganizationSettingOut"
-                    },
-                    "links": {
-                        "$ref": "#/components/schemas/ObjectLinks"
-                    }
-                }
-            },
-            "JsonApiOrganizationSettingOut": {
-                "required": ["id", "type"],
-                "type": "object",
-                "properties": {
-                    "type": {
-                        "type": "string",
-                        "description": "Object type",
-                        "example": "organizationSetting",
-                        "enum": ["organizationSetting"]
-                    },
-                    "id": {
-                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
-                        "type": "string",
-                        "description": "API identifier of an object",
-                        "example": "id1"
-                    },
-                    "attributes": {
-                        "type": "object",
-                        "properties": {
-                            "content": {
-                                "type": "object",
-                                "description": "Free-form JSON content. Maximum supported length is 15000 characters.",
-                                "example": {}
-                            },
-                            "type": {
-                                "type": "string",
-                                "enum": [
-                                    "TIMEZONE",
-                                    "ACTIVE_THEME",
-                                    "ACTIVE_COLOR_PALETTE",
-                                    "ACTIVE_LLM_ENDPOINT",
-                                    "WHITE_LABELING",
-                                    "LOCALE",
-                                    "METADATA_LOCALE",
-                                    "FORMAT_LOCALE",
-                                    "MAPBOX_TOKEN",
-                                    "WEEK_START",
-                                    "SHOW_HIDDEN_CATALOG_ITEMS",
-                                    "OPERATOR_OVERRIDES",
-                                    "TIMEZONE_VALIDATION_ENABLED",
-                                    "OPENAI_CONFIG",
-                                    "ENABLE_FILE_ANALYTICS",
-                                    "ALERT",
-                                    "SEPARATORS",
-                                    "DATE_FILTER_CONFIG",
-                                    "JIT_PROVISIONING",
-                                    "JWT_JIT_PROVISIONING",
-                                    "DASHBOARD_FILTERS_APPLY_MODE",
-                                    "ENABLE_SLIDES_EXPORT",
-                                    "AI_RATE_LIMIT",
-                                    "ATTACHMENT_SIZE_LIMIT",
-                                    "ATTACHMENT_LINK_TTL"
-                                ]
-                            }
-                        }
-                    }
-                },
-                "description": "JSON:API representation of organizationSetting entity."
-            },
-            "JsonApiThemeOutDocument": {
-                "required": ["data"],
-                "type": "object",
-                "properties": {
-                    "data": {
-                        "$ref": "#/components/schemas/JsonApiThemeOut"
-                    },
-                    "links": {
-                        "$ref": "#/components/schemas/ObjectLinks"
-                    }
-                }
-            },
-            "JsonApiThemeOut": {
-                "required": ["attributes", "id", "type"],
-                "type": "object",
-                "properties": {
-                    "type": {
-                        "type": "string",
-                        "description": "Object type",
-                        "example": "theme",
-                        "enum": ["theme"]
-                    },
-                    "id": {
-                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
-                        "type": "string",
-                        "description": "API identifier of an object",
-                        "example": "id1"
-                    },
-                    "attributes": {
-                        "required": ["content", "name"],
-                        "type": "object",
-                        "properties": {
-                            "name": {
-                                "maxLength": 255,
-                                "type": "string"
-                            },
-                            "content": {
-                                "type": "object",
-                                "description": "Free-form JSON content. Maximum supported length is 15000 characters.",
-                                "example": {}
-                            }
-                        }
-                    }
-                },
-                "description": "JSON:API representation of theme entity."
-            },
-            "JsonApiUserGroupOutDocument": {
-                "required": ["data"],
-                "type": "object",
-                "properties": {
-                    "data": {
-                        "$ref": "#/components/schemas/JsonApiUserGroupOut"
-                    },
-                    "links": {
-                        "$ref": "#/components/schemas/ObjectLinks"
-                    },
-                    "included": {
-                        "uniqueItems": true,
-                        "type": "array",
-                        "description": "Included resources",
-                        "items": {
-                            "$ref": "#/components/schemas/JsonApiUserGroupOutWithLinks"
-                        }
-                    }
-                }
-            },
-            "JsonApiUserIdentifierOutDocument": {
-                "required": ["data"],
-                "type": "object",
-                "properties": {
-                    "data": {
-                        "$ref": "#/components/schemas/JsonApiUserIdentifierOut"
-                    },
-                    "links": {
-                        "$ref": "#/components/schemas/ObjectLinks"
-                    }
-                }
-            },
-            "JsonApiUserIdentifierOut": {
-                "required": ["id", "type"],
-                "type": "object",
-                "properties": {
-                    "type": {
-                        "type": "string",
-                        "description": "Object type",
-                        "example": "userIdentifier",
-                        "enum": ["userIdentifier"]
-                    },
-                    "id": {
-                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
-                        "type": "string",
-                        "description": "API identifier of an object",
-                        "example": "id1"
-                    },
-                    "attributes": {
-                        "type": "object",
-                        "properties": {
-                            "firstname": {
-                                "maxLength": 255,
-                                "type": "string"
-                            },
-                            "lastname": {
-                                "maxLength": 255,
-                                "type": "string"
-                            },
-                            "email": {
-                                "maxLength": 255,
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "description": "JSON:API representation of userIdentifier entity."
-            },
-            "JsonApiUserOutDocument": {
-                "required": ["data"],
-                "type": "object",
-                "properties": {
-                    "data": {
-                        "$ref": "#/components/schemas/JsonApiUserOut"
-                    },
-                    "links": {
-                        "$ref": "#/components/schemas/ObjectLinks"
-                    },
-                    "included": {
-                        "uniqueItems": true,
-                        "type": "array",
-                        "description": "Included resources",
-                        "items": {
-                            "$ref": "#/components/schemas/JsonApiUserGroupOutWithLinks"
-                        }
-                    }
-                }
-            },
-            "JsonApiWorkspaceOut": {
-                "required": ["id", "type"],
-                "type": "object",
-                "properties": {
-                    "type": {
-                        "type": "string",
-                        "description": "Object type",
-                        "example": "workspace",
-                        "enum": ["workspace"]
-                    },
-                    "id": {
-                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
-                        "type": "string",
-                        "description": "API identifier of an object",
-                        "example": "id1"
-                    },
-                    "meta": {
-                        "type": "object",
-                        "properties": {
-                            "config": {
-                                "type": "object",
-                                "properties": {
-                                    "dataSamplingAvailable": {
-                                        "type": "boolean",
-                                        "description": "is sampling enabled - based on type of data-source connected to this workspace",
-                                        "default": false
-                                    },
-                                    "approximateCountAvailable": {
-                                        "type": "boolean",
-                                        "description": "is approximate count enabled - based on type of data-source connected to this workspace",
-                                        "default": false
-                                    },
-                                    "showAllValuesOnDatesAvailable": {
-                                        "type": "boolean",
-                                        "description": "is 'show all values' displayed for dates - based on type of data-source connected to this workspace",
-                                        "default": false
-                                    }
-                                }
-                            },
-                            "permissions": {
-                                "type": "array",
-                                "description": "List of valid permissions for a logged-in user.",
-                                "items": {
-                                    "type": "string",
-                                    "enum": [
-                                        "MANAGE",
-                                        "ANALYZE",
-                                        "EXPORT",
-                                        "EXPORT_TABULAR",
-                                        "EXPORT_PDF",
-                                        "CREATE_AUTOMATION",
-                                        "USE_AI_ASSISTANT",
-                                        "CREATE_FILTER_VIEW",
-                                        "VIEW"
-                                    ]
-                                }
-                            },
-                            "hierarchy": {
-                                "required": ["childrenCount"],
-                                "type": "object",
-                                "properties": {
-                                    "childrenCount": {
-                                        "type": "integer",
-                                        "description": "include the number of direct children of each workspace",
-                                        "format": "int32"
-                                    }
-                                }
-                            },
-                            "dataModel": {
-                                "required": ["datasetCount"],
-                                "type": "object",
-                                "properties": {
-                                    "datasetCount": {
-                                        "type": "integer",
-                                        "description": "include the number of dataset of each workspace",
-                                        "format": "int32"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "attributes": {
-                        "type": "object",
-                        "properties": {
-                            "name": {
-                                "maxLength": 255,
-                                "type": "string",
-                                "nullable": true
-                            },
-                            "earlyAccess": {
-                                "maxLength": 255,
-                                "type": "string",
-                                "description": "The early access feature identifier. It is used to enable experimental features. Deprecated in favor of earlyAccessValues.",
-                                "nullable": true,
-                                "deprecated": true
-                            },
-                            "earlyAccessValues": {
-                                "type": "array",
-                                "description": "The early access feature identifiers. They are used to enable experimental features.",
-                                "nullable": true,
-                                "items": {
-                                    "maxLength": 255,
-                                    "type": "string"
-                                }
-                            },
-                            "description": {
-                                "maxLength": 255,
-                                "type": "string",
-                                "nullable": true
-                            },
-                            "prefix": {
-                                "maxLength": 255,
-                                "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
-                                "type": "string",
-                                "description": "Custom prefix of entity identifiers in workspace",
-                                "nullable": true
-                            },
-                            "cacheExtraLimit": {
-                                "type": "integer",
-                                "format": "int64"
-                            },
-                            "dataSource": {
-                                "required": ["id"],
-                                "type": "object",
-                                "properties": {
-                                    "id": {
-                                        "type": "string",
-                                        "description": "The ID of the used data source.",
-                                        "example": "snowflake.instance.1"
-                                    },
-                                    "schemaPath": {
-                                        "type": "array",
-                                        "description": "The full schema path as array of its path parts. Will be rendered as subPath1.subPath2...",
-                                        "items": {
-                                            "type": "string",
-                                            "description": "The part of the schema path.",
-                                            "example": "subPath"
-                                        }
-                                    }
-                                },
-                                "description": "The data source used for the particular workspace instead of the one defined in the LDM inherited from its parent workspace. Such data source cannot be defined for a single or a top-parent workspace."
-                            }
-                        }
-                    },
-                    "relationships": {
-                        "type": "object",
-                        "properties": {
-                            "parent": {
-                                "required": ["data"],
-                                "type": "object",
-                                "properties": {
-                                    "data": {
-                                        "$ref": "#/components/schemas/JsonApiWorkspaceToOneLinkage"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "JSON:API representation of workspace entity."
-            },
-            "JsonApiWorkspaceLinkage": {
-                "required": ["id", "type"],
-                "type": "object",
-                "properties": {
-                    "id": {
-                        "type": "string"
-                    },
-                    "type": {
-                        "type": "string",
-                        "enum": ["workspace"]
-                    }
-                },
-                "description": "The \\\"type\\\" and \\\"id\\\" to non-empty members."
-            },
-            "JsonApiWorkspaceToOneLinkage": {
-                "description": "References to other resource objects in a to-one (\\\"relationship\\\"). Relationships can be specified by including a member in a resource's links object.",
-                "nullable": true,
-                "oneOf": [
-                    {
-                        "$ref": "#/components/schemas/JsonApiWorkspaceLinkage"
-                    }
-                ]
-            },
-            "JsonApiWorkspaceOutWithLinks": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/JsonApiWorkspaceOut"
-                    },
-                    {
-                        "$ref": "#/components/schemas/ObjectLinksContainer"
-                    }
-                ]
-            },
-            "JsonApiWorkspaceOutDocument": {
-                "required": ["data"],
-                "type": "object",
-                "properties": {
-                    "data": {
-                        "$ref": "#/components/schemas/JsonApiWorkspaceOut"
-                    },
-                    "links": {
-                        "$ref": "#/components/schemas/ObjectLinks"
-                    },
-                    "included": {
-                        "uniqueItems": true,
-                        "type": "array",
-                        "description": "Included resources",
-                        "items": {
-                            "$ref": "#/components/schemas/JsonApiWorkspaceOutWithLinks"
-                        }
-                    }
-                }
-            },
             "JsonApiAnalyticalDashboardPatchDocument": {
                 "required": ["data"],
                 "type": "object",
@@ -17436,6 +15202,42 @@
                     }
                 },
                 "description": "JSON:API representation of patching analyticalDashboard entity."
+            },
+            "JsonApiUserIdentifierOut": {
+                "required": ["id", "type"],
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "description": "Object type",
+                        "example": "userIdentifier",
+                        "enum": ["userIdentifier"]
+                    },
+                    "id": {
+                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
+                        "type": "string",
+                        "description": "API identifier of an object",
+                        "example": "id1"
+                    },
+                    "attributes": {
+                        "type": "object",
+                        "properties": {
+                            "firstname": {
+                                "maxLength": 255,
+                                "type": "string"
+                            },
+                            "lastname": {
+                                "maxLength": 255,
+                                "type": "string"
+                            },
+                            "email": {
+                                "maxLength": 255,
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "description": "JSON:API representation of userIdentifier entity."
             },
             "JsonApiUserIdentifierOutWithLinks": {
                 "allOf": [
@@ -20588,6 +18390,20 @@
                     }
                 ]
             },
+            "JsonApiUserLinkage": {
+                "required": ["id", "type"],
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "string",
+                        "enum": ["user"]
+                    }
+                },
+                "description": "The \\\"type\\\" and \\\"id\\\" to non-empty members."
+            },
             "JsonApiUserToManyLinkage": {
                 "type": "array",
                 "description": "References to other resource objects in a to-many (\\\"relationship\\\"). Relationships can be specified by including a member in a resource's links object.",
@@ -21079,7 +18895,7 @@
                 "type": "object",
                 "properties": {
                     "relativeDateFilter": {
-                        "required": ["from", "granularity", "to", "dataset"],
+                        "required": ["granularity", "dataset"],
                         "type": "object",
                         "properties": {
                             "granularity": {
@@ -21106,14 +18922,16 @@
                             },
                             "from": {
                                 "type": "integer",
-                                "description": "Start of the filtering interval. Specified by number of periods (with respect to given granularity). Typically negative (historical time interval like -2 for '2 days/weeks, ... ago').",
+                                "description": "Start of the filtering interval. Specified by number of periods (with respect to given granularity). Typically negative (historical time interval like -2 for '2 days/weeks, ... ago'). If null, then start of the range is unbounded.",
                                 "format": "int32",
+                                "nullable": true,
                                 "example": -6
                             },
                             "to": {
                                 "type": "integer",
-                                "description": "End of the filtering interval. Specified by number of periods (with respect to given granularity). Value 'O' is representing current time-interval (current day, week, ...).",
+                                "description": "End of the filtering interval. Specified by number of periods (with respect to given granularity). Value 'O' is representing current time-interval (current day, week, ...). If null, then end of the range is unbounded.",
                                 "format": "int32",
+                                "nullable": true,
                                 "example": 0
                             },
                             "localIdentifier": {
@@ -21128,7 +18946,7 @@
                         }
                     }
                 },
-                "description": "A date filter specifying a time interval that is relative to the current date. For example, last week, next month, and so on. Field dataset is representing qualifier of date dimension."
+                "description": "A date filter specifying a time interval that is relative to the current date. For example, last week, next month, and so on. Field dataset is representing qualifier of date dimension. The 'from' and 'to' properties mark the boundaries of the interval. If 'from' is omitted, all values earlier than 'to' are included. If 'to' is omitted, all values later than 'from' are included. It is not allowed to omit both."
             },
             "RelativeWrapper": {
                 "required": ["relative"],
@@ -21391,6 +19209,218 @@
                 },
                 "description": "Export request object describing the export properties and metadata for dashboard PDF exports."
             },
+            "JsonApiNotificationChannelOut": {
+                "required": ["id", "type"],
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "description": "Object type",
+                        "example": "notificationChannel",
+                        "enum": ["notificationChannel"]
+                    },
+                    "id": {
+                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
+                        "type": "string",
+                        "description": "API identifier of an object",
+                        "example": "id1"
+                    },
+                    "attributes": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "maxLength": 255,
+                                "type": "string",
+                                "nullable": true
+                            },
+                            "description": {
+                                "maxLength": 10000,
+                                "type": "string",
+                                "nullable": true
+                            },
+                            "destination": {
+                                "description": "The destination where the notifications are to be sent.",
+                                "oneOf": [
+                                    {
+                                        "$ref": "#/components/schemas/DefaultSmtp"
+                                    },
+                                    {
+                                        "$ref": "#/components/schemas/InPlatform"
+                                    },
+                                    {
+                                        "$ref": "#/components/schemas/Smtp"
+                                    },
+                                    {
+                                        "$ref": "#/components/schemas/Webhook"
+                                    }
+                                ]
+                            },
+                            "destinationType": {
+                                "type": "string",
+                                "nullable": true,
+                                "enum": ["WEBHOOK", "SMTP", "DEFAULT_SMTP", "IN_PLATFORM"]
+                            },
+                            "customDashboardUrl": {
+                                "maxLength": 255,
+                                "type": "string",
+                                "description": "Custom dashboard url that is going to be used in the notification. If not specified it is going to be deduced based on the context. Allowed placeholders are:\n{workspaceId}\n{dashboardId}\n{automationId}\n{asOfDate}\n"
+                            },
+                            "dashboardLinkVisibility": {
+                                "type": "string",
+                                "description": "Dashboard link visibility in notifications.\nHIDDEN - the link will not be included\nINTERNAL_ONLY - only internal users will see the link\nALL - all users will see the link\n",
+                                "enum": ["HIDDEN", "INTERNAL_ONLY", "ALL"]
+                            },
+                            "notificationSource": {
+                                "maxLength": 10000,
+                                "type": "string",
+                                "description": "Human-readable description of the source of the notification. If specified, this propertywill be included in the notifications to this channel.Allowed placeholders are:\n{{workspaceId}}\n{{workspaceName}}\n{{workspaceDescription}}\n{{dashboardId}}\n{{dashboardName}}\n{{dashboardDescription}}\n"
+                            },
+                            "allowedRecipients": {
+                                "type": "string",
+                                "description": "Allowed recipients of notifications from this channel.\nCREATOR - only the creator\nINTERNAL - all users within the organization\nEXTERNAL - all recipients including those outside the organization\n",
+                                "enum": ["CREATOR", "INTERNAL", "EXTERNAL"]
+                            },
+                            "inPlatformNotification": {
+                                "type": "string",
+                                "description": "In-platform notifications configuration. No effect if the destination type is IN_PLATFORM.\nDISABLED - in-platform notifications are not sent\nENABLED - in-platform notifications are sent in addition to the regular notifications\n",
+                                "enum": ["DISABLED", "ENABLED"]
+                            }
+                        }
+                    }
+                },
+                "description": "JSON:API representation of notificationChannel entity."
+            },
+            "DefaultSmtp": {
+                "required": ["type"],
+                "type": "object",
+                "description": "Default SMTP destination for notifications.",
+                "allOf": [
+                    {
+                        "type": "object",
+                        "properties": {
+                            "fromEmail": {
+                                "type": "string",
+                                "description": "E-mail address to send notifications from. Currently this does not have any effect. E-mail 'no-reply@gooddata.com' is used instead.",
+                                "format": "email",
+                                "default": "no-reply@gooddata.com"
+                            },
+                            "fromEmailName": {
+                                "type": "string",
+                                "description": "An optional e-mail name to send notifications from. Currently this does not have any effect. E-mail from name 'GoodData' is used instead.",
+                                "default": "GoodData"
+                            },
+                            "type": {
+                                "type": "string",
+                                "description": "The destination type.",
+                                "enum": ["DEFAULT_SMTP"]
+                            }
+                        }
+                    }
+                ]
+            },
+            "InPlatform": {
+                "required": ["type"],
+                "type": "object",
+                "description": "In-platform destination for notifications.",
+                "allOf": [
+                    {
+                        "type": "object",
+                        "properties": {
+                            "type": {
+                                "type": "string",
+                                "description": "The destination type.",
+                                "enum": ["IN_PLATFORM"]
+                            }
+                        }
+                    }
+                ]
+            },
+            "Smtp": {
+                "required": ["type"],
+                "type": "object",
+                "description": "Custom SMTP destination for notifications. The properties host, port, username, and password are required on create and update",
+                "allOf": [
+                    {
+                        "type": "object",
+                        "properties": {
+                            "fromEmail": {
+                                "type": "string",
+                                "description": "E-mail address to send notifications from.",
+                                "format": "email",
+                                "default": "no-reply@gooddata.com"
+                            },
+                            "fromEmailName": {
+                                "type": "string",
+                                "description": "An optional e-mail name to send notifications from.",
+                                "default": "GoodData"
+                            },
+                            "host": {
+                                "type": "string",
+                                "description": "The SMTP server address."
+                            },
+                            "port": {
+                                "type": "integer",
+                                "description": "The SMTP server port.",
+                                "format": "int32",
+                                "enum": [25, 465, 587, 2525]
+                            },
+                            "username": {
+                                "type": "string",
+                                "description": "The SMTP server username."
+                            },
+                            "password": {
+                                "type": "string",
+                                "description": "The SMTP server password.",
+                                "writeOnly": true
+                            },
+                            "type": {
+                                "type": "string",
+                                "description": "The destination type.",
+                                "enum": ["SMTP"]
+                            }
+                        }
+                    }
+                ]
+            },
+            "Webhook": {
+                "required": ["type"],
+                "type": "object",
+                "description": "Webhook destination for notifications. The property url is required on create and update.",
+                "allOf": [
+                    {
+                        "type": "object",
+                        "properties": {
+                            "url": {
+                                "maxLength": 255,
+                                "pattern": "https?\\://.*",
+                                "type": "string",
+                                "description": "The webhook URL.",
+                                "example": "https://webhook.site/something"
+                            },
+                            "token": {
+                                "maxLength": 10000,
+                                "type": "string",
+                                "description": "Bearer token for the webhook.",
+                                "nullable": true,
+                                "writeOnly": true,
+                                "example": "secret"
+                            },
+                            "hasToken": {
+                                "maxLength": 10000,
+                                "type": "boolean",
+                                "description": "Flag indicating if webhook has a token.",
+                                "nullable": true,
+                                "readOnly": true
+                            },
+                            "type": {
+                                "type": "string",
+                                "description": "The destination type.",
+                                "enum": ["WEBHOOK"]
+                            }
+                        }
+                    }
+                ]
+            },
             "JsonApiNotificationChannelOutWithLinks": {
                 "allOf": [
                     {
@@ -21568,6 +19598,91 @@
                 "allOf": [
                     {
                         "$ref": "#/components/schemas/JsonApiExportDefinitionOut"
+                    },
+                    {
+                        "$ref": "#/components/schemas/ObjectLinksContainer"
+                    }
+                ]
+            },
+            "JsonApiUserOut": {
+                "required": ["id", "type"],
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "description": "Object type",
+                        "example": "user",
+                        "enum": ["user"]
+                    },
+                    "id": {
+                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
+                        "type": "string",
+                        "description": "API identifier of an object",
+                        "example": "id1"
+                    },
+                    "attributes": {
+                        "type": "object",
+                        "properties": {
+                            "authenticationId": {
+                                "maxLength": 255,
+                                "type": "string"
+                            },
+                            "firstname": {
+                                "maxLength": 255,
+                                "type": "string"
+                            },
+                            "lastname": {
+                                "maxLength": 255,
+                                "type": "string"
+                            },
+                            "email": {
+                                "maxLength": 255,
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "relationships": {
+                        "type": "object",
+                        "properties": {
+                            "userGroups": {
+                                "required": ["data"],
+                                "type": "object",
+                                "properties": {
+                                    "data": {
+                                        "$ref": "#/components/schemas/JsonApiUserGroupToManyLinkage"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "JSON:API representation of user entity."
+            },
+            "JsonApiUserGroupLinkage": {
+                "required": ["id", "type"],
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "string",
+                        "enum": ["userGroup"]
+                    }
+                },
+                "description": "The \\\"type\\\" and \\\"id\\\" to non-empty members."
+            },
+            "JsonApiUserGroupToManyLinkage": {
+                "type": "array",
+                "description": "References to other resource objects in a to-many (\\\"relationship\\\"). Relationships can be specified by including a member in a resource's links object.",
+                "items": {
+                    "$ref": "#/components/schemas/JsonApiUserGroupLinkage"
+                }
+            },
+            "JsonApiUserOutWithLinks": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/JsonApiUserOut"
                     },
                     {
                         "$ref": "#/components/schemas/ObjectLinksContainer"
@@ -22392,6 +20507,15 @@
                 },
                 "description": "JSON:API representation of patching filterView entity."
             },
+            "JsonApiUserToOneLinkage": {
+                "description": "References to other resource objects in a to-one (\\\"relationship\\\"). Relationships can be specified by including a member in a resource's links object.",
+                "nullable": true,
+                "oneOf": [
+                    {
+                        "$ref": "#/components/schemas/JsonApiUserLinkage"
+                    }
+                ]
+            },
             "JsonApiFilterViewOutIncludes": {
                 "oneOf": [
                     {
@@ -22800,6 +20924,67 @@
                     }
                 },
                 "description": "JSON:API representation of patching userDataFilter entity."
+            },
+            "JsonApiUserGroupToOneLinkage": {
+                "description": "References to other resource objects in a to-one (\\\"relationship\\\"). Relationships can be specified by including a member in a resource's links object.",
+                "nullable": true,
+                "oneOf": [
+                    {
+                        "$ref": "#/components/schemas/JsonApiUserGroupLinkage"
+                    }
+                ]
+            },
+            "JsonApiUserGroupOut": {
+                "required": ["id", "type"],
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "description": "Object type",
+                        "example": "userGroup",
+                        "enum": ["userGroup"]
+                    },
+                    "id": {
+                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
+                        "type": "string",
+                        "description": "API identifier of an object",
+                        "example": "id1"
+                    },
+                    "attributes": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "maxLength": 255,
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "relationships": {
+                        "type": "object",
+                        "properties": {
+                            "parents": {
+                                "required": ["data"],
+                                "type": "object",
+                                "properties": {
+                                    "data": {
+                                        "$ref": "#/components/schemas/JsonApiUserGroupToManyLinkage"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "JSON:API representation of userGroup entity."
+            },
+            "JsonApiUserGroupOutWithLinks": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/JsonApiUserGroupOut"
+                    },
+                    {
+                        "$ref": "#/components/schemas/ObjectLinksContainer"
+                    }
+                ]
             },
             "JsonApiUserDataFilterOutIncludes": {
                 "oneOf": [
@@ -23572,17 +21757,17 @@
                 },
                 "description": "JSON:API representation of workspaceSetting entity."
             },
-            "JsonApiAnalyticalDashboardPostOptionalIdDocument": {
+            "JsonApiAnalyticalDashboardInDocument": {
                 "required": ["data"],
                 "type": "object",
                 "properties": {
                     "data": {
-                        "$ref": "#/components/schemas/JsonApiAnalyticalDashboardPostOptionalId"
+                        "$ref": "#/components/schemas/JsonApiAnalyticalDashboardIn"
                     }
                 }
             },
-            "JsonApiAnalyticalDashboardPostOptionalId": {
-                "required": ["attributes", "type"],
+            "JsonApiAnalyticalDashboardIn": {
+                "required": ["attributes", "id", "type"],
                 "type": "object",
                 "properties": {
                     "type": {
@@ -23955,17 +22140,17 @@
                 },
                 "description": "JSON:API representation of automation entity."
             },
-            "JsonApiCustomApplicationSettingPostOptionalIdDocument": {
+            "JsonApiCustomApplicationSettingInDocument": {
                 "required": ["data"],
                 "type": "object",
                 "properties": {
                     "data": {
-                        "$ref": "#/components/schemas/JsonApiCustomApplicationSettingPostOptionalId"
+                        "$ref": "#/components/schemas/JsonApiCustomApplicationSettingIn"
                     }
                 }
             },
-            "JsonApiCustomApplicationSettingPostOptionalId": {
-                "required": ["attributes", "type"],
+            "JsonApiCustomApplicationSettingIn": {
+                "required": ["attributes", "id", "type"],
                 "type": "object",
                 "properties": {
                     "type": {
@@ -23998,17 +22183,17 @@
                 },
                 "description": "JSON:API representation of customApplicationSetting entity."
             },
-            "JsonApiDashboardPluginPostOptionalIdDocument": {
+            "JsonApiDashboardPluginInDocument": {
                 "required": ["data"],
                 "type": "object",
                 "properties": {
                     "data": {
-                        "$ref": "#/components/schemas/JsonApiDashboardPluginPostOptionalId"
+                        "$ref": "#/components/schemas/JsonApiDashboardPluginIn"
                     }
                 }
             },
-            "JsonApiDashboardPluginPostOptionalId": {
-                "required": ["type"],
+            "JsonApiDashboardPluginIn": {
+                "required": ["id", "type"],
                 "type": "object",
                 "properties": {
                     "type": {
@@ -24055,17 +22240,17 @@
                 },
                 "description": "JSON:API representation of dashboardPlugin entity."
             },
-            "JsonApiExportDefinitionPostOptionalIdDocument": {
+            "JsonApiExportDefinitionInDocument": {
                 "required": ["data"],
                 "type": "object",
                 "properties": {
                     "data": {
-                        "$ref": "#/components/schemas/JsonApiExportDefinitionPostOptionalId"
+                        "$ref": "#/components/schemas/JsonApiExportDefinitionIn"
                     }
                 }
             },
-            "JsonApiExportDefinitionPostOptionalId": {
-                "required": ["type"],
+            "JsonApiExportDefinitionIn": {
+                "required": ["id", "type"],
                 "type": "object",
                 "properties": {
                     "type": {
@@ -24140,17 +22325,17 @@
                 },
                 "description": "JSON:API representation of exportDefinition entity."
             },
-            "JsonApiFilterContextPostOptionalIdDocument": {
+            "JsonApiFilterContextInDocument": {
                 "required": ["data"],
                 "type": "object",
                 "properties": {
                     "data": {
-                        "$ref": "#/components/schemas/JsonApiFilterContextPostOptionalId"
+                        "$ref": "#/components/schemas/JsonApiFilterContextIn"
                     }
                 }
             },
-            "JsonApiFilterContextPostOptionalId": {
-                "required": ["attributes", "type"],
+            "JsonApiFilterContextIn": {
+                "required": ["attributes", "id", "type"],
                 "type": "object",
                 "properties": {
                     "type": {
@@ -24284,17 +22469,17 @@
                 },
                 "description": "JSON:API representation of filterView entity."
             },
-            "JsonApiMetricPostOptionalIdDocument": {
+            "JsonApiMetricInDocument": {
                 "required": ["data"],
                 "type": "object",
                 "properties": {
                     "data": {
-                        "$ref": "#/components/schemas/JsonApiMetricPostOptionalId"
+                        "$ref": "#/components/schemas/JsonApiMetricIn"
                     }
                 }
             },
-            "JsonApiMetricPostOptionalId": {
-                "required": ["attributes", "type"],
+            "JsonApiMetricIn": {
+                "required": ["attributes", "id", "type"],
                 "type": "object",
                 "properties": {
                     "type": {
@@ -24349,17 +22534,17 @@
                 },
                 "description": "JSON:API representation of metric entity."
             },
-            "JsonApiUserDataFilterPostOptionalIdDocument": {
+            "JsonApiUserDataFilterInDocument": {
                 "required": ["data"],
                 "type": "object",
                 "properties": {
                     "data": {
-                        "$ref": "#/components/schemas/JsonApiUserDataFilterPostOptionalId"
+                        "$ref": "#/components/schemas/JsonApiUserDataFilterIn"
                     }
                 }
             },
-            "JsonApiUserDataFilterPostOptionalId": {
-                "required": ["attributes", "type"],
+            "JsonApiUserDataFilterIn": {
+                "required": ["attributes", "id", "type"],
                 "type": "object",
                 "properties": {
                     "type": {
@@ -24427,17 +22612,17 @@
                 },
                 "description": "JSON:API representation of userDataFilter entity."
             },
-            "JsonApiVisualizationObjectPostOptionalIdDocument": {
+            "JsonApiVisualizationObjectInDocument": {
                 "required": ["data"],
                 "type": "object",
                 "properties": {
                     "data": {
-                        "$ref": "#/components/schemas/JsonApiVisualizationObjectPostOptionalId"
+                        "$ref": "#/components/schemas/JsonApiVisualizationObjectIn"
                     }
                 }
             },
-            "JsonApiVisualizationObjectPostOptionalId": {
-                "required": ["attributes", "type"],
+            "JsonApiVisualizationObjectIn": {
+                "required": ["attributes", "id", "type"],
                 "type": "object",
                 "properties": {
                     "type": {
@@ -24609,17 +22794,17 @@
                 },
                 "description": "JSON:API representation of workspaceDataFilter entity."
             },
-            "JsonApiWorkspaceSettingPostOptionalIdDocument": {
+            "JsonApiWorkspaceSettingInDocument": {
                 "required": ["data"],
                 "type": "object",
                 "properties": {
                     "data": {
-                        "$ref": "#/components/schemas/JsonApiWorkspaceSettingPostOptionalId"
+                        "$ref": "#/components/schemas/JsonApiWorkspaceSettingIn"
                     }
                 }
             },
-            "JsonApiWorkspaceSettingPostOptionalId": {
-                "required": ["type"],
+            "JsonApiWorkspaceSettingIn": {
+                "required": ["id", "type"],
                 "type": "object",
                 "properties": {
                     "type": {
@@ -24676,6 +22861,2563 @@
                     }
                 },
                 "description": "JSON:API representation of workspaceSetting entity."
+            },
+            "JsonApiCookieSecurityConfigurationPatchDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiCookieSecurityConfigurationPatch"
+                    }
+                }
+            },
+            "JsonApiCookieSecurityConfigurationPatch": {
+                "required": ["id", "type"],
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "description": "Object type",
+                        "example": "cookieSecurityConfiguration",
+                        "enum": ["cookieSecurityConfiguration"]
+                    },
+                    "id": {
+                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
+                        "type": "string",
+                        "description": "API identifier of an object",
+                        "example": "id1"
+                    },
+                    "attributes": {
+                        "type": "object",
+                        "properties": {
+                            "lastRotation": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "rotationInterval": {
+                                "type": "string",
+                                "description": "Length of interval between automatic rotations expressed in format of ISO 8601 duration",
+                                "example": "P30D"
+                            }
+                        }
+                    }
+                },
+                "description": "JSON:API representation of patching cookieSecurityConfiguration entity."
+            },
+            "JsonApiCookieSecurityConfigurationOutDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiCookieSecurityConfigurationOut"
+                    },
+                    "links": {
+                        "$ref": "#/components/schemas/ObjectLinks"
+                    }
+                }
+            },
+            "JsonApiCookieSecurityConfigurationOut": {
+                "required": ["id", "type"],
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "description": "Object type",
+                        "example": "cookieSecurityConfiguration",
+                        "enum": ["cookieSecurityConfiguration"]
+                    },
+                    "id": {
+                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
+                        "type": "string",
+                        "description": "API identifier of an object",
+                        "example": "id1"
+                    },
+                    "attributes": {
+                        "type": "object",
+                        "properties": {
+                            "lastRotation": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "rotationInterval": {
+                                "type": "string",
+                                "description": "Length of interval between automatic rotations expressed in format of ISO 8601 duration",
+                                "example": "P30D"
+                            }
+                        }
+                    }
+                },
+                "description": "JSON:API representation of cookieSecurityConfiguration entity."
+            },
+            "JsonApiOrganizationPatchDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiOrganizationPatch"
+                    }
+                }
+            },
+            "JsonApiOrganizationPatch": {
+                "required": ["id", "type"],
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "description": "Object type",
+                        "example": "organization",
+                        "enum": ["organization"]
+                    },
+                    "id": {
+                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
+                        "type": "string",
+                        "description": "API identifier of an object",
+                        "example": "id1"
+                    },
+                    "attributes": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "maxLength": 255,
+                                "type": "string",
+                                "nullable": true
+                            },
+                            "hostname": {
+                                "maxLength": 255,
+                                "type": "string"
+                            },
+                            "allowedOrigins": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
+                            "oauthIssuerLocation": {
+                                "maxLength": 255,
+                                "type": "string"
+                            },
+                            "oauthClientId": {
+                                "maxLength": 255,
+                                "type": "string"
+                            },
+                            "oauthClientSecret": {
+                                "maxLength": 255,
+                                "type": "string"
+                            },
+                            "earlyAccess": {
+                                "maxLength": 255,
+                                "type": "string",
+                                "description": "The early access feature identifier. It is used to enable experimental features. Deprecated in favor of earlyAccessValues.",
+                                "nullable": true,
+                                "deprecated": true
+                            },
+                            "earlyAccessValues": {
+                                "type": "array",
+                                "description": "The early access feature identifiers. They are used to enable experimental features.",
+                                "nullable": true,
+                                "items": {
+                                    "maxLength": 255,
+                                    "type": "string"
+                                }
+                            },
+                            "oauthIssuerId": {
+                                "maxLength": 255,
+                                "type": "string",
+                                "description": "Any string identifying the OIDC provider. This value is used as suffix for OAuth2 callback (redirect) URL. If not defined, the standard callback URL is used. This value is valid only for external OIDC providers, not for the internal DEX provider.",
+                                "example": "myOidcProvider"
+                            },
+                            "oauthSubjectIdClaim": {
+                                "maxLength": 255,
+                                "type": "string",
+                                "description": "Any string identifying the claim in ID token, that should be used for user identification. The default value is 'sub'.",
+                                "example": "oid"
+                            },
+                            "oauthCustomAuthAttributes": {
+                                "maxLength": 10000,
+                                "type": "object",
+                                "additionalProperties": {
+                                    "type": "string"
+                                },
+                                "description": "Map of additional authentication attributes that should be added to the OAuth2 authentication requests, where the key is the name of the attribute and the value is the value of the attribute."
+                            },
+                            "oauthCustomScopes": {
+                                "type": "array",
+                                "description": "List of additional OAuth scopes which may be required by other providers (e.g. Snowflake)",
+                                "nullable": true,
+                                "items": {
+                                    "maxLength": 255,
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "relationships": {
+                        "type": "object",
+                        "properties": {
+                            "identityProvider": {
+                                "required": ["data"],
+                                "type": "object",
+                                "properties": {
+                                    "data": {
+                                        "$ref": "#/components/schemas/JsonApiIdentityProviderToOneLinkage"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "JSON:API representation of patching organization entity."
+            },
+            "JsonApiIdentityProviderLinkage": {
+                "required": ["id", "type"],
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "string",
+                        "enum": ["identityProvider"]
+                    }
+                },
+                "description": "The \\\"type\\\" and \\\"id\\\" to non-empty members."
+            },
+            "JsonApiIdentityProviderToOneLinkage": {
+                "description": "References to other resource objects in a to-one (\\\"relationship\\\"). Relationships can be specified by including a member in a resource's links object.",
+                "nullable": true,
+                "oneOf": [
+                    {
+                        "$ref": "#/components/schemas/JsonApiIdentityProviderLinkage"
+                    }
+                ]
+            },
+            "JsonApiIdentityProviderOut": {
+                "required": ["id", "type"],
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "description": "Object type",
+                        "example": "identityProvider",
+                        "enum": ["identityProvider"]
+                    },
+                    "id": {
+                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
+                        "type": "string",
+                        "description": "API identifier of an object",
+                        "example": "id1"
+                    },
+                    "attributes": {
+                        "type": "object",
+                        "properties": {
+                            "identifiers": {
+                                "type": "array",
+                                "description": "List of identifiers for this IdP, where an identifier is a domain name. Users with email addresses belonging to these domains will be authenticated by this IdP.",
+                                "example": ["gooddata.com"],
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
+                            "customClaimMapping": {
+                                "maxLength": 10000,
+                                "type": "object",
+                                "additionalProperties": {
+                                    "type": "string"
+                                },
+                                "description": "Map of custom claim overrides. To be used when your Idp does not provide default claims (sub, email, name, given_name, family_name). Define the key pair for the claim you wish to override, where the key is the default name of the attribute and the value is your custom name for the given attribute."
+                            },
+                            "oauthClientId": {
+                                "maxLength": 255,
+                                "type": "string",
+                                "description": "The OAuth client id of your OIDC provider. This field is mandatory for OIDC IdP."
+                            },
+                            "oauthIssuerLocation": {
+                                "maxLength": 255,
+                                "type": "string",
+                                "description": "The location of your OIDC provider. This field is mandatory for OIDC IdP."
+                            },
+                            "oauthIssuerId": {
+                                "maxLength": 255,
+                                "type": "string",
+                                "description": "Any string identifying the OIDC provider. This value is used as suffix for OAuth2 callback (redirect) URL. If not defined, the standard callback URL is used. This value is valid only for external OIDC providers, not for the internal DEX provider.",
+                                "example": "myOidcProvider"
+                            },
+                            "oauthSubjectIdClaim": {
+                                "maxLength": 255,
+                                "type": "string",
+                                "description": "Any string identifying the claim in ID token, that should be used for user identification. The default value is 'sub'.",
+                                "example": "oid"
+                            },
+                            "oauthCustomAuthAttributes": {
+                                "maxLength": 10000,
+                                "type": "object",
+                                "additionalProperties": {
+                                    "type": "string"
+                                },
+                                "description": "Map of additional authentication attributes that should be added to the OAuth2 authentication requests, where the key is the name of the attribute and the value is the value of the attribute."
+                            },
+                            "oauthCustomScopes": {
+                                "type": "array",
+                                "description": "List of additional OAuth scopes which may be required by other providers (e.g. Snowflake)",
+                                "nullable": true,
+                                "items": {
+                                    "maxLength": 255,
+                                    "type": "string"
+                                }
+                            },
+                            "idpType": {
+                                "type": "string",
+                                "description": "Type of IdP for management purposes. MANAGED_IDP represents a GoodData managed IdP used in single OIDC setup, which is protected from altering/deletion. FIM_IDP represents a GoodData managed IdP used in federated identity management setup, which is protected from altering/deletion. CUSTOM_IDP represents customer's own IdP, protected from deletion if currently used by org for authentication, deletable otherwise.",
+                                "enum": ["MANAGED_IDP", "FIM_IDP", "CUSTOM_IDP"]
+                            }
+                        }
+                    }
+                },
+                "description": "JSON:API representation of identityProvider entity."
+            },
+            "JsonApiIdentityProviderOutWithLinks": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/JsonApiIdentityProviderOut"
+                    },
+                    {
+                        "$ref": "#/components/schemas/ObjectLinksContainer"
+                    }
+                ]
+            },
+            "JsonApiOrganizationOutIncludes": {
+                "oneOf": [
+                    {
+                        "$ref": "#/components/schemas/JsonApiUserOutWithLinks"
+                    },
+                    {
+                        "$ref": "#/components/schemas/JsonApiUserGroupOutWithLinks"
+                    },
+                    {
+                        "$ref": "#/components/schemas/JsonApiIdentityProviderOutWithLinks"
+                    }
+                ]
+            },
+            "JsonApiOrganizationOutDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiOrganizationOut"
+                    },
+                    "links": {
+                        "$ref": "#/components/schemas/ObjectLinks"
+                    },
+                    "included": {
+                        "uniqueItems": true,
+                        "type": "array",
+                        "description": "Included resources",
+                        "items": {
+                            "$ref": "#/components/schemas/JsonApiOrganizationOutIncludes"
+                        }
+                    }
+                }
+            },
+            "JsonApiOrganizationOut": {
+                "required": ["id", "type"],
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "description": "Object type",
+                        "example": "organization",
+                        "enum": ["organization"]
+                    },
+                    "id": {
+                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
+                        "type": "string",
+                        "description": "API identifier of an object",
+                        "example": "id1"
+                    },
+                    "meta": {
+                        "type": "object",
+                        "properties": {
+                            "permissions": {
+                                "type": "array",
+                                "description": "List of valid permissions for a logged-in user.",
+                                "items": {
+                                    "type": "string",
+                                    "enum": ["MANAGE", "SELF_CREATE_TOKEN"]
+                                }
+                            }
+                        }
+                    },
+                    "attributes": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "maxLength": 255,
+                                "type": "string",
+                                "nullable": true
+                            },
+                            "hostname": {
+                                "maxLength": 255,
+                                "type": "string"
+                            },
+                            "allowedOrigins": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
+                            "oauthIssuerLocation": {
+                                "maxLength": 255,
+                                "type": "string"
+                            },
+                            "oauthClientId": {
+                                "maxLength": 255,
+                                "type": "string"
+                            },
+                            "earlyAccess": {
+                                "maxLength": 255,
+                                "type": "string",
+                                "description": "The early access feature identifier. It is used to enable experimental features. Deprecated in favor of earlyAccessValues.",
+                                "nullable": true,
+                                "deprecated": true
+                            },
+                            "earlyAccessValues": {
+                                "type": "array",
+                                "description": "The early access feature identifiers. They are used to enable experimental features.",
+                                "nullable": true,
+                                "items": {
+                                    "maxLength": 255,
+                                    "type": "string"
+                                }
+                            },
+                            "oauthIssuerId": {
+                                "maxLength": 255,
+                                "type": "string",
+                                "description": "Any string identifying the OIDC provider. This value is used as suffix for OAuth2 callback (redirect) URL. If not defined, the standard callback URL is used. This value is valid only for external OIDC providers, not for the internal DEX provider.",
+                                "example": "myOidcProvider"
+                            },
+                            "cacheSettings": {
+                                "type": "object",
+                                "properties": {
+                                    "extraCacheBudget": {
+                                        "type": "integer",
+                                        "format": "int64"
+                                    },
+                                    "cacheStrategy": {
+                                        "maxLength": 255,
+                                        "type": "string",
+                                        "enum": ["DURABLE", "EPHEMERAL"]
+                                    }
+                                }
+                            },
+                            "oauthSubjectIdClaim": {
+                                "maxLength": 255,
+                                "type": "string",
+                                "description": "Any string identifying the claim in ID token, that should be used for user identification. The default value is 'sub'.",
+                                "example": "oid"
+                            },
+                            "oauthCustomAuthAttributes": {
+                                "maxLength": 10000,
+                                "type": "object",
+                                "additionalProperties": {
+                                    "type": "string"
+                                },
+                                "description": "Map of additional authentication attributes that should be added to the OAuth2 authentication requests, where the key is the name of the attribute and the value is the value of the attribute."
+                            },
+                            "oauthCustomScopes": {
+                                "type": "array",
+                                "description": "List of additional OAuth scopes which may be required by other providers (e.g. Snowflake)",
+                                "nullable": true,
+                                "items": {
+                                    "maxLength": 255,
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "relationships": {
+                        "type": "object",
+                        "properties": {
+                            "bootstrapUser": {
+                                "required": ["data"],
+                                "type": "object",
+                                "properties": {
+                                    "data": {
+                                        "$ref": "#/components/schemas/JsonApiUserToOneLinkage"
+                                    }
+                                }
+                            },
+                            "bootstrapUserGroup": {
+                                "required": ["data"],
+                                "type": "object",
+                                "properties": {
+                                    "data": {
+                                        "$ref": "#/components/schemas/JsonApiUserGroupToOneLinkage"
+                                    }
+                                }
+                            },
+                            "identityProvider": {
+                                "required": ["data"],
+                                "type": "object",
+                                "properties": {
+                                    "data": {
+                                        "$ref": "#/components/schemas/JsonApiIdentityProviderToOneLinkage"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "JSON:API representation of organization entity."
+            },
+            "JsonApiApiTokenOutDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiApiTokenOut"
+                    },
+                    "links": {
+                        "$ref": "#/components/schemas/ObjectLinks"
+                    }
+                }
+            },
+            "JsonApiApiTokenOut": {
+                "required": ["id", "type"],
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "description": "Object type",
+                        "example": "apiToken",
+                        "enum": ["apiToken"]
+                    },
+                    "id": {
+                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
+                        "type": "string",
+                        "description": "API identifier of an object",
+                        "example": "id1"
+                    },
+                    "attributes": {
+                        "type": "object",
+                        "properties": {
+                            "bearerToken": {
+                                "type": "string",
+                                "description": "The value of the Bearer token. It is only returned when the API token is created."
+                            }
+                        }
+                    }
+                },
+                "description": "JSON:API representation of apiToken entity."
+            },
+            "JsonApiUserSettingOutDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiUserSettingOut"
+                    },
+                    "links": {
+                        "$ref": "#/components/schemas/ObjectLinks"
+                    }
+                }
+            },
+            "JsonApiUserSettingOut": {
+                "required": ["id", "type"],
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "description": "Object type",
+                        "example": "userSetting",
+                        "enum": ["userSetting"]
+                    },
+                    "id": {
+                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
+                        "type": "string",
+                        "description": "API identifier of an object",
+                        "example": "id1"
+                    },
+                    "attributes": {
+                        "type": "object",
+                        "properties": {
+                            "content": {
+                                "type": "object",
+                                "description": "Free-form JSON content. Maximum supported length is 15000 characters.",
+                                "example": {}
+                            },
+                            "type": {
+                                "type": "string",
+                                "enum": [
+                                    "TIMEZONE",
+                                    "ACTIVE_THEME",
+                                    "ACTIVE_COLOR_PALETTE",
+                                    "ACTIVE_LLM_ENDPOINT",
+                                    "WHITE_LABELING",
+                                    "LOCALE",
+                                    "METADATA_LOCALE",
+                                    "FORMAT_LOCALE",
+                                    "MAPBOX_TOKEN",
+                                    "WEEK_START",
+                                    "SHOW_HIDDEN_CATALOG_ITEMS",
+                                    "OPERATOR_OVERRIDES",
+                                    "TIMEZONE_VALIDATION_ENABLED",
+                                    "OPENAI_CONFIG",
+                                    "ENABLE_FILE_ANALYTICS",
+                                    "ALERT",
+                                    "SEPARATORS",
+                                    "DATE_FILTER_CONFIG",
+                                    "JIT_PROVISIONING",
+                                    "JWT_JIT_PROVISIONING",
+                                    "DASHBOARD_FILTERS_APPLY_MODE",
+                                    "ENABLE_SLIDES_EXPORT",
+                                    "AI_RATE_LIMIT",
+                                    "ATTACHMENT_SIZE_LIMIT",
+                                    "ATTACHMENT_LINK_TTL"
+                                ]
+                            }
+                        }
+                    }
+                },
+                "description": "JSON:API representation of userSetting entity."
+            },
+            "JsonApiColorPalettePatchDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiColorPalettePatch"
+                    }
+                }
+            },
+            "JsonApiColorPalettePatch": {
+                "required": ["attributes", "id", "type"],
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "description": "Object type",
+                        "example": "colorPalette",
+                        "enum": ["colorPalette"]
+                    },
+                    "id": {
+                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
+                        "type": "string",
+                        "description": "API identifier of an object",
+                        "example": "id1"
+                    },
+                    "attributes": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "maxLength": 255,
+                                "type": "string"
+                            },
+                            "content": {
+                                "type": "object",
+                                "description": "Free-form JSON content. Maximum supported length is 15000 characters.",
+                                "example": {}
+                            }
+                        }
+                    }
+                },
+                "description": "JSON:API representation of patching colorPalette entity."
+            },
+            "JsonApiColorPaletteOutDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiColorPaletteOut"
+                    },
+                    "links": {
+                        "$ref": "#/components/schemas/ObjectLinks"
+                    }
+                }
+            },
+            "JsonApiColorPaletteOut": {
+                "required": ["attributes", "id", "type"],
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "description": "Object type",
+                        "example": "colorPalette",
+                        "enum": ["colorPalette"]
+                    },
+                    "id": {
+                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
+                        "type": "string",
+                        "description": "API identifier of an object",
+                        "example": "id1"
+                    },
+                    "attributes": {
+                        "required": ["content", "name"],
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "maxLength": 255,
+                                "type": "string"
+                            },
+                            "content": {
+                                "type": "object",
+                                "description": "Free-form JSON content. Maximum supported length is 15000 characters.",
+                                "example": {}
+                            }
+                        }
+                    }
+                },
+                "description": "JSON:API representation of colorPalette entity."
+            },
+            "JsonApiCspDirectivePatchDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiCspDirectivePatch"
+                    }
+                }
+            },
+            "JsonApiCspDirectivePatch": {
+                "required": ["attributes", "id", "type"],
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "description": "Object type",
+                        "example": "cspDirective",
+                        "enum": ["cspDirective"]
+                    },
+                    "id": {
+                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
+                        "type": "string",
+                        "description": "API identifier of an object",
+                        "example": "id1"
+                    },
+                    "attributes": {
+                        "type": "object",
+                        "properties": {
+                            "sources": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "JSON:API representation of patching cspDirective entity."
+            },
+            "JsonApiCspDirectiveOutDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiCspDirectiveOut"
+                    },
+                    "links": {
+                        "$ref": "#/components/schemas/ObjectLinks"
+                    }
+                }
+            },
+            "JsonApiCspDirectiveOut": {
+                "required": ["attributes", "id", "type"],
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "description": "Object type",
+                        "example": "cspDirective",
+                        "enum": ["cspDirective"]
+                    },
+                    "id": {
+                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
+                        "type": "string",
+                        "description": "API identifier of an object",
+                        "example": "id1"
+                    },
+                    "attributes": {
+                        "required": ["sources"],
+                        "type": "object",
+                        "properties": {
+                            "sources": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "JSON:API representation of cspDirective entity."
+            },
+            "JsonApiDataSourcePatchDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiDataSourcePatch"
+                    }
+                }
+            },
+            "JsonApiDataSourcePatch": {
+                "required": ["attributes", "id", "type"],
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "description": "Object type",
+                        "example": "dataSource",
+                        "enum": ["dataSource"]
+                    },
+                    "id": {
+                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
+                        "type": "string",
+                        "description": "API identifier of an object",
+                        "example": "id1"
+                    },
+                    "attributes": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "maxLength": 255,
+                                "type": "string",
+                                "description": "User-facing name of the data source."
+                            },
+                            "type": {
+                                "type": "string",
+                                "description": "Type of the database providing the data for the data source.",
+                                "enum": [
+                                    "POSTGRESQL",
+                                    "REDSHIFT",
+                                    "VERTICA",
+                                    "SNOWFLAKE",
+                                    "ADS",
+                                    "BIGQUERY",
+                                    "MSSQL",
+                                    "PRESTO",
+                                    "DREMIO",
+                                    "DRILL",
+                                    "GREENPLUM",
+                                    "AZURESQL",
+                                    "SYNAPSESQL",
+                                    "DATABRICKS",
+                                    "GDSTORAGE",
+                                    "CLICKHOUSE",
+                                    "MYSQL",
+                                    "MARIADB",
+                                    "ORACLE",
+                                    "PINOT",
+                                    "SINGLESTORE",
+                                    "MOTHERDUCK",
+                                    "FLEXCONNECT",
+                                    "STARROCKS",
+                                    "ATHENA"
+                                ]
+                            },
+                            "url": {
+                                "maxLength": 255,
+                                "type": "string",
+                                "description": "The URL of the database providing the data for the data source.",
+                                "nullable": true
+                            },
+                            "schema": {
+                                "maxLength": 255,
+                                "type": "string",
+                                "description": "The schema to use as the root of the data for the data source."
+                            },
+                            "username": {
+                                "maxLength": 255,
+                                "type": "string",
+                                "description": "The username to use to connect to the database providing the data for the data source.",
+                                "nullable": true
+                            },
+                            "password": {
+                                "maxLength": 255,
+                                "type": "string",
+                                "description": "The password to use to connect to the database providing the data for the data source.",
+                                "nullable": true
+                            },
+                            "privateKey": {
+                                "maxLength": 15000,
+                                "type": "string",
+                                "description": "The private key to use to connect to the database providing the data for the data source.",
+                                "nullable": true
+                            },
+                            "privateKeyPassphrase": {
+                                "maxLength": 255,
+                                "type": "string",
+                                "description": "The passphrase used to encrypt the private key.",
+                                "nullable": true
+                            },
+                            "token": {
+                                "maxLength": 10000,
+                                "type": "string",
+                                "description": "The token to use to connect to the database providing the data for the data source (for example a BigQuery Service Account).",
+                                "nullable": true
+                            },
+                            "clientId": {
+                                "maxLength": 255,
+                                "type": "string",
+                                "description": "The client id to use to connect to the database providing the data for the data source (for example a Databricks Service Account).",
+                                "nullable": true
+                            },
+                            "clientSecret": {
+                                "maxLength": 255,
+                                "type": "string",
+                                "description": "The client secret to use to connect to the database providing the data for the data source (for example a Databricks Service Account).",
+                                "nullable": true
+                            },
+                            "parameters": {
+                                "type": "array",
+                                "description": "Additional parameters to be used when connecting to the database providing the data for the data source.",
+                                "nullable": true,
+                                "items": {
+                                    "required": ["name", "value"],
+                                    "type": "object",
+                                    "properties": {
+                                        "name": {
+                                            "type": "string"
+                                        },
+                                        "value": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            },
+                            "cacheStrategy": {
+                                "type": "string",
+                                "description": "Determines how the results coming from a particular datasource should be cached.",
+                                "nullable": true,
+                                "enum": ["ALWAYS", "NEVER"]
+                            }
+                        }
+                    }
+                },
+                "description": "JSON:API representation of patching dataSource entity."
+            },
+            "JsonApiDataSourceOutDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiDataSourceOut"
+                    },
+                    "links": {
+                        "$ref": "#/components/schemas/ObjectLinks"
+                    }
+                }
+            },
+            "JsonApiDataSourceOut": {
+                "required": ["attributes", "id", "type"],
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "description": "Object type",
+                        "example": "dataSource",
+                        "enum": ["dataSource"]
+                    },
+                    "id": {
+                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
+                        "type": "string",
+                        "description": "API identifier of an object",
+                        "example": "id1"
+                    },
+                    "meta": {
+                        "type": "object",
+                        "properties": {
+                            "permissions": {
+                                "type": "array",
+                                "description": "List of valid permissions for a logged-in user.",
+                                "items": {
+                                    "type": "string",
+                                    "enum": ["MANAGE", "USE"]
+                                }
+                            }
+                        }
+                    },
+                    "attributes": {
+                        "required": ["name", "schema", "type"],
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "maxLength": 255,
+                                "type": "string",
+                                "description": "User-facing name of the data source."
+                            },
+                            "type": {
+                                "type": "string",
+                                "description": "Type of the database providing the data for the data source.",
+                                "enum": [
+                                    "POSTGRESQL",
+                                    "REDSHIFT",
+                                    "VERTICA",
+                                    "SNOWFLAKE",
+                                    "ADS",
+                                    "BIGQUERY",
+                                    "MSSQL",
+                                    "PRESTO",
+                                    "DREMIO",
+                                    "DRILL",
+                                    "GREENPLUM",
+                                    "AZURESQL",
+                                    "SYNAPSESQL",
+                                    "DATABRICKS",
+                                    "GDSTORAGE",
+                                    "CLICKHOUSE",
+                                    "MYSQL",
+                                    "MARIADB",
+                                    "ORACLE",
+                                    "PINOT",
+                                    "SINGLESTORE",
+                                    "MOTHERDUCK",
+                                    "FLEXCONNECT",
+                                    "STARROCKS",
+                                    "ATHENA"
+                                ]
+                            },
+                            "url": {
+                                "maxLength": 255,
+                                "type": "string",
+                                "description": "The URL of the database providing the data for the data source.",
+                                "nullable": true
+                            },
+                            "schema": {
+                                "maxLength": 255,
+                                "type": "string",
+                                "description": "The schema to use as the root of the data for the data source."
+                            },
+                            "username": {
+                                "maxLength": 255,
+                                "type": "string",
+                                "description": "The username to use to connect to the database providing the data for the data source.",
+                                "nullable": true
+                            },
+                            "clientId": {
+                                "maxLength": 255,
+                                "type": "string",
+                                "description": "The client id to use to connect to the database providing the data for the data source (for example a Databricks Service Account).",
+                                "nullable": true
+                            },
+                            "parameters": {
+                                "type": "array",
+                                "description": "Additional parameters to be used when connecting to the database providing the data for the data source.",
+                                "nullable": true,
+                                "items": {
+                                    "required": ["name", "value"],
+                                    "type": "object",
+                                    "properties": {
+                                        "name": {
+                                            "type": "string"
+                                        },
+                                        "value": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            },
+                            "decodedParameters": {
+                                "type": "array",
+                                "description": "Decoded parameters to be used when connecting to the database providing the data for the data source.",
+                                "nullable": true,
+                                "items": {
+                                    "required": ["name", "value"],
+                                    "type": "object",
+                                    "properties": {
+                                        "name": {
+                                            "type": "string"
+                                        },
+                                        "value": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            },
+                            "cacheStrategy": {
+                                "type": "string",
+                                "description": "Determines how the results coming from a particular datasource should be cached.",
+                                "nullable": true,
+                                "enum": ["ALWAYS", "NEVER"]
+                            },
+                            "authenticationType": {
+                                "type": "string",
+                                "description": "Type of authentication used to connect to the database.",
+                                "nullable": true,
+                                "enum": [
+                                    "USERNAME_PASSWORD",
+                                    "TOKEN",
+                                    "KEY_PAIR",
+                                    "CLIENT_SECRET",
+                                    "ACCESS_TOKEN"
+                                ]
+                            }
+                        }
+                    }
+                },
+                "description": "JSON:API representation of dataSource entity."
+            },
+            "JsonApiExportTemplatePatchDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiExportTemplatePatch"
+                    }
+                }
+            },
+            "JsonApiExportTemplatePatch": {
+                "required": ["attributes", "id", "type"],
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "description": "Object type",
+                        "example": "exportTemplate",
+                        "enum": ["exportTemplate"]
+                    },
+                    "id": {
+                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
+                        "type": "string",
+                        "description": "API identifier of an object",
+                        "example": "id1"
+                    },
+                    "attributes": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "maxLength": 255,
+                                "type": "string",
+                                "description": "User-facing name of the Slides template."
+                            },
+                            "dashboardSlidesTemplate": {
+                                "required": ["appliedOn"],
+                                "type": "object",
+                                "properties": {
+                                    "appliedOn": {
+                                        "minItems": 1,
+                                        "type": "array",
+                                        "description": "Export types this template applies to.",
+                                        "example": ["PDF", "PPTX"],
+                                        "items": {
+                                            "type": "string",
+                                            "enum": ["PDF", "PPTX"]
+                                        }
+                                    },
+                                    "coverSlide": {
+                                        "$ref": "#/components/schemas/CoverSlideTemplate"
+                                    },
+                                    "introSlide": {
+                                        "$ref": "#/components/schemas/IntroSlideTemplate"
+                                    },
+                                    "sectionSlide": {
+                                        "$ref": "#/components/schemas/SectionSlideTemplate"
+                                    },
+                                    "contentSlide": {
+                                        "$ref": "#/components/schemas/ContentSlideTemplate"
+                                    }
+                                },
+                                "description": "Template for dashboard slides export.\nAvailable variables: {{currentPageNumber}}, {{dashboardDateFilters}}, {{dashboardDescription}}, {{dashboardFilters}}, {{dashboardId}}, {{dashboardName}}, {{dashboardTags}}, {{dashboardUrl}}, {{exportedAt}}, {{exportedBy}}, {{logo}}, {{totalPages}}, {{workspaceId}}, {{workspaceName}}",
+                                "nullable": true
+                            },
+                            "widgetSlidesTemplate": {
+                                "required": ["appliedOn"],
+                                "type": "object",
+                                "properties": {
+                                    "appliedOn": {
+                                        "minItems": 1,
+                                        "type": "array",
+                                        "description": "Export types this template applies to.",
+                                        "example": ["PDF", "PPTX"],
+                                        "items": {
+                                            "type": "string",
+                                            "enum": ["PDF", "PPTX"]
+                                        }
+                                    },
+                                    "contentSlide": {
+                                        "$ref": "#/components/schemas/ContentSlideTemplate"
+                                    }
+                                },
+                                "description": "Template for widget slides export.\nAvailable variables: {{currentPageNumber}}, {{dashboardDateFilters}}, {{dashboardDescription}}, {{dashboardFilters}}, {{dashboardId}}, {{dashboardName}}, {{dashboardTags}}, {{dashboardUrl}}, {{exportedAt}}, {{exportedBy}}, {{logo}}, {{totalPages}}, {{workspaceId}}, {{workspaceName}}",
+                                "nullable": true
+                            }
+                        }
+                    }
+                },
+                "description": "JSON:API representation of patching exportTemplate entity."
+            },
+            "ContentSlideTemplate": {
+                "type": "object",
+                "properties": {
+                    "header": {
+                        "$ref": "#/components/schemas/RunningSection"
+                    },
+                    "footer": {
+                        "$ref": "#/components/schemas/RunningSection"
+                    },
+                    "descriptionField": {
+                        "type": "string",
+                        "nullable": true,
+                        "example": "{{dashboardFilters}}"
+                    }
+                },
+                "description": "Settings for content slide.",
+                "nullable": true
+            },
+            "CoverSlideTemplate": {
+                "type": "object",
+                "properties": {
+                    "header": {
+                        "$ref": "#/components/schemas/RunningSection"
+                    },
+                    "footer": {
+                        "$ref": "#/components/schemas/RunningSection"
+                    },
+                    "descriptionField": {
+                        "type": "string",
+                        "nullable": true,
+                        "example": "Exported at: {{exportedAt}}"
+                    },
+                    "backgroundImage": {
+                        "type": "boolean",
+                        "description": "Show background image on the slide.",
+                        "default": true
+                    }
+                },
+                "description": "Settings for cover slide.",
+                "nullable": true
+            },
+            "IntroSlideTemplate": {
+                "type": "object",
+                "properties": {
+                    "header": {
+                        "$ref": "#/components/schemas/RunningSection"
+                    },
+                    "footer": {
+                        "$ref": "#/components/schemas/RunningSection"
+                    },
+                    "titleField": {
+                        "type": "string",
+                        "nullable": true,
+                        "example": "Introduction"
+                    },
+                    "descriptionField": {
+                        "type": "string",
+                        "nullable": true,
+                        "example": "About:\n{{dashboardDescription}}\n\n{{dashboardFilters}}"
+                    },
+                    "backgroundImage": {
+                        "type": "boolean",
+                        "description": "Show background image on the slide.",
+                        "default": true
+                    }
+                },
+                "description": "Settings for intro slide.",
+                "nullable": true
+            },
+            "RunningSection": {
+                "type": "object",
+                "properties": {
+                    "left": {
+                        "type": "string",
+                        "description": "Either {{logo}} variable or custom text with combination of other variables.",
+                        "nullable": true
+                    },
+                    "right": {
+                        "type": "string",
+                        "description": "Either {{logo}} variable or custom text with combination of other variables.",
+                        "nullable": true
+                    }
+                },
+                "description": "Footer section of the slide",
+                "nullable": true
+            },
+            "SectionSlideTemplate": {
+                "type": "object",
+                "properties": {
+                    "header": {
+                        "$ref": "#/components/schemas/RunningSection"
+                    },
+                    "footer": {
+                        "$ref": "#/components/schemas/RunningSection"
+                    },
+                    "backgroundImage": {
+                        "type": "boolean",
+                        "description": "Show background image on the slide.",
+                        "default": true
+                    }
+                },
+                "description": "Settings for section slide.",
+                "nullable": true
+            },
+            "JsonApiExportTemplateOutDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiExportTemplateOut"
+                    },
+                    "links": {
+                        "$ref": "#/components/schemas/ObjectLinks"
+                    }
+                }
+            },
+            "JsonApiExportTemplateOut": {
+                "required": ["attributes", "id", "type"],
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "description": "Object type",
+                        "example": "exportTemplate",
+                        "enum": ["exportTemplate"]
+                    },
+                    "id": {
+                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
+                        "type": "string",
+                        "description": "API identifier of an object",
+                        "example": "id1"
+                    },
+                    "attributes": {
+                        "required": ["name"],
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "maxLength": 255,
+                                "type": "string",
+                                "description": "User-facing name of the Slides template."
+                            },
+                            "dashboardSlidesTemplate": {
+                                "required": ["appliedOn"],
+                                "type": "object",
+                                "properties": {
+                                    "appliedOn": {
+                                        "minItems": 1,
+                                        "type": "array",
+                                        "description": "Export types this template applies to.",
+                                        "example": ["PDF", "PPTX"],
+                                        "items": {
+                                            "type": "string",
+                                            "enum": ["PDF", "PPTX"]
+                                        }
+                                    },
+                                    "coverSlide": {
+                                        "$ref": "#/components/schemas/CoverSlideTemplate"
+                                    },
+                                    "introSlide": {
+                                        "$ref": "#/components/schemas/IntroSlideTemplate"
+                                    },
+                                    "sectionSlide": {
+                                        "$ref": "#/components/schemas/SectionSlideTemplate"
+                                    },
+                                    "contentSlide": {
+                                        "$ref": "#/components/schemas/ContentSlideTemplate"
+                                    }
+                                },
+                                "description": "Template for dashboard slides export.\nAvailable variables: {{currentPageNumber}}, {{dashboardDateFilters}}, {{dashboardDescription}}, {{dashboardFilters}}, {{dashboardId}}, {{dashboardName}}, {{dashboardTags}}, {{dashboardUrl}}, {{exportedAt}}, {{exportedBy}}, {{logo}}, {{totalPages}}, {{workspaceId}}, {{workspaceName}}",
+                                "nullable": true
+                            },
+                            "widgetSlidesTemplate": {
+                                "required": ["appliedOn"],
+                                "type": "object",
+                                "properties": {
+                                    "appliedOn": {
+                                        "minItems": 1,
+                                        "type": "array",
+                                        "description": "Export types this template applies to.",
+                                        "example": ["PDF", "PPTX"],
+                                        "items": {
+                                            "type": "string",
+                                            "enum": ["PDF", "PPTX"]
+                                        }
+                                    },
+                                    "contentSlide": {
+                                        "$ref": "#/components/schemas/ContentSlideTemplate"
+                                    }
+                                },
+                                "description": "Template for widget slides export.\nAvailable variables: {{currentPageNumber}}, {{dashboardDateFilters}}, {{dashboardDescription}}, {{dashboardFilters}}, {{dashboardId}}, {{dashboardName}}, {{dashboardTags}}, {{dashboardUrl}}, {{exportedAt}}, {{exportedBy}}, {{logo}}, {{totalPages}}, {{workspaceId}}, {{workspaceName}}",
+                                "nullable": true
+                            }
+                        }
+                    }
+                },
+                "description": "JSON:API representation of exportTemplate entity."
+            },
+            "JsonApiIdentityProviderPatchDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiIdentityProviderPatch"
+                    }
+                }
+            },
+            "JsonApiIdentityProviderPatch": {
+                "required": ["id", "type"],
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "description": "Object type",
+                        "example": "identityProvider",
+                        "enum": ["identityProvider"]
+                    },
+                    "id": {
+                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
+                        "type": "string",
+                        "description": "API identifier of an object",
+                        "example": "id1"
+                    },
+                    "attributes": {
+                        "type": "object",
+                        "properties": {
+                            "identifiers": {
+                                "type": "array",
+                                "description": "List of identifiers for this IdP, where an identifier is a domain name. Users with email addresses belonging to these domains will be authenticated by this IdP.",
+                                "example": ["gooddata.com"],
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
+                            "customClaimMapping": {
+                                "maxLength": 10000,
+                                "type": "object",
+                                "additionalProperties": {
+                                    "type": "string"
+                                },
+                                "description": "Map of custom claim overrides. To be used when your Idp does not provide default claims (sub, email, name, given_name, family_name). Define the key pair for the claim you wish to override, where the key is the default name of the attribute and the value is your custom name for the given attribute."
+                            },
+                            "samlMetadata": {
+                                "maxLength": 15000,
+                                "type": "string",
+                                "description": "Base64 encoded xml document with SAML metadata. This document is issued by your SAML provider. It includes the issuer's name, expiration information, and keys that can be used to validate the response from the identity provider. This field is mandatory for SAML IdP."
+                            },
+                            "oauthClientId": {
+                                "maxLength": 255,
+                                "type": "string",
+                                "description": "The OAuth client id of your OIDC provider. This field is mandatory for OIDC IdP."
+                            },
+                            "oauthClientSecret": {
+                                "maxLength": 255,
+                                "type": "string",
+                                "description": "The OAuth client secret of your OIDC provider. This field is mandatory for OIDC IdP."
+                            },
+                            "oauthIssuerLocation": {
+                                "maxLength": 255,
+                                "type": "string",
+                                "description": "The location of your OIDC provider. This field is mandatory for OIDC IdP."
+                            },
+                            "oauthIssuerId": {
+                                "maxLength": 255,
+                                "type": "string",
+                                "description": "Any string identifying the OIDC provider. This value is used as suffix for OAuth2 callback (redirect) URL. If not defined, the standard callback URL is used. This value is valid only for external OIDC providers, not for the internal DEX provider.",
+                                "example": "myOidcProvider"
+                            },
+                            "oauthSubjectIdClaim": {
+                                "maxLength": 255,
+                                "type": "string",
+                                "description": "Any string identifying the claim in ID token, that should be used for user identification. The default value is 'sub'.",
+                                "example": "oid"
+                            },
+                            "oauthCustomAuthAttributes": {
+                                "maxLength": 10000,
+                                "type": "object",
+                                "additionalProperties": {
+                                    "type": "string"
+                                },
+                                "description": "Map of additional authentication attributes that should be added to the OAuth2 authentication requests, where the key is the name of the attribute and the value is the value of the attribute."
+                            },
+                            "oauthCustomScopes": {
+                                "type": "array",
+                                "description": "List of additional OAuth scopes which may be required by other providers (e.g. Snowflake)",
+                                "nullable": true,
+                                "items": {
+                                    "maxLength": 255,
+                                    "type": "string"
+                                }
+                            },
+                            "idpType": {
+                                "type": "string",
+                                "description": "Type of IdP for management purposes. MANAGED_IDP represents a GoodData managed IdP used in single OIDC setup, which is protected from altering/deletion. FIM_IDP represents a GoodData managed IdP used in federated identity management setup, which is protected from altering/deletion. CUSTOM_IDP represents customer's own IdP, protected from deletion if currently used by org for authentication, deletable otherwise.",
+                                "enum": ["MANAGED_IDP", "FIM_IDP", "CUSTOM_IDP"]
+                            }
+                        }
+                    }
+                },
+                "description": "JSON:API representation of patching identityProvider entity."
+            },
+            "JsonApiIdentityProviderOutDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiIdentityProviderOut"
+                    },
+                    "links": {
+                        "$ref": "#/components/schemas/ObjectLinks"
+                    }
+                }
+            },
+            "JsonApiJwkPatchDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiJwkPatch"
+                    }
+                }
+            },
+            "JsonApiJwkPatch": {
+                "required": ["id", "type"],
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "description": "Object type",
+                        "example": "jwk",
+                        "enum": ["jwk"]
+                    },
+                    "id": {
+                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
+                        "type": "string",
+                        "description": "API identifier of an object",
+                        "example": "id1"
+                    },
+                    "attributes": {
+                        "type": "object",
+                        "properties": {
+                            "content": {
+                                "type": "object",
+                                "description": "Specification of the cryptographic key",
+                                "example": {
+                                    "kyt": "RSA",
+                                    "alg": "RS256",
+                                    "use": "sig"
+                                },
+                                "oneOf": [
+                                    {
+                                        "$ref": "#/components/schemas/RsaSpecification"
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                },
+                "description": "JSON:API representation of patching jwk entity."
+            },
+            "RsaSpecification": {
+                "required": ["alg", "e", "kid", "kty", "n", "use"],
+                "type": "object",
+                "properties": {
+                    "kty": {
+                        "type": "string",
+                        "enum": ["RSA"]
+                    },
+                    "alg": {
+                        "type": "string",
+                        "enum": ["RS256", "RS384", "RS512"]
+                    },
+                    "use": {
+                        "type": "string",
+                        "enum": ["sig"]
+                    },
+                    "x5c": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "n": {
+                        "type": "string"
+                    },
+                    "e": {
+                        "type": "string"
+                    },
+                    "kid": {
+                        "maxLength": 255,
+                        "minLength": 0,
+                        "pattern": "^[^.]",
+                        "type": "string"
+                    },
+                    "x5t": {
+                        "type": "string"
+                    }
+                }
+            },
+            "JsonApiJwkOutDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiJwkOut"
+                    },
+                    "links": {
+                        "$ref": "#/components/schemas/ObjectLinks"
+                    }
+                }
+            },
+            "JsonApiJwkOut": {
+                "required": ["id", "type"],
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "description": "Object type",
+                        "example": "jwk",
+                        "enum": ["jwk"]
+                    },
+                    "id": {
+                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
+                        "type": "string",
+                        "description": "API identifier of an object",
+                        "example": "id1"
+                    },
+                    "attributes": {
+                        "type": "object",
+                        "properties": {
+                            "content": {
+                                "type": "object",
+                                "description": "Specification of the cryptographic key",
+                                "example": {
+                                    "kyt": "RSA",
+                                    "alg": "RS256",
+                                    "use": "sig"
+                                },
+                                "oneOf": [
+                                    {
+                                        "$ref": "#/components/schemas/RsaSpecification"
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                },
+                "description": "JSON:API representation of jwk entity."
+            },
+            "JsonApiLlmEndpointPatchDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiLlmEndpointPatch"
+                    }
+                }
+            },
+            "JsonApiLlmEndpointPatch": {
+                "required": ["attributes", "id", "type"],
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "description": "Object type",
+                        "example": "llmEndpoint",
+                        "enum": ["llmEndpoint"]
+                    },
+                    "id": {
+                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
+                        "type": "string",
+                        "description": "API identifier of an object",
+                        "example": "id1"
+                    },
+                    "attributes": {
+                        "type": "object",
+                        "properties": {
+                            "title": {
+                                "maxLength": 255,
+                                "type": "string",
+                                "description": "User-facing title of the LLM Provider."
+                            },
+                            "provider": {
+                                "type": "string",
+                                "description": "LLM Provider.",
+                                "enum": ["OPENAI", "AZURE_OPENAI"]
+                            },
+                            "baseUrl": {
+                                "maxLength": 255,
+                                "type": "string",
+                                "description": "Custom LLM endpoint.",
+                                "nullable": true
+                            },
+                            "token": {
+                                "maxLength": 10000,
+                                "type": "string",
+                                "description": "The token to use to connect to the LLM provider."
+                            },
+                            "llmOrganization": {
+                                "maxLength": 255,
+                                "type": "string",
+                                "description": "Organization in LLM provider.",
+                                "nullable": true
+                            },
+                            "llmModel": {
+                                "maxLength": 255,
+                                "type": "string",
+                                "description": "LLM Model. We provide a default model for each provider, but you can override it here."
+                            }
+                        }
+                    }
+                },
+                "description": "JSON:API representation of patching llmEndpoint entity."
+            },
+            "JsonApiLlmEndpointOutDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiLlmEndpointOut"
+                    },
+                    "links": {
+                        "$ref": "#/components/schemas/ObjectLinks"
+                    }
+                }
+            },
+            "JsonApiLlmEndpointOut": {
+                "required": ["attributes", "id", "type"],
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "description": "Object type",
+                        "example": "llmEndpoint",
+                        "enum": ["llmEndpoint"]
+                    },
+                    "id": {
+                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
+                        "type": "string",
+                        "description": "API identifier of an object",
+                        "example": "id1"
+                    },
+                    "attributes": {
+                        "required": ["title"],
+                        "type": "object",
+                        "properties": {
+                            "title": {
+                                "maxLength": 255,
+                                "type": "string",
+                                "description": "User-facing title of the LLM Provider."
+                            },
+                            "provider": {
+                                "type": "string",
+                                "description": "LLM Provider.",
+                                "enum": ["OPENAI", "AZURE_OPENAI"]
+                            },
+                            "baseUrl": {
+                                "maxLength": 255,
+                                "type": "string",
+                                "description": "Custom LLM endpoint.",
+                                "nullable": true
+                            },
+                            "llmOrganization": {
+                                "maxLength": 255,
+                                "type": "string",
+                                "description": "Organization in LLM provider.",
+                                "nullable": true
+                            },
+                            "llmModel": {
+                                "maxLength": 255,
+                                "type": "string",
+                                "description": "LLM Model. We provide a default model for each provider, but you can override it here."
+                            }
+                        }
+                    }
+                },
+                "description": "JSON:API representation of llmEndpoint entity."
+            },
+            "JsonApiNotificationChannelPatchDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiNotificationChannelPatch"
+                    }
+                }
+            },
+            "JsonApiNotificationChannelPatch": {
+                "required": ["id", "type"],
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "description": "Object type",
+                        "example": "notificationChannel",
+                        "enum": ["notificationChannel"]
+                    },
+                    "id": {
+                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
+                        "type": "string",
+                        "description": "API identifier of an object",
+                        "example": "id1"
+                    },
+                    "attributes": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "maxLength": 255,
+                                "type": "string",
+                                "nullable": true
+                            },
+                            "description": {
+                                "maxLength": 10000,
+                                "type": "string",
+                                "nullable": true
+                            },
+                            "destination": {
+                                "description": "The destination where the notifications are to be sent.",
+                                "oneOf": [
+                                    {
+                                        "$ref": "#/components/schemas/DefaultSmtp"
+                                    },
+                                    {
+                                        "$ref": "#/components/schemas/InPlatform"
+                                    },
+                                    {
+                                        "$ref": "#/components/schemas/Smtp"
+                                    },
+                                    {
+                                        "$ref": "#/components/schemas/Webhook"
+                                    }
+                                ]
+                            },
+                            "customDashboardUrl": {
+                                "maxLength": 255,
+                                "type": "string",
+                                "description": "Custom dashboard url that is going to be used in the notification. If not specified it is going to be deduced based on the context. Allowed placeholders are:\n{workspaceId}\n{dashboardId}\n{automationId}\n{asOfDate}\n"
+                            },
+                            "dashboardLinkVisibility": {
+                                "type": "string",
+                                "description": "Dashboard link visibility in notifications.\nHIDDEN - the link will not be included\nINTERNAL_ONLY - only internal users will see the link\nALL - all users will see the link\n",
+                                "enum": ["HIDDEN", "INTERNAL_ONLY", "ALL"]
+                            },
+                            "notificationSource": {
+                                "maxLength": 10000,
+                                "type": "string",
+                                "description": "Human-readable description of the source of the notification. If specified, this propertywill be included in the notifications to this channel.Allowed placeholders are:\n{{workspaceId}}\n{{workspaceName}}\n{{workspaceDescription}}\n{{dashboardId}}\n{{dashboardName}}\n{{dashboardDescription}}\n"
+                            },
+                            "allowedRecipients": {
+                                "type": "string",
+                                "description": "Allowed recipients of notifications from this channel.\nCREATOR - only the creator\nINTERNAL - all users within the organization\nEXTERNAL - all recipients including those outside the organization\n",
+                                "enum": ["CREATOR", "INTERNAL", "EXTERNAL"]
+                            },
+                            "inPlatformNotification": {
+                                "type": "string",
+                                "description": "In-platform notifications configuration. No effect if the destination type is IN_PLATFORM.\nDISABLED - in-platform notifications are not sent\nENABLED - in-platform notifications are sent in addition to the regular notifications\n",
+                                "enum": ["DISABLED", "ENABLED"]
+                            }
+                        }
+                    }
+                },
+                "description": "JSON:API representation of patching notificationChannel entity."
+            },
+            "JsonApiNotificationChannelOutDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiNotificationChannelOut"
+                    },
+                    "links": {
+                        "$ref": "#/components/schemas/ObjectLinks"
+                    }
+                }
+            },
+            "JsonApiOrganizationSettingPatchDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiOrganizationSettingPatch"
+                    }
+                }
+            },
+            "JsonApiOrganizationSettingPatch": {
+                "required": ["id", "type"],
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "description": "Object type",
+                        "example": "organizationSetting",
+                        "enum": ["organizationSetting"]
+                    },
+                    "id": {
+                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
+                        "type": "string",
+                        "description": "API identifier of an object",
+                        "example": "id1"
+                    },
+                    "attributes": {
+                        "type": "object",
+                        "properties": {
+                            "content": {
+                                "type": "object",
+                                "description": "Free-form JSON content. Maximum supported length is 15000 characters.",
+                                "example": {}
+                            },
+                            "type": {
+                                "type": "string",
+                                "enum": [
+                                    "TIMEZONE",
+                                    "ACTIVE_THEME",
+                                    "ACTIVE_COLOR_PALETTE",
+                                    "ACTIVE_LLM_ENDPOINT",
+                                    "WHITE_LABELING",
+                                    "LOCALE",
+                                    "METADATA_LOCALE",
+                                    "FORMAT_LOCALE",
+                                    "MAPBOX_TOKEN",
+                                    "WEEK_START",
+                                    "SHOW_HIDDEN_CATALOG_ITEMS",
+                                    "OPERATOR_OVERRIDES",
+                                    "TIMEZONE_VALIDATION_ENABLED",
+                                    "OPENAI_CONFIG",
+                                    "ENABLE_FILE_ANALYTICS",
+                                    "ALERT",
+                                    "SEPARATORS",
+                                    "DATE_FILTER_CONFIG",
+                                    "JIT_PROVISIONING",
+                                    "JWT_JIT_PROVISIONING",
+                                    "DASHBOARD_FILTERS_APPLY_MODE",
+                                    "ENABLE_SLIDES_EXPORT",
+                                    "AI_RATE_LIMIT",
+                                    "ATTACHMENT_SIZE_LIMIT",
+                                    "ATTACHMENT_LINK_TTL"
+                                ]
+                            }
+                        }
+                    }
+                },
+                "description": "JSON:API representation of patching organizationSetting entity."
+            },
+            "JsonApiOrganizationSettingOutDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiOrganizationSettingOut"
+                    },
+                    "links": {
+                        "$ref": "#/components/schemas/ObjectLinks"
+                    }
+                }
+            },
+            "JsonApiOrganizationSettingOut": {
+                "required": ["id", "type"],
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "description": "Object type",
+                        "example": "organizationSetting",
+                        "enum": ["organizationSetting"]
+                    },
+                    "id": {
+                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
+                        "type": "string",
+                        "description": "API identifier of an object",
+                        "example": "id1"
+                    },
+                    "attributes": {
+                        "type": "object",
+                        "properties": {
+                            "content": {
+                                "type": "object",
+                                "description": "Free-form JSON content. Maximum supported length is 15000 characters.",
+                                "example": {}
+                            },
+                            "type": {
+                                "type": "string",
+                                "enum": [
+                                    "TIMEZONE",
+                                    "ACTIVE_THEME",
+                                    "ACTIVE_COLOR_PALETTE",
+                                    "ACTIVE_LLM_ENDPOINT",
+                                    "WHITE_LABELING",
+                                    "LOCALE",
+                                    "METADATA_LOCALE",
+                                    "FORMAT_LOCALE",
+                                    "MAPBOX_TOKEN",
+                                    "WEEK_START",
+                                    "SHOW_HIDDEN_CATALOG_ITEMS",
+                                    "OPERATOR_OVERRIDES",
+                                    "TIMEZONE_VALIDATION_ENABLED",
+                                    "OPENAI_CONFIG",
+                                    "ENABLE_FILE_ANALYTICS",
+                                    "ALERT",
+                                    "SEPARATORS",
+                                    "DATE_FILTER_CONFIG",
+                                    "JIT_PROVISIONING",
+                                    "JWT_JIT_PROVISIONING",
+                                    "DASHBOARD_FILTERS_APPLY_MODE",
+                                    "ENABLE_SLIDES_EXPORT",
+                                    "AI_RATE_LIMIT",
+                                    "ATTACHMENT_SIZE_LIMIT",
+                                    "ATTACHMENT_LINK_TTL"
+                                ]
+                            }
+                        }
+                    }
+                },
+                "description": "JSON:API representation of organizationSetting entity."
+            },
+            "JsonApiThemePatchDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiThemePatch"
+                    }
+                }
+            },
+            "JsonApiThemePatch": {
+                "required": ["attributes", "id", "type"],
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "description": "Object type",
+                        "example": "theme",
+                        "enum": ["theme"]
+                    },
+                    "id": {
+                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
+                        "type": "string",
+                        "description": "API identifier of an object",
+                        "example": "id1"
+                    },
+                    "attributes": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "maxLength": 255,
+                                "type": "string"
+                            },
+                            "content": {
+                                "type": "object",
+                                "description": "Free-form JSON content. Maximum supported length is 15000 characters.",
+                                "example": {}
+                            }
+                        }
+                    }
+                },
+                "description": "JSON:API representation of patching theme entity."
+            },
+            "JsonApiThemeOutDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiThemeOut"
+                    },
+                    "links": {
+                        "$ref": "#/components/schemas/ObjectLinks"
+                    }
+                }
+            },
+            "JsonApiThemeOut": {
+                "required": ["attributes", "id", "type"],
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "description": "Object type",
+                        "example": "theme",
+                        "enum": ["theme"]
+                    },
+                    "id": {
+                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
+                        "type": "string",
+                        "description": "API identifier of an object",
+                        "example": "id1"
+                    },
+                    "attributes": {
+                        "required": ["content", "name"],
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "maxLength": 255,
+                                "type": "string"
+                            },
+                            "content": {
+                                "type": "object",
+                                "description": "Free-form JSON content. Maximum supported length is 15000 characters.",
+                                "example": {}
+                            }
+                        }
+                    }
+                },
+                "description": "JSON:API representation of theme entity."
+            },
+            "JsonApiUserGroupPatchDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiUserGroupPatch"
+                    }
+                }
+            },
+            "JsonApiUserGroupPatch": {
+                "required": ["id", "type"],
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "description": "Object type",
+                        "example": "userGroup",
+                        "enum": ["userGroup"]
+                    },
+                    "id": {
+                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
+                        "type": "string",
+                        "description": "API identifier of an object",
+                        "example": "id1"
+                    },
+                    "attributes": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "maxLength": 255,
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "relationships": {
+                        "type": "object",
+                        "properties": {
+                            "parents": {
+                                "required": ["data"],
+                                "type": "object",
+                                "properties": {
+                                    "data": {
+                                        "$ref": "#/components/schemas/JsonApiUserGroupToManyLinkage"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "JSON:API representation of patching userGroup entity."
+            },
+            "JsonApiUserGroupOutDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiUserGroupOut"
+                    },
+                    "links": {
+                        "$ref": "#/components/schemas/ObjectLinks"
+                    },
+                    "included": {
+                        "uniqueItems": true,
+                        "type": "array",
+                        "description": "Included resources",
+                        "items": {
+                            "$ref": "#/components/schemas/JsonApiUserGroupOutWithLinks"
+                        }
+                    }
+                }
+            },
+            "JsonApiUserPatchDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiUserPatch"
+                    }
+                }
+            },
+            "JsonApiUserPatch": {
+                "required": ["id", "type"],
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "description": "Object type",
+                        "example": "user",
+                        "enum": ["user"]
+                    },
+                    "id": {
+                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
+                        "type": "string",
+                        "description": "API identifier of an object",
+                        "example": "id1"
+                    },
+                    "attributes": {
+                        "type": "object",
+                        "properties": {
+                            "authenticationId": {
+                                "maxLength": 255,
+                                "type": "string"
+                            },
+                            "firstname": {
+                                "maxLength": 255,
+                                "type": "string"
+                            },
+                            "lastname": {
+                                "maxLength": 255,
+                                "type": "string"
+                            },
+                            "email": {
+                                "maxLength": 255,
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "relationships": {
+                        "type": "object",
+                        "properties": {
+                            "userGroups": {
+                                "required": ["data"],
+                                "type": "object",
+                                "properties": {
+                                    "data": {
+                                        "$ref": "#/components/schemas/JsonApiUserGroupToManyLinkage"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "JSON:API representation of patching user entity."
+            },
+            "JsonApiUserOutDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiUserOut"
+                    },
+                    "links": {
+                        "$ref": "#/components/schemas/ObjectLinks"
+                    },
+                    "included": {
+                        "uniqueItems": true,
+                        "type": "array",
+                        "description": "Included resources",
+                        "items": {
+                            "$ref": "#/components/schemas/JsonApiUserGroupOutWithLinks"
+                        }
+                    }
+                }
+            },
+            "JsonApiWorkspacePatchDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiWorkspacePatch"
+                    }
+                }
+            },
+            "JsonApiWorkspacePatch": {
+                "required": ["id", "type"],
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "description": "Object type",
+                        "example": "workspace",
+                        "enum": ["workspace"]
+                    },
+                    "id": {
+                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
+                        "type": "string",
+                        "description": "API identifier of an object",
+                        "example": "id1"
+                    },
+                    "attributes": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "maxLength": 255,
+                                "type": "string",
+                                "nullable": true
+                            },
+                            "earlyAccess": {
+                                "maxLength": 255,
+                                "type": "string",
+                                "description": "The early access feature identifier. It is used to enable experimental features. Deprecated in favor of earlyAccessValues.",
+                                "nullable": true,
+                                "deprecated": true
+                            },
+                            "earlyAccessValues": {
+                                "type": "array",
+                                "description": "The early access feature identifiers. They are used to enable experimental features.",
+                                "nullable": true,
+                                "items": {
+                                    "maxLength": 255,
+                                    "type": "string"
+                                }
+                            },
+                            "description": {
+                                "maxLength": 255,
+                                "type": "string",
+                                "nullable": true
+                            },
+                            "prefix": {
+                                "maxLength": 255,
+                                "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
+                                "type": "string",
+                                "description": "Custom prefix of entity identifiers in workspace",
+                                "nullable": true
+                            },
+                            "cacheExtraLimit": {
+                                "type": "integer",
+                                "format": "int64"
+                            },
+                            "dataSource": {
+                                "required": ["id"],
+                                "type": "object",
+                                "properties": {
+                                    "id": {
+                                        "type": "string",
+                                        "description": "The ID of the used data source.",
+                                        "example": "snowflake.instance.1"
+                                    },
+                                    "schemaPath": {
+                                        "type": "array",
+                                        "description": "The full schema path as array of its path parts. Will be rendered as subPath1.subPath2...",
+                                        "items": {
+                                            "type": "string",
+                                            "description": "The part of the schema path.",
+                                            "example": "subPath"
+                                        }
+                                    }
+                                },
+                                "description": "The data source used for the particular workspace instead of the one defined in the LDM inherited from its parent workspace. Such data source cannot be defined for a single or a top-parent workspace."
+                            }
+                        }
+                    },
+                    "relationships": {
+                        "type": "object",
+                        "properties": {
+                            "parent": {
+                                "required": ["data"],
+                                "type": "object",
+                                "properties": {
+                                    "data": {
+                                        "$ref": "#/components/schemas/JsonApiWorkspaceToOneLinkage"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "JSON:API representation of patching workspace entity."
+            },
+            "JsonApiWorkspaceLinkage": {
+                "required": ["id", "type"],
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "string",
+                        "enum": ["workspace"]
+                    }
+                },
+                "description": "The \\\"type\\\" and \\\"id\\\" to non-empty members."
+            },
+            "JsonApiWorkspaceToOneLinkage": {
+                "description": "References to other resource objects in a to-one (\\\"relationship\\\"). Relationships can be specified by including a member in a resource's links object.",
+                "nullable": true,
+                "oneOf": [
+                    {
+                        "$ref": "#/components/schemas/JsonApiWorkspaceLinkage"
+                    }
+                ]
+            },
+            "JsonApiWorkspaceOut": {
+                "required": ["id", "type"],
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "description": "Object type",
+                        "example": "workspace",
+                        "enum": ["workspace"]
+                    },
+                    "id": {
+                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
+                        "type": "string",
+                        "description": "API identifier of an object",
+                        "example": "id1"
+                    },
+                    "meta": {
+                        "type": "object",
+                        "properties": {
+                            "config": {
+                                "type": "object",
+                                "properties": {
+                                    "dataSamplingAvailable": {
+                                        "type": "boolean",
+                                        "description": "is sampling enabled - based on type of data-source connected to this workspace",
+                                        "default": false
+                                    },
+                                    "approximateCountAvailable": {
+                                        "type": "boolean",
+                                        "description": "is approximate count enabled - based on type of data-source connected to this workspace",
+                                        "default": false
+                                    },
+                                    "showAllValuesOnDatesAvailable": {
+                                        "type": "boolean",
+                                        "description": "is 'show all values' displayed for dates - based on type of data-source connected to this workspace",
+                                        "default": false
+                                    }
+                                }
+                            },
+                            "permissions": {
+                                "type": "array",
+                                "description": "List of valid permissions for a logged-in user.",
+                                "items": {
+                                    "type": "string",
+                                    "enum": [
+                                        "MANAGE",
+                                        "ANALYZE",
+                                        "EXPORT",
+                                        "EXPORT_TABULAR",
+                                        "EXPORT_PDF",
+                                        "CREATE_AUTOMATION",
+                                        "USE_AI_ASSISTANT",
+                                        "CREATE_FILTER_VIEW",
+                                        "VIEW"
+                                    ]
+                                }
+                            },
+                            "hierarchy": {
+                                "required": ["childrenCount"],
+                                "type": "object",
+                                "properties": {
+                                    "childrenCount": {
+                                        "type": "integer",
+                                        "description": "include the number of direct children of each workspace",
+                                        "format": "int32"
+                                    }
+                                }
+                            },
+                            "dataModel": {
+                                "required": ["datasetCount"],
+                                "type": "object",
+                                "properties": {
+                                    "datasetCount": {
+                                        "type": "integer",
+                                        "description": "include the number of dataset of each workspace",
+                                        "format": "int32"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "attributes": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "maxLength": 255,
+                                "type": "string",
+                                "nullable": true
+                            },
+                            "earlyAccess": {
+                                "maxLength": 255,
+                                "type": "string",
+                                "description": "The early access feature identifier. It is used to enable experimental features. Deprecated in favor of earlyAccessValues.",
+                                "nullable": true,
+                                "deprecated": true
+                            },
+                            "earlyAccessValues": {
+                                "type": "array",
+                                "description": "The early access feature identifiers. They are used to enable experimental features.",
+                                "nullable": true,
+                                "items": {
+                                    "maxLength": 255,
+                                    "type": "string"
+                                }
+                            },
+                            "description": {
+                                "maxLength": 255,
+                                "type": "string",
+                                "nullable": true
+                            },
+                            "prefix": {
+                                "maxLength": 255,
+                                "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
+                                "type": "string",
+                                "description": "Custom prefix of entity identifiers in workspace",
+                                "nullable": true
+                            },
+                            "cacheExtraLimit": {
+                                "type": "integer",
+                                "format": "int64"
+                            },
+                            "dataSource": {
+                                "required": ["id"],
+                                "type": "object",
+                                "properties": {
+                                    "id": {
+                                        "type": "string",
+                                        "description": "The ID of the used data source.",
+                                        "example": "snowflake.instance.1"
+                                    },
+                                    "schemaPath": {
+                                        "type": "array",
+                                        "description": "The full schema path as array of its path parts. Will be rendered as subPath1.subPath2...",
+                                        "items": {
+                                            "type": "string",
+                                            "description": "The part of the schema path.",
+                                            "example": "subPath"
+                                        }
+                                    }
+                                },
+                                "description": "The data source used for the particular workspace instead of the one defined in the LDM inherited from its parent workspace. Such data source cannot be defined for a single or a top-parent workspace."
+                            }
+                        }
+                    },
+                    "relationships": {
+                        "type": "object",
+                        "properties": {
+                            "parent": {
+                                "required": ["data"],
+                                "type": "object",
+                                "properties": {
+                                    "data": {
+                                        "$ref": "#/components/schemas/JsonApiWorkspaceToOneLinkage"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "JSON:API representation of workspace entity."
+            },
+            "JsonApiWorkspaceOutWithLinks": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/JsonApiWorkspaceOut"
+                    },
+                    {
+                        "$ref": "#/components/schemas/ObjectLinksContainer"
+                    }
+                ]
+            },
+            "JsonApiWorkspaceOutDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiWorkspaceOut"
+                    },
+                    "links": {
+                        "$ref": "#/components/schemas/ObjectLinks"
+                    },
+                    "included": {
+                        "uniqueItems": true,
+                        "type": "array",
+                        "description": "Included resources",
+                        "items": {
+                            "$ref": "#/components/schemas/JsonApiWorkspaceOutWithLinks"
+                        }
+                    }
+                }
             },
             "JsonApiAnalyticalDashboardOutList": {
                 "required": ["data"],
@@ -25344,1532 +26086,6 @@
                 },
                 "description": "A JSON:API document with a list of resources"
             },
-            "JsonApiAnalyticalDashboardInDocument": {
-                "required": ["data"],
-                "type": "object",
-                "properties": {
-                    "data": {
-                        "$ref": "#/components/schemas/JsonApiAnalyticalDashboardIn"
-                    }
-                }
-            },
-            "JsonApiAnalyticalDashboardIn": {
-                "required": ["attributes", "id", "type"],
-                "type": "object",
-                "properties": {
-                    "type": {
-                        "type": "string",
-                        "description": "Object type",
-                        "example": "analyticalDashboard",
-                        "enum": ["analyticalDashboard"]
-                    },
-                    "id": {
-                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
-                        "type": "string",
-                        "description": "API identifier of an object",
-                        "example": "id1"
-                    },
-                    "attributes": {
-                        "required": ["content"],
-                        "type": "object",
-                        "properties": {
-                            "title": {
-                                "maxLength": 255,
-                                "type": "string"
-                            },
-                            "description": {
-                                "maxLength": 10000,
-                                "type": "string"
-                            },
-                            "tags": {
-                                "type": "array",
-                                "items": {
-                                    "type": "string"
-                                }
-                            },
-                            "areRelationsValid": {
-                                "type": "boolean"
-                            },
-                            "content": {
-                                "type": "object",
-                                "description": "Free-form JSON content. Maximum supported length is 250000 characters.",
-                                "example": {
-                                    "identifier": {
-                                        "id": "label.leaf",
-                                        "type": "label"
-                                    },
-                                    "someBoolProp": false
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "JSON:API representation of analyticalDashboard entity."
-            },
-            "JsonApiCustomApplicationSettingInDocument": {
-                "required": ["data"],
-                "type": "object",
-                "properties": {
-                    "data": {
-                        "$ref": "#/components/schemas/JsonApiCustomApplicationSettingIn"
-                    }
-                }
-            },
-            "JsonApiCustomApplicationSettingIn": {
-                "required": ["attributes", "id", "type"],
-                "type": "object",
-                "properties": {
-                    "type": {
-                        "type": "string",
-                        "description": "Object type",
-                        "example": "customApplicationSetting",
-                        "enum": ["customApplicationSetting"]
-                    },
-                    "id": {
-                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
-                        "type": "string",
-                        "description": "API identifier of an object",
-                        "example": "id1"
-                    },
-                    "attributes": {
-                        "required": ["applicationName", "content"],
-                        "type": "object",
-                        "properties": {
-                            "applicationName": {
-                                "maxLength": 255,
-                                "type": "string"
-                            },
-                            "content": {
-                                "type": "object",
-                                "description": "Free-form JSON content. Maximum supported length is 15000 characters.",
-                                "example": {}
-                            }
-                        }
-                    }
-                },
-                "description": "JSON:API representation of customApplicationSetting entity."
-            },
-            "JsonApiDashboardPluginInDocument": {
-                "required": ["data"],
-                "type": "object",
-                "properties": {
-                    "data": {
-                        "$ref": "#/components/schemas/JsonApiDashboardPluginIn"
-                    }
-                }
-            },
-            "JsonApiDashboardPluginIn": {
-                "required": ["id", "type"],
-                "type": "object",
-                "properties": {
-                    "type": {
-                        "type": "string",
-                        "description": "Object type",
-                        "example": "dashboardPlugin",
-                        "enum": ["dashboardPlugin"]
-                    },
-                    "id": {
-                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
-                        "type": "string",
-                        "description": "API identifier of an object",
-                        "example": "id1"
-                    },
-                    "attributes": {
-                        "type": "object",
-                        "properties": {
-                            "title": {
-                                "maxLength": 255,
-                                "type": "string"
-                            },
-                            "description": {
-                                "maxLength": 10000,
-                                "type": "string"
-                            },
-                            "tags": {
-                                "type": "array",
-                                "items": {
-                                    "type": "string"
-                                }
-                            },
-                            "areRelationsValid": {
-                                "type": "boolean"
-                            },
-                            "content": {
-                                "type": "object",
-                                "description": "Free-form JSON content. Maximum supported length is 250000 characters.",
-                                "example": {
-                                    "url": "<plugin-url>"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "JSON:API representation of dashboardPlugin entity."
-            },
-            "JsonApiExportDefinitionInDocument": {
-                "required": ["data"],
-                "type": "object",
-                "properties": {
-                    "data": {
-                        "$ref": "#/components/schemas/JsonApiExportDefinitionIn"
-                    }
-                }
-            },
-            "JsonApiExportDefinitionIn": {
-                "required": ["id", "type"],
-                "type": "object",
-                "properties": {
-                    "type": {
-                        "type": "string",
-                        "description": "Object type",
-                        "example": "exportDefinition",
-                        "enum": ["exportDefinition"]
-                    },
-                    "id": {
-                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
-                        "type": "string",
-                        "description": "API identifier of an object",
-                        "example": "id1"
-                    },
-                    "attributes": {
-                        "type": "object",
-                        "properties": {
-                            "title": {
-                                "maxLength": 255,
-                                "type": "string"
-                            },
-                            "description": {
-                                "maxLength": 10000,
-                                "type": "string"
-                            },
-                            "tags": {
-                                "type": "array",
-                                "items": {
-                                    "type": "string"
-                                }
-                            },
-                            "requestPayload": {
-                                "type": "object",
-                                "description": "JSON content to be used as export request payload for /export/tabular and /export/visual endpoints. ",
-                                "oneOf": [
-                                    {
-                                        "$ref": "#/components/schemas/VisualExportRequest"
-                                    },
-                                    {
-                                        "$ref": "#/components/schemas/TabularExportRequest"
-                                    }
-                                ]
-                            },
-                            "areRelationsValid": {
-                                "type": "boolean"
-                            }
-                        }
-                    },
-                    "relationships": {
-                        "type": "object",
-                        "properties": {
-                            "visualizationObject": {
-                                "required": ["data"],
-                                "type": "object",
-                                "properties": {
-                                    "data": {
-                                        "$ref": "#/components/schemas/JsonApiVisualizationObjectToOneLinkage"
-                                    }
-                                }
-                            },
-                            "analyticalDashboard": {
-                                "required": ["data"],
-                                "type": "object",
-                                "properties": {
-                                    "data": {
-                                        "$ref": "#/components/schemas/JsonApiAnalyticalDashboardToOneLinkage"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "JSON:API representation of exportDefinition entity."
-            },
-            "JsonApiFilterContextInDocument": {
-                "required": ["data"],
-                "type": "object",
-                "properties": {
-                    "data": {
-                        "$ref": "#/components/schemas/JsonApiFilterContextIn"
-                    }
-                }
-            },
-            "JsonApiFilterContextIn": {
-                "required": ["attributes", "id", "type"],
-                "type": "object",
-                "properties": {
-                    "type": {
-                        "type": "string",
-                        "description": "Object type",
-                        "example": "filterContext",
-                        "enum": ["filterContext"]
-                    },
-                    "id": {
-                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
-                        "type": "string",
-                        "description": "API identifier of an object",
-                        "example": "id1"
-                    },
-                    "attributes": {
-                        "required": ["content"],
-                        "type": "object",
-                        "properties": {
-                            "title": {
-                                "maxLength": 255,
-                                "type": "string"
-                            },
-                            "description": {
-                                "maxLength": 10000,
-                                "type": "string"
-                            },
-                            "tags": {
-                                "type": "array",
-                                "items": {
-                                    "type": "string"
-                                }
-                            },
-                            "areRelationsValid": {
-                                "type": "boolean"
-                            },
-                            "content": {
-                                "type": "object",
-                                "description": "Free-form JSON content. Maximum supported length is 250000 characters.",
-                                "example": {
-                                    "identifier": {
-                                        "id": "label.leaf",
-                                        "type": "label"
-                                    },
-                                    "someBoolProp": false
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "JSON:API representation of filterContext entity."
-            },
-            "JsonApiMetricInDocument": {
-                "required": ["data"],
-                "type": "object",
-                "properties": {
-                    "data": {
-                        "$ref": "#/components/schemas/JsonApiMetricIn"
-                    }
-                }
-            },
-            "JsonApiMetricIn": {
-                "required": ["attributes", "id", "type"],
-                "type": "object",
-                "properties": {
-                    "type": {
-                        "type": "string",
-                        "description": "Object type",
-                        "example": "metric",
-                        "enum": ["metric"]
-                    },
-                    "id": {
-                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
-                        "type": "string",
-                        "description": "API identifier of an object",
-                        "example": "id1"
-                    },
-                    "attributes": {
-                        "required": ["content"],
-                        "type": "object",
-                        "properties": {
-                            "title": {
-                                "maxLength": 255,
-                                "type": "string"
-                            },
-                            "description": {
-                                "maxLength": 10000,
-                                "type": "string"
-                            },
-                            "tags": {
-                                "type": "array",
-                                "items": {
-                                    "type": "string"
-                                }
-                            },
-                            "areRelationsValid": {
-                                "type": "boolean"
-                            },
-                            "content": {
-                                "required": ["maql"],
-                                "type": "object",
-                                "properties": {
-                                    "format": {
-                                        "maxLength": 2048,
-                                        "type": "string"
-                                    },
-                                    "maql": {
-                                        "maxLength": 10000,
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "JSON:API representation of metric entity."
-            },
-            "JsonApiUserDataFilterInDocument": {
-                "required": ["data"],
-                "type": "object",
-                "properties": {
-                    "data": {
-                        "$ref": "#/components/schemas/JsonApiUserDataFilterIn"
-                    }
-                }
-            },
-            "JsonApiUserDataFilterIn": {
-                "required": ["attributes", "id", "type"],
-                "type": "object",
-                "properties": {
-                    "type": {
-                        "type": "string",
-                        "description": "Object type",
-                        "example": "userDataFilter",
-                        "enum": ["userDataFilter"]
-                    },
-                    "id": {
-                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
-                        "type": "string",
-                        "description": "API identifier of an object",
-                        "example": "id1"
-                    },
-                    "attributes": {
-                        "required": ["maql"],
-                        "type": "object",
-                        "properties": {
-                            "title": {
-                                "maxLength": 255,
-                                "type": "string"
-                            },
-                            "description": {
-                                "maxLength": 10000,
-                                "type": "string"
-                            },
-                            "tags": {
-                                "type": "array",
-                                "items": {
-                                    "type": "string"
-                                }
-                            },
-                            "areRelationsValid": {
-                                "type": "boolean"
-                            },
-                            "maql": {
-                                "maxLength": 10000,
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "relationships": {
-                        "type": "object",
-                        "properties": {
-                            "user": {
-                                "required": ["data"],
-                                "type": "object",
-                                "properties": {
-                                    "data": {
-                                        "$ref": "#/components/schemas/JsonApiUserToOneLinkage"
-                                    }
-                                }
-                            },
-                            "userGroup": {
-                                "required": ["data"],
-                                "type": "object",
-                                "properties": {
-                                    "data": {
-                                        "$ref": "#/components/schemas/JsonApiUserGroupToOneLinkage"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "JSON:API representation of userDataFilter entity."
-            },
-            "JsonApiVisualizationObjectInDocument": {
-                "required": ["data"],
-                "type": "object",
-                "properties": {
-                    "data": {
-                        "$ref": "#/components/schemas/JsonApiVisualizationObjectIn"
-                    }
-                }
-            },
-            "JsonApiVisualizationObjectIn": {
-                "required": ["attributes", "id", "type"],
-                "type": "object",
-                "properties": {
-                    "type": {
-                        "type": "string",
-                        "description": "Object type",
-                        "example": "visualizationObject",
-                        "enum": ["visualizationObject"]
-                    },
-                    "id": {
-                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
-                        "type": "string",
-                        "description": "API identifier of an object",
-                        "example": "id1"
-                    },
-                    "attributes": {
-                        "required": ["content"],
-                        "type": "object",
-                        "properties": {
-                            "title": {
-                                "maxLength": 255,
-                                "type": "string"
-                            },
-                            "description": {
-                                "maxLength": 10000,
-                                "type": "string"
-                            },
-                            "tags": {
-                                "type": "array",
-                                "items": {
-                                    "type": "string"
-                                }
-                            },
-                            "areRelationsValid": {
-                                "type": "boolean"
-                            },
-                            "content": {
-                                "type": "object",
-                                "description": "Free-form JSON content. Maximum supported length is 250000 characters.",
-                                "example": {
-                                    "identifier": {
-                                        "id": "label.leaf",
-                                        "type": "label"
-                                    },
-                                    "someBoolProp": false
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "JSON:API representation of visualizationObject entity."
-            },
-            "JsonApiWorkspaceSettingInDocument": {
-                "required": ["data"],
-                "type": "object",
-                "properties": {
-                    "data": {
-                        "$ref": "#/components/schemas/JsonApiWorkspaceSettingIn"
-                    }
-                }
-            },
-            "JsonApiWorkspaceSettingIn": {
-                "required": ["id", "type"],
-                "type": "object",
-                "properties": {
-                    "type": {
-                        "type": "string",
-                        "description": "Object type",
-                        "example": "workspaceSetting",
-                        "enum": ["workspaceSetting"]
-                    },
-                    "id": {
-                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
-                        "type": "string",
-                        "description": "API identifier of an object",
-                        "example": "id1"
-                    },
-                    "attributes": {
-                        "type": "object",
-                        "properties": {
-                            "content": {
-                                "type": "object",
-                                "description": "Free-form JSON content. Maximum supported length is 15000 characters.",
-                                "example": {}
-                            },
-                            "type": {
-                                "type": "string",
-                                "enum": [
-                                    "TIMEZONE",
-                                    "ACTIVE_THEME",
-                                    "ACTIVE_COLOR_PALETTE",
-                                    "ACTIVE_LLM_ENDPOINT",
-                                    "WHITE_LABELING",
-                                    "LOCALE",
-                                    "METADATA_LOCALE",
-                                    "FORMAT_LOCALE",
-                                    "MAPBOX_TOKEN",
-                                    "WEEK_START",
-                                    "SHOW_HIDDEN_CATALOG_ITEMS",
-                                    "OPERATOR_OVERRIDES",
-                                    "TIMEZONE_VALIDATION_ENABLED",
-                                    "OPENAI_CONFIG",
-                                    "ENABLE_FILE_ANALYTICS",
-                                    "ALERT",
-                                    "SEPARATORS",
-                                    "DATE_FILTER_CONFIG",
-                                    "JIT_PROVISIONING",
-                                    "JWT_JIT_PROVISIONING",
-                                    "DASHBOARD_FILTERS_APPLY_MODE",
-                                    "ENABLE_SLIDES_EXPORT",
-                                    "AI_RATE_LIMIT",
-                                    "ATTACHMENT_SIZE_LIMIT",
-                                    "ATTACHMENT_LINK_TTL"
-                                ]
-                            }
-                        }
-                    }
-                },
-                "description": "JSON:API representation of workspaceSetting entity."
-            },
-            "JsonApiColorPalettePatchDocument": {
-                "required": ["data"],
-                "type": "object",
-                "properties": {
-                    "data": {
-                        "$ref": "#/components/schemas/JsonApiColorPalettePatch"
-                    }
-                }
-            },
-            "JsonApiColorPalettePatch": {
-                "required": ["attributes", "id", "type"],
-                "type": "object",
-                "properties": {
-                    "type": {
-                        "type": "string",
-                        "description": "Object type",
-                        "example": "colorPalette",
-                        "enum": ["colorPalette"]
-                    },
-                    "id": {
-                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
-                        "type": "string",
-                        "description": "API identifier of an object",
-                        "example": "id1"
-                    },
-                    "attributes": {
-                        "type": "object",
-                        "properties": {
-                            "name": {
-                                "maxLength": 255,
-                                "type": "string"
-                            },
-                            "content": {
-                                "type": "object",
-                                "description": "Free-form JSON content. Maximum supported length is 15000 characters.",
-                                "example": {}
-                            }
-                        }
-                    }
-                },
-                "description": "JSON:API representation of patching colorPalette entity."
-            },
-            "JsonApiCspDirectivePatchDocument": {
-                "required": ["data"],
-                "type": "object",
-                "properties": {
-                    "data": {
-                        "$ref": "#/components/schemas/JsonApiCspDirectivePatch"
-                    }
-                }
-            },
-            "JsonApiCspDirectivePatch": {
-                "required": ["attributes", "id", "type"],
-                "type": "object",
-                "properties": {
-                    "type": {
-                        "type": "string",
-                        "description": "Object type",
-                        "example": "cspDirective",
-                        "enum": ["cspDirective"]
-                    },
-                    "id": {
-                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
-                        "type": "string",
-                        "description": "API identifier of an object",
-                        "example": "id1"
-                    },
-                    "attributes": {
-                        "type": "object",
-                        "properties": {
-                            "sources": {
-                                "type": "array",
-                                "items": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "JSON:API representation of patching cspDirective entity."
-            },
-            "JsonApiDataSourcePatchDocument": {
-                "required": ["data"],
-                "type": "object",
-                "properties": {
-                    "data": {
-                        "$ref": "#/components/schemas/JsonApiDataSourcePatch"
-                    }
-                }
-            },
-            "JsonApiDataSourcePatch": {
-                "required": ["attributes", "id", "type"],
-                "type": "object",
-                "properties": {
-                    "type": {
-                        "type": "string",
-                        "description": "Object type",
-                        "example": "dataSource",
-                        "enum": ["dataSource"]
-                    },
-                    "id": {
-                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
-                        "type": "string",
-                        "description": "API identifier of an object",
-                        "example": "id1"
-                    },
-                    "attributes": {
-                        "type": "object",
-                        "properties": {
-                            "name": {
-                                "maxLength": 255,
-                                "type": "string",
-                                "description": "User-facing name of the data source."
-                            },
-                            "type": {
-                                "type": "string",
-                                "description": "Type of the database providing the data for the data source.",
-                                "enum": [
-                                    "POSTGRESQL",
-                                    "REDSHIFT",
-                                    "VERTICA",
-                                    "SNOWFLAKE",
-                                    "ADS",
-                                    "BIGQUERY",
-                                    "MSSQL",
-                                    "PRESTO",
-                                    "DREMIO",
-                                    "DRILL",
-                                    "GREENPLUM",
-                                    "AZURESQL",
-                                    "SYNAPSESQL",
-                                    "DATABRICKS",
-                                    "GDSTORAGE",
-                                    "CLICKHOUSE",
-                                    "MYSQL",
-                                    "MARIADB",
-                                    "ORACLE",
-                                    "PINOT",
-                                    "SINGLESTORE",
-                                    "MOTHERDUCK",
-                                    "FLEXCONNECT",
-                                    "STARROCKS",
-                                    "ATHENA"
-                                ]
-                            },
-                            "url": {
-                                "maxLength": 255,
-                                "type": "string",
-                                "description": "The URL of the database providing the data for the data source.",
-                                "nullable": true
-                            },
-                            "schema": {
-                                "maxLength": 255,
-                                "type": "string",
-                                "description": "The schema to use as the root of the data for the data source."
-                            },
-                            "username": {
-                                "maxLength": 255,
-                                "type": "string",
-                                "description": "The username to use to connect to the database providing the data for the data source.",
-                                "nullable": true
-                            },
-                            "password": {
-                                "maxLength": 255,
-                                "type": "string",
-                                "description": "The password to use to connect to the database providing the data for the data source.",
-                                "nullable": true
-                            },
-                            "privateKey": {
-                                "maxLength": 15000,
-                                "type": "string",
-                                "description": "The private key to use to connect to the database providing the data for the data source.",
-                                "nullable": true
-                            },
-                            "privateKeyPassphrase": {
-                                "maxLength": 255,
-                                "type": "string",
-                                "description": "The passphrase used to encrypt the private key.",
-                                "nullable": true
-                            },
-                            "token": {
-                                "maxLength": 10000,
-                                "type": "string",
-                                "description": "The token to use to connect to the database providing the data for the data source (for example a BigQuery Service Account).",
-                                "nullable": true
-                            },
-                            "clientId": {
-                                "maxLength": 255,
-                                "type": "string",
-                                "description": "The client id to use to connect to the database providing the data for the data source (for example a Databricks Service Account).",
-                                "nullable": true
-                            },
-                            "clientSecret": {
-                                "maxLength": 255,
-                                "type": "string",
-                                "description": "The client secret to use to connect to the database providing the data for the data source (for example a Databricks Service Account).",
-                                "nullable": true
-                            },
-                            "parameters": {
-                                "type": "array",
-                                "description": "Additional parameters to be used when connecting to the database providing the data for the data source.",
-                                "nullable": true,
-                                "items": {
-                                    "required": ["name", "value"],
-                                    "type": "object",
-                                    "properties": {
-                                        "name": {
-                                            "type": "string"
-                                        },
-                                        "value": {
-                                            "type": "string"
-                                        }
-                                    }
-                                }
-                            },
-                            "cacheStrategy": {
-                                "type": "string",
-                                "description": "Determines how the results coming from a particular datasource should be cached.",
-                                "nullable": true,
-                                "enum": ["ALWAYS", "NEVER"]
-                            }
-                        }
-                    }
-                },
-                "description": "JSON:API representation of patching dataSource entity."
-            },
-            "JsonApiExportTemplatePatchDocument": {
-                "required": ["data"],
-                "type": "object",
-                "properties": {
-                    "data": {
-                        "$ref": "#/components/schemas/JsonApiExportTemplatePatch"
-                    }
-                }
-            },
-            "JsonApiExportTemplatePatch": {
-                "required": ["attributes", "id", "type"],
-                "type": "object",
-                "properties": {
-                    "type": {
-                        "type": "string",
-                        "description": "Object type",
-                        "example": "exportTemplate",
-                        "enum": ["exportTemplate"]
-                    },
-                    "id": {
-                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
-                        "type": "string",
-                        "description": "API identifier of an object",
-                        "example": "id1"
-                    },
-                    "attributes": {
-                        "type": "object",
-                        "properties": {
-                            "name": {
-                                "maxLength": 255,
-                                "type": "string",
-                                "description": "User-facing name of the Slides template."
-                            },
-                            "dashboardSlidesTemplate": {
-                                "required": ["appliedOn"],
-                                "type": "object",
-                                "properties": {
-                                    "appliedOn": {
-                                        "minItems": 1,
-                                        "type": "array",
-                                        "description": "Export types this template applies to.",
-                                        "example": ["PDF", "PPTX"],
-                                        "items": {
-                                            "type": "string",
-                                            "enum": ["PDF", "PPTX"]
-                                        }
-                                    },
-                                    "coverSlide": {
-                                        "$ref": "#/components/schemas/CoverSlideTemplate"
-                                    },
-                                    "introSlide": {
-                                        "$ref": "#/components/schemas/IntroSlideTemplate"
-                                    },
-                                    "sectionSlide": {
-                                        "$ref": "#/components/schemas/SectionSlideTemplate"
-                                    },
-                                    "contentSlide": {
-                                        "$ref": "#/components/schemas/ContentSlideTemplate"
-                                    }
-                                },
-                                "description": "Template for dashboard slides export.\nAvailable variables: {{currentPageNumber}}, {{dashboardDateFilters}}, {{dashboardDescription}}, {{dashboardFilters}}, {{dashboardId}}, {{dashboardName}}, {{dashboardTags}}, {{dashboardUrl}}, {{exportedAt}}, {{exportedBy}}, {{logo}}, {{totalPages}}, {{workspaceId}}, {{workspaceName}}",
-                                "nullable": true
-                            },
-                            "widgetSlidesTemplate": {
-                                "required": ["appliedOn"],
-                                "type": "object",
-                                "properties": {
-                                    "appliedOn": {
-                                        "minItems": 1,
-                                        "type": "array",
-                                        "description": "Export types this template applies to.",
-                                        "example": ["PDF", "PPTX"],
-                                        "items": {
-                                            "type": "string",
-                                            "enum": ["PDF", "PPTX"]
-                                        }
-                                    },
-                                    "contentSlide": {
-                                        "$ref": "#/components/schemas/ContentSlideTemplate"
-                                    }
-                                },
-                                "description": "Template for widget slides export.\nAvailable variables: {{currentPageNumber}}, {{dashboardDateFilters}}, {{dashboardDescription}}, {{dashboardFilters}}, {{dashboardId}}, {{dashboardName}}, {{dashboardTags}}, {{dashboardUrl}}, {{exportedAt}}, {{exportedBy}}, {{logo}}, {{totalPages}}, {{workspaceId}}, {{workspaceName}}",
-                                "nullable": true
-                            }
-                        }
-                    }
-                },
-                "description": "JSON:API representation of patching exportTemplate entity."
-            },
-            "JsonApiIdentityProviderPatchDocument": {
-                "required": ["data"],
-                "type": "object",
-                "properties": {
-                    "data": {
-                        "$ref": "#/components/schemas/JsonApiIdentityProviderPatch"
-                    }
-                }
-            },
-            "JsonApiIdentityProviderPatch": {
-                "required": ["id", "type"],
-                "type": "object",
-                "properties": {
-                    "type": {
-                        "type": "string",
-                        "description": "Object type",
-                        "example": "identityProvider",
-                        "enum": ["identityProvider"]
-                    },
-                    "id": {
-                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
-                        "type": "string",
-                        "description": "API identifier of an object",
-                        "example": "id1"
-                    },
-                    "attributes": {
-                        "type": "object",
-                        "properties": {
-                            "identifiers": {
-                                "type": "array",
-                                "description": "List of identifiers for this IdP, where an identifier is a domain name. Users with email addresses belonging to these domains will be authenticated by this IdP.",
-                                "example": ["gooddata.com"],
-                                "items": {
-                                    "type": "string"
-                                }
-                            },
-                            "customClaimMapping": {
-                                "maxLength": 10000,
-                                "type": "object",
-                                "additionalProperties": {
-                                    "type": "string"
-                                },
-                                "description": "Map of custom claim overrides. To be used when your Idp does not provide default claims (sub, email, name, given_name, family_name). Define the key pair for the claim you wish to override, where the key is the default name of the attribute and the value is your custom name for the given attribute."
-                            },
-                            "samlMetadata": {
-                                "maxLength": 15000,
-                                "type": "string",
-                                "description": "Base64 encoded xml document with SAML metadata. This document is issued by your SAML provider. It includes the issuer's name, expiration information, and keys that can be used to validate the response from the identity provider. This field is mandatory for SAML IdP."
-                            },
-                            "oauthClientId": {
-                                "maxLength": 255,
-                                "type": "string",
-                                "description": "The OAuth client id of your OIDC provider. This field is mandatory for OIDC IdP."
-                            },
-                            "oauthClientSecret": {
-                                "maxLength": 255,
-                                "type": "string",
-                                "description": "The OAuth client secret of your OIDC provider. This field is mandatory for OIDC IdP."
-                            },
-                            "oauthIssuerLocation": {
-                                "maxLength": 255,
-                                "type": "string",
-                                "description": "The location of your OIDC provider. This field is mandatory for OIDC IdP."
-                            },
-                            "oauthIssuerId": {
-                                "maxLength": 255,
-                                "type": "string",
-                                "description": "Any string identifying the OIDC provider. This value is used as suffix for OAuth2 callback (redirect) URL. If not defined, the standard callback URL is used. This value is valid only for external OIDC providers, not for the internal DEX provider.",
-                                "example": "myOidcProvider"
-                            },
-                            "oauthSubjectIdClaim": {
-                                "maxLength": 255,
-                                "type": "string",
-                                "description": "Any string identifying the claim in ID token, that should be used for user identification. The default value is 'sub'.",
-                                "example": "oid"
-                            },
-                            "oauthCustomAuthAttributes": {
-                                "maxLength": 10000,
-                                "type": "object",
-                                "additionalProperties": {
-                                    "type": "string"
-                                },
-                                "description": "Map of additional authentication attributes that should be added to the OAuth2 authentication requests, where the key is the name of the attribute and the value is the value of the attribute."
-                            },
-                            "oauthCustomScopes": {
-                                "type": "array",
-                                "description": "List of additional OAuth scopes which may be required by other providers (e.g. Snowflake)",
-                                "nullable": true,
-                                "items": {
-                                    "maxLength": 255,
-                                    "type": "string"
-                                }
-                            },
-                            "idpType": {
-                                "type": "string",
-                                "description": "Type of IdP for management purposes. MANAGED_IDP represents a GoodData managed IdP used in single OIDC setup, which is protected from altering/deletion. FIM_IDP represents a GoodData managed IdP used in federated identity management setup, which is protected from altering/deletion. CUSTOM_IDP represents customer's own IdP, protected from deletion if currently used by org for authentication, deletable otherwise.",
-                                "enum": ["MANAGED_IDP", "FIM_IDP", "CUSTOM_IDP"]
-                            }
-                        }
-                    }
-                },
-                "description": "JSON:API representation of patching identityProvider entity."
-            },
-            "JsonApiJwkPatchDocument": {
-                "required": ["data"],
-                "type": "object",
-                "properties": {
-                    "data": {
-                        "$ref": "#/components/schemas/JsonApiJwkPatch"
-                    }
-                }
-            },
-            "JsonApiJwkPatch": {
-                "required": ["id", "type"],
-                "type": "object",
-                "properties": {
-                    "type": {
-                        "type": "string",
-                        "description": "Object type",
-                        "example": "jwk",
-                        "enum": ["jwk"]
-                    },
-                    "id": {
-                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
-                        "type": "string",
-                        "description": "API identifier of an object",
-                        "example": "id1"
-                    },
-                    "attributes": {
-                        "type": "object",
-                        "properties": {
-                            "content": {
-                                "type": "object",
-                                "description": "Specification of the cryptographic key",
-                                "example": {
-                                    "kyt": "RSA",
-                                    "alg": "RS256",
-                                    "use": "sig"
-                                },
-                                "oneOf": [
-                                    {
-                                        "$ref": "#/components/schemas/RsaSpecification"
-                                    }
-                                ]
-                            }
-                        }
-                    }
-                },
-                "description": "JSON:API representation of patching jwk entity."
-            },
-            "JsonApiLlmEndpointPatchDocument": {
-                "required": ["data"],
-                "type": "object",
-                "properties": {
-                    "data": {
-                        "$ref": "#/components/schemas/JsonApiLlmEndpointPatch"
-                    }
-                }
-            },
-            "JsonApiLlmEndpointPatch": {
-                "required": ["attributes", "id", "type"],
-                "type": "object",
-                "properties": {
-                    "type": {
-                        "type": "string",
-                        "description": "Object type",
-                        "example": "llmEndpoint",
-                        "enum": ["llmEndpoint"]
-                    },
-                    "id": {
-                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
-                        "type": "string",
-                        "description": "API identifier of an object",
-                        "example": "id1"
-                    },
-                    "attributes": {
-                        "type": "object",
-                        "properties": {
-                            "title": {
-                                "maxLength": 255,
-                                "type": "string",
-                                "description": "User-facing title of the LLM Provider."
-                            },
-                            "provider": {
-                                "type": "string",
-                                "description": "LLM Provider.",
-                                "enum": ["OPENAI", "AZURE_OPENAI"]
-                            },
-                            "baseUrl": {
-                                "maxLength": 255,
-                                "type": "string",
-                                "description": "Custom LLM endpoint.",
-                                "nullable": true
-                            },
-                            "token": {
-                                "maxLength": 10000,
-                                "type": "string",
-                                "description": "The token to use to connect to the LLM provider."
-                            },
-                            "llmOrganization": {
-                                "maxLength": 255,
-                                "type": "string",
-                                "description": "Organization in LLM provider.",
-                                "nullable": true
-                            },
-                            "llmModel": {
-                                "maxLength": 255,
-                                "type": "string",
-                                "description": "LLM Model. We provide a default model for each provider, but you can override it here."
-                            }
-                        }
-                    }
-                },
-                "description": "JSON:API representation of patching llmEndpoint entity."
-            },
-            "JsonApiNotificationChannelPatchDocument": {
-                "required": ["data"],
-                "type": "object",
-                "properties": {
-                    "data": {
-                        "$ref": "#/components/schemas/JsonApiNotificationChannelPatch"
-                    }
-                }
-            },
-            "JsonApiNotificationChannelPatch": {
-                "required": ["id", "type"],
-                "type": "object",
-                "properties": {
-                    "type": {
-                        "type": "string",
-                        "description": "Object type",
-                        "example": "notificationChannel",
-                        "enum": ["notificationChannel"]
-                    },
-                    "id": {
-                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
-                        "type": "string",
-                        "description": "API identifier of an object",
-                        "example": "id1"
-                    },
-                    "attributes": {
-                        "type": "object",
-                        "properties": {
-                            "name": {
-                                "maxLength": 255,
-                                "type": "string",
-                                "nullable": true
-                            },
-                            "description": {
-                                "maxLength": 10000,
-                                "type": "string",
-                                "nullable": true
-                            },
-                            "destination": {
-                                "description": "The destination where the notifications are to be sent.",
-                                "oneOf": [
-                                    {
-                                        "$ref": "#/components/schemas/DefaultSmtp"
-                                    },
-                                    {
-                                        "$ref": "#/components/schemas/InPlatform"
-                                    },
-                                    {
-                                        "$ref": "#/components/schemas/Smtp"
-                                    },
-                                    {
-                                        "$ref": "#/components/schemas/Webhook"
-                                    }
-                                ]
-                            },
-                            "customDashboardUrl": {
-                                "maxLength": 255,
-                                "type": "string",
-                                "description": "Custom dashboard url that is going to be used in the notification. If not specified it is going to be deduced based on the context. Allowed placeholders are:\n{workspaceId}\n{dashboardId}\n{automationId}\n{asOfDate}\n"
-                            },
-                            "dashboardLinkVisibility": {
-                                "type": "string",
-                                "description": "Dashboard link visibility in notifications.\nHIDDEN - the link will not be included\nINTERNAL_ONLY - only internal users will see the link\nALL - all users will see the link\n",
-                                "enum": ["HIDDEN", "INTERNAL_ONLY", "ALL"]
-                            },
-                            "notificationSource": {
-                                "maxLength": 10000,
-                                "type": "string",
-                                "description": "Human-readable description of the source of the notification. If specified, this propertywill be included in the notifications to this channel.Allowed placeholders are:\n{{workspaceId}}\n{{workspaceName}}\n{{workspaceDescription}}\n{{dashboardId}}\n{{dashboardName}}\n{{dashboardDescription}}\n"
-                            },
-                            "allowedRecipients": {
-                                "type": "string",
-                                "description": "Allowed recipients of notifications from this channel.\nCREATOR - only the creator\nINTERNAL - all users within the organization\nEXTERNAL - all recipients including those outside the organization\n",
-                                "enum": ["CREATOR", "INTERNAL", "EXTERNAL"]
-                            },
-                            "inPlatformNotification": {
-                                "type": "string",
-                                "description": "In-platform notifications configuration. No effect if the destination type is IN_PLATFORM.\nDISABLED - in-platform notifications are not sent\nENABLED - in-platform notifications are sent in addition to the regular notifications\n",
-                                "enum": ["DISABLED", "ENABLED"]
-                            }
-                        }
-                    }
-                },
-                "description": "JSON:API representation of patching notificationChannel entity."
-            },
-            "JsonApiOrganizationSettingPatchDocument": {
-                "required": ["data"],
-                "type": "object",
-                "properties": {
-                    "data": {
-                        "$ref": "#/components/schemas/JsonApiOrganizationSettingPatch"
-                    }
-                }
-            },
-            "JsonApiOrganizationSettingPatch": {
-                "required": ["id", "type"],
-                "type": "object",
-                "properties": {
-                    "type": {
-                        "type": "string",
-                        "description": "Object type",
-                        "example": "organizationSetting",
-                        "enum": ["organizationSetting"]
-                    },
-                    "id": {
-                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
-                        "type": "string",
-                        "description": "API identifier of an object",
-                        "example": "id1"
-                    },
-                    "attributes": {
-                        "type": "object",
-                        "properties": {
-                            "content": {
-                                "type": "object",
-                                "description": "Free-form JSON content. Maximum supported length is 15000 characters.",
-                                "example": {}
-                            },
-                            "type": {
-                                "type": "string",
-                                "enum": [
-                                    "TIMEZONE",
-                                    "ACTIVE_THEME",
-                                    "ACTIVE_COLOR_PALETTE",
-                                    "ACTIVE_LLM_ENDPOINT",
-                                    "WHITE_LABELING",
-                                    "LOCALE",
-                                    "METADATA_LOCALE",
-                                    "FORMAT_LOCALE",
-                                    "MAPBOX_TOKEN",
-                                    "WEEK_START",
-                                    "SHOW_HIDDEN_CATALOG_ITEMS",
-                                    "OPERATOR_OVERRIDES",
-                                    "TIMEZONE_VALIDATION_ENABLED",
-                                    "OPENAI_CONFIG",
-                                    "ENABLE_FILE_ANALYTICS",
-                                    "ALERT",
-                                    "SEPARATORS",
-                                    "DATE_FILTER_CONFIG",
-                                    "JIT_PROVISIONING",
-                                    "JWT_JIT_PROVISIONING",
-                                    "DASHBOARD_FILTERS_APPLY_MODE",
-                                    "ENABLE_SLIDES_EXPORT",
-                                    "AI_RATE_LIMIT",
-                                    "ATTACHMENT_SIZE_LIMIT",
-                                    "ATTACHMENT_LINK_TTL"
-                                ]
-                            }
-                        }
-                    }
-                },
-                "description": "JSON:API representation of patching organizationSetting entity."
-            },
-            "JsonApiThemePatchDocument": {
-                "required": ["data"],
-                "type": "object",
-                "properties": {
-                    "data": {
-                        "$ref": "#/components/schemas/JsonApiThemePatch"
-                    }
-                }
-            },
-            "JsonApiThemePatch": {
-                "required": ["attributes", "id", "type"],
-                "type": "object",
-                "properties": {
-                    "type": {
-                        "type": "string",
-                        "description": "Object type",
-                        "example": "theme",
-                        "enum": ["theme"]
-                    },
-                    "id": {
-                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
-                        "type": "string",
-                        "description": "API identifier of an object",
-                        "example": "id1"
-                    },
-                    "attributes": {
-                        "type": "object",
-                        "properties": {
-                            "name": {
-                                "maxLength": 255,
-                                "type": "string"
-                            },
-                            "content": {
-                                "type": "object",
-                                "description": "Free-form JSON content. Maximum supported length is 15000 characters.",
-                                "example": {}
-                            }
-                        }
-                    }
-                },
-                "description": "JSON:API representation of patching theme entity."
-            },
-            "JsonApiUserGroupPatchDocument": {
-                "required": ["data"],
-                "type": "object",
-                "properties": {
-                    "data": {
-                        "$ref": "#/components/schemas/JsonApiUserGroupPatch"
-                    }
-                }
-            },
-            "JsonApiUserGroupPatch": {
-                "required": ["id", "type"],
-                "type": "object",
-                "properties": {
-                    "type": {
-                        "type": "string",
-                        "description": "Object type",
-                        "example": "userGroup",
-                        "enum": ["userGroup"]
-                    },
-                    "id": {
-                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
-                        "type": "string",
-                        "description": "API identifier of an object",
-                        "example": "id1"
-                    },
-                    "attributes": {
-                        "type": "object",
-                        "properties": {
-                            "name": {
-                                "maxLength": 255,
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "relationships": {
-                        "type": "object",
-                        "properties": {
-                            "parents": {
-                                "required": ["data"],
-                                "type": "object",
-                                "properties": {
-                                    "data": {
-                                        "$ref": "#/components/schemas/JsonApiUserGroupToManyLinkage"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "JSON:API representation of patching userGroup entity."
-            },
-            "JsonApiUserPatchDocument": {
-                "required": ["data"],
-                "type": "object",
-                "properties": {
-                    "data": {
-                        "$ref": "#/components/schemas/JsonApiUserPatch"
-                    }
-                }
-            },
-            "JsonApiUserPatch": {
-                "required": ["id", "type"],
-                "type": "object",
-                "properties": {
-                    "type": {
-                        "type": "string",
-                        "description": "Object type",
-                        "example": "user",
-                        "enum": ["user"]
-                    },
-                    "id": {
-                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
-                        "type": "string",
-                        "description": "API identifier of an object",
-                        "example": "id1"
-                    },
-                    "attributes": {
-                        "type": "object",
-                        "properties": {
-                            "authenticationId": {
-                                "maxLength": 255,
-                                "type": "string"
-                            },
-                            "firstname": {
-                                "maxLength": 255,
-                                "type": "string"
-                            },
-                            "lastname": {
-                                "maxLength": 255,
-                                "type": "string"
-                            },
-                            "email": {
-                                "maxLength": 255,
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "relationships": {
-                        "type": "object",
-                        "properties": {
-                            "userGroups": {
-                                "required": ["data"],
-                                "type": "object",
-                                "properties": {
-                                    "data": {
-                                        "$ref": "#/components/schemas/JsonApiUserGroupToManyLinkage"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "JSON:API representation of patching user entity."
-            },
-            "JsonApiWorkspacePatchDocument": {
-                "required": ["data"],
-                "type": "object",
-                "properties": {
-                    "data": {
-                        "$ref": "#/components/schemas/JsonApiWorkspacePatch"
-                    }
-                }
-            },
-            "JsonApiWorkspacePatch": {
-                "required": ["id", "type"],
-                "type": "object",
-                "properties": {
-                    "type": {
-                        "type": "string",
-                        "description": "Object type",
-                        "example": "workspace",
-                        "enum": ["workspace"]
-                    },
-                    "id": {
-                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
-                        "type": "string",
-                        "description": "API identifier of an object",
-                        "example": "id1"
-                    },
-                    "attributes": {
-                        "type": "object",
-                        "properties": {
-                            "name": {
-                                "maxLength": 255,
-                                "type": "string",
-                                "nullable": true
-                            },
-                            "earlyAccess": {
-                                "maxLength": 255,
-                                "type": "string",
-                                "description": "The early access feature identifier. It is used to enable experimental features. Deprecated in favor of earlyAccessValues.",
-                                "nullable": true,
-                                "deprecated": true
-                            },
-                            "earlyAccessValues": {
-                                "type": "array",
-                                "description": "The early access feature identifiers. They are used to enable experimental features.",
-                                "nullable": true,
-                                "items": {
-                                    "maxLength": 255,
-                                    "type": "string"
-                                }
-                            },
-                            "description": {
-                                "maxLength": 255,
-                                "type": "string",
-                                "nullable": true
-                            },
-                            "prefix": {
-                                "maxLength": 255,
-                                "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
-                                "type": "string",
-                                "description": "Custom prefix of entity identifiers in workspace",
-                                "nullable": true
-                            },
-                            "cacheExtraLimit": {
-                                "type": "integer",
-                                "format": "int64"
-                            },
-                            "dataSource": {
-                                "required": ["id"],
-                                "type": "object",
-                                "properties": {
-                                    "id": {
-                                        "type": "string",
-                                        "description": "The ID of the used data source.",
-                                        "example": "snowflake.instance.1"
-                                    },
-                                    "schemaPath": {
-                                        "type": "array",
-                                        "description": "The full schema path as array of its path parts. Will be rendered as subPath1.subPath2...",
-                                        "items": {
-                                            "type": "string",
-                                            "description": "The part of the schema path.",
-                                            "example": "subPath"
-                                        }
-                                    }
-                                },
-                                "description": "The data source used for the particular workspace instead of the one defined in the LDM inherited from its parent workspace. Such data source cannot be defined for a single or a top-parent workspace."
-                            }
-                        }
-                    },
-                    "relationships": {
-                        "type": "object",
-                        "properties": {
-                            "parent": {
-                                "required": ["data"],
-                                "type": "object",
-                                "properties": {
-                                    "data": {
-                                        "$ref": "#/components/schemas/JsonApiWorkspaceToOneLinkage"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "JSON:API representation of patching workspace entity."
-            },
             "JsonApiColorPaletteInDocument": {
                 "required": ["data"],
                 "type": "object",
@@ -27099,17 +26315,17 @@
                 },
                 "description": "JSON:API representation of dataSource entity."
             },
-            "JsonApiExportTemplatePostOptionalIdDocument": {
+            "JsonApiExportTemplateInDocument": {
                 "required": ["data"],
                 "type": "object",
                 "properties": {
                     "data": {
-                        "$ref": "#/components/schemas/JsonApiExportTemplatePostOptionalId"
+                        "$ref": "#/components/schemas/JsonApiExportTemplateIn"
                     }
                 }
             },
-            "JsonApiExportTemplatePostOptionalId": {
-                "required": ["attributes", "type"],
+            "JsonApiExportTemplateIn": {
+                "required": ["attributes", "id", "type"],
                 "type": "object",
                 "properties": {
                     "type": {
@@ -27405,17 +26621,17 @@
                 },
                 "description": "JSON:API representation of llmEndpoint entity."
             },
-            "JsonApiNotificationChannelPostOptionalIdDocument": {
+            "JsonApiNotificationChannelInDocument": {
                 "required": ["data"],
                 "type": "object",
                 "properties": {
                     "data": {
-                        "$ref": "#/components/schemas/JsonApiNotificationChannelPostOptionalId"
+                        "$ref": "#/components/schemas/JsonApiNotificationChannelIn"
                     }
                 }
             },
-            "JsonApiNotificationChannelPostOptionalId": {
-                "required": ["type"],
+            "JsonApiNotificationChannelIn": {
+                "required": ["id", "type"],
                 "type": "object",
                 "properties": {
                     "type": {
@@ -27820,16 +27036,16 @@
                 },
                 "description": "JSON:API representation of workspace entity."
             },
-            "JsonApiCookieSecurityConfigurationPatchDocument": {
+            "JsonApiCookieSecurityConfigurationInDocument": {
                 "required": ["data"],
                 "type": "object",
                 "properties": {
                     "data": {
-                        "$ref": "#/components/schemas/JsonApiCookieSecurityConfigurationPatch"
+                        "$ref": "#/components/schemas/JsonApiCookieSecurityConfigurationIn"
                     }
                 }
             },
-            "JsonApiCookieSecurityConfigurationPatch": {
+            "JsonApiCookieSecurityConfigurationIn": {
                 "required": ["id", "type"],
                 "type": "object",
                 "properties": {
@@ -27860,18 +27076,18 @@
                         }
                     }
                 },
-                "description": "JSON:API representation of patching cookieSecurityConfiguration entity."
+                "description": "JSON:API representation of cookieSecurityConfiguration entity."
             },
-            "JsonApiOrganizationPatchDocument": {
+            "JsonApiOrganizationInDocument": {
                 "required": ["data"],
                 "type": "object",
                 "properties": {
                     "data": {
-                        "$ref": "#/components/schemas/JsonApiOrganizationPatch"
+                        "$ref": "#/components/schemas/JsonApiOrganizationIn"
                     }
                 }
             },
-            "JsonApiOrganizationPatch": {
+            "JsonApiOrganizationIn": {
                 "required": ["id", "type"],
                 "type": "object",
                 "properties": {
@@ -27979,7 +27195,589 @@
                         }
                     }
                 },
-                "description": "JSON:API representation of patching organization entity."
+                "description": "JSON:API representation of organization entity."
+            },
+            "JsonApiAnalyticalDashboardPostOptionalIdDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiAnalyticalDashboardPostOptionalId"
+                    }
+                }
+            },
+            "JsonApiAnalyticalDashboardPostOptionalId": {
+                "required": ["attributes", "type"],
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "description": "Object type",
+                        "example": "analyticalDashboard",
+                        "enum": ["analyticalDashboard"]
+                    },
+                    "id": {
+                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
+                        "type": "string",
+                        "description": "API identifier of an object",
+                        "example": "id1"
+                    },
+                    "attributes": {
+                        "required": ["content"],
+                        "type": "object",
+                        "properties": {
+                            "title": {
+                                "maxLength": 255,
+                                "type": "string"
+                            },
+                            "description": {
+                                "maxLength": 10000,
+                                "type": "string"
+                            },
+                            "tags": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
+                            "areRelationsValid": {
+                                "type": "boolean"
+                            },
+                            "content": {
+                                "type": "object",
+                                "description": "Free-form JSON content. Maximum supported length is 250000 characters.",
+                                "example": {
+                                    "identifier": {
+                                        "id": "label.leaf",
+                                        "type": "label"
+                                    },
+                                    "someBoolProp": false
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "JSON:API representation of analyticalDashboard entity."
+            },
+            "JsonApiCustomApplicationSettingPostOptionalIdDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiCustomApplicationSettingPostOptionalId"
+                    }
+                }
+            },
+            "JsonApiCustomApplicationSettingPostOptionalId": {
+                "required": ["attributes", "type"],
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "description": "Object type",
+                        "example": "customApplicationSetting",
+                        "enum": ["customApplicationSetting"]
+                    },
+                    "id": {
+                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
+                        "type": "string",
+                        "description": "API identifier of an object",
+                        "example": "id1"
+                    },
+                    "attributes": {
+                        "required": ["applicationName", "content"],
+                        "type": "object",
+                        "properties": {
+                            "applicationName": {
+                                "maxLength": 255,
+                                "type": "string"
+                            },
+                            "content": {
+                                "type": "object",
+                                "description": "Free-form JSON content. Maximum supported length is 15000 characters.",
+                                "example": {}
+                            }
+                        }
+                    }
+                },
+                "description": "JSON:API representation of customApplicationSetting entity."
+            },
+            "JsonApiDashboardPluginPostOptionalIdDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiDashboardPluginPostOptionalId"
+                    }
+                }
+            },
+            "JsonApiDashboardPluginPostOptionalId": {
+                "required": ["type"],
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "description": "Object type",
+                        "example": "dashboardPlugin",
+                        "enum": ["dashboardPlugin"]
+                    },
+                    "id": {
+                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
+                        "type": "string",
+                        "description": "API identifier of an object",
+                        "example": "id1"
+                    },
+                    "attributes": {
+                        "type": "object",
+                        "properties": {
+                            "title": {
+                                "maxLength": 255,
+                                "type": "string"
+                            },
+                            "description": {
+                                "maxLength": 10000,
+                                "type": "string"
+                            },
+                            "tags": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
+                            "areRelationsValid": {
+                                "type": "boolean"
+                            },
+                            "content": {
+                                "type": "object",
+                                "description": "Free-form JSON content. Maximum supported length is 250000 characters.",
+                                "example": {
+                                    "url": "<plugin-url>"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "JSON:API representation of dashboardPlugin entity."
+            },
+            "JsonApiExportDefinitionPostOptionalIdDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiExportDefinitionPostOptionalId"
+                    }
+                }
+            },
+            "JsonApiExportDefinitionPostOptionalId": {
+                "required": ["type"],
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "description": "Object type",
+                        "example": "exportDefinition",
+                        "enum": ["exportDefinition"]
+                    },
+                    "id": {
+                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
+                        "type": "string",
+                        "description": "API identifier of an object",
+                        "example": "id1"
+                    },
+                    "attributes": {
+                        "type": "object",
+                        "properties": {
+                            "title": {
+                                "maxLength": 255,
+                                "type": "string"
+                            },
+                            "description": {
+                                "maxLength": 10000,
+                                "type": "string"
+                            },
+                            "tags": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
+                            "requestPayload": {
+                                "type": "object",
+                                "description": "JSON content to be used as export request payload for /export/tabular and /export/visual endpoints. ",
+                                "oneOf": [
+                                    {
+                                        "$ref": "#/components/schemas/VisualExportRequest"
+                                    },
+                                    {
+                                        "$ref": "#/components/schemas/TabularExportRequest"
+                                    }
+                                ]
+                            },
+                            "areRelationsValid": {
+                                "type": "boolean"
+                            }
+                        }
+                    },
+                    "relationships": {
+                        "type": "object",
+                        "properties": {
+                            "visualizationObject": {
+                                "required": ["data"],
+                                "type": "object",
+                                "properties": {
+                                    "data": {
+                                        "$ref": "#/components/schemas/JsonApiVisualizationObjectToOneLinkage"
+                                    }
+                                }
+                            },
+                            "analyticalDashboard": {
+                                "required": ["data"],
+                                "type": "object",
+                                "properties": {
+                                    "data": {
+                                        "$ref": "#/components/schemas/JsonApiAnalyticalDashboardToOneLinkage"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "JSON:API representation of exportDefinition entity."
+            },
+            "JsonApiFilterContextPostOptionalIdDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiFilterContextPostOptionalId"
+                    }
+                }
+            },
+            "JsonApiFilterContextPostOptionalId": {
+                "required": ["attributes", "type"],
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "description": "Object type",
+                        "example": "filterContext",
+                        "enum": ["filterContext"]
+                    },
+                    "id": {
+                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
+                        "type": "string",
+                        "description": "API identifier of an object",
+                        "example": "id1"
+                    },
+                    "attributes": {
+                        "required": ["content"],
+                        "type": "object",
+                        "properties": {
+                            "title": {
+                                "maxLength": 255,
+                                "type": "string"
+                            },
+                            "description": {
+                                "maxLength": 10000,
+                                "type": "string"
+                            },
+                            "tags": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
+                            "areRelationsValid": {
+                                "type": "boolean"
+                            },
+                            "content": {
+                                "type": "object",
+                                "description": "Free-form JSON content. Maximum supported length is 250000 characters.",
+                                "example": {
+                                    "identifier": {
+                                        "id": "label.leaf",
+                                        "type": "label"
+                                    },
+                                    "someBoolProp": false
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "JSON:API representation of filterContext entity."
+            },
+            "JsonApiMetricPostOptionalIdDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiMetricPostOptionalId"
+                    }
+                }
+            },
+            "JsonApiMetricPostOptionalId": {
+                "required": ["attributes", "type"],
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "description": "Object type",
+                        "example": "metric",
+                        "enum": ["metric"]
+                    },
+                    "id": {
+                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
+                        "type": "string",
+                        "description": "API identifier of an object",
+                        "example": "id1"
+                    },
+                    "attributes": {
+                        "required": ["content"],
+                        "type": "object",
+                        "properties": {
+                            "title": {
+                                "maxLength": 255,
+                                "type": "string"
+                            },
+                            "description": {
+                                "maxLength": 10000,
+                                "type": "string"
+                            },
+                            "tags": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
+                            "areRelationsValid": {
+                                "type": "boolean"
+                            },
+                            "content": {
+                                "required": ["maql"],
+                                "type": "object",
+                                "properties": {
+                                    "format": {
+                                        "maxLength": 2048,
+                                        "type": "string"
+                                    },
+                                    "maql": {
+                                        "maxLength": 10000,
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "JSON:API representation of metric entity."
+            },
+            "JsonApiUserDataFilterPostOptionalIdDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiUserDataFilterPostOptionalId"
+                    }
+                }
+            },
+            "JsonApiUserDataFilterPostOptionalId": {
+                "required": ["attributes", "type"],
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "description": "Object type",
+                        "example": "userDataFilter",
+                        "enum": ["userDataFilter"]
+                    },
+                    "id": {
+                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
+                        "type": "string",
+                        "description": "API identifier of an object",
+                        "example": "id1"
+                    },
+                    "attributes": {
+                        "required": ["maql"],
+                        "type": "object",
+                        "properties": {
+                            "title": {
+                                "maxLength": 255,
+                                "type": "string"
+                            },
+                            "description": {
+                                "maxLength": 10000,
+                                "type": "string"
+                            },
+                            "tags": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
+                            "areRelationsValid": {
+                                "type": "boolean"
+                            },
+                            "maql": {
+                                "maxLength": 10000,
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "relationships": {
+                        "type": "object",
+                        "properties": {
+                            "user": {
+                                "required": ["data"],
+                                "type": "object",
+                                "properties": {
+                                    "data": {
+                                        "$ref": "#/components/schemas/JsonApiUserToOneLinkage"
+                                    }
+                                }
+                            },
+                            "userGroup": {
+                                "required": ["data"],
+                                "type": "object",
+                                "properties": {
+                                    "data": {
+                                        "$ref": "#/components/schemas/JsonApiUserGroupToOneLinkage"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "JSON:API representation of userDataFilter entity."
+            },
+            "JsonApiVisualizationObjectPostOptionalIdDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiVisualizationObjectPostOptionalId"
+                    }
+                }
+            },
+            "JsonApiVisualizationObjectPostOptionalId": {
+                "required": ["attributes", "type"],
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "description": "Object type",
+                        "example": "visualizationObject",
+                        "enum": ["visualizationObject"]
+                    },
+                    "id": {
+                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
+                        "type": "string",
+                        "description": "API identifier of an object",
+                        "example": "id1"
+                    },
+                    "attributes": {
+                        "required": ["content"],
+                        "type": "object",
+                        "properties": {
+                            "title": {
+                                "maxLength": 255,
+                                "type": "string"
+                            },
+                            "description": {
+                                "maxLength": 10000,
+                                "type": "string"
+                            },
+                            "tags": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
+                            "areRelationsValid": {
+                                "type": "boolean"
+                            },
+                            "content": {
+                                "type": "object",
+                                "description": "Free-form JSON content. Maximum supported length is 250000 characters.",
+                                "example": {
+                                    "identifier": {
+                                        "id": "label.leaf",
+                                        "type": "label"
+                                    },
+                                    "someBoolProp": false
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "JSON:API representation of visualizationObject entity."
+            },
+            "JsonApiWorkspaceSettingPostOptionalIdDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiWorkspaceSettingPostOptionalId"
+                    }
+                }
+            },
+            "JsonApiWorkspaceSettingPostOptionalId": {
+                "required": ["type"],
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "description": "Object type",
+                        "example": "workspaceSetting",
+                        "enum": ["workspaceSetting"]
+                    },
+                    "id": {
+                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
+                        "type": "string",
+                        "description": "API identifier of an object",
+                        "example": "id1"
+                    },
+                    "attributes": {
+                        "type": "object",
+                        "properties": {
+                            "content": {
+                                "type": "object",
+                                "description": "Free-form JSON content. Maximum supported length is 15000 characters.",
+                                "example": {}
+                            },
+                            "type": {
+                                "type": "string",
+                                "enum": [
+                                    "TIMEZONE",
+                                    "ACTIVE_THEME",
+                                    "ACTIVE_COLOR_PALETTE",
+                                    "ACTIVE_LLM_ENDPOINT",
+                                    "WHITE_LABELING",
+                                    "LOCALE",
+                                    "METADATA_LOCALE",
+                                    "FORMAT_LOCALE",
+                                    "MAPBOX_TOKEN",
+                                    "WEEK_START",
+                                    "SHOW_HIDDEN_CATALOG_ITEMS",
+                                    "OPERATOR_OVERRIDES",
+                                    "TIMEZONE_VALIDATION_ENABLED",
+                                    "OPENAI_CONFIG",
+                                    "ENABLE_FILE_ANALYTICS",
+                                    "ALERT",
+                                    "SEPARATORS",
+                                    "DATE_FILTER_CONFIG",
+                                    "JIT_PROVISIONING",
+                                    "JWT_JIT_PROVISIONING",
+                                    "DASHBOARD_FILTERS_APPLY_MODE",
+                                    "ENABLE_SLIDES_EXPORT",
+                                    "AI_RATE_LIMIT",
+                                    "ATTACHMENT_SIZE_LIMIT",
+                                    "ATTACHMENT_LINK_TTL"
+                                ]
+                            }
+                        }
+                    }
+                },
+                "description": "JSON:API representation of workspaceSetting entity."
             },
             "JsonApiColorPaletteOutWithLinks": {
                 "allOf": [
@@ -28086,6 +27884,82 @@
                 },
                 "description": "A JSON:API document with a list of resources"
             },
+            "JsonApiDataSourceIdentifierOut": {
+                "required": ["attributes", "id", "type"],
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "description": "Object type",
+                        "example": "dataSourceIdentifier",
+                        "enum": ["dataSourceIdentifier"]
+                    },
+                    "id": {
+                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
+                        "type": "string",
+                        "description": "API identifier of an object",
+                        "example": "id1"
+                    },
+                    "meta": {
+                        "type": "object",
+                        "properties": {
+                            "permissions": {
+                                "type": "array",
+                                "description": "List of valid permissions for a logged-in user.",
+                                "items": {
+                                    "type": "string",
+                                    "enum": ["MANAGE", "USE"]
+                                }
+                            }
+                        }
+                    },
+                    "attributes": {
+                        "required": ["name", "schema", "type"],
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "maxLength": 255,
+                                "type": "string"
+                            },
+                            "schema": {
+                                "maxLength": 255,
+                                "type": "string"
+                            },
+                            "type": {
+                                "type": "string",
+                                "enum": [
+                                    "POSTGRESQL",
+                                    "REDSHIFT",
+                                    "VERTICA",
+                                    "SNOWFLAKE",
+                                    "ADS",
+                                    "BIGQUERY",
+                                    "MSSQL",
+                                    "PRESTO",
+                                    "DREMIO",
+                                    "DRILL",
+                                    "GREENPLUM",
+                                    "AZURESQL",
+                                    "SYNAPSESQL",
+                                    "DATABRICKS",
+                                    "GDSTORAGE",
+                                    "CLICKHOUSE",
+                                    "MYSQL",
+                                    "MARIADB",
+                                    "ORACLE",
+                                    "PINOT",
+                                    "SINGLESTORE",
+                                    "MOTHERDUCK",
+                                    "FLEXCONNECT",
+                                    "STARROCKS",
+                                    "ATHENA"
+                                ]
+                            }
+                        }
+                    }
+                },
+                "description": "JSON:API representation of dataSourceIdentifier entity."
+            },
             "JsonApiDataSourceOutWithLinks": {
                 "allOf": [
                     {
@@ -28155,6 +28029,38 @@
                     }
                 },
                 "description": "A JSON:API document with a list of resources"
+            },
+            "JsonApiEntitlementOut": {
+                "required": ["id", "type"],
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "description": "Object type",
+                        "example": "entitlement",
+                        "enum": ["entitlement"]
+                    },
+                    "id": {
+                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
+                        "type": "string",
+                        "description": "API identifier of an object",
+                        "example": "id1"
+                    },
+                    "attributes": {
+                        "type": "object",
+                        "properties": {
+                            "value": {
+                                "maxLength": 255,
+                                "type": "string"
+                            },
+                            "expiry": {
+                                "type": "string",
+                                "format": "date"
+                            }
+                        }
+                    }
+                },
+                "description": "JSON:API representation of entitlement entity."
             },
             "JsonApiExportTemplateOutWithLinks": {
                 "allOf": [
@@ -28320,6 +28226,49 @@
                     }
                 },
                 "description": "A JSON:API document with a list of resources"
+            },
+            "JsonApiNotificationChannelIdentifierOut": {
+                "required": ["id", "type"],
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "description": "Object type",
+                        "example": "notificationChannelIdentifier",
+                        "enum": ["notificationChannelIdentifier"]
+                    },
+                    "id": {
+                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
+                        "type": "string",
+                        "description": "API identifier of an object",
+                        "example": "id1"
+                    },
+                    "attributes": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "maxLength": 255,
+                                "type": "string",
+                                "nullable": true
+                            },
+                            "description": {
+                                "maxLength": 10000,
+                                "type": "string",
+                                "nullable": true
+                            },
+                            "destinationType": {
+                                "type": "string",
+                                "enum": ["WEBHOOK", "SMTP", "DEFAULT_SMTP", "IN_PLATFORM"]
+                            },
+                            "allowedRecipients": {
+                                "type": "string",
+                                "description": "Allowed recipients of notifications from this channel.\nCREATOR - only the creator\nINTERNAL - all users within the organization\nEXTERNAL - all recipients including those outside the organization\n",
+                                "enum": ["CREATOR", "INTERNAL", "EXTERNAL"]
+                            }
+                        }
+                    }
+                },
+                "description": "JSON:API representation of notificationChannelIdentifier entity."
             },
             "JsonApiNotificationChannelOutList": {
                 "required": ["data"],
@@ -28540,17 +28489,17 @@
                 },
                 "description": "A JSON:API document with a list of resources"
             },
-            "JsonApiExportTemplateInDocument": {
+            "JsonApiExportTemplatePostOptionalIdDocument": {
                 "required": ["data"],
                 "type": "object",
                 "properties": {
                     "data": {
-                        "$ref": "#/components/schemas/JsonApiExportTemplateIn"
+                        "$ref": "#/components/schemas/JsonApiExportTemplatePostOptionalId"
                     }
                 }
             },
-            "JsonApiExportTemplateIn": {
-                "required": ["attributes", "id", "type"],
+            "JsonApiExportTemplatePostOptionalId": {
+                "required": ["attributes", "type"],
                 "type": "object",
                 "properties": {
                     "type": {
@@ -28630,17 +28579,17 @@
                 },
                 "description": "JSON:API representation of exportTemplate entity."
             },
-            "JsonApiNotificationChannelInDocument": {
+            "JsonApiNotificationChannelPostOptionalIdDocument": {
                 "required": ["data"],
                 "type": "object",
                 "properties": {
                     "data": {
-                        "$ref": "#/components/schemas/JsonApiNotificationChannelIn"
+                        "$ref": "#/components/schemas/JsonApiNotificationChannelPostOptionalId"
                     }
                 }
             },
-            "JsonApiNotificationChannelIn": {
-                "required": ["id", "type"],
+            "JsonApiNotificationChannelPostOptionalId": {
+                "required": ["type"],
                 "type": "object",
                 "properties": {
                     "type": {
@@ -28714,167 +28663,6 @@
                     }
                 },
                 "description": "JSON:API representation of notificationChannel entity."
-            },
-            "JsonApiCookieSecurityConfigurationInDocument": {
-                "required": ["data"],
-                "type": "object",
-                "properties": {
-                    "data": {
-                        "$ref": "#/components/schemas/JsonApiCookieSecurityConfigurationIn"
-                    }
-                }
-            },
-            "JsonApiCookieSecurityConfigurationIn": {
-                "required": ["id", "type"],
-                "type": "object",
-                "properties": {
-                    "type": {
-                        "type": "string",
-                        "description": "Object type",
-                        "example": "cookieSecurityConfiguration",
-                        "enum": ["cookieSecurityConfiguration"]
-                    },
-                    "id": {
-                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
-                        "type": "string",
-                        "description": "API identifier of an object",
-                        "example": "id1"
-                    },
-                    "attributes": {
-                        "type": "object",
-                        "properties": {
-                            "lastRotation": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "rotationInterval": {
-                                "type": "string",
-                                "description": "Length of interval between automatic rotations expressed in format of ISO 8601 duration",
-                                "example": "P30D"
-                            }
-                        }
-                    }
-                },
-                "description": "JSON:API representation of cookieSecurityConfiguration entity."
-            },
-            "JsonApiOrganizationInDocument": {
-                "required": ["data"],
-                "type": "object",
-                "properties": {
-                    "data": {
-                        "$ref": "#/components/schemas/JsonApiOrganizationIn"
-                    }
-                }
-            },
-            "JsonApiOrganizationIn": {
-                "required": ["id", "type"],
-                "type": "object",
-                "properties": {
-                    "type": {
-                        "type": "string",
-                        "description": "Object type",
-                        "example": "organization",
-                        "enum": ["organization"]
-                    },
-                    "id": {
-                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
-                        "type": "string",
-                        "description": "API identifier of an object",
-                        "example": "id1"
-                    },
-                    "attributes": {
-                        "type": "object",
-                        "properties": {
-                            "name": {
-                                "maxLength": 255,
-                                "type": "string",
-                                "nullable": true
-                            },
-                            "hostname": {
-                                "maxLength": 255,
-                                "type": "string"
-                            },
-                            "allowedOrigins": {
-                                "type": "array",
-                                "items": {
-                                    "type": "string"
-                                }
-                            },
-                            "oauthIssuerLocation": {
-                                "maxLength": 255,
-                                "type": "string"
-                            },
-                            "oauthClientId": {
-                                "maxLength": 255,
-                                "type": "string"
-                            },
-                            "oauthClientSecret": {
-                                "maxLength": 255,
-                                "type": "string"
-                            },
-                            "earlyAccess": {
-                                "maxLength": 255,
-                                "type": "string",
-                                "description": "The early access feature identifier. It is used to enable experimental features. Deprecated in favor of earlyAccessValues.",
-                                "nullable": true,
-                                "deprecated": true
-                            },
-                            "earlyAccessValues": {
-                                "type": "array",
-                                "description": "The early access feature identifiers. They are used to enable experimental features.",
-                                "nullable": true,
-                                "items": {
-                                    "maxLength": 255,
-                                    "type": "string"
-                                }
-                            },
-                            "oauthIssuerId": {
-                                "maxLength": 255,
-                                "type": "string",
-                                "description": "Any string identifying the OIDC provider. This value is used as suffix for OAuth2 callback (redirect) URL. If not defined, the standard callback URL is used. This value is valid only for external OIDC providers, not for the internal DEX provider.",
-                                "example": "myOidcProvider"
-                            },
-                            "oauthSubjectIdClaim": {
-                                "maxLength": 255,
-                                "type": "string",
-                                "description": "Any string identifying the claim in ID token, that should be used for user identification. The default value is 'sub'.",
-                                "example": "oid"
-                            },
-                            "oauthCustomAuthAttributes": {
-                                "maxLength": 10000,
-                                "type": "object",
-                                "additionalProperties": {
-                                    "type": "string"
-                                },
-                                "description": "Map of additional authentication attributes that should be added to the OAuth2 authentication requests, where the key is the name of the attribute and the value is the value of the attribute."
-                            },
-                            "oauthCustomScopes": {
-                                "type": "array",
-                                "description": "List of additional OAuth scopes which may be required by other providers (e.g. Snowflake)",
-                                "nullable": true,
-                                "items": {
-                                    "maxLength": 255,
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    },
-                    "relationships": {
-                        "type": "object",
-                        "properties": {
-                            "identityProvider": {
-                                "required": ["data"],
-                                "type": "object",
-                                "properties": {
-                                    "data": {
-                                        "$ref": "#/components/schemas/JsonApiIdentityProviderToOneLinkage"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "JSON:API representation of organization entity."
             },
             "JsonApiAttributeOutDocument": {
                 "required": ["data"],
@@ -28953,6 +28741,220 @@
                         "items": {
                             "$ref": "#/components/schemas/JsonApiAttributeOutWithLinks"
                         }
+                    }
+                }
+            },
+            "JsonApiApiTokenOutWithLinks": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/JsonApiApiTokenOut"
+                    },
+                    {
+                        "$ref": "#/components/schemas/ObjectLinksContainer"
+                    }
+                ]
+            },
+            "JsonApiApiTokenOutList": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "uniqueItems": true,
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/JsonApiApiTokenOutWithLinks"
+                        }
+                    },
+                    "links": {
+                        "$ref": "#/components/schemas/ListLinks"
+                    },
+                    "meta": {
+                        "type": "object",
+                        "properties": {
+                            "page": {
+                                "$ref": "#/components/schemas/PageMetadata"
+                            }
+                        }
+                    }
+                },
+                "description": "A JSON:API document with a list of resources"
+            },
+            "JsonApiUserSettingOutWithLinks": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/JsonApiUserSettingOut"
+                    },
+                    {
+                        "$ref": "#/components/schemas/ObjectLinksContainer"
+                    }
+                ]
+            },
+            "JsonApiUserSettingOutList": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "uniqueItems": true,
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/JsonApiUserSettingOutWithLinks"
+                        }
+                    },
+                    "links": {
+                        "$ref": "#/components/schemas/ListLinks"
+                    },
+                    "meta": {
+                        "type": "object",
+                        "properties": {
+                            "page": {
+                                "$ref": "#/components/schemas/PageMetadata"
+                            }
+                        }
+                    }
+                },
+                "description": "A JSON:API document with a list of resources"
+            },
+            "JsonApiUserSettingInDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiUserSettingIn"
+                    }
+                }
+            },
+            "JsonApiUserSettingIn": {
+                "required": ["id", "type"],
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "description": "Object type",
+                        "example": "userSetting",
+                        "enum": ["userSetting"]
+                    },
+                    "id": {
+                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
+                        "type": "string",
+                        "description": "API identifier of an object",
+                        "example": "id1"
+                    },
+                    "attributes": {
+                        "type": "object",
+                        "properties": {
+                            "content": {
+                                "type": "object",
+                                "description": "Free-form JSON content. Maximum supported length is 15000 characters.",
+                                "example": {}
+                            },
+                            "type": {
+                                "type": "string",
+                                "enum": [
+                                    "TIMEZONE",
+                                    "ACTIVE_THEME",
+                                    "ACTIVE_COLOR_PALETTE",
+                                    "ACTIVE_LLM_ENDPOINT",
+                                    "WHITE_LABELING",
+                                    "LOCALE",
+                                    "METADATA_LOCALE",
+                                    "FORMAT_LOCALE",
+                                    "MAPBOX_TOKEN",
+                                    "WEEK_START",
+                                    "SHOW_HIDDEN_CATALOG_ITEMS",
+                                    "OPERATOR_OVERRIDES",
+                                    "TIMEZONE_VALIDATION_ENABLED",
+                                    "OPENAI_CONFIG",
+                                    "ENABLE_FILE_ANALYTICS",
+                                    "ALERT",
+                                    "SEPARATORS",
+                                    "DATE_FILTER_CONFIG",
+                                    "JIT_PROVISIONING",
+                                    "JWT_JIT_PROVISIONING",
+                                    "DASHBOARD_FILTERS_APPLY_MODE",
+                                    "ENABLE_SLIDES_EXPORT",
+                                    "AI_RATE_LIMIT",
+                                    "ATTACHMENT_SIZE_LIMIT",
+                                    "ATTACHMENT_LINK_TTL"
+                                ]
+                            }
+                        }
+                    }
+                },
+                "description": "JSON:API representation of userSetting entity."
+            },
+            "JsonApiApiTokenInDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiApiTokenIn"
+                    }
+                }
+            },
+            "JsonApiApiTokenIn": {
+                "required": ["id", "type"],
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "description": "Object type",
+                        "example": "apiToken",
+                        "enum": ["apiToken"]
+                    },
+                    "id": {
+                        "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
+                        "type": "string",
+                        "description": "API identifier of an object",
+                        "example": "id1"
+                    }
+                },
+                "description": "JSON:API representation of apiToken entity."
+            },
+            "JsonApiDataSourceIdentifierOutDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiDataSourceIdentifierOut"
+                    },
+                    "links": {
+                        "$ref": "#/components/schemas/ObjectLinks"
+                    }
+                }
+            },
+            "JsonApiEntitlementOutDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiEntitlementOut"
+                    },
+                    "links": {
+                        "$ref": "#/components/schemas/ObjectLinks"
+                    }
+                }
+            },
+            "JsonApiNotificationChannelIdentifierOutDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiNotificationChannelIdentifierOut"
+                    },
+                    "links": {
+                        "$ref": "#/components/schemas/ObjectLinks"
+                    }
+                }
+            },
+            "JsonApiUserIdentifierOutDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiUserIdentifierOut"
+                    },
+                    "links": {
+                        "$ref": "#/components/schemas/ObjectLinks"
                     }
                 }
             },
@@ -33611,6 +33613,15 @@
             }
         },
         "parameters": {
+            "idPathParameter": {
+                "name": "id",
+                "in": "path",
+                "required": true,
+                "schema": {
+                    "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
+                    "type": "string"
+                }
+            },
             "page": {
                 "name": "page",
                 "in": "query",
@@ -33638,15 +33649,6 @@
                     "items": {
                         "type": "string"
                     }
-                }
-            },
-            "idPathParameter": {
-                "name": "id",
-                "in": "path",
-                "required": true,
-                "schema": {
-                    "pattern": "^(?!\\.)[.A-Za-z0-9_-]{1,255}$",
-                    "type": "string"
                 }
             }
         }

--- a/libs/sdk-backend-tiger/src/convertors/fromBackend/afm/FilterConverter.ts
+++ b/libs/sdk-backend-tiger/src/convertors/fromBackend/afm/FilterConverter.ts
@@ -1,4 +1,4 @@
-// (C) 2024 GoodData Corporation
+// (C) 2024-2025 GoodData Corporation
 
 import {
     FilterDefinition,
@@ -96,12 +96,19 @@ export const convertFilter = (filter: FilterDefinition): IFilter => {
             },
         };
     } else if (isRelativeDateFilter(filter)) {
+        const { from, to } = filter.relativeDateFilter;
+        // After the backend enabled `from` and `to` to be optional, we need to handle the case
+        // where some is missing for now. It was agreed to replace the missing value with
+        // the present value instead of 0. This can be removed once we also start using optional bounds.
+        const effectiveFrom = from ?? to ?? 0;
+        const effectiveTo = to ?? from ?? 0;
+
         return {
             relativeDateFilter: {
                 dataSet: toObjRef(filter.relativeDateFilter.dataset),
                 localIdentifier: filter.relativeDateFilter.localIdentifier,
-                from: filter.relativeDateFilter.from,
-                to: filter.relativeDateFilter.to,
+                from: effectiveFrom,
+                to: effectiveTo,
                 granularity: toSdkGranularity(filter.relativeDateFilter.granularity),
             },
         };


### PR DESCRIPTION
- relative date filter bounds are now nullable

risk: low

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```

#### Commands for Bear platform working on branch rel/9.9

```
extended-test-legacy --backstop
extended-test-legacy --isolated
extended-test-legacy --record
```
