### PR TITLE
ci: replace 3rdparty images with pullthrough cache

### DIFF
--- a/libs/sdk-backend-tiger/docker-compose-isolated-gdcui.yaml
+++ b/libs/sdk-backend-tiger/docker-compose-isolated-gdcui.yaml
@@ -15,7 +15,7 @@ services:
             - backend-mock
 
     backend-mock:
-        image: 020413372491.dkr.ecr.us-east-1.amazonaws.com/3rdparty/wiremock/wiremock:3.13.1
+        image: 020413372491.dkr.ecr.us-east-1.amazonaws.com/pullthrough/docker.io/wiremock/wiremock:3.13.1
         command: "--https-port 8442 --enable-browser-proxying"
         user: "$USER_UID:$USER_GID"
         volumes:

--- a/libs/sdk-backend-tiger/docker-compose-isolated-record-gdcui.yaml
+++ b/libs/sdk-backend-tiger/docker-compose-isolated-record-gdcui.yaml
@@ -17,7 +17,7 @@ services:
             - backend-mock
 
     backend-mock:
-        image: 020413372491.dkr.ecr.us-east-1.amazonaws.com/3rdparty/wiremock/wiremock:3.13.1
+        image: 020413372491.dkr.ecr.us-east-1.amazonaws.com/pullthrough/docker.io/wiremock/wiremock:3.13.1
         command: "--https-port 8442 --enable-browser-proxying  --verbose --extensions org.gooddata.extensions.ResponseHeadersTransformer,org.gooddata.extensions.RequestHeadersTransformer"
         user: "$USER_UID:$USER_GID"
         volumes:

--- a/libs/sdk-backend-tiger/docker-compose-isolated-record.yaml
+++ b/libs/sdk-backend-tiger/docker-compose-isolated-record.yaml
@@ -16,7 +16,7 @@ services:
             - backend-mock
 
     backend-mock:
-        image: 020413372491.dkr.ecr.us-east-1.amazonaws.com/3rdparty/wiremock/wiremock:3.13.1
+        image: 020413372491.dkr.ecr.us-east-1.amazonaws.com/pullthrough/docker.io/wiremock/wiremock:3.13.1
         command: "--https-port 8442 --enable-browser-proxying  --verbose --extensions org.gooddata.extensions.ResponseHeadersTransformer,org.gooddata.extensions.RequestHeadersTransformer"
         user: "$USER_UID:$USER_GID"
         volumes:

--- a/libs/sdk-backend-tiger/docker-compose-isolated.yaml
+++ b/libs/sdk-backend-tiger/docker-compose-isolated.yaml
@@ -14,7 +14,7 @@ services:
             - backend-mock
 
     backend-mock:
-        image: 020413372491.dkr.ecr.us-east-1.amazonaws.com/3rdparty/wiremock/wiremock:3.13.1
+        image: 020413372491.dkr.ecr.us-east-1.amazonaws.com/pullthrough/docker.io/wiremock/wiremock:3.13.1
         command: "--https-port 8442 --enable-browser-proxying"
         user: "$USER_UID:$USER_GID"
         volumes:

--- a/libs/sdk-ui-tests-e2e/Dockerfile
+++ b/libs/sdk-ui-tests-e2e/Dockerfile
@@ -8,7 +8,7 @@ ENV FORCE_COLOR 0
 
 RUN npm run build-scenarios
 
-FROM 020413372491.dkr.ecr.us-east-1.amazonaws.com/3rdparty/nginxinc/nginx-unprivileged:1.25.2-alpine
+FROM 020413372491.dkr.ecr.us-east-1.amazonaws.com/pullthrough/docker.io/nginxinc/nginx-unprivileged:1.25.2-alpine
 
 COPY --from=build-stage ./nginx/nginx.conf /etc/nginx/nginx.conf
 COPY --from=build-stage ./scenarios/build /usr/share/nginx/html/gooddata-ui-sdk/
@@ -17,5 +17,5 @@ ARG GIT_COMMIT=unspecified
 LABEL image_name="Gooddata ui sdk Scenarios"
 LABEL maintainer="RAIL <rail@gooddata.com>"
 LABEL git_repository_url="https://github.com/gooddata/gooddata-ui-sdk"
-LABEL parent_image="020413372491.dkr.ecr.us-east-1.amazonaws.com/3rdparty/nginxinc/nginx-unprivileged:1.23.1-alpine"
+LABEL parent_image="020413372491.dkr.ecr.us-east-1.amazonaws.com/pullthrough/docker.io/nginxinc/nginx-unprivileged:1.23.1-alpine"
 LABEL git_commit=$GIT_COMMIT

--- a/libs/sdk-ui-tests-e2e/Dockerfile_local
+++ b/libs/sdk-ui-tests-e2e/Dockerfile_local
@@ -1,6 +1,6 @@
 # (C) 2021 GoodData Corporation
 
-FROM 020413372491.dkr.ecr.us-east-1.amazonaws.com/3rdparty/nginxinc/nginx-unprivileged:1.25.2-alpine
+FROM 020413372491.dkr.ecr.us-east-1.amazonaws.com/pullthrough/docker.io/nginxinc/nginx-unprivileged:1.25.2-alpine
 
 RUN ls -l
 
