### PR TITLE
fix: handle switch to single mode, allow invalid selectin propagation and its handling

### DIFF
--- a/common/changes/@gooddata/sdk-ui-all/ine-clear-fix_2025-07-18-11-58.json
+++ b/common/changes/@gooddata/sdk-ui-all/ine-clear-fix_2025-07-18-11-58.json
@@ -1,0 +1,10 @@
+{
+    "changes": [
+        {
+            "packageName": "@gooddata/sdk-ui-all",
+            "comment": "fix of selection mode switching. Allow propagation of invalid AF selection together with isInvalid flag. Dashboard component can now handle invalid state.",
+            "type": "none"
+        }
+    ],
+    "packageName": "@gooddata/sdk-ui-all"
+}

--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -613,13 +613,14 @@ export interface ChangeAttributeFilterSelection extends IDashboardCommand {
 }
 
 // @public
-export function changeAttributeFilterSelection(filterLocalId: string, elements: IAttributeElements, selectionType: AttributeFilterSelectionType, correlationId?: string): ChangeAttributeFilterSelection;
+export function changeAttributeFilterSelection(filterLocalId: string, elements: IAttributeElements, selectionType: AttributeFilterSelectionType, correlationId?: string, isSelectionInvalid?: boolean): ChangeAttributeFilterSelection;
 
 // @public
 export interface ChangeAttributeFilterSelectionPayload {
     readonly elements: IAttributeElements;
     readonly filterLocalId: string;
     readonly isResultOfMigration?: boolean;
+    readonly isSelectionInvalid?: boolean;
     readonly isWorkingSelectionChange?: boolean;
     readonly selectionType: AttributeFilterSelectionType;
 }
@@ -1008,7 +1009,7 @@ export interface ChangeSharingPayload {
 }
 
 // @public
-export function changeWorkingAttributeFilterSelection(filterLocalId: string, elements: IAttributeElements, selectionType: AttributeFilterSelectionType, correlationId?: string): ChangeAttributeFilterSelection;
+export function changeWorkingAttributeFilterSelection(filterLocalId: string, elements: IAttributeElements, selectionType: AttributeFilterSelectionType, correlationId?: string, isSelectionInvalid?: boolean): ChangeAttributeFilterSelection;
 
 // @public
 export function clearDateFilterSelection(correlationId?: string, dataSet?: ObjRef, isWorkingSelectionChange?: boolean, localIdentifier?: string): ChangeDateFilterSelection;
