### PR TITLE
fix: aria attributes in Input, DropdownButton

### DIFF
--- a/libs/sdk-ui-kit/api/sdk-ui-kit.api.md
+++ b/libs/sdk-ui-kit/api/sdk-ui-kit.api.md
@@ -1708,7 +1708,7 @@ export interface IDropdownButtonProps {
 
 // @internal (undocumented)
 export interface IDropdownButtonRenderProps {
-    accessibilityConfig: Pick<IButtonAccessibilityConfig, "role" | "isExpanded" | "popupId">;
+    accessibilityConfig: Pick<IButtonAccessibilityConfig, "role" | "isExpanded" | "popupId" | "ariaLabel">;
     ariaAttributes: {
         role: React_2.AriaRole;
     } & Pick<React_2.AriaAttributes, "aria-haspopup" | "aria-expanded" | "aria-controls">;
@@ -5936,7 +5936,7 @@ export type UiIconButtonProps = UiIconButtonPublicProps;
 // @internal (undocumented)
 export interface UiIconButtonPublicProps {
     // (undocumented)
-    accessibilityConfig?: IDropdownButtonRenderProps["accessibilityConfig"] & Pick<React_2.AriaAttributes, "aria-label">;
+    accessibilityConfig?: IDropdownButtonRenderProps["accessibilityConfig"];
     // (undocumented)
     ariaAttributes?: IDropdownButtonRenderProps["ariaAttributes"];
     // (undocumented)

--- a/libs/sdk-ui-kit/src/@ui/UiIconButton/UiIconButtonRenderer.tsx
+++ b/libs/sdk-ui-kit/src/@ui/UiIconButton/UiIconButtonRenderer.tsx
@@ -35,8 +35,7 @@ export interface UiIconButtonPublicProps {
     dataId?: string;
     dataTestId?: string;
     ariaAttributes?: IDropdownButtonRenderProps["ariaAttributes"];
-    accessibilityConfig?: IDropdownButtonRenderProps["accessibilityConfig"] &
-        Pick<React.AriaAttributes, "aria-label">;
+    accessibilityConfig?: IDropdownButtonRenderProps["accessibilityConfig"];
 }
 
 export interface UiIconButtonInternalProps {

--- a/libs/sdk-ui-kit/src/Dropdown/Dropdown.tsx
+++ b/libs/sdk-ui-kit/src/Dropdown/Dropdown.tsx
@@ -64,7 +64,7 @@ export interface IDropdownButtonRenderProps {
     /**
      * Props supporting accessibility that can be passed down to a <Button/>
      */
-    accessibilityConfig: Pick<IButtonAccessibilityConfig, "role" | "isExpanded" | "popupId">;
+    accessibilityConfig: Pick<IButtonAccessibilityConfig, "role" | "isExpanded" | "popupId" | "ariaLabel">;
 }
 
 /**

--- a/libs/sdk-ui-kit/src/Form/InputPure.tsx
+++ b/libs/sdk-ui-kit/src/Form/InputPure.tsx
@@ -205,7 +205,7 @@ export class InputPure extends React.PureComponent<InputPureProps> implements ID
                     variant="tertiary"
                     onClick={onIconButtonClick}
                     accessibilityConfig={{
-                        "aria-label": iconButtonLabel,
+                        ariaLabel: iconButtonLabel,
                     }}
                 />
             </span>


### PR DESCRIPTION
JIRA:F1-1565
risk:low

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```

#### Commands for Bear platform working on branch rel/9.9

```
extended-test-legacy --backstop
extended-test-legacy --isolated
extended-test-legacy --record
```
