### PR TITLE
fix: remove obsolete UiMenu props

### DIFF
--- a/common/changes/@gooddata/sdk-ui-all/ine-lx-1328_2025-07-11-10-48.json
+++ b/common/changes/@gooddata/sdk-ui-all/ine-lx-1328_2025-07-11-10-48.json
@@ -1,0 +1,10 @@
+{
+    "changes": [
+        {
+            "packageName": "@gooddata/sdk-ui-all",
+            "comment": "remove obsolete UiMenu props ",
+            "type": "none"
+        }
+    ],
+    "packageName": "@gooddata/sdk-ui-all"
+}

--- a/libs/sdk-ui-dashboard/src/presentation/drill/DrillSelect/DrillSelectDropdown.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/drill/DrillSelect/DrillSelectDropdown.tsx
@@ -187,7 +187,8 @@ export const DrillSelectDropdown: React.FC<DrillSelectDropdownProps> = ({
                             shouldCloseOnSelect={false}
                             onClose={onClose}
                             onUnhandledKeyDown={handleKeyDown}
-                            className="gd-drill-modal-picker-body"
+                            maxHeight={160}
+                            containerBottomPadding="medium"
                             ariaAttributes={{
                                 id: "drill-select-menu",
                                 "aria-label": intl.formatMessage({ id: "drill_modal_picker.label" }),

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insightMenu/DefaultDashboardInsightMenu/DashboardInsightMenu/index.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insightMenu/DefaultDashboardInsightMenu/DashboardInsightMenu/index.tsx
@@ -8,7 +8,7 @@ import {
     separatorStaticItem,
     UiFocusManager,
 } from "@gooddata/sdk-ui-kit";
-import cx from "classnames";
+
 import {
     IDashboardInsightMenuProps,
     IInsightMenuSubmenu,
@@ -133,15 +133,19 @@ export const DashboardInsightMenuBody: React.FC<
     const menuId = `insight-menu-${widgetRefAsString}`;
     const menuLabelId = `${menuId}-label`;
 
-    const menuClassName = (context: IUiMenuContext<IMenuItemData, unknown>) => {
-        return cx("insight-configuration-menu", getSelectedMenuId(context));
+    const getMaxHeight = (context: IUiMenuContext<IMenuItemData, unknown>) => {
+        if (getSelectedMenuId(context) === "Alerts") {
+            return 500;
+        }
+        return 350;
     };
 
     return (
         <UiFocusManager enableAutofocus={{ initialFocus: menuId }} enableFocusTrap enableReturnFocusOnUnmount>
             <DashboardInsightMenuContainer>
                 <UiMenu<IMenuItemData, IMenuData>
-                    className={menuClassName}
+                    maxHeight={getMaxHeight}
+                    containerBottomPadding="small"
                     items={uiMenuItems}
                     onClose={onClose}
                     InteractiveItem={CustomUiMenuInteractiveItemComponent}

--- a/libs/sdk-ui-kit/api/sdk-ui-kit.api.md
+++ b/libs/sdk-ui-kit/api/sdk-ui-kit.api.md
@@ -6049,18 +6049,18 @@ export function UiMenu<T extends IUiMenuItemData = object, M extends object = ob
 export interface UiMenuProps<T extends IUiMenuItemData = object, M = object> extends Partial<IUiMenuPluggableComponents<T>> {
     // (undocumented)
     ariaAttributes: Omit<IDropdownBodyRenderProps["ariaAttributes"], "role">;
-    // @deprecated (undocumented)
-    className?: ((context: IUiMenuContext<T>) => string | undefined) | string;
+    // (undocumented)
+    containerBottomPadding?: "none" | "small" | "medium";
     // (undocumented)
     dataTestId?: ((context: IUiMenuContext<T>) => string | undefined) | string;
     // (undocumented)
     isDisabledFocusable?: boolean;
-    // @deprecated (undocumented)
-    itemClassName?: ((item: IUiMenuItem<T>) => string | undefined) | string;
     // (undocumented)
     itemDataTestId?: ((item: IUiMenuItem<T>) => string | undefined) | string;
     // (undocumented)
     items: IUiMenuItem<T>[];
+    // (undocumented)
+    maxHeight?: ((context: IUiMenuContext<T>) => number | undefined) | number;
     // (undocumented)
     maxWidth?: number;
     // (undocumented)

--- a/libs/sdk-ui-kit/src/@ui/UiMenu/UiMenu.scss
+++ b/libs/sdk-ui-kit/src/@ui/UiMenu/UiMenu.scss
@@ -19,6 +19,14 @@
         height: 100%;
         overflow-y: auto;
         overflow-x: hidden;
+
+        &--container-bottom-padding-small {
+            padding-bottom: 8px;
+        }
+
+        &--container-bottom-padding-medium {
+            padding-bottom: 10px;
+        }
     }
 
     @media #{variables.$small-only} {

--- a/libs/sdk-ui-kit/src/@ui/UiMenu/UiMenu.tsx
+++ b/libs/sdk-ui-kit/src/@ui/UiMenu/UiMenu.tsx
@@ -31,13 +31,14 @@ export function UiMenu<T extends IUiMenuItemData = object, M extends object = ob
     props: UiMenuProps<T, M>,
 ): React.ReactNode {
     const {
-        className,
         dataTestId,
         maxWidth,
+        maxHeight,
         ariaAttributes,
         onUnhandledKeyDown,
         shouldKeyboardActionPreventDefault,
         shouldKeyboardActionStopPropagation,
+        containerBottomPadding = "none",
     } = props;
 
     const menuComponentRef = React.useRef<HTMLMenuElement>(null);
@@ -85,14 +86,14 @@ export function UiMenu<T extends IUiMenuItemData = object, M extends object = ob
         }
     }, [shownCustomContentItemId, menuComponentRef]);
 
-    const menuClassName = typeof className === "function" ? className(contextStoreValue) : className;
     const menuDataTestId = typeof dataTestId === "function" ? dataTestId(contextStoreValue) : dataTestId;
+    const maxHeightValue = typeof maxHeight === "function" ? maxHeight(contextStoreValue) : maxHeight;
 
     return (
         <UiMenuContextStore value={contextStoreValue}>
             <div
-                className={cx(b(), b({ controlType }), menuClassName)}
-                style={{ maxWidth }}
+                className={cx(b(), b({ controlType }))}
+                style={{ maxWidth, maxHeight: maxHeightValue }}
                 onKeyDownCapture={() => setControlType("keyboard")}
                 onMouseMoveCapture={() => setControlType("mouse")}
                 data-testid={menuDataTestId}
@@ -105,7 +106,9 @@ export function UiMenu<T extends IUiMenuItemData = object, M extends object = ob
                     <>
                         <MenuHeader />
                         <div
-                            className={e("items-container")}
+                            className={e("items-container", {
+                                "container-bottom-padding": containerBottomPadding,
+                            })}
                             ref={itemsContainerRef as React.MutableRefObject<HTMLDivElement>}
                         >
                             <menu

--- a/libs/sdk-ui-kit/src/@ui/UiMenu/hooks.tsx
+++ b/libs/sdk-ui-kit/src/@ui/UiMenu/hooks.tsx
@@ -46,7 +46,6 @@ export function useUiMenuContextValue<T extends IUiMenuItemData = object, M = ob
     const {
         items,
 
-        itemClassName,
         itemDataTestId,
 
         onSelect,
@@ -197,7 +196,6 @@ export function useUiMenuContextValue<T extends IUiMenuItemData = object, M = ob
         onClose,
         items,
         onSelect: handleSelectItem,
-        itemClassName,
         itemDataTestId,
         isItemFocusable,
         makeItemId,

--- a/libs/sdk-ui-kit/src/@ui/UiMenu/tests/UiMenu.test.tsx
+++ b/libs/sdk-ui-kit/src/@ui/UiMenu/tests/UiMenu.test.tsx
@@ -358,15 +358,6 @@ describe("UiMenu", () => {
         expect(menu).toHaveAttribute("aria-activedescendant", expect.stringContaining("item4"));
     });
 
-    it("should add itemClassName to items", () => {
-        renderMenu({
-            itemClassName: "test-item-class",
-        });
-
-        const items = screen.getByRole("menu").querySelectorAll(".test-item-class");
-        expect(items).toHaveLength(7); // All items should have the class (including group and its items)
-    });
-
     it("should add data-test-id to items", () => {
         renderMenu({
             itemDataTestId: "item-data-test-id",

--- a/libs/sdk-ui-kit/src/@ui/UiMenu/types.ts
+++ b/libs/sdk-ui-kit/src/@ui/UiMenu/types.ts
@@ -192,19 +192,14 @@ export interface UiMenuProps<T extends IUiMenuItemData = object, M = object>
     extends Partial<IUiMenuPluggableComponents<T>> {
     items: IUiMenuItem<T>[];
 
-    /**
-     * @deprecated use `dataTestId` instead. Prop will be removed.
-     */
-    className?: ((context: IUiMenuContext<T>) => string | undefined) | string;
     dataTestId?: ((context: IUiMenuContext<T>) => string | undefined) | string;
 
-    /**
-     * @deprecated use `itemDataTestId` instead. Prop will be removed.
-     */
-    itemClassName?: ((item: IUiMenuItem<T>) => string | undefined) | string;
     itemDataTestId?: ((item: IUiMenuItem<T>) => string | undefined) | string;
 
     maxWidth?: number;
+    maxHeight?: ((context: IUiMenuContext<T>) => number | undefined) | number;
+
+    containerBottomPadding?: "none" | "small" | "medium";
 
     onSelect?: (item: IUiMenuInteractiveItem<T>) => void;
     onLevelChange?: (level: number, item?: IUiMenuContentItem<T> | IUiMenuInteractiveItem<T>) => void;


### PR DESCRIPTION
Introduce new prop for menu max heigh and bottom padding

JIRA: LX-1328
risk: low

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```

#### Commands for Bear platform working on branch rel/9.9

```
extended-test-legacy --backstop
extended-test-legacy --isolated
extended-test-legacy --record
```
