### PR TITLE
fix: consider also parent when evaluating minimal width of children

### DIFF
--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/layout/containerWidthSanitization.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/layout/containerWidthSanitization.ts
@@ -1,10 +1,21 @@
 // (C) 2025 GoodData Corporation
 
-import { IDashboardLayout, ScreenSize, IInsight, ISettings, isDashboardLayout } from "@gooddata/sdk-model";
+import {
+    IDashboardLayout,
+    ScreenSize,
+    IInsight,
+    ISettings,
+    isDashboardLayout,
+    IDashboardLayoutContainerDirection,
+} from "@gooddata/sdk-model";
 
 import { ExtendedDashboardWidget, IItemWithWidth } from "../../types/layoutTypes.js";
 import { findItem } from "../../../_staging/layout/coordinates.js";
-import { implicitLayoutItemSizeFromXlSize, getMinWidth } from "../../../_staging/layout/sizing.js";
+import {
+    implicitLayoutItemSizeFromXlSize,
+    getMinWidth,
+    determineWidthForScreen,
+} from "../../../_staging/layout/sizing.js";
 import { ILayoutItemPath } from "../../../types.js";
 import { getLayoutConfiguration } from "../../../_staging/dashboard/flexibleLayout/layoutConfiguration.js";
 import { ObjRefMap } from "../../../_staging/metadata/objRefMap.js";
@@ -62,6 +73,7 @@ export function getChildWidgetLayoutPathsWithMinWidths(
     settings: ISettings,
     insightMap: ObjRefMap<IInsight>,
     screen: ScreenSize,
+    parentDirection: IDashboardLayoutContainerDirection,
 ): IItemWithWidth[] {
     return layout.sections.flatMap((section, sectionIndex) =>
         section.items.flatMap((item, itemIndex) => {
@@ -69,23 +81,29 @@ export function getChildWidgetLayoutPathsWithMinWidths(
             if (item.widget === undefined) {
                 return [];
             }
+
             if (isDashboardLayout(item.widget) && getLayoutDirection(item.widget) === "column") {
                 // For nested layouts with a column direction, process children recursively and include
                 // the container itself
+                const containerMinWidth = getMinWidth(item.widget, insightMap, screen, settings, "column");
                 const childItems = getChildWidgetLayoutPathsWithMinWidths(
                     item.widget,
                     currentPath,
                     settings,
                     insightMap,
                     screen,
+                    "column",
                 );
-                const containerMinWidth = getMinWidth(item.widget, insightMap, screen, settings, "column");
+
                 return [...childItems, { itemPath: currentPath, width: containerMinWidth }];
             } else {
                 // For other widgets (including nested layouts with a row direction, layout will never be
-                // a column at this point), return their path and minimum default width.
+                // a column at this point), return their path and minimum default width or
+                // current width when they are inside of column group (= stretched and can not be smaller).
                 const minWidth = getMinWidth(item.widget, insightMap, screen, settings, "row");
-                return [{ itemPath: currentPath, width: minWidth }];
+                const currentWidth = determineWidthForScreen(screen, item.size);
+                const width = parentDirection === "column" ? currentWidth : minWidth;
+                return [{ itemPath: currentPath, width }];
             }
         }),
     );

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/layout/toggleLayoutDirectionHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/layout/toggleLayoutDirectionHandler.ts
@@ -39,7 +39,14 @@ function findChildItemsWithNewWidth(
 
     if (isDashboardLayoutItem(parent) && isDashboardLayout(parent.widget)) {
         return direction === "row"
-            ? getChildWidgetLayoutPathsWithMinWidths(parent.widget, parentPath, settings, insightMap, screen)
+            ? getChildWidgetLayoutPathsWithMinWidths(
+                  parent.widget,
+                  parentPath,
+                  settings,
+                  insightMap,
+                  screen,
+                  direction,
+              )
             : getChildWidgetLayoutPaths(parent.widget, parentPath).map((itemPath) => ({
                   itemPath,
                   width: parent.size.xl.gridWidth,


### PR DESCRIPTION
JIRA: LX-1292
risk: low

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```

#### Commands for Bear platform working on branch rel/9.9

```
extended-test-legacy --backstop
extended-test-legacy --isolated
extended-test-legacy --record
```
