### PR TITLE
fix: read validation items from updated controller state

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/DefaultDashboardAttributeFilter.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/DefaultDashboardAttributeFilter.tsx
@@ -400,9 +400,6 @@ const DefaultDashboardAttributeFilterInner = (props: IDashboardAttributeFilterPr
                         {...props}
                         onShowFilteredElements={handleShowFilteredElements}
                         enableShowingFilteredElements={enableShowingFilteredElements}
-                        isFilteredByLimitingValidationItems={
-                            (filter.attributeFilter.validateElementsBy?.length ?? 0) > 0
-                        }
                     />
                 );
             }
@@ -418,9 +415,6 @@ const DefaultDashboardAttributeFilterInner = (props: IDashboardAttributeFilterPr
                         );
                     }}
                     enableShowingFilteredElements={enableShowingFilteredElements}
-                    isFilteredByLimitingValidationItems={
-                        (filter.attributeFilter.validateElementsBy?.length ?? 0) > 0
-                    }
                 />
             );
         };

--- a/libs/sdk-ui-filters/api/sdk-ui-filters.api.md
+++ b/libs/sdk-ui-filters/api/sdk-ui-filters.api.md
@@ -130,6 +130,7 @@ export type AttributeFilterControllerData = {
     enableShowingFilteredElements?: boolean;
     irrelevantSelection?: IAttributeElement[];
     limitingValidationItems?: ObjRef[];
+    isFilteredByLimitingValidationItems?: boolean;
     isFilteredByDependentDateFilters?: boolean;
     enableDuplicatedLabelValuesInAttributeFilter?: boolean;
     enableAttributeFilterVirtualised?: boolean;
@@ -580,6 +581,7 @@ export interface IAttributeFilterElementsSelectProps {
     // (undocumented)
     isApplyDisabled?: boolean;
     isFilteredByDependentDateFilters?: boolean;
+    isFilteredByLimitingValidationItems?: boolean;
     isFilteredByParentFilters: boolean;
     isInverted: boolean;
     isLoading: boolean;

--- a/libs/sdk-ui-filters/src/AttributeFilter/Components/Dropdown/AttributeFilterDropdownBody.tsx
+++ b/libs/sdk-ui-filters/src/AttributeFilter/Components/Dropdown/AttributeFilterDropdownBody.tsx
@@ -42,6 +42,7 @@ export const AttributeFilterDropdownBody: React.FC<IAttributeFilterDropdownBodyP
         parentFilterAttributes,
         isFilteredByParentFilters,
         isFilteredByDependentDateFilters,
+        isFilteredByLimitingValidationItems,
         fullscreenOnMobile,
         selectionMode,
         title,
@@ -102,6 +103,7 @@ export const AttributeFilterDropdownBody: React.FC<IAttributeFilterDropdownBodyP
                 attributeTitle={title}
                 enableShowingFilteredElements={enableShowingFilteredElements}
                 isFilteredByDependentDateFilters={isFilteredByDependentDateFilters}
+                isFilteredByLimitingValidationItems={isFilteredByLimitingValidationItems}
                 onShowFilteredElements={onShowFilteredElements}
                 irrelevantSelection={irrelevantSelection}
                 onClearIrrelevantSelection={onClearIrrelevantSelection}

--- a/libs/sdk-ui-filters/src/AttributeFilter/Components/ElementsSelect/AttributeFilterElementsSelect.tsx
+++ b/libs/sdk-ui-filters/src/AttributeFilter/Components/ElementsSelect/AttributeFilterElementsSelect.tsx
@@ -59,6 +59,7 @@ export const AttributeFilterElementsSelect: React.FC<IAttributeFilterElementsSel
         isApplyDisabled,
 
         isFilteredByDependentDateFilters,
+        isFilteredByLimitingValidationItems,
         enableAttributeFilterVirtualised,
         withoutApply,
     } = props;
@@ -119,6 +120,7 @@ export const AttributeFilterElementsSelect: React.FC<IAttributeFilterElementsSel
                     onApplyButtonClick={onApplyButtonClick}
                     isApplyDisabled={isApplyDisabled}
                     isFilteredByDependentDateFilters={isFilteredByDependentDateFilters}
+                    isFilteredByLimitingValidationItems={isFilteredByLimitingValidationItems}
                     withoutApply={withoutApply}
                 />
             ) : (
@@ -188,6 +190,7 @@ export const AttributeFilterElementsSelect: React.FC<IAttributeFilterElementsSel
                             <StatusBarComponent
                                 getItemTitle={getItemTitle}
                                 isFilteredByParentFilters={isFilteredByParentFilters}
+                                isFilteredByLimitingValidationItems={isFilteredByLimitingValidationItems}
                                 isFilteredByDependentDateFilters={isFilteredByDependentDateFilters}
                                 isInverted={isInverted}
                                 parentFilterTitles={parentFilterTitles}

--- a/libs/sdk-ui-filters/src/AttributeFilter/Components/ElementsSelect/AttributeFilterVirtualisedElementsSelect.tsx
+++ b/libs/sdk-ui-filters/src/AttributeFilter/Components/ElementsSelect/AttributeFilterVirtualisedElementsSelect.tsx
@@ -34,6 +34,7 @@ interface IAttributeFilterVirtualisedElementsSelect {
     error?: GoodDataSdkError;
     enableShowingFilteredElements?: boolean;
     isFilteredByDependentDateFilters?: boolean;
+    isFilteredByLimitingValidationItems: boolean;
     attributeTitle?: string;
     onShowFilteredElements?: () => void;
     irrelevantSelection?: IAttributeElement[];
@@ -89,6 +90,7 @@ export const AttributeFilterVirtualisedElementsSelect: React.FC<IAttributeFilter
         isApplyDisabled,
 
         isFilteredByDependentDateFilters,
+        isFilteredByLimitingValidationItems,
         withoutApply,
     } = props;
 
@@ -195,6 +197,7 @@ export const AttributeFilterVirtualisedElementsSelect: React.FC<IAttributeFilter
                         getItemTitle={getItemTitle}
                         isFilteredByParentFilters={isFilteredByParentFilters}
                         isFilteredByDependentDateFilters={isFilteredByDependentDateFilters}
+                        isFilteredByLimitingValidationItems={isFilteredByLimitingValidationItems}
                         isInverted={isInverted}
                         parentFilterTitles={parentFilterTitles}
                         selectedItems={selectedItems}

--- a/libs/sdk-ui-filters/src/AttributeFilter/Components/ElementsSelect/types.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilter/Components/ElementsSelect/types.ts
@@ -128,6 +128,14 @@ export interface IAttributeFilterElementsSelectProps {
     isFilteredByDependentDateFilters?: boolean;
 
     /**
+     * Indicate that elements are filtered by limiting validation items
+     *
+     * @beta
+     * @remarks Use only when platform supports limiting validation items.
+     */
+    isFilteredByLimitingValidationItems?: boolean;
+
+    /**
      * Title of the attribute
      * @remarks Used only when showing filtered elements is enabled.
      */

--- a/libs/sdk-ui-filters/src/AttributeFilter/hooks/types.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilter/hooks/types.ts
@@ -163,6 +163,11 @@ export type AttributeFilterControllerData = {
     limitingValidationItems?: ObjRef[];
 
     /**
+     * If true, AttributeFilter is filtering elements by validation items.
+     */
+    isFilteredByLimitingValidationItems?: boolean;
+
+    /**
      * If true, AttributeFilter is filtering elements by dependent date filters.
      *
      * @beta

--- a/libs/sdk-ui-filters/src/AttributeFilter/hooks/useAttributeFilterControllerData.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilter/hooks/useAttributeFilterControllerData.ts
@@ -76,6 +76,11 @@ export function useAttributeFilterControllerData(
         initialElementsPageStatus === "success" &&
         !isEmpty(limitingDateFilters);
 
+    const isFilteredByLimitingValidationItems =
+        shouldIncludeLimitingFilters &&
+        initialElementsPageStatus === "success" &&
+        !isEmpty(limitingValidationItems);
+
     const isFiltering = useIsFiltering(handler);
 
     const parentFilterAttributes = handler.getLimitingAttributeFiltersAttributes();
@@ -137,6 +142,7 @@ export function useAttributeFilterControllerData(
         irrelevantSelection,
 
         limitingValidationItems,
+        isFilteredByLimitingValidationItems,
     };
 }
 


### PR DESCRIPTION
Read validation items from up to date controller state instead of persisted filter

JIRA: LX-1228
risk: low

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```

#### Commands for Bear platform working on branch rel/9.9

```
extended-test-legacy --backstop
extended-test-legacy --isolated
extended-test-legacy --record
```
