### PR TITLE
fix(docs): Fix SemanticSearch example

### DIFF
--- a/docs/content/en/latest/references/embed_semantic_search/_index.md
+++ b/docs/content/en/latest/references/embed_semantic_search/_index.md
@@ -23,7 +23,7 @@ GoodData.UI provides a React component for embedding a semantic search interface
 
 ```tsx
 import * as React from "react";
-import { SemanticSearch, ISemanticSearchResultItem } from "@gooddata/sdk-ui-semantic-search";
+import { SemanticSearch } from "@gooddata/sdk-ui-semantic-search";
 
 // Import required styles
 import "@gooddata/sdk-ui-semantic-search/styles/css/main.css";
@@ -34,12 +34,12 @@ const App = () => {
             {/* Wrap the search UI in a container of desired size */}
             <SemanticSearch
                 // Handle item selection
-                onSelect={(item: ISemanticSearchResultItem) => {
+                onSelect={(item) => {
                     console.log(`Selected item: ${item.title}`);
                     // Handle the selected item, e.g., navigate to the dashboard
                 }}
                 // Optional: Handle search errors
-                onError={(errorMessage: string) => {
+                onError={(errorMessage) => {
                     console.error(`Search error: ${errorMessage}`);
                 }}
                 // Optional: Filter by object types


### PR DESCRIPTION
risk: low
jira: GDAI-473

This PR fixes the `SemanticSearch` example, especially `ISemanticSearchResultItem,` which is actually not exported via `@gooddata/sdk-ui-semantic-search` but via `@gooddata/sdk-model`. Using implicit types in the example for the simplicity. 

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```

#### Commands for Bear platform working on branch rel/9.9

```
extended-test-legacy --backstop
extended-test-legacy --isolated
extended-test-legacy --record
```