@@ -4013,6 +4014,8 @@ export interface FilterContextState {
     filterContextDefinition?: IFilterContextDefinition;
     // @beta
     filterContextIdentity?: IDashboardObjectIdentity;
+    // @alpha
+    filtersWithInvalidSelection: string[];
     // @beta
     originalFilterContextDefinition?: IFilterContextDefinition;
     // @alpha
@@ -4478,7 +4481,7 @@ export interface IDashboardAttributeFilterProps {
     filter: IDashboardAttributeFilter;
     isDraggable?: boolean;
     onClose?: () => void;
-    onFilterChanged: (filter: IDashboardAttributeFilter, displayAsLabel?: ObjRef, isWorkingSelectionChange?: boolean, isResultOfMigration?: boolean) => void;
+    onFilterChanged: (filter: IDashboardAttributeFilter, displayAsLabel?: ObjRef, isWorkingSelectionChange?: boolean, isResultOfMigration?: boolean, isSelectionInvalid?: boolean) => void;
     overlayPositionType?: OverlayPositionType;
     // @alpha
     readonly?: boolean;
@@ -8891,6 +8894,9 @@ export const selectFilterContextFilters: DashboardSelector<FilterContextItem[]>;
 // @internal
 export const selectFilterContextIdentity: DashboardSelector<IDashboardObjectIdentity | undefined>;
 
+// @public
+export const selectFiltersWithInvalidSelection: DashboardSelector<string[]>;
+
 // @internal (undocumented)
 export const selectFilterValidationIncompatibleDefaultFiltersOverride: DashboardSelector<boolean>;
 
@@ -9220,6 +9226,9 @@ export const selectMapboxToken: DashboardSelector<string | undefined>;
 
 // @alpha (undocumented)
 export const selectMenuButtonItemsVisibility: DashboardSelector<IMenuButtonItemsVisibility>;
+
+// @public
+export const selectNamesOfFiltersWithInvalidSelection: DashboardSelector<string[]>;
 
 // @alpha
 export const selectNotificationChannels: DashboardSelector<INotificationChannelIdentifier[] | INotificationChannelMetadataObject[]>;

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/filterContext/attributeFilter/changeAttributeFilterSelectionHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/filterContext/attributeFilter/changeAttributeFilterSelectionHandler.ts
@@ -27,8 +27,14 @@ export function* changeAttributeFilterSelectionHandler(
     ctx: DashboardContext,
     cmd: ChangeAttributeFilterSelection,
 ): SagaIterator<void> {
-    const { elements, filterLocalId, selectionType, isWorkingSelectionChange, isResultOfMigration } =
-        cmd.payload;
+    const {
+        elements,
+        filterLocalId,
+        selectionType,
+        isWorkingSelectionChange,
+        isResultOfMigration,
+        isSelectionInvalid,
+    } = cmd.payload;
 
     // validate filterLocalId
     const affectedFilter: ReturnType<ReturnType<typeof selectFilterContextAttributeFilterByLocalId>> =
@@ -52,6 +58,7 @@ export function* changeAttributeFilterSelectionHandler(
             isWorkingSelectionChange: isWorkingSelectionChange && isApplyAllAtOnceEnabledAndSet,
             enableImmediateAttributeFilterDisplayAsLabelMigration,
             isResultOfMigration,
+            isSelectionInvalid,
         }),
     );
 

--- a/libs/sdk-ui-dashboard/src/model/commands/filters.ts
+++ b/libs/sdk-ui-dashboard/src/model/commands/filters.ts
@@ -522,6 +522,13 @@ export interface ChangeAttributeFilterSelectionPayload {
      * metadata level.
      */
     readonly isResultOfMigration?: boolean;
+
+    /**
+     * Indicates if the current filter selection is invalid.
+     * When true, the filter's localId should be added to filtersWithInvalidSelection array in state.
+     * When false, the filter's localId should be removed from filtersWithInvalidSelection array.
+     */
+    readonly isSelectionInvalid?: boolean;
 }
 
 /**
@@ -577,6 +584,7 @@ export function changeAttributeFilterSelection(
     elements: IAttributeElements,
     selectionType: AttributeFilterSelectionType,
     correlationId?: string,
+    isSelectionInvalid?: boolean,
 ): ChangeAttributeFilterSelection {
     return {
         type: "GDC.DASH/CMD.FILTER_CONTEXT.ATTRIBUTE_FILTER.CHANGE_SELECTION",
@@ -585,6 +593,7 @@ export function changeAttributeFilterSelection(
             filterLocalId,
             elements,
             selectionType,
+            isSelectionInvalid,
         },
     };
 }
@@ -677,6 +686,7 @@ export function changeWorkingAttributeFilterSelection(
     elements: IAttributeElements,
     selectionType: AttributeFilterSelectionType,
     correlationId?: string,
+    isSelectionInvalid?: boolean,
 ): ChangeAttributeFilterSelection {
     return {
         type: "GDC.DASH/CMD.FILTER_CONTEXT.ATTRIBUTE_FILTER.CHANGE_SELECTION",
@@ -686,6 +696,7 @@ export function changeWorkingAttributeFilterSelection(
             elements,
             selectionType,
             isWorkingSelectionChange: true,
+            isSelectionInvalid,
         },
     };
 }

--- a/libs/sdk-ui-dashboard/src/model/store/filterContext/filterContextReducers.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/filterContext/filterContextReducers.ts
@@ -252,6 +252,7 @@ export interface IUpdateAttributeFilterSelectionPayload {
     readonly isWorkingSelectionChange?: boolean;
     readonly enableImmediateAttributeFilterDisplayAsLabelMigration?: boolean;
     readonly isResultOfMigration?: boolean;
+    readonly isSelectionInvalid?: boolean;
 }
 
 const updateAttributeFilterSelection: FilterContextReducer<
@@ -264,6 +265,7 @@ const updateAttributeFilterSelection: FilterContextReducer<
         isWorkingSelectionChange,
         enableImmediateAttributeFilterDisplayAsLabelMigration,
         isResultOfMigration,
+        isSelectionInvalid,
     } = action.payload;
     const filterContextDefinition = isWorkingSelectionChange
         ? state.workingFilterContextDefinition
@@ -316,6 +318,19 @@ const updateAttributeFilterSelection: FilterContextReducer<
                 negativeSelection,
             };
         }
+    }
+
+    // Handle isSelectionInvalid flag to update filtersWithInvalidSelection array
+    if (isSelectionInvalid) {
+        // Add filterLocalId to the array if not already present
+        if (!state.filtersWithInvalidSelection.includes(filterLocalId)) {
+            state.filtersWithInvalidSelection.push(filterLocalId);
+        }
+    } else {
+        // Remove filterLocalId from the array if present
+        state.filtersWithInvalidSelection = state.filtersWithInvalidSelection.filter(
+            (id) => id !== filterLocalId,
+        );
     }
 };
 

--- a/libs/sdk-ui-dashboard/src/model/store/filterContext/filterContextState.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/filterContext/filterContextState.ts
@@ -43,6 +43,13 @@ export interface IWorkingFilterContextDefinition {
  */
 export interface FilterContextState {
     /**
+     * Array of local IDs for filters that have invalid selections.
+     * This is used to track and indicate filters that have selection problems.
+     * @alpha
+     */
+    filtersWithInvalidSelection: string[];
+
+    /**
      * Filter context definition contains the actual filters to use. They are applied and used to compute insights data.
      * Filter context definition is present.
      * @beta
@@ -111,6 +118,7 @@ export interface FilterContextState {
 }
 
 export const filterContextInitialState: FilterContextState = {
+    filtersWithInvalidSelection: [],
     filterContextDefinition: undefined,
     workingFilterContextDefinition: undefined,
     filterContextIdentity: undefined,

--- a/libs/sdk-ui-dashboard/src/model/store/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/index.ts
@@ -192,6 +192,7 @@ export {
     selectFilterContextAttributeFilterByDisplayForm,
     selectOriginalFilterContextDefinition,
     selectOriginalFilterContextFilters,
+    selectFiltersWithInvalidSelection,
     selectAttributeFilterDescendants,
     selectAttributeFilterDisplayFormByLocalId,
     selectIsCircularDependency,
@@ -201,6 +202,7 @@ export {
     selectFilterContextDateFilterByDataSet,
     selectPreloadedAttributesWithReferences,
     selectDefaultFilterOverrides,
+    selectNamesOfFiltersWithInvalidSelection,
 } from "./filterContext/filterContextSelectors.js";
 export { getFilterIdentifier } from "./filterContext/filterContextUtils.js";
 export type { IImplicitDrillWithPredicates } from "./widgetDrills/widgetDrillSelectors.js";

--- a/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/types.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/types.ts
@@ -36,12 +36,14 @@ export interface IDashboardAttributeFilterProps {
      * @param isResultOfMigration - internal value, specifies that filter change was caused by displayAsLabel
      *  ad-hoc migration, the param will be removed once the usage of displayAsLabel is migrated on database
      *  metadata level.
+     * @param isSelectionInvalid - specifies if filter selection is invalid
      */
     onFilterChanged: (
         filter: IDashboardAttributeFilter,
         displayAsLabel?: ObjRef,
         isWorkingSelectionChange?: boolean,
         isResultOfMigration?: boolean,
+        isSelectionInvalid?: boolean,
     ) => void;
 
     /**

--- a/libs/sdk-ui-dashboard/src/presentation/filterBar/filterBar/DefaultFilterBar.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/filterBar/filterBar/DefaultFilterBar.tsx
@@ -92,6 +92,7 @@ export const useFilterBarProps = (): IFilterBarProps => {
             displayAsLabel?: ObjRef,
             isWorkingSelectionChange?: boolean,
             isResultOfMigration?: boolean,
+            isSelectionInvalid?: boolean,
         ) => {
             const convertedFilter = supportElementUris
                 ? filter
@@ -138,6 +139,8 @@ export const useFilterBarProps = (): IFilterBarProps => {
                         localIdentifier!,
                         attributeElements,
                         negativeSelection ? "NOT_IN" : "IN",
+                        undefined,
+                        isSelectionInvalid,
                     ),
                 );
             } else if (isResultOfMigration) {

--- a/libs/sdk-ui-dashboard/src/presentation/localization/bundles/en-US.json
+++ b/libs/sdk-ui-dashboard/src/presentation/localization/bundles/en-US.json
@@ -110,6 +110,10 @@
         "value": "<link>Apply filters</link> to see updated data.",
         "comment": "Message banner shown when filters are changed but not yet applied. The <link> tags create a clickable action to apply the filters."
     },
+    "filterBar.invalidFilterSelection": {
+        "value": "To apply changes, select valid values for these filters: {names}",
+        "comment": "Message shown on disabled Apply button."
+    },
     "filterBar.executionTimestampNotificationMessage": {
         "value": "<bold>Note.</bold> You're viewing up-to-date data, but for any relative date filters the dashboard treats {date} as “today.”",
         "comment": "Message banner describing dashboard with specific data timestamp. Placeholder {date} is replaced with the current date."

--- a/libs/sdk-ui-filters/api/sdk-ui-filters.api.md
+++ b/libs/sdk-ui-filters/api/sdk-ui-filters.api.md
@@ -87,7 +87,7 @@ export type AttributeFilterController = AttributeFilterControllerData & Attribut
 
 // @public
 export type AttributeFilterControllerCallbacks = {
-    onApply: () => void;
+    onApply: (applyRegardlessWithoutApplySetting?: boolean, applyToWorkingOnly?: boolean) => void;
     onLoadNextElementsPage: () => void;
     onSearch: (search: string) => void;
     onSelect: (selectedItems: IAttributeElement[], isInverted: boolean) => void;
@@ -1204,7 +1204,10 @@ export function newAttributeFilterHandler(backend: IAnalyticalBackend, workspace
 export function newAttributeFilterHandler(backend: IAnalyticalBackend, workspace: string, attributeFilter: IAttributeFilter, options: IMultiSelectAttributeFilterHandlerOptions): IMultiSelectAttributeFilterHandler;
 
 // @public (undocumented)
-export type OnApplyCallbackType = (filter: IAttributeFilter, isInverted: boolean, selectionMode?: DashboardAttributeFilterSelectionMode, selectionTitles?: IAttributeElement[], displayAsLabel?: ObjRef, isResultOfMigration?: boolean) => void;
+export type OnApplyCallbackType = (filter: IAttributeFilter, isInverted: boolean, selectionMode?: DashboardAttributeFilterSelectionMode, selectionTitles?: IAttributeElement[], displayAsLabel?: ObjRef, isResultOfMigration?: boolean, additionalProps?: {
+    isSelectionInvalid?: boolean;
+    applyToWorkingOnly?: boolean;
+}) => void;
 
 // @public
 export type OnInitCancelCallbackPayload = CallbackPayloadWithCorrelation;
@@ -1307,7 +1310,9 @@ export type OnLoadNextElementsPageStartCallbackPayload = CallbackPayloadWithCorr
 export type OnLoadNextElementsPageSuccessCallbackPayload = CallbackPayloadWithCorrelation<ILoadElementsResult>;
 
 // @public (undocumented)
-export type OnSelectCallbackType = (filter: IAttributeFilter, isInverted: boolean, selectionMode?: DashboardAttributeFilterSelectionMode, selectionTitles?: IAttributeElement[], displayAsLabel?: ObjRef) => void;
+export type OnSelectCallbackType = (filter: IAttributeFilter, isInverted: boolean, selectionMode?: DashboardAttributeFilterSelectionMode, selectionTitles?: IAttributeElement[], displayAsLabel?: ObjRef, additionalProps?: {
+    isSelectionInvalid?: boolean;
+}) => void;
 
 // @public
 export type OnSelectionChangedCallbackPayload<T> = {

--- a/libs/sdk-ui-filters/src/AttributeFilter/Components/Dropdown/AttributeFilterDropdown.tsx
+++ b/libs/sdk-ui-filters/src/AttributeFilter/Components/Dropdown/AttributeFilterDropdown.tsx
@@ -124,7 +124,7 @@ export const AttributeFilterDropdown: React.VFC = () => {
                 >
                     <DropdownBodyComponent
                         onApplyButtonClick={() => {
-                            onApply();
+                            onApply(true, withoutApply);
                             closeDropdown();
                         }}
                         onCancelButtonClick={closeDropdown}

--- a/libs/sdk-ui-filters/src/AttributeFilter/hooks/types.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilter/hooks/types.ts
@@ -190,8 +190,10 @@ export type AttributeFilterControllerData = {
 export type AttributeFilterControllerCallbacks = {
     /**
      * Apply changes from working selection to committed selection.
+     * @param applyRegardlessWithoutApplySetting - If true, apply changes regardless of the withoutApply setting.
+     * @param applyToWorkingOnly - If true, apply changes to working selection only.
      */
-    onApply: () => void;
+    onApply: (applyRegardlessWithoutApplySetting?: boolean, applyToWorkingOnly?: boolean) => void;
 
     /**
      * Request next page of elements that respect current search criteria.

--- a/libs/sdk-ui-filters/src/AttributeFilter/hooks/useAttributeFilterController.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilter/hooks/useAttributeFilterController.ts
@@ -504,7 +504,14 @@ function useInitOrReload(
             };
         }
         return undefined;
-    }, [handler, displayAsLabel, enableDuplicatedLabelValuesInAttributeFilter, onApply, selectionMode, isSelectionInvalid]);
+    }, [
+        handler,
+        displayAsLabel,
+        enableDuplicatedLabelValuesInAttributeFilter,
+        onApply,
+        selectionMode,
+        isSelectionInvalid,
+    ]);
 }
 
 type UpdateFilterProps = {
@@ -827,7 +834,7 @@ function useCallbacks(
                 );
             }
         },
-        [handler, enableDuplicatedLabelValuesInAttributeFilter, handlerState, selectionMode, isSelectionInvalid],
+        [handler, enableDuplicatedLabelValuesInAttributeFilter, handlerState, selectionMode],
     );
 
     const onSelect = useCallback(

--- a/libs/sdk-ui-filters/src/AttributeFilter/types.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilter/types.ts
@@ -38,6 +38,10 @@ export type OnApplyCallbackType = (
     selectionTitles?: IAttributeElement[],
     displayAsLabel?: ObjRef,
     isResultOfMigration?: boolean,
+    additionalProps?: {
+        isSelectionInvalid?: boolean;
+        applyToWorkingOnly?: boolean;
+    },
 ) => void;
 
 /**
@@ -49,6 +53,9 @@ export type OnSelectCallbackType = (
     selectionMode?: DashboardAttributeFilterSelectionMode,
     selectionTitles?: IAttributeElement[],
     displayAsLabel?: ObjRef,
+    additionalProps?: {
+        isSelectionInvalid?: boolean;
+    },
 ) => void;
 
 /**


### PR DESCRIPTION
<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```

#### Commands for Bear platform working on branch rel/9.9

```
extended-test-legacy --backstop
extended-test-legacy --isolated
extended-test-legacy --record
```
