### PR TITLE
fix: input question field isn't auto-focused after re-opening.

### DIFF
--- a/libs/sdk-ui-gen-ai/src/components/Input.tsx
+++ b/libs/sdk-ui-gen-ai/src/components/Input.tsx
@@ -1,5 +1,5 @@
 // (C) 2024-2025 GoodData Corporation
-import React, { ReactNode, useEffect, useMemo, useRef, useState } from "react";
+import React, { ReactNode, useEffect, useMemo, useReducer, useRef, useState } from "react";
 import cx from "classnames";
 import { connect } from "react-redux";
 import { defineMessages, FormattedMessage, injectIntl } from "react-intl";
@@ -75,6 +75,7 @@ const InputComponent: React.FC<
 
     // Force focus when autofocus is enables on the first mount, right after the initial state is loaded
     const forceFocusOnce = useRef<boolean>(autofocus);
+    const [updates, update] = useReducer((x) => x + 1, 0);
     useEffect(() => {
         // Autofocus the textarea when the chat is not disabled and the user is not focusing on another element
         // Important, given the disabled states changes depending on the agent's loading state
@@ -84,10 +85,14 @@ const InputComponent: React.FC<
         }
         const makeFocus = forceFocusOnce.current || document.activeElement === document.body;
         if (makeFocus) {
-            editorApi.focus();
-            forceFocusOnce.current = document.activeElement !== editorApi.contentDOM;
+            if (!editorApi.inView) {
+                update();
+            } else {
+                editorApi.focus();
+                forceFocusOnce.current = document.activeElement !== editorApi.contentDOM;
+            }
         }
-    }, [isBusy, editorApi]);
+    }, [isBusy, editorApi, updates]);
     useEffect(
         () => () => {
             forceFocusOnce.current = true;


### PR DESCRIPTION
risk: low
JIRA: GDAI-464

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```

#### Commands for Bear platform working on branch rel/9.9

```
extended-test-legacy --backstop
extended-test-legacy --isolated
extended-test-legacy --record
```
