### PR TITLE
feat: use only one prop instead of using two props meaning the same

### DIFF
--- a/common/changes/@gooddata/sdk-ui-all/ine-lx-prop-cleanup_2025-07-16-09-47.json
+++ b/common/changes/@gooddata/sdk-ui-all/ine-lx-prop-cleanup_2025-07-16-09-47.json
@@ -1,0 +1,10 @@
+{
+    "changes": [
+        {
+            "packageName": "@gooddata/sdk-ui-all",
+            "comment": "Deprecate enableDashboardFiltersApplyModes prop and use only withoutApply.",
+            "type": "none"
+        }
+    ],
+    "packageName": "@gooddata/sdk-ui-all"
+}

--- a/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/DefaultDashboardAttributeFilter.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/DefaultDashboardAttributeFilter.tsx
@@ -499,7 +499,6 @@ const DefaultDashboardAttributeFilterInner = (props: IDashboardAttributeFilterPr
                 }
                 enableAttributeFilterVirtualised={enableAttributeFilterVirtualisedList}
                 withoutApply={isApplyAllAtOnceEnabledAndSet}
-                enableDashboardFiltersApplyModes={isApplyAllAtOnceEnabledAndSet}
                 enableDashboardFiltersApplyWithoutLoading={true}
             />
         </AttributeFilterParentFilteringProvider>

--- a/libs/sdk-ui-dashboard/src/presentation/filterBar/dateFilter/DefaultDashboardDateFilter.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/filterBar/dateFilter/DefaultDashboardDateFilter.tsx
@@ -185,7 +185,6 @@ export const DefaultDashboardDateFilter = (props: IDashboardDateFilterProps): JS
             showDropDownHeaderMessage={!filter?.dateFilter.dataSet}
             FilterConfigurationComponent={isConfigurationEnabled ? FilterConfigurationComponent : undefined}
             withoutApply={isApplyAllAtOnceEnabledAndSet}
-            enableDashboardFiltersApplyModes={isApplyAllAtOnceEnabledAndSet}
             ButtonComponent={ButtonComponent}
             overlayPositionType={overlayPositionType}
         />

