### PR TITLE
fix: render row end hotspot only when a widget is dragged to fix the row height resizer offset

### DIFF
--- a/common/changes/@gooddata/sdk-ui-all/pdo-lx-1251-allow-resize-of-row-container_2025-07-10-13-14.json
+++ b/common/changes/@gooddata/sdk-ui-all/pdo-lx-1251-allow-resize-of-row-container_2025-07-10-13-14.json
@@ -1,0 +1,10 @@
+{
+    "changes": [
+        {
+            "packageName": "@gooddata/sdk-ui-all",
+            "comment": "fix(sdk-ui-dashboard): documentation link displayed in tooltip shown over the new Column container item of dashboard leads to the related part of documentation page now",
+            "type": "none"
+        }
+    ],
+    "packageName": "@gooddata/sdk-ui-all"
+}

--- a/common/changes/@gooddata/sdk-ui-all/pdo-lx-1251-allow-resize-of-row-container_2025-07-10-13-19.json
+++ b/common/changes/@gooddata/sdk-ui-all/pdo-lx-1251-allow-resize-of-row-container_2025-07-10-13-19.json
@@ -1,0 +1,10 @@
+{
+    "changes": [
+        {
+            "packageName": "@gooddata/sdk-ui-all",
+            "comment": "fix(sdk-ui-dashboard): render row end hotspot only when a widget is dragged to fix the row height resizer offset in the column container",
+            "type": "none"
+        }
+    ],
+    "packageName": "@gooddata/sdk-ui-all"
+}

--- a/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/AddDashboardLayoutWidgetButton.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/AddDashboardLayoutWidgetButton.tsx
@@ -29,35 +29,29 @@ export const AddDashboardLayoutWidgetButton: React.FC = () => {
     return (
         <div className="add-item-placeholder add-panel-item s-add-dashboard-layout">
             <Icon.ColumnContainer color={theme?.palette?.complementary?.c6 ?? "#94a1ad"} />
-            <div className={"add-panel-item__text"}>
+            <div className="add-panel-item__text">
                 <FormattedMessage id="addPanel.dashboardLayout" />
                 <OverlayControllerProvider overlayController={overlayController}>
                     <UiTooltip
-                        arrowPlacement={"left"}
+                        arrowPlacement="left"
                         content={
                             <div className={tooltipBem.b()}>
                                 <div className={tooltipBem.e("image")} />
-
                                 <div className={tooltipBem.e("text")}>
                                     <FormattedMessage id="addPanel.dashboardLayout.tooltip" />
                                 </div>
-
-                                <div className={tooltipBem.e("actions")}>
-                                    {!isWhiteLabeled ? (
+                                {isWhiteLabeled ? null : (
+                                    <div className={tooltipBem.e("actions")}>
                                         <UiLink
-                                            variant={"inverse"}
-                                            rel={"noreferrer noopener"}
-                                            target={"_blank"}
-                                            href={
-                                                "https://www.gooddata.com/docs/cloud/create-dashboards/dashboard-layout/"
-                                            }
+                                            variant="inverse"
+                                            rel="noreferrer noopener"
+                                            target="_blank"
+                                            href="https://www.gooddata.com/docs/cloud/create-dashboards/dashboard-layout/#column-container"
                                         >
-                                            <FormattedMessage
-                                                id={"addPanel.dashboardLayout.tooltip.learnMore"}
-                                            />
+                                            <FormattedMessage id="addPanel.dashboardLayout.tooltip.learnMore" />
                                         </UiLink>
-                                    ) : null}
-                                </div>
+                                    </div>
+                                )}
                             </div>
                         }
                         anchor={

--- a/libs/sdk-ui-dashboard/src/presentation/flexibleLayout/dragAndDrop/draggableWidget/RowEndHotspot.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/flexibleLayout/dragAndDrop/draggableWidget/RowEndHotspot.tsx
@@ -21,6 +21,7 @@ import { getRemainingWidthInRow, getRemainingHeightInColumn } from "../../rowEnd
 import { getLayoutConfiguration } from "../../../../_staging/dashboard/flexibleLayout/layoutConfiguration.js";
 import { getDashboardLayoutItemHeight } from "../../../../_staging/layout/sizing.js";
 import { useDashboardItemPathAndSize } from "../../../dashboard/components/DashboardItemPathAndSizeContext.js";
+import { useIsDraggingWidget } from "../../../dragAndDrop/index.js";
 
 import { WidgetDropZoneColumn } from "./WidgetDropZoneColumn.js";
 import { Hotspot } from "./Hotspot.js";
@@ -70,6 +71,7 @@ export type RowEndHotspotProps<TWidget = IDashboardWidget> = {
 };
 
 export const RowEndHotspot = ({ item, rowIndex }: RowEndHotspotProps<ExtendedDashboardWidget | unknown>) => {
+    const isDraggingWidget = useIsDraggingWidget();
     const { enableRowEndHotspot, gridWidth, gridHeight, hideDropzoneText } = useShouldShowRowEndHotspot(
         item,
         rowIndex,
@@ -100,7 +102,7 @@ export const RowEndHotspot = ({ item, rowIndex }: RowEndHotspotProps<ExtendedDas
         return computedHeight === undefined ? {} : { height: computedHeight };
     }, [layoutItemSize]);
 
-    if (!enableRowEndHotspot) {
+    if (!enableRowEndHotspot || !isDraggingWidget) {
         return null;
     }
 


### PR DESCRIPTION
JIRA: DP-3197
risk: low<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```

#### Commands for Bear platform working on branch rel/9.9

```
extended-test-legacy --backstop
extended-test-legacy --isolated
extended-test-legacy --record
```
