### PR TITLE
fix: make the last column drop zone take all the remaining space

### DIFF
--- a/common/changes/@gooddata/sdk-ui-all/pdo-lx-1283-heigh-dropzone_2025-07-07-14-12.json
+++ b/common/changes/@gooddata/sdk-ui-all/pdo-lx-1283-heigh-dropzone_2025-07-07-14-12.json
@@ -1,0 +1,10 @@
+{
+    "changes": [
+        {
+            "packageName": "@gooddata/sdk-ui-all",
+            "comment": "Make the last column drop zone in flexible layouts take all the remaining space of the column.",
+            "type": "none"
+        }
+    ],
+    "packageName": "@gooddata/sdk-ui-all"
+}

--- a/libs/sdk-ui-dashboard/src/presentation/flexibleLayout/DefaultDashboardLayoutRenderer/GridLayoutElement.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/flexibleLayout/DefaultDashboardLayoutRenderer/GridLayoutElement.tsx
@@ -1,6 +1,6 @@
 // (C) 2024-2025 GoodData Corporation
 
-import React, { CSSProperties, MouseEventHandler, forwardRef } from "react";
+import React, { CSSProperties, MouseEventHandler, forwardRef, useMemo } from "react";
 import cx from "classnames";
 import { IDashboardLayoutSizeByScreenSize } from "@gooddata/sdk-model";
 
@@ -73,10 +73,13 @@ export const GridLayoutElement = forwardRef<HTMLDivElement, IGridLayoutElementPr
             `gd-grid-layout__item--span-${validWidth}`, // CSS Grid columns size class name
             className,
         );
