### PR TITLE
fix: disable save button and fresh init

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/components/Attachments/AttachmentsList.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/components/Attachments/AttachmentsList.tsx
@@ -39,6 +39,11 @@ export function AttachmentsList<T extends WidgetAttachmentType | DashboardAttach
     const intl = useIntl();
     const [mergeHeaders, setMergeHeaders] = useState(xlsxSettings.mergeHeaders ?? true);
     const [exportInfo, setExportInfo] = useState(xlsxSettings.exportInfo ?? true);
+
+    const isSettingsDirty =
+        mergeHeaders !== (xlsxSettings.mergeHeaders ?? true) ||
+        exportInfo !== (xlsxSettings.exportInfo ?? true);
+
     return (
         <>
             {attachments.map((attachment) => (
@@ -54,6 +59,12 @@ export function AttachmentsList<T extends WidgetAttachmentType | DashboardAttach
                             overlayPositionType={OVERLAY_POSITION_TYPE}
                             alignPoints={DROPDOWN_ALIGN_POINTS}
                             autofocusOnOpen={true}
+                            onOpenStateChanged={(isOpen) => {
+                                if (!isOpen) {
+                                    setMergeHeaders(xlsxSettings.mergeHeaders ?? true);
+                                    setExportInfo(xlsxSettings.exportInfo ?? true);
+                                }
+                            }}
                             renderButton={({ toggleDropdown, buttonRef }) => (
                                 <button
                                     className="gd-attachment-chip-button"
@@ -130,6 +141,7 @@ export function AttachmentsList<T extends WidgetAttachmentType | DashboardAttach
                                                 });
                                                 closeDropdown();
                                             }}
+                                            disabled={!isSettingsDirty}
                                         />
                                     </div>
                                 </div>

--- a/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/components/Attachments/DashboardAttachments.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/components/Attachments/DashboardAttachments.tsx
@@ -67,7 +67,6 @@ export const DashboardAttachments = ({
                     mode="dashboard"
                 />
                 <AttachmentsSelect<DashboardAttachmentType>
-                    key={selectedAttachments.join()}
                     attachments={SUPPORTED_DASHBOARD_ATTACHMENTS.map((format) => ({
                         type: format,
                         selected: selectedAttachments.includes(format),

--- a/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/components/Attachments/WidgetAttachments.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/components/Attachments/WidgetAttachments.tsx
@@ -58,7 +58,6 @@ export const WidgetAttachments = ({
                     mode="widget"
                 />
                 <AttachmentsSelect<WidgetAttachmentType>
-                    key={selectedAttachments.join()}
                     attachments={SUPPORTED_WIDGET_ATTACHMENTS.map((format) => ({
                         type: format,
                         selected: selectedAttachments.includes(format),


### PR DESCRIPTION
changes:
- disable buttons when no changes made
- anchor attachment select dialog to trigger and close on scroll
- init dialogs (attachments/settings) with current data (by reverting to original on close)

risk: low
JIRA: F1-1555

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```

#### Commands for Bear platform working on branch rel/9.9

```
extended-test-legacy --backstop
extended-test-legacy --isolated
extended-test-legacy --record
```
