### PR TITLE
fix: do not render favicon when null/empty

### DIFF
--- a/libs/sdk-ui-kit/src/DocumentHeader/DocumentHeader.tsx
+++ b/libs/sdk-ui-kit/src/DocumentHeader/DocumentHeader.tsx
@@ -30,19 +30,23 @@ const DocumentHeader: React.FC<IDocumentHeaderProps> = ({
 
         document.title = getEffectiveTitle(pageTitle, brandTitle);
 
-        const linkAppleQuery = document.querySelector("link[rel='apple-touch-icon']");
-        const linkApple = (linkAppleQuery || document.createElement("link")) as HTMLLinkElement;
-        linkApple.rel = "apple-touch-icon";
-        linkApple.type = "image/png";
-        linkApple.href = appleTouchIconUrl;
-        if (!linkAppleQuery) document.head.appendChild(linkApple);
+        if (appleTouchIconUrl) {
+            const linkAppleQuery = document.querySelector("link[rel='apple-touch-icon']");
+            const linkApple = (linkAppleQuery || document.createElement("link")) as HTMLLinkElement;
+            linkApple.rel = "apple-touch-icon";
+            linkApple.type = "image/png";
+            linkApple.href = appleTouchIconUrl;
+            if (!linkAppleQuery) document.head.appendChild(linkApple);
+        }
 
-        const linkFaviconQuery = document.querySelector("link[rel~='icon']");
-        const linkFavicon = (linkFaviconQuery || document.createElement("link")) as HTMLLinkElement;
-        linkFavicon.rel = "shortcut icon";
-        linkFavicon.type = "image/x-icon";
-        linkFavicon.href = faviconUrl;
-        if (!linkFaviconQuery) document.head.appendChild(linkFavicon);
+        if (faviconUrl) {
+            const linkFaviconQuery = document.querySelector("link[rel~='icon']");
+            const linkFavicon = (linkFaviconQuery || document.createElement("link")) as HTMLLinkElement;
+            linkFavicon.rel = "shortcut icon";
+            linkFavicon.type = "image/x-icon";
+            linkFavicon.href = faviconUrl;
+            if (!linkFaviconQuery) document.head.appendChild(linkFavicon);
+        }
     }, [pageTitle, brandTitle, appleTouchIconUrl, faviconUrl]);
 
     return null;


### PR DESCRIPTION
risk: low
JIRA: STL-1572


<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```

#### Commands for Bear platform working on branch rel/9.9

```
extended-test-legacy --backstop
extended-test-legacy --isolated
extended-test-legacy --record
```