@@ -11,5 +11,5 @@ ARG GIT_COMMIT=unspecified
 LABEL image_name="GOODDATA UI SDK - development"
 LABEL maintainer="RAIL <rail@gooddata.com>"
 LABEL git_repository_url="https://github.com/gooddata/gooddata-ui-sdk"
-LABEL parent_image="020413372491.dkr.ecr.us-east-1.amazonaws.com/3rdparty/nginxinc/nginx-unprivileged:1.23.1-alpine"
+LABEL parent_image="020413372491.dkr.ecr.us-east-1.amazonaws.com/pullthrough/docker.io/nginxinc/nginx-unprivileged:1.23.1-alpine"
 LABEL git_commit=$GIT_COMMIT

--- a/libs/sdk-ui-tests-e2e/README.md
+++ b/libs/sdk-ui-tests-e2e/README.md
@@ -69,13 +69,6 @@ To run the tests against a mock backend follow these steps:
     - videos in `cypress/videos`
     - if you are running tests in record mode, then you can see all calls logged in `recording/mappings`
 
-### Running things on Apple Silicon
-
-Currently, our ECR images do not support ARM64 tags, so to run Docker things in this repo locally, search for
-`020413372491.dkr.ecr.us-east-1.amazonaws.com/3rdparty/` in this folder and remove it.
-This will make your docker use upstream images that do support ARM64 and thus your Mac will run them natively.
-Do not commit this change!
-
 ### Run tests against wiremock backend with live Cypress controls (tests are importing their recorded mapping files)
 
 Good for debugging the tooling when tests are passing with live backend but fail on CI.

--- a/libs/sdk-ui-tests-e2e/docker-compose-isolated-gdcui.yaml
+++ b/libs/sdk-ui-tests-e2e/docker-compose-isolated-gdcui.yaml
@@ -34,7 +34,7 @@ services:
             - backend-mock
 
     backend-mock:
-        image: 020413372491.dkr.ecr.us-east-1.amazonaws.com/3rdparty/wiremock/wiremock:3.13.1
+        image: 020413372491.dkr.ecr.us-east-1.amazonaws.com/pullthrough/docker.io/wiremock/wiremock:3.13.1
         # Use "--print-all-network-traffic --verbose" for verbose logging
         command: "--proxy-all=${HOST:-https://staging3.intgdc.com} --extensions org.gooddata.extensions.ResponseHeadersTransformer,org.gooddata.extensions.RequestHeadersTransformer"
         user: "$USER_UID:$USER_GID"

--- a/libs/sdk-ui-tests-e2e/docker-compose-isolated.yaml
+++ b/libs/sdk-ui-tests-e2e/docker-compose-isolated.yaml
@@ -33,7 +33,7 @@ services:
             - backend-mock
 
     backend-mock:
-        image: 020413372491.dkr.ecr.us-east-1.amazonaws.com/3rdparty/wiremock/wiremock:3.13.1
+        image: 020413372491.dkr.ecr.us-east-1.amazonaws.com/pullthrough/docker.io/wiremock/wiremock:3.13.1
         # Use "--print-all-network-traffic --verbose" for verbose logging
         command: "--proxy-all=${HOST:-https://staging3.intgdc.com} --extensions org.gooddata.extensions.ResponseHeadersTransformer,org.gooddata.extensions.RequestHeadersTransformer"
         user: "$USER_UID:$USER_GID"


### PR DESCRIPTION
risk: nonprod
JIRA: INFRA-4077

<!--
Description of changes.
-->

---

> [!IMPORTANT]
> Please, **don't forget to run `rush change`** for the commits that introduce **new features** or **significant changes** 🙏 This information is used to generate the [change log](https://github.com/gooddata/gooddata-ui-sdk/blob/master/libs/sdk-ui-all/CHANGELOG.md).

---

### Run extended test by pull request comment

Commands can be triggered by posting a comment with specific text on the pull request. It is possible to trigger multiple commands simultaneously.

```
extended-test --backstop | --integrated | --isolated | --record [--filter <file1>,<file2>,...,<fileN>]
```

#### Explanation

-   `--backstop` The command to run screen tests (optionally with keeping passing screenshots).
-   `--integrated` The command to run integrated tests against the live backend.
-   `--isolated` The command to run isolated tests against recordings.
-   `--record` The command to create new recordings for isolated tests.
-   `--filter` (Optional) A comma-separated list of test files to run. This parameter is valid only for the `--integrated`, `--isolated`, and `--record` commands.

#### Examples

```
extended-test --backstop
extended-test --backstop --keep-passing-screenshots
extended-test --integrated
extended-test --integrated --filter test1.spec.ts,test2.spec.ts
extended-test --isolated
extended-test --isolated --filter test1.spec.ts,test2.spec.ts
extended-test --record
extended-test --record --filter test1.spec.ts,test2.spec.ts
```

#### Commands for Bear platform working on branch rel/9.9

```
extended-test-legacy --backstop
extended-test-legacy --isolated
extended-test-legacy --record
```