--- a/libs/sdk-ui-filters/api/sdk-ui-filters.api.md
+++ b/libs/sdk-ui-filters/api/sdk-ui-filters.api.md
@@ -410,6 +410,7 @@ export interface IAttributeFilterCoreProps {
     // @alpha
     displayAsLabel?: ObjRef;
     enableAttributeFilterVirtualised?: boolean;
+    // @deprecated
     enableDashboardFiltersApplyModes?: boolean;
     // @deprecated
     enableDashboardFiltersApplyWithoutLoading?: boolean;
@@ -797,6 +798,7 @@ export interface IDateFilterOwnProps extends IDateFilterStatePropsIntersection {
     dateFilterMode: VisibilityMode;
     // (undocumented)
     dateFormat?: string;
+    // @deprecated
     enableDashboardFiltersApplyModes?: boolean;
     // @alpha
     FilterConfigurationComponent?: React_2.ComponentType<IFilterConfigurationProps>;

--- a/libs/sdk-ui-filters/src/AttributeFilter/AttributeFilterProviders.tsx
+++ b/libs/sdk-ui-filters/src/AttributeFilter/AttributeFilterProviders.tsx
@@ -34,6 +34,8 @@ export const AttributeFilterProviders: React.FC<IAttributeFilterBaseProps & { ch
         selectFirst = false,
         disabled,
         customIcon,
+        withoutApply,
+        overlayPositionType,
         onApply,
         onSelect,
         onError,
@@ -54,6 +56,7 @@ export const AttributeFilterProviders: React.FC<IAttributeFilterBaseProps & { ch
         enableAttributeFilterVirtualised,
         enableImmediateAttributeFilterDisplayAsLabelMigration = false,
         enableDashboardFiltersApplyWithoutLoading = false,
+        enableDashboardFiltersApplyModes = false,
     } = props;
 
     const DefaultComponents = getAttributeFilterDefaultComponents(props);
@@ -117,9 +120,8 @@ export const AttributeFilterProviders: React.FC<IAttributeFilterBaseProps & { ch
                         enableImmediateAttributeFilterDisplayAsLabelMigration
                     }
                     enableAttributeFilterVirtualised={enableAttributeFilterVirtualised}
-                    withoutApply={props.withoutApply}
-                    enableDashboardFiltersApplyModes={props.enableDashboardFiltersApplyModes}
-                    overlayPositionType={props.overlayPositionType}
+                    withoutApply={withoutApply ?? enableDashboardFiltersApplyModes}
+                    overlayPositionType={overlayPositionType}
                     enableDashboardFiltersApplyWithoutLoading={enableDashboardFiltersApplyWithoutLoading}
                 >
                     {children}

--- a/libs/sdk-ui-filters/src/AttributeFilter/types.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilter/types.ts
@@ -303,6 +303,7 @@ export interface IAttributeFilterCoreProps {
 
     /**
      * Enables the new apply all filters at once mode
+     * @deprecated Use withoutApply instead
      */
     enableDashboardFiltersApplyModes?: boolean;
 

--- a/libs/sdk-ui-filters/src/DateFilter/DateFilter.tsx
+++ b/libs/sdk-ui-filters/src/DateFilter/DateFilter.tsx
@@ -91,6 +91,7 @@ export interface IDateFilterOwnProps extends IDateFilterStatePropsIntersection {
 
     /**
      * If new apply all filters at once mode is enabled
+     * @deprecated dont use. Will be removed in future releases. Use `withoutApply` instead
      */
     enableDashboardFiltersApplyModes?: boolean;
 
@@ -162,8 +163,9 @@ export class DateFilter extends React.PureComponent<IDateFilterProps, IDateFilte
         nextProps: IDateFilterProps,
         prevState: IDateFilterState,
     ): IDateFilterState {
+        const withoutApply = nextProps.withoutApply ?? nextProps.enableDashboardFiltersApplyModes;
         if (
-            nextProps.enableDashboardFiltersApplyModes &&
+            withoutApply &&
             nextProps.workingSelectedFilterOption &&
             nextProps.excludeCurrentPeriod !== undefined &&
             (!isEqual(nextProps.workingSelectedFilterOption, prevState.initWorkingSelectedFilterOption) ||
@@ -265,11 +267,12 @@ export class DateFilter extends React.PureComponent<IDateFilterProps, IDateFilte
             customIcon,
             showDropDownHeaderMessage,
             FilterConfigurationComponent,
-            withoutApply,
+            withoutApply: withoutApplyProp,
             enableDashboardFiltersApplyModes,
             ButtonComponent,
             overlayPositionType,
         } = this.props;
+        const withoutApply = withoutApplyProp ?? enableDashboardFiltersApplyModes;
         const { excludeCurrentPeriod, selectedFilterOption, isExcludeCurrentPeriodEnabled } = this.state;
         return dateFilterMode === "hidden" ? null : (
             <DateFilterCore
@@ -297,7 +300,7 @@ export class DateFilter extends React.PureComponent<IDateFilterProps, IDateFilte
                 weekStart={weekStart}
                 customIcon={customIcon}
                 FilterConfigurationComponent={FilterConfigurationComponent}
-                withoutApply={enableDashboardFiltersApplyModes ? withoutApply : undefined}
+                withoutApply={withoutApply}
                 ButtonComponent={ButtonComponent}
                 overlayPositionType={overlayPositionType}
             />
@@ -310,10 +313,10 @@ export class DateFilter extends React.PureComponent<IDateFilterProps, IDateFilte
     };
 
     private onChangesDiscarded = () => {
-        if (!this.props.withoutApply || !this.props.enableDashboardFiltersApplyModes) {
+        if (!this.props.withoutApply) {
             this.setState(() => DateFilter.getStateFromProps(this.props), this.handleSelectChange);
         } else if (
-            this.props.enableDashboardFiltersApplyModes &&
+            this.props.withoutApply &&
             !isEmpty(validateFilterOption(this.state.selectedFilterOption))
         ) {
             this.setState(() => DateFilter.getStateFromWorkingProps(this.props));


### PR DESCRIPTION
Props enableDashboardFiltersApplyModes and withoutApply where use both to manage the same feature. Keep only withoutApply.

risk: low

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```

#### Commands for Bear platform working on branch rel/9.9

```
extended-test-legacy --backstop
extended-test-legacy --isolated
extended-test-legacy --record
```