-        const sanitizedStyle = {
-            ...style,
-            ...exportStyles,
-        };
+        const sanitizedStyle = useMemo(
+            () => ({
+                ...style,
+                ...exportStyles,
+            }),
+            [style, exportStyles],
+        );
 
         return type === "section" ? (
             <section

--- a/libs/sdk-ui-dashboard/src/presentation/flexibleLayout/dragAndDrop/draggableWidget/RowEndHotspot.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/flexibleLayout/dragAndDrop/draggableWidget/RowEndHotspot.tsx
@@ -3,7 +3,7 @@ import { IDashboardWidget } from "@gooddata/sdk-model";
 import cx from "classnames";
 import React, { useMemo } from "react";
 
-import { isCustomWidget } from "../../../../model/index.js";
+import { isCustomWidget, ExtendedDashboardWidget } from "../../../../model/index.js";
 import {
     IDashboardLayoutItemFacade,
     DASHBOARD_LAYOUT_GRID_COLUMNS_COUNT,
@@ -11,13 +11,17 @@ import {
 import { updateItem } from "../../../../_staging/layout/coordinates.js";
 import { useScreenSize } from "../../../dashboard/components/DashboardScreenSizeContext.js";
 import { GridLayoutElement } from "../../DefaultDashboardLayoutRenderer/GridLayoutElement.js";
-import { getRemainingWidthInRow } from "../../rowEndHotspotHelper.js";
+import { getRemainingWidthInRow, useRemainingHeightInColumn } from "../../rowEndHotspotHelper.js";
 import { getLayoutConfiguration } from "../../../../_staging/dashboard/flexibleLayout/layoutConfiguration.js";
+import { getDashboardLayoutItemHeight } from "../../../../_staging/layout/sizing.js";
 
 import { WidgetDropZoneColumn } from "./WidgetDropZoneColumn.js";
 import { Hotspot } from "./Hotspot.js";
 
-export const useShouldShowRowEndHotspot = (item: IDashboardLayoutItemFacade<unknown>, rowIndex: number) => {
+export const useShouldShowRowEndHotspot = (
+    item: IDashboardLayoutItemFacade<ExtendedDashboardWidget | unknown>,
+    rowIndex: number,
+) => {
     const screen = useScreenSize();
     const remainingRowGridWidth = useMemo(
         () => (isCustomWidget(item.widget()) ? 0 : getRemainingWidthInRow(item, screen, rowIndex)),
@@ -33,9 +37,15 @@ export const useShouldShowRowEndHotspot = (item: IDashboardLayoutItemFacade<unkn
         ? item.section().layout().size()?.gridWidth ?? DASHBOARD_LAYOUT_GRID_COLUMNS_COUNT
         : remainingRowGridWidth;
 
+    const remainingColumnGridHeight = useRemainingHeightInColumn(item, isLastInColumn);
+
     return {
-        enableRowEndHotspot: isLastInColumn || (showEndingHotspot && isDropZoneVisible),
+        // Column dropzone is styled to have at least 40 px; therefore, we should not show it when there is
+        // no space for it. If there is less space, a single line drop zone is rendered instead.
+        enableRowEndHotspot:
+            (isLastInColumn && remainingColumnGridHeight > 1) || (showEndingHotspot && isDropZoneVisible),
         remainingRowGridWidth: hotZoneWidth,
+        remainingColumnGridHeight,
     };
 };
 
@@ -44,46 +54,71 @@ export type RowEndHotspotProps<TWidget = IDashboardWidget> = {
     rowIndex: number;
 };
 
-export const RowEndHotspot = ({ item, rowIndex }: RowEndHotspotProps<unknown>) => {
-    const { enableRowEndHotspot, remainingRowGridWidth } = useShouldShowRowEndHotspot(item, rowIndex);
+export const RowEndHotspot = ({ item, rowIndex }: RowEndHotspotProps<ExtendedDashboardWidget | unknown>) => {
+    const { enableRowEndHotspot, remainingRowGridWidth, remainingColumnGridHeight } =
+        useShouldShowRowEndHotspot(item, rowIndex);
     const { direction } = getLayoutConfiguration(item.section().layout().raw());
+
+    // hide text if the dropzone is too small to render the text
+    const hideDropzoneText =
+        (direction === "row" && remainingRowGridWidth < 2) ||
+        (direction === "column" && remainingColumnGridHeight < 7);
+
+    const layoutItemSize = useMemo(() => {
+        const gridHeightProp = remainingColumnGridHeight > 0 ? { gridHeight: remainingColumnGridHeight } : {};
+        return {
+            xl: {
+                gridWidth: remainingRowGridWidth,
+                ...gridHeightProp,
+            },
+        };
+    }, [remainingRowGridWidth, remainingColumnGridHeight]);
+
+    const layoutPathForEndHotspot = useMemo(() => {
+        const layoutPath = item.index();
+        return updateItem(
+            layoutPath,
+            layoutPath[layoutPath.length - 1].sectionIndex,
+            layoutPath[layoutPath.length - 1].itemIndex + 1,
+        ); // increment item index manually as end hotspot is rendered as prev type
+    }, [item]);
+
+    const style: React.CSSProperties = useMemo(() => {
+        const computedHeight = getDashboardLayoutItemHeight(layoutItemSize.xl);
+        return computedHeight === undefined ? {} : { height: computedHeight };
+    }, [layoutItemSize]);
 
     if (!enableRowEndHotspot) {
         return null;
     }
 
-    const layoutPath = item.index();
-    const layoutPathForEndHotspot = updateItem(
-        layoutPath,
-        layoutPath[layoutPath.length - 1].sectionIndex,
-        layoutPath[layoutPath.length - 1].itemIndex + 1,
-    ); // increment item index manually as end hotspot is rendered as prev type
-
     return (
         <>
             <GridLayoutElement
                 type="item"
-                layoutItemSize={{
-                    xl: { gridWidth: remainingRowGridWidth },
-                    lg: { gridWidth: remainingRowGridWidth },
-                    md: { gridWidth: remainingRowGridWidth },
-                    sm: { gridWidth: remainingRowGridWidth },
-                    xs: { gridWidth: remainingRowGridWidth },
-                }}
+                layoutItemSize={layoutItemSize}
                 className={cx(
                     "gd-fluidlayout-column",
                     "gd-fluidlayout-column-dropzone",
                     "s-fluid-layout-column",
                     "gd-fluidlayout-column-row-end-hotspot",
                     {
-                        "gd-fluidlayout-column-dropzone__text--hidden": remainingRowGridWidth < 2,
+                        "gd-fluidlayout-column-dropzone__text--hidden": hideDropzoneText,
                         "gd-first-container-row-dropzone": rowIndex === 0,
+                        "gd-fluidlayout-column-row-end-hotspot--direction-row": direction === "row",
+                        "gd-fluidlayout-column-row-end-hotspot--direction-column": direction === "column",
+                        [`s-fluid-layout-column-height-${remainingColumnGridHeight}`]:
+                            remainingColumnGridHeight > 0,
                     },
                 )}
+                style={style}
             >
                 <WidgetDropZoneColumn
                     layoutPath={layoutPathForEndHotspot}
                     gridWidthOverride={remainingRowGridWidth}
+                    gridHeightOverride={
+                        remainingColumnGridHeight === 0 ? undefined : remainingColumnGridHeight
+                    }
                     isLastInSection={true}
                 />
                 <Hotspot

--- a/libs/sdk-ui-dashboard/src/presentation/flexibleLayout/rowEndHotspotHelper.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/flexibleLayout/rowEndHotspotHelper.ts
@@ -1,9 +1,14 @@
 // (C) 2022-2025 GoodData Corporation
 
+import { useMemo } from "react";
 import { ScreenSize } from "@gooddata/sdk-model";
 
 import { DASHBOARD_LAYOUT_GRID_COLUMNS_COUNT } from "../../_staging/dashboard/flexibleLayout/config.js";
 import { IDashboardLayoutItemFacade } from "../../_staging/dashboard/flexibleLayout/index.js";
+import { getContainerHeight } from "../../_staging/layout/sizing.js";
+import { useDashboardSelector, selectSettings, ExtendedDashboardWidget } from "../../model/index.js";
+import { useScreenSize } from "../dashboard/components/DashboardScreenSizeContext.js";
+import { useDashboardItemPathAndSize } from "../dashboard/components/DashboardItemPathAndSizeContext.js";
 
 export function getRemainingWidthInRow(
     item: IDashboardLayoutItemFacade<unknown>,
@@ -17,4 +22,29 @@ export function getRemainingWidthInRow(
         0,
     );
     return parentWidth - lastRowLength;
+}
+
+export function useRemainingHeightInColumn(
+    item: IDashboardLayoutItemFacade<ExtendedDashboardWidget | unknown>,
+    isLastInColumn: boolean,
+): number {
+    const screen = useScreenSize();
+    const settings = useDashboardSelector(selectSettings);
+    const { layoutItem } = useDashboardItemPathAndSize();
+
+    // Do not count the remaining height of the column for each row in the column, just the last.
+    return useMemo(() => {
+        if (!isLastInColumn) {
+            return 0;
+        }
+
+        const container = layoutItem?.raw();
+        const containerContentHeight = getContainerHeight(container!, screen, settings);
+
+        const parentHeight = item.section().layout().size()?.gridHeight ?? 0;
+        const remainingHeight = parentHeight - containerContentHeight;
+
+        // sanitize for possible negative values caused by wrong metadata
+        return remainingHeight > 0 ? remainingHeight : 0;
+    }, [item, isLastInColumn, layoutItem, screen, settings]);
 }

--- a/libs/sdk-ui-dashboard/styles/scss/dashboardNestedLayoutWidget.scss
+++ b/libs/sdk-ui-dashboard/styles/scss/dashboardNestedLayoutWidget.scss
@@ -7,7 +7,7 @@
 .gd-dashboard-nested-layout-widget {
     .gd-dashboard-nested-layout-content.dash-item-content {
         border-radius: 0;
-        padding: 19px 10px 18px 10px;
+        padding: 19px 10px 15px 10px;
     }
     & .is-selectable {
         &.gd-dashboard-nested-layout-content.dash-item-content:not(.is-selected):hover,
@@ -195,7 +195,8 @@
             height: 50%;
 
             &#{$dropzoneRoot}--full {
-                width: 50%;
+                width: 100%;
+                height: 100%;
             }
         }
 

--- a/libs/sdk-ui-dashboard/styles/scss/dragAndDrop.scss
+++ b/libs/sdk-ui-dashboard/styles/scss/dragAndDrop.scss
@@ -767,6 +767,12 @@
         padding: 10px;
     }
 
+    .gd-fluidlayout-column-dropzone__text--hidden {
+        .drop-target-inner {
+            padding: 4px;
+        }
+    }
+
     .drop-target-message {
         position: unset;
         top: unset;
@@ -828,15 +834,25 @@
 
     .gd-fluidlayout-column-row-end-hotspot {
         min-height: unset;
+
         .widget-dropzone-box {
             padding: 10px 0;
         }
+
         .drag-info-placeholder-inner {
             padding: 0;
         }
+
+        &.gd-fluidlayout-column-row-end-hotspot--direction-column.gd-fluidlayout-column-dropzone__text--hidden {
+            .widget-dropzone-box {
+                padding: 0;
+            }
+        }
+
         &.gd-first-container-row-dropzone .widget-dropzone-box {
             padding-top: 0;
         }
+
         .drag-info-placeholder-drop-target,
         .drop-target-inner {
             position: unset;

--- a/libs/sdk-ui-tests-e2e/cypress/tools/enum/DropZone.ts
+++ b/libs/sdk-ui-tests-e2e/cypress/tools/enum/DropZone.ts
@@ -7,7 +7,7 @@ export const enum DropZone {
 }
 
 export const enum WidgetDropZone {
-    PREV = ".dropzone.prev,.gd-grid-layout-dropzone.prev",
-    NEXT = ".dropzone.next,.gd-grid-layout-dropzone.next",
+    PREV = ".dropzone.prev,.s-dropzone-prev",
+    NEXT = ".dropzone.next,.s-dropzone-next",
     LAST = ".s-last-drop-position",
 }


### PR DESCRIPTION
JIRA: LX-1283
risk: low<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```

#### Commands for Bear platform working on branch rel/9.9

```
extended-test-legacy --backstop
extended-test-legacy --isolated
extended-test-legacy --record
```
